### PR TITLE
fix(autoreview): simplify helper paths in SKILL.md

### DIFF
--- a/skills/autoreview/SKILL.md
+++ b/skills/autoreview/SKILL.md
@@ -57,6 +57,12 @@ export AUTOREVIEW_HARNESS=".agents/skills/autoreview/scripts/test-review-harness
 ```
 
 ```bash
+# Source checkout of openclaw/agent-skills:
+export AUTOREVIEW="skills/autoreview/scripts/autoreview"
+export AUTOREVIEW_HARNESS="skills/autoreview/scripts/test-review-harness"
+```
+
+```bash
 # Global skill:
 export AGENTS_HOME="${AGENTS_HOME:-$HOME/.agents}"
 export AUTOREVIEW="$AGENTS_HOME/skills/autoreview/scripts/autoreview"

--- a/skills/autoreview/SKILL.md
+++ b/skills/autoreview/SKILL.md
@@ -44,12 +44,33 @@ Use when:
 - If Gitcrawl reports a portable manifest mismatch, source/runtime DB health error, or stale portable-store checkout, run `gitcrawl doctor --json` and inspect `source_db_health`, `runtime_db_health`, and `portable_store_status` before falling back to live GitHub.
 - Do not push just to review. Push only when the user requested push/ship/PR update.
 
+## Skill Path (set once)
+
+Set the skill script paths once, then use `"$AUTOREVIEW"` and `"$AUTOREVIEW_HARNESS"` in the examples below.
+
+Choose one:
+
+```bash
+# Project-local skill in the current repo:
+export AUTOREVIEW=".agents/skills/autoreview/scripts/autoreview"
+export AUTOREVIEW_HARNESS=".agents/skills/autoreview/scripts/test-review-harness"
+```
+
+```bash
+# Global skill:
+export AGENTS_HOME="${AGENTS_HOME:-$HOME/.agents}"
+export AUTOREVIEW="$AGENTS_HOME/skills/autoreview/scripts/autoreview"
+export AUTOREVIEW_HARNESS="$AGENTS_HOME/skills/autoreview/scripts/test-review-harness"
+```
+
+When using Claude Code, set `AGENTS_HOME="$HOME/.claude"` for global skills. Project-local skills live under `.claude/skills/` in the current repo.
+
 ## Pick Target
 
 Dirty local work:
 
 ```bash
-<autoreview-helper> --mode local
+"$AUTOREVIEW" --mode local
 ```
 
 Use this only when the patch is actually unstaged/staged/untracked in the
@@ -62,32 +83,26 @@ only proves there is no local patch.
 Branch/PR work:
 
 ```bash
-<autoreview-helper> --mode branch --base origin/main
+"$AUTOREVIEW" --mode branch --base origin/main
 ```
 
 Optional review context is first-class:
 
 ```bash
-<autoreview-helper> --mode branch --base origin/main --prompt-file /tmp/review-notes.md --dataset /tmp/evidence.json
+"$AUTOREVIEW" --mode branch --base origin/main --prompt-file /tmp/review-notes.md --dataset /tmp/evidence.json
 ```
 
 If an open PR exists, use its actual base:
 
 ```bash
 base=$(gh pr view --json baseRefName --jq .baseRefName)
-<autoreview-helper> --mode branch --base "origin/$base"
+"$AUTOREVIEW" --mode branch --base "origin/$base"
 ```
 
 Committed single change:
 
 ```bash
-<autoreview-helper> --mode commit --commit HEAD
-```
-
-or with the helper:
-
-```bash
-/Users/steipete/Projects/agent-scripts/skills/autoreview/scripts/autoreview --mode commit --commit HEAD
+"$AUTOREVIEW" --mode commit --commit HEAD
 ```
 
 Use commit review for already-landed or already-pushed work on `main`. Reviewing
