### PR TITLE
sensei: improve skill frontmatter for cross-model trigger accuracy

### DIFF
--- a/skills/agent-transcript/SKILL.md
+++ b/skills/agent-transcript/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agent-transcript
-description: "**UTILITY SKILL** — Add a redacted agent session transcript to GitHub PR or issue bodies as local-only provenance for OpenClaw workflows. WHEN: \"add transcript to PR\", \"agent transcript\", \"include session log in issue\", \"redact and append transcript\", \"OpenClaw PR provenance\"."
+description: "Add a redacted agent session transcript to a GitHub PR or issue body as local-only provenance for OpenClaw workflows."
 ---
 
 # Agent Transcript

--- a/skills/agent-transcript/SKILL.md
+++ b/skills/agent-transcript/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agent-transcript
-description: "Add a redacted agent transcript section to GitHub PR or issue bodies during OpenClaw agent-created PR/issue workflows."
+description: "**UTILITY SKILL** — Add a redacted agent session transcript to GitHub PR or issue bodies as local-only provenance for OpenClaw workflows. WHEN: \"add transcript to PR\", \"agent transcript\", \"include session log in issue\", \"redact and append transcript\", \"OpenClaw PR provenance\"."
 ---
 
 # Agent Transcript

--- a/skills/autoreview/SKILL.md
+++ b/skills/autoreview/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: autoreview
-description: "Auto Review closeout. Codex review is the default when no engine is set and is the recommended reviewer."
+description: "**WORKFLOW SKILL** — Run a structured code review (Codex default, Claude optional) as a closeout check on a local or PR branch before commit or ship. WHEN: \"autoreview\", \"codex review\", \"claude review\", \"second-model review\", \"review before ship\". INVOKES: bundled review helper script."
 ---
 
 # Auto Review

--- a/skills/autoreview/SKILL.md
+++ b/skills/autoreview/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: autoreview
-description: "**WORKFLOW SKILL** — Run a structured code review (Codex default, Claude optional) as a closeout check on a local or PR branch before commit or ship. WHEN: \"autoreview\", \"codex review\", \"claude review\", \"second-model review\", \"review before ship\". INVOKES: bundled review helper script."
+description: "Run a structured code review (Codex default, Claude optional) as a closeout check on a local or PR branch before commit or ship."
 ---
 
 # Auto Review

--- a/skills/crabbox/SKILL.md
+++ b/skills/crabbox/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: crabbox
-description: "**WORKFLOW SKILL** — Run OpenClaw remote validation on Linux, macOS, Windows, and WSL2 via the Crabbox wrapper, including delegated Blacksmith Testbox proof. WHEN: \"crabbox\", \"testbox\", \"remote validation\", \"CI parity check\", \"warmed reusable box\". Report the actual provider and lease id."
+description: "Run OpenClaw remote validation on Linux, macOS, Windows, or WSL2 via the Crabbox or Testbox wrapper, including delegated Blacksmith proof. Report the actual provider and lease id."
 metadata:
   version: "2026-05-27"
 ---

--- a/skills/crabbox/SKILL.md
+++ b/skills/crabbox/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: crabbox
-description: "Use the Crabbox wrapper for OpenClaw remote validation across Linux, macOS, Windows, and WSL2, including delegated Blacksmith Testbox proof. Report the actual provider and id."
+description: "**WORKFLOW SKILL** — Run OpenClaw remote validation on Linux, macOS, Windows, and WSL2 via the Crabbox wrapper, including delegated Blacksmith Testbox proof. WHEN: \"crabbox\", \"testbox\", \"remote validation\", \"CI parity check\", \"warmed reusable box\". Report the actual provider and lease id."
 metadata:
   version: "2026-05-27"
 ---

--- a/skills/handoff/SKILL.md
+++ b/skills/handoff/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: handoff
-description: "Write a path-free handoff prompt for another agent and copy it to clipboard."
+description: "**UTILITY SKILL** — Write a path-free, clipboard-ready handoff prompt that lets another agent investigate, discuss, or pick up a specific task. WHEN: \"handoff <task>\", \"write a handoff\", \"delegate this\", \"prompt for another agent\", \"prepare handoff\"."
 ---
 
 # Handoff

--- a/skills/handoff/SKILL.md
+++ b/skills/handoff/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: handoff
-description: "**UTILITY SKILL** — Write a path-free, clipboard-ready handoff prompt that lets another agent investigate, discuss, or pick up a specific task. WHEN: \"handoff <task>\", \"write a handoff\", \"delegate this\", \"prompt for another agent\", \"prepare handoff\"."
+description: "Write a path-free, clipboard-ready handoff prompt that lets another agent investigate, discuss, or pick up a specific task."
 ---
 
 # Handoff

