### PR TITLE
fix(autoreview): parse `claude --output-format json` array output

### DIFF
--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -856,22 +856,25 @@ def extract_json(text: str) -> dict[str, Any]:
         if isinstance(result_json, dict) and "findings" in result_json:
             return result_json
         raise SystemExit(f"review engine result was not structured JSON:\n{parsed['result'][:2000]}")
+    if isinstance(parsed, list):
+        events_report = _report_from_events(parsed)
+        if events_report:
+            return events_report
     jsonl_report = extract_json_from_jsonl(stripped)
     if jsonl_report:
         return jsonl_report
     raise SystemExit(f"review engine returned unexpected JSON shape:\n{json.dumps(parsed)[:2000]}")
 
 
-def extract_json_from_jsonl(text: str) -> dict[str, Any] | None:
+def _report_from_events(events: list[Any]) -> dict[str, Any] | None:
+    """Pull the structured report out of a list of engine stream events.
+
+    Shared by the JSONL path (one event per line) and the JSON-array path
+    (e.g. some `claude --output-format json` versions/configurations return
+    [{type:system,init}, ..., {type:result,...}] rather than a bare object).
+    """
     candidates: list[str | dict[str, Any]] = []
-    for line in text.splitlines():
-        line = line.strip()
-        if not line:
-            continue
-        try:
-            event = json.loads(line)
-        except json.JSONDecodeError:
-            continue
+    for event in events:
         if not isinstance(event, dict):
             continue
         part = event.get("part")
@@ -893,6 +896,19 @@ def extract_json_from_jsonl(text: str) -> dict[str, Any] | None:
         if isinstance(parsed, dict) and "findings" in parsed:
             return parsed
     return None
+
+
+def extract_json_from_jsonl(text: str) -> dict[str, Any] | None:
+    events: list[Any] = []
+    for line in text.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            events.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+    return _report_from_events(events)
 
 
 def write_executable(path: Path, text: str) -> None:
@@ -1096,6 +1112,36 @@ def self_test_engine_isolation() -> int:
     return 0
 
 
+def self_test_json_array_parser() -> int:
+    report = {
+        "findings": [],
+        "overall_correctness": "patch is correct",
+        "overall_explanation": "parser self-test",
+        "overall_confidence": 0.99,
+    }
+    result_events = [
+        {"type": "system", "subtype": "init"},
+        {"type": "assistant", "message": {"content": [{"type": "text", "text": "working"}]}},
+        {"type": "result", "result": json.dumps(report)},
+    ]
+    if extract_json(json.dumps(result_events)) != report:
+        raise SystemExit("json array parser self-test failed for result event")
+    jsonl = "\n".join(json.dumps(event) for event in result_events)
+    if extract_json(jsonl) != report:
+        raise SystemExit("json array parser self-test failed for jsonl result event")
+
+    structured_report = {**report, "overall_explanation": "structured output"}
+    if extract_json(json.dumps([{"type": "result", "structured_output": structured_report}])) != structured_report:
+        raise SystemExit("json array parser self-test failed for structured output event")
+
+    text_report = {**report, "overall_explanation": "text event"}
+    if extract_json(json.dumps([{"part": {"text": json.dumps(text_report)}}])) != text_report:
+        raise SystemExit("json array parser self-test failed for text event")
+
+    print("autoreview json array parser self-test: ok")
+    return 0
+
+
 def parse_json_candidate(text: str) -> Any | None:
     stripped = text.strip()
     if stripped.startswith("```"):
@@ -1284,6 +1330,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--expect-findings", action="store_true", help="Treat findings as success; for harness acceptance tests.")
     parser.add_argument("--dry-run", action="store_true")
     parser.add_argument("--self-test-engine-isolation", action="store_true", help=argparse.SUPPRESS)
+    parser.add_argument("--self-test-json-array-parser", action="store_true", help=argparse.SUPPRESS)
     args = parser.parse_args()
     if args.engine not in ENGINES:
         raise SystemExit(f"invalid --engine/AUTOREVIEW_ENGINE: {args.engine}")
@@ -1453,6 +1500,8 @@ def main() -> int:
     args = parse_args()
     if args.self_test_engine_isolation:
         return self_test_engine_isolation()
+    if args.self_test_json_array_parser:
+        return self_test_json_array_parser()
     reviewers = reviewer_args(args)
     repo = repo_root()
     target, target_ref = choose_target(repo, args.mode, args.base)


### PR DESCRIPTION
## Problem

Running autoreview with `--engine claude` on a current Claude CLI fails immediately:

```
review engine returned unexpected JSON shape:
[{"type": "system", "subtype": "init", ...}]
```

`run_claude()` invokes `claude --print --output-format json`, but current Claude CLI versions return that as a **JSON array of stream events** (`[{type:system,init}, ..., {type:result,...}]`) rather than a single result object. `extract_json()` only handles dict shapes and line-delimited JSONL, so a top-level **list** falls through every branch to the `unexpected JSON shape` `SystemExit`. The result event (with the structured `findings`) is right there in the array, but never read — so `--engine claude` is effectively unusable.

## Fix

- Factor the event candidate-extraction loop out of `extract_json_from_jsonl()` into a shared `_report_from_events(events)`.
- In `extract_json()`, when the parsed payload is a `list`, run it through `_report_from_events()` before falling through to the error.

Dict and JSONL paths are byte-for-byte unchanged, and the other engines (codex/droid/copilot) are untouched — so this is backward compatible and additive (+25/−9, one file).

## Validation

Ran `autoreview --engine claude --mode commit --commit HEAD` across several review cycles against a real ~300-line diff. Before: the `unexpected JSON shape` exit on every run. After: parses correctly, returns structured findings, and converges to `autoreview clean: no accepted/actionable findings reported`. `python -m py_compile` passes.
