### PR TITLE
chore: add validation coverage and installer ergonomics

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Validate skill frontmatter
         run: scripts/validate-skills
       - name: Check Ruby scripts
-        run: ruby -c scripts/install-skills && ruby -c scripts/validate-skills
+        run: ruby -c scripts/install-skills && ruby -c scripts/validate-skills && ruby scripts/install-skills.test.rb
       - name: Check shell scripts
         run: bash -n skills/autoreview/scripts/test-review-harness
       - name: Check Python scripts

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,33 @@
+name: validate
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Validate skill frontmatter
+        run: scripts/validate-skills
+      - name: Check Ruby scripts
+        run: ruby -c scripts/install-skills && ruby -c scripts/validate-skills
+      - name: Check shell scripts
+        run: bash -n skills/autoreview/scripts/test-review-harness
+      - name: Check Python scripts
+        run: python3 -m py_compile skills/autoreview/scripts/autoreview skills/autoreview/scripts/test-review-harness.py
+      - name: Check Node scripts
+        run: node --check skills/agent-transcript/scripts/agent-transcript
+      - name: Run Node tests
+        run: node --test skills/agent-transcript/scripts/agent-transcript.test.mjs skills/session-viewer/scripts/session-viewer.test.ts

--- a/README.md
+++ b/README.md
@@ -11,11 +11,13 @@ repo.
 
 ## Included Skills
 
+- `agent-transcript`: local-only, redacted PR/issue transcript provenance.
 - `autoreview`: structured closeout/code-review workflow plus helper script.
 - `crabbox`: Crabbox/Testbox remote validation workflow for broad or CI-parity
   proof.
 - `handoff`: path-free prompt handoff workflow for delegating a task to another
   agent.
+- `session-viewer`: local searchable HTML viewer for agent session JSONL.
 
 Repo-specific product skills should stay in the repo they describe. For example,
 an `acpx` usage skill belongs in `openclaw/acpx`; a general review helper belongs
@@ -28,6 +30,18 @@ Clone the repo:
 ```sh
 git clone https://github.com/openclaw/agent-skills.git
 cd agent-skills
+```
+
+List available skills:
+
+```sh
+scripts/install-skills --list
+```
+
+Preview an install without changing files:
+
+```sh
+scripts/install-skills --dry-run
 ```
 
 Install all skills into the default agent skill directory:
@@ -52,6 +66,12 @@ Use copies instead of symlinks:
 
 ```sh
 scripts/install-skills --mode copy --target ~/.agents/skills
+```
+
+Replace an existing installed skill:
+
+```sh
+scripts/install-skills --force autoreview
 ```
 
 Symlinks are best for local development because changes in this checkout are
@@ -109,6 +129,9 @@ without setup.
 
 ```text
 skills/
+  agent-transcript/
+    SKILL.md
+    scripts/
   autoreview/
     SKILL.md
     scripts/
@@ -116,6 +139,9 @@ skills/
     SKILL.md
   handoff/
     SKILL.md
+  session-viewer/
+    SKILL.md
+    scripts/
 scripts/
   install-skills
   validate-skills
@@ -130,10 +156,18 @@ Run this after edits:
 
 ```sh
 scripts/validate-skills
