### PR TITLE
docs(autoreview): document model and thinking per engine

### DIFF
--- a/skills/autoreview/SKILL.md
+++ b/skills/autoreview/SKILL.md
@@ -150,15 +150,49 @@ Set reviewer models and thinking/effort explicitly:
 "$AUTOREVIEW" --reviewers codex,claude --model codex=gpt-5.1 --thinking codex=high --model claude=sonnet --thinking claude=max
 ```
 
-Inline syntax is also supported:
+Inline syntax is also supported for simple model IDs:
 
 ```bash
 "$AUTOREVIEW" --reviewers codex:gpt-5.1:high,claude:sonnet:max
 ```
 
-Codex maps thinking to `model_reasoning_effort` and accepts `none`, `minimal`,
-`low`, `medium`, `high`, or `xhigh`. Claude maps thinking to `--effort` and also accepts `max`.
-Engines without a real thinking knob reject `--thinking`.
+For models with slashes or extra colons, prefer keyed form:
+
+```bash
+"$AUTOREVIEW" --engine droid --model claude-opus-4-8
+"$AUTOREVIEW" --reviewers codex,droid --model codex=gpt-5.1 --model droid=claude-opus-4-8
+```
+
+## Models and thinking
+
+The helper accepts `--model` globally or per engine (`engine=model`) and `--thinking` globally or per engine (`engine=level`). Repeat either flag for multiple reviewers.
+
+On current `main`, Droid supports `--model` only; `--thinking` is rejected until Droid reasoning support lands.
+
+| Engine | Model flag | Example model IDs | Thinking flag | Accepted levels |
+|--------|------------|-------------------|---------------|-----------------|
+| **codex** (default) | `codex --model X exec ...` | `gpt-5.1`, `o3` | `-c model_reasoning_effort=Y` | `none`, `minimal`, `low`, `medium`, `high`, `xhigh` |
+| **claude** | `claude --model X` | `sonnet`, `opus`, full Anthropic IDs | `--effort Y` | `low`, `medium`, `high`, `xhigh`, `max` |
+| **droid** | `droid exec --model X` | `claude-opus-4-8`, Factory model IDs | not supported on `main` | n/a |
+| **copilot** | `copilot --model X` | `gpt-5.2`, Copilot model aliases | not supported | n/a |
+
+Examples matching current `main` behavior:
+
+```bash
+# Codex with explicit model and reasoning
+"$AUTOREVIEW" --engine codex --model gpt-5.1 --thinking high
+
+# Claude Code aliases or full model names
+"$AUTOREVIEW" --engine claude --model sonnet --thinking max
+
+# Factory Droid (model only)
+"$AUTOREVIEW" --engine droid --model claude-opus-4-8
+
+# GitHub Copilot (model only; no thinking knob)
+"$AUTOREVIEW" --engine copilot --model gpt-5.2
+```
+
+Codex maps thinking to `model_reasoning_effort`. Claude maps thinking to `--effort`. Droid and Copilot reject `--thinking`.
 
 ## Review engine isolation
 


### PR DESCRIPTION
## Summary
- add a **Models and thinking** section to `skills/autoreview/SKILL.md`
- document `--model` / `--thinking` forwarding for Codex, Claude, Droid, and Copilot
- show keyed-form examples for complex model IDs (slashes, colons)
- **Droid is documented as model-only on current `main`**; reasoning-effort docs will follow in PR #16

## Why
Model selection is already wired in the helper (`--model engine=id`, panel syntax, per-engine CLI flags) but was only partially documented. This makes explicit invocation discoverable for all current main engines without advertising unshipped Droid thinking support.

## Validation

```bash
$ ruby scripts/validate-skills
validated 5 skills

$ python3 skills/autoreview/scripts/autoreview --mode local --engine codex --model gpt-5.1 --thinking high --dry-run
autoreview target: local
engine: codex
model: gpt-5.1
thinking: high
tools: on
web_search: on

$ python3 skills/autoreview/scripts/autoreview --mode local --engine claude --model sonnet --thinking max --dry-run
autoreview target: local
engine: claude
model: sonnet
thinking: max
tools: on
web_search: on

$ python3 skills/autoreview/scripts/autoreview --mode local --engine droid --model claude-opus-4-8 --dry-run
autoreview target: local
engine: droid
model: claude-opus-4-8
tools: on
web_search: on

$ python3 skills/autoreview/scripts/autoreview --mode local --engine copilot --model gpt-5.2 --dry-run
autoreview target: local
engine: copilot
model: gpt-5.2
tools: on
web_search: on

$ python3 skills/autoreview/scripts/autoreview --mode local --engine droid --model claude-opus-4-8 --thinking low --dry-run
invalid thinking level for droid: low (valid: none)
```

## Notes
- Pi model docs land separately in PR #15 once that engine merges.
- After PR #16 merges, a follow-up can extend the Droid row with `-r` / reasoning-effort levels.