### PR TITLE
feat(autoreview): add droid reasoning effort

### DIFF
--- a/skills/autoreview/SKILL.md
+++ b/skills/autoreview/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: autoreview
-description: "Run a structured code review (Codex default, Claude optional) as a closeout check on a local or PR branch before commit or ship."
+description: "Run a structured code review (Codex default, optional Claude, Droid, or Copilot) as a closeout check on a local or PR branch before commit or ship."
 ---
 
 # Auto Review
@@ -11,7 +11,7 @@ Codex review is the default when no engine is set. It usually delivers the best 
 
 Use when:
 
-- user asks for Codex review / Claude review / autoreview / second-model review
+- user asks for Codex review / Claude review / Droid review / autoreview / second-model review
 - after non-trivial code edits, before final/commit/ship
 - reviewing a local branch or PR branch after fixes
 
@@ -135,7 +135,7 @@ Tradeoff: tests may force code changes that stale the review. If tests or review
 Run multiple reviewers against one frozen bundle:
 
 ```bash
-"$AUTOREVIEW" --reviewers codex,claude
+"$AUTOREVIEW" --reviewers codex,claude,droid
 ```
 
 `--panel` is shorthand for Codex plus Claude unless `--engine` changes the first reviewer:
@@ -158,7 +158,9 @@ Inline syntax is also supported:
 
 Codex maps thinking to `model_reasoning_effort` and accepts `low`, `medium`,
 `high`, or `xhigh`. Claude maps thinking to `--effort` and also accepts `max`.
-Engines without a real thinking knob reject `--thinking`.
+Droid maps thinking to `-r, --reasoning-effort` and accepts `off`, `none`,
+`low`, `medium`, or `high`. Engines without a real thinking knob reject
+`--thinking`.
 
 ## Context Efficiency
 
@@ -205,6 +207,7 @@ The helper:
 - supports `--stream-engine-output` or `AUTOREVIEW_STREAM_ENGINE_OUTPUT=1` for live engine text while preserving structured validation; Codex and Claude hide tool/file event details, emit compact activity summaries, and report usage at turn completion
 - supports opt-in review panels with `--panel` / `--reviewers`, plus per-engine `--model` and `--thinking`
 - allows read-only tools and web search by default where the selected CLI supports them; forbids nested review in the prompt; Codex is run through `codex exec` with read-only sandbox and structured output
+- runs Droid with `droid exec` in read-only mode, forwards `--model` and `-r, --reasoning-effort`, and switches `--output-format` to `stream-json` when streaming is enabled
 - prints `review still running: <engine> elapsed=<seconds>s pid=<pid>` to stderr at long-running intervals while waiting for the selected review engine, unless streamed output or compact Codex activity has been visible recently
 - prints `autoreview clean: no accepted/actionable findings reported` when the selected review command exits 0
 - exits nonzero when accepted/actionable findings are present

--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -815,6 +815,10 @@ def extract_json_from_jsonl(text: str) -> dict[str, Any] | None:
             candidates.append(data["content"])
         if isinstance(event.get("result"), str):
             candidates.append(event["result"])
+        if isinstance(event.get("text"), str):
+            candidates.append(event["text"])
+        if isinstance(event.get("finalText"), str):
+            candidates.append(event["finalText"])
         if isinstance(event.get("structured_output"), dict):
             candidates.append(event["structured_output"])
     for candidate in reversed(candidates):
@@ -826,6 +830,31 @@ def extract_json_from_jsonl(text: str) -> dict[str, Any] | None:
         if isinstance(parsed, dict) and "findings" in parsed:
             return parsed
     return None
+
+
+def self_test_jsonl_parser() -> int:
+    report = {
+        "findings": [],
+        "overall_correctness": "patch is correct",
+        "overall_explanation": "ok",
+        "overall_confidence": 0.9,
+    }
+    payload = json.dumps(report)
+    droid_stream = "\n".join(
+        [
+            json.dumps({"type": "system", "subtype": "init", "model": "claude-opus-4-8"}),
+            json.dumps({"type": "message", "role": "assistant", "text": payload}),
+            json.dumps({"type": "completion", "finalText": payload, "numTurns": 1}),
+        ]
+    )
+    parsed = extract_json_from_jsonl(droid_stream)
+    if parsed != report:
+        raise SystemExit("droid stream-json parser self-test failed")
+    codex_style = json.dumps({"part": {"text": payload}})
+    if extract_json_from_jsonl(codex_style) != report:
+        raise SystemExit("codex-style jsonl parser self-test failed")
+    print("autoreview jsonl parser self-test: ok")
+    return 0
 
 
 def parse_json_candidate(text: str) -> Any | None:
@@ -1015,6 +1044,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--require-finding", action="append", default=[], help="Require finding text to contain this substring.")
     parser.add_argument("--expect-findings", action="store_true", help="Treat findings as success; for harness acceptance tests.")
     parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--self-test-jsonl-parser", action="store_true", help=argparse.SUPPRESS)
     args = parser.parse_args()
     if args.engine not in ENGINES:
         raise SystemExit(f"invalid --engine/AUTOREVIEW_ENGINE: {args.engine}")