+ruby -c scripts/install-skills && ruby -c scripts/validate-skills
+bash -n skills/autoreview/scripts/test-review-harness
+python3 -m py_compile skills/autoreview/scripts/autoreview skills/autoreview/scripts/test-review-harness.py
+node --check skills/agent-transcript/scripts/agent-transcript
+node --test skills/agent-transcript/scripts/agent-transcript.test.mjs skills/session-viewer/scripts/session-viewer.test.ts
 ```
 
 The validator checks every `skills/*/SKILL.md` for YAML frontmatter plus required
 `name` and `description`.
+
+Session exports can contain sensitive conversation data. Treat `session-viewer`
+HTML as local/private output unless it has been separately redacted and reviewed.
 
 ## Editing Rules
 

--- a/scripts/install-skills
+++ b/scripts/install-skills
@@ -10,6 +10,9 @@ skills_root = File.join(root, "skills")
 options = {
   target: File.expand_path("~/.agents/skills"),
   mode: "symlink",
+  dry_run: false,
+  force: false,
+  list: false,
   skills: []
 }
 
@@ -17,6 +20,9 @@ parser = OptionParser.new do |opts|
   opts.banner = "Usage: scripts/install-skills [options] [skill ...]"
   opts.on("--target DIR", "Install target. Default: ~/.agents/skills") { |v| options[:target] = File.expand_path(v) }
   opts.on("--mode MODE", "symlink or copy. Default: symlink") { |v| options[:mode] = v }
+  opts.on("--dry-run", "Print actions without changing files") { options[:dry_run] = true }
+  opts.on("--force", "Replace an existing skill at the target path") { options[:force] = true }
+  opts.on("--list", "List available skills and exit") { options[:list] = true }
   opts.on("-h", "--help", "Show help") do
     puts opts
     exit
@@ -32,6 +38,12 @@ unless %w[symlink copy].include?(options[:mode])
 end
 
 available = Dir.children(skills_root).select { |name| File.file?(File.join(skills_root, name, "SKILL.md")) }.sort
+
+if options[:list]
+  puts available.join("\n")
+  exit
+end
+
 selected = options[:skills].empty? ? available : options[:skills]
 
 missing = selected - available
@@ -41,22 +53,28 @@ if missing.any?
   exit 1
 end
 
-FileUtils.mkdir_p(options[:target])
+FileUtils.mkdir_p(options[:target]) unless options[:dry_run]
 
 selected.each do |name|
   source = File.join(skills_root, name)
   target = File.join(options[:target], name)
 
   if File.exist?(target) || File.symlink?(target)
-    warn "exists, skipping: #{target}"
-    next
+    unless options[:force]
+      warn "exists, skipping: #{target}"
+      next
+    end
+
+    puts "remove #{target}" if options[:dry_run]
+    FileUtils.rm_rf(target) unless options[:dry_run]
   end
 
   if options[:mode] == "symlink"
-    FileUtils.ln_s(source, target)
+    FileUtils.ln_s(source, target) unless options[:dry_run]
   else
-    FileUtils.cp_r(source, target)
+    FileUtils.cp_r(source, target) unless options[:dry_run]
   end
 
-  puts "#{options[:mode]} #{name} -> #{target}"
+  prefix = options[:dry_run] ? "would #{options[:mode]}" : options[:mode]
+  puts "#{prefix} #{name} -> #{target}"
 end

--- a/scripts/install-skills
+++ b/scripts/install-skills
@@ -4,6 +4,12 @@
 require "fileutils"
 require "optparse"
 
+def same_real_path?(left, right)
+  File.realpath(left) == File.realpath(right)
+rescue Errno::ENOENT
+  false
+end
+
 root = File.expand_path("..", __dir__)
 skills_root = File.join(root, "skills")
 
@@ -62,6 +68,11 @@ selected.each do |name|
   if File.exist?(target) || File.symlink?(target)
     unless options[:force]
       warn "exists, skipping: #{target}"
+      next
+    end
+
+    if same_real_path?(source, target)
+      warn "target is source, skipping: #{target}"
       next
     end
 

--- a/scripts/install-skills
+++ b/scripts/install-skills
@@ -71,7 +71,7 @@ selected.each do |name|
       next
     end
 
-    if same_real_path?(source, target)
+    if !File.symlink?(target) && same_real_path?(source, target)
       warn "target is source, skipping: #{target}"
       next
     end

--- a/scripts/install-skills.test.rb
+++ b/scripts/install-skills.test.rb
@@ -29,4 +29,32 @@ class InstallSkillsTest < Minitest::Test
       assert_path_exists File.join(dir, "skills", "sample", "SKILL.md")
     end
   end
+
+  def test_force_copy_replaces_existing_symlink
+    Dir.mktmpdir do |dir|
+      FileUtils.mkdir_p(File.join(dir, "repo", "scripts"))
+      FileUtils.mkdir_p(File.join(dir, "repo", "skills", "sample"))
+      FileUtils.mkdir_p(File.join(dir, "target"))
+      FileUtils.cp(File.join(__dir__, "install-skills"), File.join(dir, "repo", "scripts", "install-skills"))
+      File.write(File.join(dir, "repo", "skills", "sample", "SKILL.md"), "---\nname: sample\ndescription: sample\n---\n")
+      FileUtils.ln_s(File.join(dir, "repo", "skills", "sample"), File.join(dir, "target", "sample"))
+
+      stdout, stderr, status = Open3.capture3(
+        RbConfig.ruby,
+        File.join(dir, "repo", "scripts", "install-skills"),
+        "--target",
+        File.join(dir, "target"),
+        "--force",
+        "--mode",
+        "copy",
+        "sample"
+      )
+
+      assert status.success?, stderr
+      assert_includes stdout, "copy sample"
+      refute File.symlink?(File.join(dir, "target", "sample"))
+      assert_path_exists File.join(dir, "target", "sample", "SKILL.md")
+      assert_path_exists File.join(dir, "repo", "skills", "sample", "SKILL.md")
+    end
+  end
 end

--- a/scripts/install-skills.test.rb
+++ b/scripts/install-skills.test.rb
@@ -1,0 +1,32 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "fileutils"
+require "minitest/autorun"
+require "open3"
+require "tmpdir"
+
+class InstallSkillsTest < Minitest::Test
+  def test_force_skips_target_that_is_source
+    Dir.mktmpdir do |dir|
+      FileUtils.mkdir_p(File.join(dir, "scripts"))
+      FileUtils.mkdir_p(File.join(dir, "skills", "sample"))
+      FileUtils.cp(File.join(__dir__, "install-skills"), File.join(dir, "scripts", "install-skills"))
+      File.write(File.join(dir, "skills", "sample", "SKILL.md"), "---\nname: sample\ndescription: sample\n---\n")
+
+      stdout, stderr, status = Open3.capture3(
+        RbConfig.ruby,
+        File.join(dir, "scripts", "install-skills"),
+        "--target",
+        File.join(dir, "skills"),
+        "--force",
+        "sample"
+      )
+
+      assert status.success?, stderr
+      assert_includes stderr, "target is source, skipping"
+      assert_empty stdout
+      assert_path_exists File.join(dir, "skills", "sample", "SKILL.md")
+    end
+  end
+end

--- a/skills/agent-transcript/SKILL.md
+++ b/skills/agent-transcript/SKILL.md
@@ -81,6 +81,12 @@ skills/agent-transcript/scripts/agent-transcript append-body \
 7. If the user approves, use the enriched trimmed body file for creation/update.
 8. If no safe session is found, say nothing and continue without transcript. If the user declines, continue without transcript and do not add any transcript placeholder section.
 
+## Validate
+
+```bash
+node --test skills/agent-transcript/scripts/agent-transcript.test.mjs
+```
+
 ## Review Artifacts
 
 For manual audits across many PR/session candidates, create a local HTML preview from a local JSON file. This is for maintainers only and is not part of the PR/issue workflow:

--- a/skills/agent-transcript/scripts/agent-transcript.test.mjs
+++ b/skills/agent-transcript/scripts/agent-transcript.test.mjs
@@ -1,0 +1,90 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+const script = path.resolve("skills/agent-transcript/scripts/agent-transcript");
+
+function tempDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "agent-transcript-test-"));
+}
+
+function writeJsonl(file, rows) {
+  fs.writeFileSync(file, `${rows.map((row) => JSON.stringify(row)).join("\n")}\n`);
+}
+
+function run(args, options = {}) {
+  return execFileSync(process.execPath, [script, ...args], {
+    cwd: path.resolve("."),
+    encoding: "utf8",
+    ...options,
+  });
+}
+
+test("render redacts common secrets and local identifiers", () => {
+  const dir = tempDir();
+  const session = path.join(dir, "session.jsonl");
+  writeJsonl(session, [
+    {
+      type: "response_item",
+      payload: {
+        role: "user",
+        content: [
+          {
+            type: "text",
+            text: "Use /Users/ahmed/project, email person@example.com, and header Bearer abcdefghijklmnopqrstuvwxyz123456.",
+          },
+        ],
+      },
+    },
+    { type: "response_item", payload: { role: "assistant", content: [{ type: "text", text: "Done." }] } },
+  ]);
+
+  const output = run(["render", "--session", session]);
+  assert.match(output, /\[LOCAL_PATH\]/);
+  assert.match(output, /\[REDACTED_EMAIL\]/);
+  assert.match(output, /\[REDACTED_AUTH_HEADER\]/);
+  assert.doesNotMatch(output, /person@example\.com/);
+  assert.doesNotMatch(output, /abcdefghijklmnopqrstuvwxyz123456/);
+});
+
+test("render drops raw tool outputs but keeps a compact tool summary", () => {
+  const dir = tempDir();
+  const session = path.join(dir, "session.jsonl");
+  writeJsonl(session, [
+    { type: "response_item", payload: { role: "user", content: [{ type: "text", text: "Run tests." }] } },
+    { type: "response_item", payload: { type: "function_call", name: "exec_command", arguments: "npm test" } },
+    {
+      type: "response_item",
+      payload: { type: "function_call_output", output: "raw output with sk-abcdefghijklmnopqrstuvwxyz123456" },
+    },
+  ]);
+
+  const output = run(["render", "--session", session]);
+  assert.match(output, /tool summary/);
+  assert.match(output, /1 execute/);
+  assert.doesNotMatch(output, /raw output/);
+  assert.doesNotMatch(output, /sk-abcdefghijklmnopqrstuvwxyz123456/);
+});
+
+test("append-body replaces an existing transcript section", () => {
+  const dir = tempDir();
+  const session = path.join(dir, "session.jsonl");
+  const body = path.join(dir, "body.md");
+  writeJsonl(session, [
+    { type: "response_item", payload: { role: "user", content: [{ type: "text", text: "New scoped work." }] } },
+    { type: "response_item", payload: { role: "assistant", content: [{ type: "text", text: "Implemented." }] } },
+  ]);
+  fs.writeFileSync(
+    body,
+    "# PR\n\n<!-- agent-transcript:start -->\nold transcript\n<!-- agent-transcript:end -->\n"
+  );
+
+  const output = run(["append-body", "--body", body, "--session", session]);
+  assert.match(output, /# PR/);
+  assert.match(output, /New scoped work/);
+  assert.doesNotMatch(output, /old transcript/);
+  assert.equal((output.match(/agent-transcript:start/g) || []).length, 1);
+});


### PR DESCRIPTION
## Summary

- add a GitHub Actions validation workflow for skills, Ruby, shell, Python, and Node checks
- add agent-transcript tests covering redaction, dropped raw tool output, and append-body replacement
- add installer ergonomics: --list, --dry-run, and --force
- update README to list all five skills, document validation, and mark session-viewer HTML as local/private unless reviewed

## Validation

```text
scripts/validate-skills
validated 5 skills

ruby -c scripts/install-skills
Syntax OK

ruby -c scripts/validate-skills
Syntax OK

bash -n skills/autoreview/scripts/test-review-harness

python3 -m py_compile skills/autoreview/scripts/autoreview skills/autoreview/scripts/test-review-harness.py

node --check skills/agent-transcript/scripts/agent-transcript

node --test skills/agent-transcript/scripts/agent-transcript.test.mjs skills/session-viewer/scripts/session-viewer.test.ts
30 tests, 30 pass

scripts/install-skills --list
agent-transcript
autoreview
crabbox
handoff
session-viewer

scripts/install-skills --dry-run autoreview
would symlink autoreview -> /root/.agents/skills/autoreview
```

## Notes

This is the first foundation pass from a repo audit. It intentionally avoids duplicating the larger autoreview hardening work already proposed in PR #1.