@@ -100,7 +115,7 @@ with `--base`.
 Format first if formatting can change line locations. Then it is OK to run tests and review in parallel:
 
 ```bash
-scripts/autoreview --parallel-tests "<focused test command>"
+"$AUTOREVIEW" --parallel-tests "<focused test command>"
 ```
 
 On Windows, the default `--parallel-tests` shell preserves the platform `cmd.exe`
@@ -114,25 +129,25 @@ Tradeoff: tests may force code changes that stale the review. If tests or review
 Run multiple reviewers against one frozen bundle:
 
 ```bash
-<autoreview-helper> --reviewers codex,claude
+"$AUTOREVIEW" --reviewers codex,claude
 ```
 
 `--panel` is shorthand for Codex plus Claude unless `--engine` changes the first reviewer:
 
 ```bash
-<autoreview-helper> --panel
+"$AUTOREVIEW" --panel
 ```
 
 Set reviewer models and thinking/effort explicitly:
 
 ```bash
-<autoreview-helper> --reviewers codex,claude --model codex=gpt-5.1 --thinking codex=high --model claude=sonnet --thinking claude=max
+"$AUTOREVIEW" --reviewers codex,claude --model codex=gpt-5.1 --thinking codex=high --model claude=sonnet --thinking claude=max
 ```
 
 Inline syntax is also supported:
 
 ```bash
-<autoreview-helper> --reviewers codex:gpt-5.1:high,claude:sonnet:max
+"$AUTOREVIEW" --reviewers codex:gpt-5.1:high,claude:sonnet:max
 ```
 
 Codex maps thinking to `model_reasoning_effort` and accepts `low`, `medium`,
@@ -145,16 +160,16 @@ Run the helper directly so target selection, engine choice, structured validatio
 
 ## Helper
 
-OpenClaw repo-local helper:
+After setting `AUTOREVIEW` and `AUTOREVIEW_HARNESS` above:
 
 ```bash
-.agents/skills/autoreview/scripts/autoreview --help
+"$AUTOREVIEW" --help
 ```
 
-`agent-scripts` checkout helper:
+The smoke harness has thin shell wrappers over a shared Python implementation:
 
 ```bash
-skills/autoreview/scripts/autoreview --help
+"$AUTOREVIEW_HARNESS" --fixture benign --engine codex
 ```
 
 On native Windows, invoke the extensionless Python helper through Python:
@@ -163,26 +178,10 @@ On native Windows, invoke the extensionless Python helper through Python:
 python skills\autoreview\scripts\autoreview --help
 ```
 
-The smoke harness has thin shell wrappers over a shared Python implementation:
-
-```bash
-skills/autoreview/scripts/test-review-harness --fixture benign --engine codex
-```
+and the smoke harness:
 
 ```powershell
 skills\autoreview\scripts\test-review-harness.ps1 -Fixture benign -Engine codex
-```
-
-Global helper from `agent-scripts`:
-
-```bash
-~/.codex/skills/agent-scripts/autoreview/scripts/autoreview --help
-```
-
-If installed from `agent-scripts`, path is:
-
-```bash
-/Users/steipete/Projects/agent-scripts/skills/autoreview/scripts/autoreview --help
 ```
 
 The helper:


### PR DESCRIPTION
## Summary

This PR cleans up `skills/autoreview/SKILL.md` by removing the hardcoded helper path and simplifying how the autoreview scripts are referenced.

## Why

The SKILL.md repeated helper paths in multiple places. Setting them once makes it easier and safer for agents to use the correct autoreview command consistently.

Also, there was a personal local path in the SKILL.md (closes https://github.com/openclaw/agent-skills/issues/12):

```bash
/Users/steipete/Projects/agent-scripts/skills/autoreview/scripts/autoreview
```

## What Changed

- Added a simple `## Skill Path (Bash)` section
- Sets `AUTOREVIEW` and `AUTOREVIEW_HARNESS` once to use those variables throughout the bash examples
- Keeps project-local and global skill setups clear
- Simplifies the `## Helper` section so it reuses the variables instead of repeating paths
- Removes personal path examples