--- a/skills/session-viewer/SKILL.md
+++ b/skills/session-viewer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: session-viewer
-description: "Render Codex, Claude, and OpenClaw/Pi session JSONL as searchable single-file HTML."
+description: "**UTILITY SKILL** — Render Codex, Claude Code, OpenClaw, or Pi session JSONL transcripts as a searchable, shareable single-file HTML viewer. WHEN: \"view session\", \"open transcript\", \"export Codex session\", \"share Claude transcript\", \"inspect JSONL session\". INVOKES: agent-transcript skill to locate JSONL when path is unknown."
 ---
 
 # Session Viewer

--- a/skills/session-viewer/SKILL.md
+++ b/skills/session-viewer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: session-viewer
-description: "**UTILITY SKILL** — Render Codex, Claude Code, OpenClaw, or Pi session JSONL transcripts as a searchable, shareable single-file HTML viewer. WHEN: \"view session\", \"open transcript\", \"export Codex session\", \"share Claude transcript\", \"inspect JSONL session\". INVOKES: agent-transcript skill to locate JSONL when path is unknown."
+description: "Render Codex, Claude Code, OpenClaw, or Pi session JSONL transcripts as a searchable, shareable single-file HTML viewer."
 ---
 
 # Session Viewer


### PR DESCRIPTION
## What

Tighten the `description` frontmatter on five skills so cross-model trigger matching is more reliable, while staying inside the `AGENTS.md` rule that skill descriptions are short trigger phrases.

Skills touched: `agent-transcript`, `autoreview`, `crabbox`, `handoff`, `session-viewer`.

## Why

Sensei (https://github.com/spboyer/sensei) flagged the original descriptions as missing key trigger keywords (e.g. `transcript`, `codex review`, `testbox`, `handoff`, `session JSONL`), which hurts skill discoverability across models. The first revision of this PR expanded them into 250–330 char paragraphs with bold `**SKILL TYPE**` prefixes and `WHEN:` / `INVOKES:` blocks, but that violated [`AGENTS.md`](../blob/main/AGENTS.md):

> Skill descriptions: short trigger phrase, not full documentation.

(Sensei's own SKILL.md prescribes a 150-char minimum, which is the root cause — filed at [spboyer/sensei#22](https://github.com/spboyer/sensei/issues/22).)

The current commit rewrites each description as a **single compact sentence** that bakes the trigger keywords into the verb/object naturally — keeping the cross-model matching value without the documentation-style structure.

## Proof — before / after

| Skill | `main` | This PR |
|---|---|---|
| `agent-transcript` | _"Add a redacted agent transcript section to GitHub PR or issue bodies during OpenClaw agent-created PR/issue workflows."_ | _"Add a redacted agent session transcript to a GitHub PR or issue body as local-only provenance for OpenClaw workflows."_ |
| `autoreview` | _"Auto Review closeout. Codex review is the default when no engine is set and is the recommended reviewer."_ | _"Run a structured code review (Codex default, Claude optional) as a closeout check on a local or PR branch before commit or ship."_ |
| `crabbox` | _"Use the Crabbox wrapper for OpenClaw remote validation across Linux, macOS, Windows, and WSL2, including delegated Blacksmith Testbox proof. Report the actual provider and id."_ | _"Run OpenClaw remote validation on Linux, macOS, Windows, or WSL2 via the Crabbox or Testbox wrapper, including delegated Blacksmith proof. Report the actual provider and lease id."_ |
| `handoff` | _"Write a path-free handoff prompt for another agent and copy it to clipboard."_ | _"Write a path-free, clipboard-ready handoff prompt that lets another agent investigate, discuss, or pick up a specific task."_ |
| `session-viewer` | _"Render Codex, Claude, and OpenClaw/Pi session JSONL as searchable single-file HTML."_ | _"Render Codex, Claude Code, OpenClaw, or Pi session JSONL transcripts as a searchable, shareable single-file HTML viewer."_ |

All descriptions are 110–180 chars — comparable to other short descriptions on `main` and well under the previous revision's 250–330.

## Validation

```
$ ruby scripts/validate-skills
validated 5 skills
```

## Notes

- Pure frontmatter — zero behavior change in any skill.
- Compatibility risk called out in the previous review (deeper description metadata schema) is gone: this revision matches the existing on-`main` shape.
- Tooling root cause is tracked upstream at [spboyer/sensei#22](https://github.com/spboyer/sensei/issues/22) so future Sensei runs respect repo policy.

@clawsweeper re-review