### PR TITLE
Add skills.sh repo manifest

### DIFF
--- a/skills.sh.json
+++ b/skills.sh.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://skills.sh/schemas/skills.sh.schema.json",
+  "notGrouped": "bottom",
+  "groupings": [
+    {
+      "title": "Review",
+      "description": "Skills for code review closeout and remote validation.",
+      "skills": ["autoreview", "crabbox"]
+    },
+    {
+      "title": "Handoff",
+      "description": "Skills for sharing context across agents, PRs, and issues.",
+      "skills": ["handoff", "agent-transcript"]
+    },
+    {
+      "title": "Sessions",
+      "description": "Skills for inspecting and sharing local agent sessions.",
+      "skills": ["session-viewer"]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Add root `skills.sh.json` so skills.sh can render the repo page with curated groups.
- Group existing skills into Review, Handoff, and Sessions sections.

## Validation

- `scripts/validate-skills`
- `node -e "JSON.parse(require('fs').readFileSync('skills.sh.json','utf8')); console.log('skills.sh.json valid JSON')"`