@@ -1182,6 +1212,8 @@ def run_panel(args: argparse.Namespace, reviewers: list[argparse.Namespace], rep
 
 def main() -> int:
     args = parse_args()
+    if args.self_test_jsonl_parser:
+        return self_test_jsonl_parser()
     reviewers = reviewer_args(args)
     repo = repo_root()
     target, target_ref = choose_target(repo, args.mode, args.base)

--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -21,7 +21,7 @@ ENGINES = ("codex", "claude", "droid", "copilot")
 THINKING_LEVELS_BY_ENGINE = {
     "codex": {"low", "medium", "high", "xhigh"},
     "claude": {"low", "medium", "high", "xhigh", "max"},
-    "droid": set(),
+    "droid": {"off", "none", "low", "medium", "high"},
     "copilot": set(),
 }
 
@@ -563,8 +563,6 @@ def run_claude(args: argparse.Namespace, repo: Path, prompt: str) -> str:
 
 
 def run_droid(args: argparse.Namespace, repo: Path, prompt: str) -> str:
-    if args.thinking:
-        raise SystemExit("--thinking is not supported by the droid engine")
     prompt_path = Path(tempfile.NamedTemporaryFile("w", suffix=".txt", delete=False).name)
     prompt_path.write_text(prompt)
     cmd = [
@@ -573,12 +571,14 @@ def run_droid(args: argparse.Namespace, repo: Path, prompt: str) -> str:
         "--cwd",
         str(repo),
         "--output-format",
-        "json",
+        "stream-json" if args.stream_engine_output else "json",
         "-f",
         str(prompt_path),
     ]
     if args.model:
         cmd.extend(["--model", args.model])
+    if args.thinking:
+        cmd.extend(["-r", args.thinking])
     if not args.tools:
         cmd.extend(["--disabled-tools", "*"])
     result = run_with_heartbeat(cmd, repo, label="droid", stream_output=args.stream_engine_output)
@@ -979,7 +979,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--reviewers", help="Comma-separated review panel, e.g. codex,claude or codex:gpt-5:high.")
     parser.add_argument("--panel", action="store_true", help="Run a Codex/Claude review panel unless --engine changes the first reviewer.")
     parser.add_argument("--model", action="append", help="Model for all reviewers or engine=model. Repeatable.")
-    parser.add_argument("--thinking", action="append", help="Thinking/effort for all reviewers or engine=level. Repeatable. Codex: low, medium, high, xhigh. Claude: low, medium, high, xhigh, max.")
+    parser.add_argument("--thinking", action="append", help="Thinking/effort for all reviewers or engine=level. Repeatable. Codex: low, medium, high, xhigh. Claude: low, medium, high, xhigh, max. Droid: off, none, low, medium, high.")
     parser.add_argument("--allow-partial-panel", action="store_true", help="Continue panel output when one reviewer fails.")
     parser.add_argument("--codex-bin", default=os.environ.get("CODEX_BIN", "codex"))
     parser.add_argument("--claude-bin", default=os.environ.get("CLAUDE_BIN", "claude"))


### PR DESCRIPTION
## Summary
- whitelist droid `reasoning-effort` levels (`off`, `none`, `low`, `medium`, `high`)
- forward `--thinking` to `-r, --reasoning-effort` on `droid exec`
- switch `--output-format` to `stream-json` when `--stream-engine-output` is on
- document the new support in SKILL.md

## Why
`run_droid` previously hard-rejected `--thinking`, even though `droid exec` exposes `-r, --reasoning-effort` with the levels above (per the Factory CLI docs and `droid exec --help`). The other engines already had thinking support, so droid was the only one missing it.

## Details
`droid exec` accepts `-r, --reasoning-effort <level>` with values `off`, `none`, `low`, `medium`, `high`. The helper now:
- lists those values in `THINKING_LEVELS_BY_ENGINE["droid"]` so the panel validator accepts them
- passes `-r <level>` when `--thinking` is set
- emits `stream-json` output (instead of `json`) when `--stream-engine-output` is enabled, matching the streaming behavior already used for codex/claude/copilot

The engine still defaults to read-only mode and disables tools with `--disabled-tools *` when `--no-tools` is passed; those behaviors are unchanged.

## Validation
- `python3 -m py_compile skills/autoreview/scripts/autoreview skills/autoreview/scripts/test-review-harness.py`
- `bash -n skills/autoreview/scripts/test-review-harness`
- `ruby -c scripts/install-skills && ruby -c scripts/validate-skills`
- `ruby scripts/validate-skills` (5 skills validated)
- `python3 skills/autoreview/scripts/autoreview --mode local --engine droid --thinking high --dry-run` (accepts the args, no longer raises)
- `python3 skills/autoreview/scripts/autoreview --mode local --engine droid --thinking bogus --dry-run` (correctly rejects with `invalid thinking level for droid: bogus (valid: high, low, medium, none, off)`)
- `python3 skills/autoreview/scripts/autoreview --mode local --engine droid --thinking low --stream-engine-output --dry-run` (accepts, switches output format)