### PR TITLE
Harden autoreview bundle generation

### DIFF
--- a/skills/autoreview/SKILL.md
+++ b/skills/autoreview/SKILL.md
@@ -92,10 +92,10 @@ Branch/PR work:
 "$AUTOREVIEW" --mode branch --base origin/main
 ```
 
-Optional review context is first-class:
+Optional review context is first-class. Prompt files and datasets must be repo-relative so review bundles cannot pull arbitrary host files:
 
 ```bash
-"$AUTOREVIEW" --mode branch --base origin/main --prompt-file /tmp/review-notes.md --dataset /tmp/evidence.json
+"$AUTOREVIEW" --mode branch --base origin/main --prompt-file review-notes.md --dataset evidence.json
 ```
 
 If an open PR exists, use its actual base:
@@ -278,12 +278,13 @@ The helper:
 - accepts `--mode uncommitted` as an alias for `--mode local`
 - otherwise uses current PR base if `gh pr view` works
 - otherwise uses `origin/main` for non-main branches
+- does not fetch automatically during branch review; the selected base ref must already resolve locally
 - supports `--engine codex`, `claude`, `droid`, `copilot`, `pi`, and `opencode`; default is `AUTOREVIEW_ENGINE` or `codex`; Codex should remain the default when nothing is set
 - resolves bare `git`, `gh`, reviewer, and PowerShell shell commands from absolute `PATH` entries only, never from the reviewed checkout; explicit relative `--*-bin` paths are resolved from the reviewed repository root
 - use `--mode commit --commit <ref>` for already-committed work, especially clean `main` after landing
 - should be left in `--mode auto` or forced to `--mode branch` for PR/branch work; do not force `--mode local` after committing
 - writes only to stdout unless `--output`, `--json-output`, or live streamed engine stderr is set
-- supports `--dry-run`, `--parallel-tests`, `--parallel-tests-shell`, `--prompt`, `--prompt-file`, `--dataset`, `--no-tools`, `--no-web-search`, and commit refs
+- supports `--dry-run`, `--parallel-tests`, `--parallel-tests-shell`, `--prompt`, repo-relative `--prompt-file`, repo-relative `--dataset`, `--no-tools`, `--no-web-search`, and commit refs
 - supports `--stream-engine-output` or `AUTOREVIEW_STREAM_ENGINE_OUTPUT=1` for live engine text while preserving structured validation; Codex and Claude hide tool/file event details, emit compact activity summaries, and report usage at turn completion
 - supports opt-in review panels with `--panel` / `--reviewers`, plus per-engine `--model`, `--thinking`, and Claude `--fallback-model`
 - uses built-in model defaults `codex=gpt-5.5` and `claude=claude-fable-5`; honors `AUTOREVIEW_MODEL`, `AUTOREVIEW_THINKING`, `AUTOREVIEW_FALLBACK_MODEL`, and per-engine `AUTOREVIEW_<ENGINE>_MODEL` / `AUTOREVIEW_<ENGINE>_THINKING` environment overrides when CLI flags are omitted

--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -20,6 +20,69 @@ from typing import Any, Callable
 
 
 ENGINES = ("codex", "claude", "droid", "copilot", "pi", "opencode")
+SAFE_GIT_CONFIG_ARGS = (
+    "-c",
+    "core.fsmonitor=false",
+    "-c",
+    "core.pager=cat",
+    "-c",
+    "diff.external=",
+    "-c",
+    "diff.renames=false",
+    "-c",
+    "pager.diff=cat",
+    "-c",
+    "pager.log=cat",
+    "-c",
+    "pager.show=cat",
+)
+SAFE_DIFF_FLAGS = ("--no-ext-diff", "--no-textconv", "--no-renames")
+ENGINE_GIT_CONFIG_OVERRIDES = (
+    ("core.fsmonitor", "false"),
+    ("core.pager", "cat"),
+    ("diff.external", ""),
+    ("diff.renames", "false"),
+    ("pager.diff", "cat"),
+    ("pager.log", "cat"),
+    ("pager.show", "cat"),
+)
+SENSITIVE_PATH_PARTS = {
+    ".aws",
+    ".azure",
+    ".config/gcloud",
+    ".docker",
+    ".gnupg",
+    ".ssh",
+    "private",
+    "secrets",
+}
+SENSITIVE_NAME_PATTERNS = [
+    re.compile(r"(^|/)\.env($|[._/-])", re.IGNORECASE),
+    re.compile(r"(^|/)(id_rsa|id_dsa|id_ecdsa|id_ed25519)(\.pub)?$", re.IGNORECASE),
+    re.compile(r"\.(pem|p12|pfx|key)$", re.IGNORECASE),
+    re.compile(
+        r"(^|/)[^/]*(secret|token|credential|credentials|service[-_]?account|private[-_]?key|apikey|api[-_]?key)[^/]*$",
+        re.IGNORECASE,
+    ),
+]
+SECRET_VALUE_PATTERNS = [
+    re.compile(r"-----BEGIN (?:RSA |DSA |EC |OPENSSH |PGP )?PRIVATE KEY-----"),
+    re.compile(
+        r"(?i)(api[_-]?key|token|secret|password)\s*[:=]\s*(?:[\"'][A-Za-z0-9_./+=-]{12,}[\"']|[A-Za-z0-9_+=/-]{20,})"
+    ),
+    re.compile(r"(?i)bearer\s+[A-Za-z0-9._-]{20,}"),
+    re.compile(r"\b(?:sk|rk|pk|org|proj)-[A-Za-z0-9_-]{20,}\b"),
+    re.compile(r"\bgithub_pat_[A-Za-z0-9_]{20,}\b"),
+    re.compile(r"\bgh[pousr]_[A-Za-z0-9_]{20,}\b"),
+    re.compile(r"\bglpat-[A-Za-z0-9_-]{20,}\b"),
+    re.compile(r"\bnpm_[A-Za-z0-9]{20,}\b"),
+    re.compile(r"\bxox[baprs]-[A-Za-z0-9-]{20,}\b"),
+    re.compile(r"\b(?:A3T|AKIA|ASIA)[A-Z0-9]{16}\b"),
+    re.compile(r"\bAIza[0-9A-Za-z_-]{35}\b"),
+    re.compile(r"\bya29\.[0-9A-Za-z_-]{20,}\b"),
+]
+MAX_BUNDLE_TEXT_BYTES = 180_000
+DEFAULT_ENGINE_PATHS = ("/usr/local/bin", "/usr/bin", "/bin")
 DEFAULT_MODEL_BY_ENGINE = {
     "codex": "gpt-5.5",
     "claude": "claude-fable-5",
@@ -93,7 +156,14 @@ SCHEMA: dict[str, Any] = {
 }
 
 
-def run(args: list[str], cwd: Path, *, input_text: str | None = None, check: bool = True) -> subprocess.CompletedProcess[str]:
+def run(
+    args: list[str],
+    cwd: Path,
+    *,
+    input_text: str | None = None,
+    check: bool = True,
+    env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
     result = subprocess.run(
         args,
         cwd=cwd,
@@ -101,6 +171,7 @@ def run(args: list[str], cwd: Path, *, input_text: str | None = None, check: boo
         text=True,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
+        env=env,
     )
     if check and result.returncode != 0:
         cmd = " ".join(args)
@@ -114,6 +185,82 @@ def subprocess_env(extra: dict[str, str] | None) -> dict[str, str] | None:
     merged = os.environ.copy()
     merged.update(extra)
     return merged
+
+
+def safe_git_env() -> dict[str, str]:
+    return {
+        "GIT_CONFIG_GLOBAL": os.devnull,
+        "GIT_CONFIG_NOSYSTEM": "1",
+        "GIT_CONFIG_SYSTEM": os.devnull,
+        "GIT_OPTIONAL_LOCKS": "0",
+        "GIT_TERMINAL_PROMPT": "0",
+        "HOME": os.environ.get("HOME", str(Path.home())),
+        "LANG": "C.UTF-8",
+        "LC_ALL": "C.UTF-8",
+        "PATH": os.pathsep.join(DEFAULT_ENGINE_PATHS),
+    }
+
+
+def safe_engine_path(repo: Path, extra_paths: list[Path] | None = None) -> str:
+    entries: list[str] = []
+    resolved_repo = repo.resolve()
+
+    def add(path: str | Path) -> None:
+        candidate = Path(path).expanduser()
+        if not candidate.is_absolute() or not candidate.exists():
+            return
+        try:
+            resolved = candidate.resolve()
+        except OSError:
+            return
+        if is_within(resolved, resolved_repo):
+            return
+        value = str(resolved)
+        if value not in entries:
+            entries.append(value)
+
+    for path in extra_paths or []:
+        add(path)
+    for part in os.environ.get("PATH", "").split(os.pathsep):
+        if part:
+            add(part)
+    for path in DEFAULT_ENGINE_PATHS:
+        add(path)
+    return os.pathsep.join(entries)
+
+
+def safe_engine_env(
+    repo: Path,
+    extra_paths: list[Path] | None = None,
+    extra: dict[str, str] | None = None,
+) -> dict[str, str]:
+    blocked_exact = {
+        "BASH_ENV",
+        "ENV",
+        "GIT_CONFIG",
+        "GIT_CONFIG_GLOBAL",
+        "GIT_CONFIG_NOSYSTEM",
+        "GIT_CONFIG_SYSTEM",
+        "GIT_OPTIONAL_LOCKS",
+        "GIT_TERMINAL_PROMPT",
+        "LD_PRELOAD",
+        "NODE_OPTIONS",
+        "PYTHONHOME",
+        "PYTHONPATH",
+    }
+    blocked_prefixes = ("GIT_", "DYLD_")
+    env = {
+        key: value
+        for key, value in os.environ.items()
+        if key not in blocked_exact and not any(key.startswith(prefix) for prefix in blocked_prefixes)
+    }
+    env["PATH"] = safe_engine_path(repo, extra_paths)
+    env["GIT_CONFIG_COUNT"] = str(len(ENGINE_GIT_CONFIG_OVERRIDES))
+    for index, (key, value) in enumerate(ENGINE_GIT_CONFIG_OVERRIDES):
+        env[f"GIT_CONFIG_KEY_{index}"] = key
+        env[f"GIT_CONFIG_VALUE_{index}"] = value
+    env.update(extra or {})
+    return env
 
 
 def parse_ps_time(value: str) -> float:
@@ -308,7 +455,7 @@ def run_with_heartbeat(
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         text=True,
-        env=subprocess_env(env),
+        env=env,
     )
     first_communicate = True
     metrics = sample_process_metrics(resolve_root, proc.pid)
@@ -344,7 +491,7 @@ def run_with_stream(
         stderr=subprocess.PIPE,
         text=True,
         bufsize=1,
-        env=subprocess_env(env),
+        env=env,
     )
     events: queue.Queue[tuple[str, str | None]] = queue.Queue()
     stdout_parts: list[str] = []
@@ -404,7 +551,16 @@ def run_with_stream(
 
 
 def git(repo: Path, *args: str, check: bool = True) -> str:
-    return run([resolve_command("git", repo), *args], repo, check=check).stdout
+    return run(
+        [resolve_command("git", repo), "--no-optional-locks", *SAFE_GIT_CONFIG_ARGS, *args],
+        repo,
+        check=check,
+        env=safe_git_env(),
+    ).stdout
+
+
+def git_path_list(repo: Path, *args: str, check: bool = True) -> list[str]:
+    return [path for path in git(repo, *args, check=check).split("\0") if path]
 
 
 def repo_root() -> Path:
@@ -414,10 +570,11 @@ def repo_root() -> Path:
     if not git_bin:
         raise SystemExit("git executable not found. Install Git or add it to PATH.")
     result = subprocess.run(
-        [git_bin, "rev-parse", "--show-toplevel"],
+        [git_bin, "--no-optional-locks", *SAFE_GIT_CONFIG_ARGS, "rev-parse", "--show-toplevel"],
         text=True,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
+        env=safe_git_env(),
     )
     if result.returncode != 0:
         raise SystemExit("autoreview must run inside a git repository")
@@ -523,6 +680,23 @@ def first_executable_candidate(path: Path, *, reject_root: Path | None = None) -
     return None
 
 
+def validate_git_ref(repo: Path, ref: str, label: str) -> str:
+    if not ref or ref.startswith("-") or ":" in ref or "\0" in ref or any(char.isspace() for char in ref):
+        raise SystemExit(f"unsafe {label} ref: {ref}")
+    result = git(
+        repo,
+        "rev-parse",
+        "--verify",
+        "--quiet",
+        "--end-of-options",
+        f"{ref}^{{commit}}",
+        check=False,
+    )
+    if not result:
+        raise SystemExit(f"unknown {label} ref: {ref}")
+    return ref
+
+
 def bounded(text: str, limit: int = 180_000) -> str:
     if len(text) <= limit:
         return text
@@ -536,29 +710,139 @@ def bounded_field(text: str, limit: int) -> str:
     return text[: max(0, limit - len(suffix))] + suffix
 
 
-def read_text(path: Path, limit: int = 40_000) -> str:
+def read_prefix(path: Path, limit: int) -> tuple[bytes, bool]:
     try:
-        data = path.read_bytes()
+        with path.open("rb") as handle:
+            data = handle.read(limit + 1)
     except OSError as exc:
+        raise SystemExit(f"unreadable file: {path}: {exc}") from exc
+    return data[:limit], len(data) > limit
+
+
+def read_text(path: Path, limit: int = MAX_BUNDLE_TEXT_BYTES) -> str:
+    try:
+        data, truncated = read_prefix(path, limit)
+    except SystemExit as exc:
         return f"[unreadable: {exc}]"
     if b"\0" in data:
         return "[binary file omitted]"
     text = data.decode("utf-8", errors="replace")
-    return bounded(text, limit)
+    if len(text) > limit:
+        text = text[:limit]
+        truncated = True
+    if truncated:
+        return text + f"\n\n[truncated at {limit} characters]\n"
+    return text
+
+
+def path_has_sensitive_part(rel: str | Path) -> bool:
+    normalized = Path(rel).as_posix().lower()
+    if "/.config/gcloud/" in f"/{normalized}/":
+        return True
+    return any(part.lower() in SENSITIVE_PATH_PARTS for part in Path(rel).parts)
+
+
+def raw_repo_path_has_symlink_component(repo: Path, rel_path: Path) -> bool:
+    current = repo.resolve()
+    for part in rel_path.parts:
+        current = current / part
+        if current.is_symlink():
+            return True
+        if not current.exists():
+            break
+    return False
+
+
+def secret_text_risk(text: str) -> bool:
+    return any(pattern.search(text) for pattern in SECRET_VALUE_PATTERNS)
+
+
+def require_no_secret_values(label: str, text: str) -> None:
+    if secret_text_risk(text):
+        raise SystemExit(
+            "refusing to include secret-like content in review bundle; "
+            f"clean or redact {label} before running autoreview"
+        )
+
+
+def file_bundle_risk(
+    repo: Path,
+    path: Path,
+    rel: str,
+    *,
+    allow_binary_omission: bool = False,
+) -> str | None:
+    normalized = rel.replace(os.sep, "/")
+    if path_has_sensitive_part(normalized):
+        return "sensitive path"
+    for pattern in SENSITIVE_NAME_PATTERNS:
+        if pattern.search(normalized):
+            return "sensitive filename"
+    if path.is_symlink():
+        return "symlink"
+    try:
+        resolved = path.resolve(strict=True)
+    except OSError as exc:
+        return f"unreadable file: {exc}"
+    if not is_within(resolved, repo.resolve()):
+        return "path outside repository"
+    if not path.is_file():
+        return "not a regular file"
+    try:
+        data, _ = read_prefix(path, MAX_BUNDLE_TEXT_BYTES)
+    except SystemExit as exc:
+        return str(exc)
+    if b"\0" in data:
+        return None if allow_binary_omission else "binary file"
+    if secret_text_risk(data.decode("utf-8", errors="replace")):
+        return "secret-like content"
+    return None
+
+
+def safe_untracked_files(repo: Path) -> list[str]:
+    files = git_path_list(repo, "ls-files", "--others", "--exclude-standard", "-z")
+    blocked: list[str] = []
+    included: list[str] = []
+    for rel in files:
+        risk = file_bundle_risk(repo, repo / rel, rel, allow_binary_omission=True)
+        if risk:
+            blocked.append(f"{rel} ({risk})")
+        else:
+            included.append(rel)
+    if blocked:
+        details = "\n".join(f"- {item}" for item in blocked[:20])
+        more = f"\n... {len(blocked) - 20} more" if len(blocked) > 20 else ""
+        raise SystemExit(
+            "refusing to include untracked sensitive files in review bundle; "
+            "stage, ignore, remove, or redact them before running autoreview:\n"
+            f"{details}{more}"
+        )
+    return included
+
+
+def local_status(repo: Path, untracked: list[str]) -> str:
+    status = git(repo, "status", "--short", "--untracked-files=no").rstrip()
+    lines = [status] if status else []
+    lines.extend(f"?? {rel}" for rel in untracked)
+    return "\n".join(lines)
 
 
 def local_bundle(repo: Path) -> str:
+    staged_patch = git(repo, "diff", *SAFE_DIFF_FLAGS, "--cached", "--patch")
+    unstaged_patch = git(repo, "diff", *SAFE_DIFF_FLAGS, "--patch")
+    untracked = safe_untracked_files(repo)
+    if not staged_patch.strip() and not unstaged_patch.strip() and not untracked:
+        raise SystemExit("no local changes to review")
     parts = [
         "# Git Status",
-        git(repo, "status", "--short"),
+        local_status(repo, untracked),
         "# Staged Diff",
-        git(repo, "diff", "--cached", "--stat"),
-        bounded(git(repo, "diff", "--cached", "--patch", "--find-renames")),
+        git(repo, "diff", *SAFE_DIFF_FLAGS, "--cached", "--stat"),
+        bounded(staged_patch),
         "# Unstaged Diff",
-        git(repo, "diff", "--stat"),
-        bounded(git(repo, "diff", "--patch", "--find-renames")),
+        git(repo, "diff", *SAFE_DIFF_FLAGS, "--stat"),
+        bounded(unstaged_patch),
     ]
-    untracked = [line for line in git(repo, "ls-files", "--others", "--exclude-standard").splitlines() if line]
     if untracked:
         parts.append("# Untracked Files")
         for rel in untracked:
@@ -568,24 +852,57 @@ def local_bundle(repo: Path) -> str:
 
 
 def branch_bundle(repo: Path, base_ref: str) -> str:
-    git(repo, "fetch", "origin", "--quiet", check=False)
+    base_ref = validate_git_ref(repo, base_ref, "base")
+    branch_patch = git(
+        repo,
+        "diff",
+        *SAFE_DIFF_FLAGS,
+        "--patch",
+        "--end-of-options",
+        f"{base_ref}...HEAD",
+    )
     return "\n\n".join(
         [
             "# Branch Diff",
             f"base: {base_ref}",
-            git(repo, "diff", "--stat", f"{base_ref}...HEAD"),
-            bounded(git(repo, "diff", "--patch", "--find-renames", f"{base_ref}...HEAD")),
+            git(
+                repo,
+                "diff",
+                *SAFE_DIFF_FLAGS,
+                "--stat",
+                "--end-of-options",
+                f"{base_ref}...HEAD",
+            ),
+            bounded(branch_patch),
         ]
     )
 
 
 def commit_bundle(repo: Path, commit_ref: str) -> str:
+    commit_ref = validate_git_ref(repo, commit_ref, "commit")
+    commit_patch = git(
+        repo,
+        "show",
+        *SAFE_DIFF_FLAGS,
+        "--patch",
+        "--format=fuller",
+        "--end-of-options",
+        commit_ref,
+    )
     return "\n\n".join(
         [
             "# Commit Diff",
             f"commit: {commit_ref}",
-            git(repo, "show", "--stat", "--format=fuller", commit_ref),
-            bounded(git(repo, "show", "--patch", "--find-renames", "--format=fuller", commit_ref)),
+            git(
+                repo,
+                "show",
+                *SAFE_DIFF_FLAGS,
+                "--stat",
+                "--format=fuller",
+                "--end-of-options",
+                commit_ref,
+            ),
+            bounded(commit_patch),
         ]
     )
 
@@ -593,40 +910,77 @@ def commit_bundle(repo: Path, commit_ref: str) -> str:
 def review_paths(repo: Path, target: str, target_ref: str | None, commit_ref: str) -> set[str]:
     names: set[str] = set()
     if target == "local":
-        sources = [
-            git(repo, "diff", "--name-only", "--cached"),
-            git(repo, "diff", "--name-only"),
-            git(repo, "ls-files", "--others", "--exclude-standard"),
-        ]
+        names.update(git_path_list(repo, "diff", *SAFE_DIFF_FLAGS, "--name-only", "--cached", "-z"))
+        names.update(git_path_list(repo, "diff", *SAFE_DIFF_FLAGS, "--name-only", "-z"))
+        names.update(safe_untracked_files(repo))
     elif target == "branch":
         assert target_ref
-        sources = [git(repo, "diff", "--name-only", f"{target_ref}...HEAD")]
+        target_ref = validate_git_ref(repo, target_ref, "base")
+        names.update(
+            git_path_list(
+                repo,
+                "diff",
+                *SAFE_DIFF_FLAGS,
+                "--name-only",
+                "-z",
+                "--end-of-options",
+                f"{target_ref}...HEAD",
+            )
+        )
     else:
-        sources = [git(repo, "show", "--name-only", "--format=", commit_ref)]
-    for source in sources:
-        for line in source.splitlines():
-            path = line.strip()
-            if path:
-                names.add(path)
+        commit_ref = validate_git_ref(repo, commit_ref, "commit")
+        names.update(
+            git_path_list(
+                repo,
+                "show",
+                *SAFE_DIFF_FLAGS,
+                "--name-only",
+                "--format=",
+                "-z",
+                "--end-of-options",
+                commit_ref,
+            )
+        )
     return names
 
 
-def load_extra_prompt(args: argparse.Namespace) -> str:
+def validate_evidence_file(repo: Path, raw_path: str, label: str) -> tuple[Path, str]:
+    original = Path(raw_path)
+    if original.is_absolute() or ".." in original.parts or not original.parts:
+        raise SystemExit(f"{label} must be a repo-relative path: {raw_path}")
+    raw_rel = original.as_posix()
+    if path_has_sensitive_part(raw_rel):
+        raise SystemExit(f"refusing to include sensitive {label}: {raw_rel}")
+    if raw_repo_path_has_symlink_component(repo, original):
+        raise SystemExit(f"refusing to include symlinked {label}: {raw_path}")
+    path = (repo / original).resolve()
+    if not is_within(path, repo.resolve()):
+        raise SystemExit(f"{label} must be inside the reviewed repository: {raw_path}")
+    rel = str(path.relative_to(repo.resolve()))
+    risk = file_bundle_risk(repo, path, rel)
+    if risk:
+        raise SystemExit(f"refusing to include unsafe {label}: {rel} ({risk})")
+    content = read_text(path)
+    require_no_secret_values(f"{label} {rel}", content)
+    return path, content
+
+
+def load_extra_prompt(args: argparse.Namespace, repo: Path) -> str:
     chunks: list[str] = []
     for value in args.prompt or []:
+        require_no_secret_values("--prompt", value)
         chunks.append(value)
     for path in args.prompt_file or []:
-        chunks.append(Path(path).read_text())
+        _, content = validate_evidence_file(repo, path, "--prompt-file")
+        chunks.append(content)
     return "\n\n".join(chunks)
 
 
-def load_datasets(args: argparse.Namespace) -> str:
+def load_datasets(args: argparse.Namespace, repo: Path) -> str:
     chunks: list[str] = []
     for spec in args.dataset or []:
-        path = Path(spec)
-        if path.is_dir():
-            raise SystemExit(f"--dataset must be a file, got directory: {path}")
-        chunks.append(f"# Dataset: {path}\n{read_text(path)}")
+        path, content = validate_evidence_file(repo, spec, "--dataset")
+        chunks.append(f"# Dataset: {path.relative_to(repo.resolve())}\n{content}")
     return "\n\n".join(chunks)
 
 
@@ -805,7 +1159,8 @@ def parse_cli_version(text: str) -> tuple[int, int, int] | None:
 
 def ensure_claude_isolation_supported(args: argparse.Namespace, repo: Path) -> None:
     claude_bin = resolve_command(args.claude_bin, repo)
-    result = run([claude_bin, "--version"], repo, check=False)
+    engine_env = safe_engine_env(repo, [Path(claude_bin).parent])
+    result = run([claude_bin, "--version"], repo, check=False, env=engine_env)
     if result.returncode != 0:
         raise SystemExit(f"claude engine requires Claude Code >= {format_version(CLAUDE_SAFE_MODE_MIN_VERSION)}; --version failed")
     version = parse_cli_version(result.stdout or result.stderr)
@@ -816,7 +1171,7 @@ def ensure_claude_isolation_supported(args: argparse.Namespace, repo: Path) -> N
             f"claude engine requires Claude Code >= {format_version(CLAUDE_SAFE_MODE_MIN_VERSION)} "
             f"for --safe-mode (found {format_version(version)})"
         )
-    help_result = run([claude_bin, "--help"], repo, check=False)
+    help_result = run([claude_bin, "--help"], repo, check=False, env=engine_env)
     help_text = f"{help_result.stdout}\n{help_result.stderr}"
     required_flags = ["--safe-mode", "--setting-sources", "--strict-mcp-config", "--disallowedTools"]
     missing = [flag for flag in required_flags if flag not in help_text]
@@ -827,10 +1182,11 @@ def ensure_claude_isolation_supported(args: argparse.Namespace, repo: Path) -> N
 
 def ensure_pi_isolation_supported(args: argparse.Namespace, repo: Path) -> str:
     pi_bin = resolve_command(args.pi_bin, repo)
+    engine_env = safe_engine_env(repo, [Path(pi_bin).parent])
     with tempfile.TemporaryDirectory(prefix="autoreview-pi-probe.") as tempdir:
         probe_cwd = Path(tempdir)
-        result = run([pi_bin, "--version"], probe_cwd, check=False)
-        help_result = run([pi_bin, "--help"], probe_cwd, check=False)
+        result = run([pi_bin, "--version"], probe_cwd, check=False, env=engine_env)
+        help_result = run([pi_bin, "--help"], probe_cwd, check=False, env=engine_env)
     if result.returncode != 0:
         raise SystemExit(f"pi engine requires Pi >= {format_version(PI_TRUST_ISOLATION_MIN_VERSION)}; --version failed")
     version = parse_cli_version(f"{result.stdout}\n{result.stderr}")
@@ -899,6 +1255,7 @@ def run_codex(args: argparse.Namespace, repo: Path, prompt: str) -> str:
         label="codex",
         stream_output=args.stream_engine_output,
         stream_display=CodexStreamDisplay() if args.stream_engine_output else None,
+        env=safe_engine_env(repo, [Path(cmd[0]).parent]),
     )
     try:
         output = output_path.read_text()
@@ -941,6 +1298,7 @@ def run_claude(args: argparse.Namespace, repo: Path, prompt: str) -> str:
         label="claude",
         stream_output=args.stream_engine_output,
         stream_display=ClaudeStreamDisplay() if args.stream_engine_output else None,
+        env=safe_engine_env(repo, [Path(cmd[0]).parent]),
     )
     if result.returncode != 0:
         raise SystemExit(f"claude engine failed ({result.returncode})\n{result.stderr or result.stdout}")
@@ -966,7 +1324,13 @@ def run_droid(args: argparse.Namespace, repo: Path, prompt: str) -> str:
         cmd.extend(["-r", args.thinking])
     if not args.tools:
         cmd.extend(["--disabled-tools", "*"])
-    result = run_with_heartbeat(cmd, repo, label="droid", stream_output=args.stream_engine_output)
+    result = run_with_heartbeat(
+        cmd,
+        repo,
+        label="droid",
+        stream_output=args.stream_engine_output,
+        env=safe_engine_env(repo, [Path(cmd[0]).parent]),
+    )
     prompt_path.unlink(missing_ok=True)
     if result.returncode != 0:
         raise SystemExit(f"droid engine failed ({result.returncode})\n{result.stderr or result.stdout}")
@@ -997,18 +1361,23 @@ def run_copilot(args: argparse.Namespace, repo: Path, prompt: str) -> str:
         ]
         if args.model:
             cmd.extend(["--model", args.model])
-        cmd.extend(
-            [
-                "--available-tools=read_agent,rg,view,web_fetch",
-                "--allow-tool=read_agent",
-                "--allow-tool=rg",
-                "--allow-tool=view",
-                "--allow-tool=web_fetch",
-            ]
-        )
+        available_tools = ["read_agent", "rg", "view"]
+        allowed_tools = available_tools[:]
         if args.web_search:
+            available_tools.append("web_fetch")
+            allowed_tools.append("web_fetch")
             cmd.append("--allow-all-urls")
-        result = run_with_heartbeat(cmd, Path(tempdir), label="copilot", stream_output=args.stream_engine_output, resolve_root=repo)
+        cmd.append(f"--available-tools={','.join(available_tools)}")
+        for tool in allowed_tools:
+            cmd.append(f"--allow-tool={tool}")
+        result = run_with_heartbeat(
+            cmd,
+            Path(tempdir),
+            label="copilot",
+            stream_output=args.stream_engine_output,
+            resolve_root=repo,
+            env=safe_engine_env(repo, [Path(cmd[0]).parent]),
+        )
     if result.returncode != 0:
         raise SystemExit(f"copilot engine failed ({result.returncode})\n{result.stderr or result.stdout}")
     return result.stdout
@@ -1042,7 +1411,11 @@ def run_opencode(args: argparse.Namespace, repo: Path, prompt: str) -> str:
             input_text=prompt,
             label="opencode",
             stream_output=args.stream_engine_output,
-            env=opencode_review_env(args.web_search),
+            env=safe_engine_env(
+                repo,
+                [Path(cmd[0]).parent],
+                opencode_review_env(args.web_search),
+            ),
             resolve_root=repo,
         )
     if result.returncode != 0:
@@ -1073,6 +1446,7 @@ def run_pi(args: argparse.Namespace, repo: Path, prompt: str) -> str:
             label="pi",
             stream_output=args.stream_engine_output,
             resolve_root=repo,
+            env=safe_engine_env(repo, [Path(cmd[0]).parent]),
         )
     if result.returncode != 0:
         raise SystemExit(f"pi engine failed ({result.returncode})\n{result.stderr or result.stdout}")
@@ -2580,7 +2954,14 @@ def main() -> int:
     else:
         bundle = commit_bundle(repo, args.commit)
         target_ref = args.commit
-    prompt = build_prompt(repo, target, target_ref, bundle, load_extra_prompt(args), load_datasets(args))
+    prompt = build_prompt(
+        repo,
+        target,
+        target_ref,
+        bundle,
+        load_extra_prompt(args, repo),
+        load_datasets(args, repo),
+    )
     changed_paths = review_paths(repo, target, target_ref, args.commit)
     print(f"bundle: {len(prompt)} chars")
 

--- a/skills/autoreview/tests/test_autoreview_hardening.py
+++ b/skills/autoreview/tests/test_autoreview_hardening.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import os
+import runpy
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "autoreview"
+
+
+def load_helper() -> dict[str, object]:
+    return runpy.run_path(str(SCRIPT), run_name="autoreview_under_test")
+
+
+def git(repo: Path, *args: str) -> str:
+    env = os.environ.copy()
+    env.update(
+        {
+            "GIT_AUTHOR_NAME": "Autoreview Test",
+            "GIT_AUTHOR_EMAIL": "autoreview@example.invalid",
+            "GIT_COMMITTER_NAME": "Autoreview Test",
+            "GIT_COMMITTER_EMAIL": "autoreview@example.invalid",
+        }
+    )
+    result = subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        env=env,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    return result.stdout
+
+
+def init_repo(tempdir: Path) -> Path:
+    repo = tempdir / "repo"
+    repo.mkdir()
+    git(repo, "init", "-q")
+    git(repo, "config", "user.name", "Autoreview Test")
+    git(repo, "config", "user.email", "autoreview@example.invalid")
+    return repo
+
+
+class AutoreviewHardeningTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.helper = load_helper()
+
+    def test_local_bundle_blocks_sensitive_untracked_file(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo = init_repo(Path(tempdir))
+            (repo / ".env").write_text("placeholder=true\n", encoding="utf-8")
+
+            with self.assertRaisesRegex(SystemExit, "untracked sensitive files"):
+                self.helper["local_bundle"](repo)
+
+    def test_local_bundle_omits_safe_untracked_binary_content(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo = init_repo(Path(tempdir))
+            (repo / "image.bin").write_bytes(b"\x89PNG\r\n\0binary-content")
+
+            bundle = self.helper["local_bundle"](repo)
+
+            self.assertIn("## image.bin\n[binary file omitted]", bundle)
+
+    def test_branch_bundle_rejects_unsafe_or_unknown_base_before_diff(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo = init_repo(Path(tempdir))
+            (repo / "tracked.txt").write_text("base\n", encoding="utf-8")
+            git(repo, "add", "tracked.txt")
+            git(repo, "commit", "-q", "-m", "base")
+
+            with self.assertRaisesRegex(SystemExit, "unsafe base ref"):
+                self.helper["branch_bundle"](repo, "--help")
+            with self.assertRaisesRegex(SystemExit, "unknown base ref"):
+                self.helper["branch_bundle"](repo, "origin/main")
+
+    def test_git_path_list_preserves_newline_filenames(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo = init_repo(Path(tempdir))
+            rel = "line\nbreak.txt"
+            (repo / rel).write_text("content\n", encoding="utf-8")
+            git(repo, "add", rel)
+
+            paths = self.helper["git_path_list"](repo, "ls-files", "-z")
+
+            self.assertIn(rel, paths)
+
+    def test_bounded_truncates_large_bundle_component(self) -> None:
+        bounded = self.helper["bounded"]("x" * 25, 10)
+
+        self.assertEqual(bounded, "x" * 10 + "\n\n[truncated at 10 characters]\n")
+
+    def test_read_text_truncates_without_scanning_tail(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            path = Path(tempdir) / "large.txt"
+            path.write_bytes(b"x" * 200_000 + b"\0tail")
+
+            text = self.helper["read_text"](path)
+
+            self.assertIn("[truncated at 180000 characters]", text)
+            self.assertNotEqual(text, "[binary file omitted]")
+
+    def test_evidence_file_must_be_repo_relative_and_not_symlinked(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            root = Path(tempdir)
+            repo = init_repo(root)
+            outside = root / "outside.md"
+            outside.write_text("outside\n", encoding="utf-8")
+
+            with self.assertRaisesRegex(SystemExit, "repo-relative"):
+                self.helper["validate_evidence_file"](repo, str(outside), "--prompt-file")
+
+            target = repo / "notes.md"
+            target.write_text("notes\n", encoding="utf-8")
+            link = repo / "link.md"
+            link.symlink_to(target)
+            with self.assertRaisesRegex(SystemExit, "symlinked"):
+                self.helper["validate_evidence_file"](repo, "link.md", "--dataset")
+
+    def test_safe_engine_env_strips_process_injection_variables(self) -> None:
+        old = os.environ.copy()
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo = init_repo(Path(tempdir))
+            try:
+                os.environ["GIT_DIR"] = "/tmp/unsafe-git-dir"
+                os.environ["GIT_CONFIG_COUNT"] = "99"
+                os.environ["DYLD_INSERT_LIBRARIES"] = "/tmp/unsafe.dylib"
+                os.environ["NODE_OPTIONS"] = "--require=/tmp/unsafe.js"
+
+                env = self.helper["safe_engine_env"](repo)
+
+                self.assertNotEqual(env.get("GIT_DIR"), "/tmp/unsafe-git-dir")
+                self.assertEqual(
+                    env["GIT_CONFIG_COUNT"],
+                    str(len(self.helper["ENGINE_GIT_CONFIG_OVERRIDES"])),
+                )
+                self.assertNotIn("DYLD_INSERT_LIBRARIES", env)
+                self.assertNotIn("NODE_OPTIONS", env)
+            finally:
+                os.environ.clear()
+                os.environ.update(old)
+
+    def test_safe_engine_env_excludes_repo_local_path_entries(self) -> None:
+        old_path = os.environ.get("PATH", "")
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo = init_repo(Path(tempdir))
+            os.environ["PATH"] = f"{repo}{os.pathsep}{old_path}"
+            try:
+                env = self.helper["safe_engine_env"](repo)
+            finally:
+                os.environ["PATH"] = old_path
+
+            self.assertNotIn(str(repo.resolve()), env["PATH"].split(os.pathsep))
+
+    def test_large_repo_relative_evidence_file_is_truncated(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo = init_repo(Path(tempdir))
+            evidence = repo / "evidence.txt"
+            evidence.write_text("x" * 600_000, encoding="utf-8")
+
+            _, content = self.helper["validate_evidence_file"](repo, "evidence.txt", "--dataset")
+
+            self.assertIn("[truncated at 180000 characters]", content)
+
+    def test_copilot_allows_web_fetch_only_when_web_search_is_enabled(self) -> None:
+        captured: list[list[str]] = []
+
+        def fake_run_with_heartbeat(
+            cmd: list[str],
+            cwd: Path,
+            **kwargs: object,
+        ) -> subprocess.CompletedProcess[str]:
+            captured.append(cmd)
+            return subprocess.CompletedProcess(cmd, 0, '{"findings":[]}', "")
+
+        self.helper["run_copilot"].__globals__["run_with_heartbeat"] = fake_run_with_heartbeat
+        self.helper["run_copilot"].__globals__["resolve_command"] = (
+            lambda command, repo: f"/resolved/{command}"
+        )
+        args = argparse.Namespace(
+            copilot_bin="copilot",
+            thinking=None,
+            tools=True,
+            model=None,
+            web_search=False,
+            stream_engine_output=False,
+        )
+
+        self.helper["run_copilot"](args, Path("/repo"), "prompt")
+
+        self.assertNotIn("--allow-tool=web_fetch", captured[-1])
+        self.assertFalse(any(arg == "--allow-all-urls" for arg in captured[-1]))
+
+        args.web_search = True
+        self.helper["run_copilot"](args, Path("/repo"), "prompt")
+
+        self.assertIn("--allow-tool=web_fetch", captured[-1])
+        self.assertIn("--allow-all-urls", captured[-1])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- harden Git bundle collection with isolated config, explicit ref validation, no implicit fetch, safe diff flags, and NUL-delimited path parsing
- reject sensitive, secret-like, symlinked, outside-repository, or unsafe untracked/evidence inputs while bounding text reads
- sanitize reviewer subprocess environments without removing current Codex, Claude, Droid, Pi, OpenCode, or Copilot isolation
- expose Copilot web fetching only when web search is enabled

## Compatibility

- current reviewer engines, model defaults, and web-search defaults remain unchanged
- `--prompt-file` and `--dataset` now require repository-relative files
- branch review requires the selected base ref to exist locally

## Validation

- `python3 -m py_compile skills/autoreview/scripts/autoreview skills/autoreview/tests/test_autoreview_hardening.py`
- `python3 -m unittest skills.autoreview.tests.test_autoreview_hardening` (11 tests)
- `scripts/validate-skills`
- `skills/autoreview/scripts/autoreview --self-test-engine-isolation`
- `skills/autoreview/scripts/autoreview --self-test-config-defaults`
- `skills/autoreview/scripts/autoreview --self-test-fallback-scope`
- structured Codex autoreview: clean, no accepted/actionable findings

The original hardening commit was ported onto current `main` rather than merging its stale helper implementation over newer reviewer-isolation work.
