### PR TITLE
feat(autoreview): model env defaults and Claude fallback-model

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -27,6 +27,10 @@ jobs:
         run: bash -n skills/autoreview/scripts/test-review-harness
       - name: Check Python scripts
         run: python3 -m py_compile skills/autoreview/scripts/autoreview skills/autoreview/scripts/test-review-harness.py
+      - name: Run autoreview self-tests
+        run: |
+          python3 skills/autoreview/scripts/autoreview --self-test-config-defaults
+          python3 skills/autoreview/scripts/autoreview --self-test-fallback-scope
       - name: Check Node scripts
         run: node --check skills/agent-transcript/scripts/agent-transcript
       - name: Run Node tests

--- a/skills/autoreview/SKILL.md
+++ b/skills/autoreview/SKILL.md
@@ -208,7 +208,7 @@ CLI flags take precedence over environment variables.
 | `AUTOREVIEW_<ENGINE>_THINKING` | Per-engine thinking override |
 | `AUTOREVIEW_CLAUDE_FALLBACK_MODEL` | Claude-only fallback chain |
 
-Codex maps thinking to `model_reasoning_effort`. Claude maps thinking to `--effort`. Droid and Copilot reject `--thinking`. Only Claude accepts `--fallback-model`; non-Claude engine-specific fallback overrides, including `AUTOREVIEW_<NONCLAUDE>_FALLBACK_MODEL`, fail closed instead of being silently ignored.
+Codex maps thinking to `model_reasoning_effort`. Claude maps thinking to `--effort`. Droid and Copilot reject `--thinking`. Only Claude accepts `--fallback-model`; global CLI fallback requires at least one Claude reviewer, while non-Claude engine-specific fallback overrides, including `AUTOREVIEW_<NONCLAUDE>_FALLBACK_MODEL`, fail closed instead of being silently ignored.
 
 ## Review engine isolation
 

--- a/skills/autoreview/SKILL.md
+++ b/skills/autoreview/SKILL.md
@@ -208,7 +208,7 @@ CLI flags take precedence over environment variables.
 | `AUTOREVIEW_<ENGINE>_THINKING` | Per-engine thinking override |
 | `AUTOREVIEW_CLAUDE_FALLBACK_MODEL` | Claude-only fallback chain |
 
-Codex maps thinking to `model_reasoning_effort`. Claude maps thinking to `--effort`. Droid and Copilot reject `--thinking`. Only Claude accepts `--fallback-model`; global CLI fallback requires at least one Claude reviewer, while non-Claude engine-specific fallback overrides, including `AUTOREVIEW_<NONCLAUDE>_FALLBACK_MODEL`, fail closed instead of being silently ignored.
+Codex maps thinking to `model_reasoning_effort`. Claude maps thinking to `--effort`. Droid and Copilot reject `--thinking`. Only Claude accepts `--fallback-model`; global CLI fallback requires at least one Claude reviewer, and engine-specific fallback overrides require that reviewer to be selected. Non-Claude fallback overrides, including `AUTOREVIEW_<NONCLAUDE>_FALLBACK_MODEL`, fail closed instead of being silently ignored.
 
 ## Review engine isolation
 

--- a/skills/autoreview/SKILL.md
+++ b/skills/autoreview/SKILL.md
@@ -150,15 +150,59 @@ Set reviewer models and thinking/effort explicitly:
 "$AUTOREVIEW" --reviewers codex,claude --model codex=gpt-5.1 --thinking codex=high --model claude=sonnet --thinking claude=max
 ```
 
-Inline syntax is also supported:
+Inline syntax is also supported for simple model IDs:
 
 ```bash
 "$AUTOREVIEW" --reviewers codex:gpt-5.1:high,claude:sonnet:max
 ```
 
-Codex maps thinking to `model_reasoning_effort` and accepts `low`, `medium`,
-`high`, or `xhigh`. Claude maps thinking to `--effort` and also accepts `max`.
-Engines without a real thinking knob reject `--thinking`.
+For models with slashes or extra colons, prefer keyed form:
+
+```bash
+"$AUTOREVIEW" --engine droid --model claude-opus-4-8
+"$AUTOREVIEW" --reviewers codex,droid --model codex=gpt-5.4 --model droid=claude-opus-4-8
+```
+
+## Models and thinking
+
+The helper accepts `--model` globally or per engine (`engine=model`) and `--thinking` globally or per engine (`engine=level`). Repeat either flag for multiple reviewers.
+
+On current `main`, Droid supports `--model` only; `--thinking` is rejected until [PR #16](https://github.com/openclaw/agent-skills/pull/16) lands.
+
+| Engine | Model flag | Example model IDs | Thinking flag | Accepted levels |
+|--------|------------|-------------------|---------------|-----------------|
+| **codex** (default) | `codex --model X exec ...` | `gpt-5.4`, `o3` | `-c model_reasoning_effort=Y` | `low`, `medium`, `high`, `xhigh` |
+| **claude** | `claude --model X` | `sonnet`, `opus`, `fable`, `haiku`, full IDs | `--effort Y` | `low`, `medium`, `high`, `xhigh`, `max` |
+| **droid** | `droid exec --model X` | `claude-opus-4-8`, Factory model IDs | not supported on `main` | — |
+| **copilot** | `copilot --model X` | `gpt-5.2`, Copilot aliases | not supported | — |
+
+Claude also supports `--fallback-model a,b` for overload/retired-model fallback chains ([model-config](https://code.claude.com/docs/en/model-config)).
+
+Examples:
+
+```bash
+"$AUTOREVIEW" --engine codex --model gpt-5.4 --thinking high
+"$AUTOREVIEW" --engine claude --model sonnet --thinking max
+"$AUTOREVIEW" --engine claude --model opus --fallback-model sonnet,haiku
+"$AUTOREVIEW" --engine droid --model claude-opus-4-8
+"$AUTOREVIEW" --engine copilot --model gpt-5.2
+```
+
+### Environment defaults
+
+CLI flags take precedence over environment variables.
+
+| Variable | Purpose |
+|----------|---------|
+| `AUTOREVIEW_MODEL` | Default `--model` for all engines |
+| `AUTOREVIEW_THINKING` | Default `--thinking` for all engines |
+| `AUTOREVIEW_FALLBACK_MODEL` | Default Claude `--fallback-model` chain |
+| `AUTOREVIEW_CODEX_MODEL` | Default Codex model |
+| `AUTOREVIEW_CLAUDE_MODEL` | Default Claude model |
+| `AUTOREVIEW_<ENGINE>_THINKING` | Per-engine thinking override |
+| `AUTOREVIEW_CLAUDE_FALLBACK_MODEL` | Claude-only fallback chain |
+
+Codex maps thinking to `model_reasoning_effort`. Claude maps thinking to `--effort`. Copilot rejects `--thinking`. Droid rejects `--thinking` on current `main`.
 
 ## Context Efficiency
 
@@ -203,7 +247,8 @@ The helper:
 - writes only to stdout unless `--output`, `--json-output`, or live streamed engine stderr is set
 - supports `--dry-run`, `--parallel-tests`, `--parallel-tests-shell`, `--prompt`, `--prompt-file`, `--dataset`, `--no-tools`, `--no-web-search`, and commit refs
 - supports `--stream-engine-output` or `AUTOREVIEW_STREAM_ENGINE_OUTPUT=1` for live engine text while preserving structured validation; Codex and Claude hide tool/file event details, emit compact activity summaries, and report usage at turn completion
-- supports opt-in review panels with `--panel` / `--reviewers`, plus per-engine `--model` and `--thinking`
+- supports opt-in review panels with `--panel` / `--reviewers`, plus per-engine `--model`, `--thinking`, and Claude `--fallback-model`
+- honors `AUTOREVIEW_MODEL`, `AUTOREVIEW_THINKING`, `AUTOREVIEW_FALLBACK_MODEL`, and per-engine `AUTOREVIEW_<ENGINE>_MODEL` / `AUTOREVIEW_<ENGINE>_THINKING` environment defaults when CLI flags are omitted
 - allows read-only tools and web search by default where the selected CLI supports them; forbids nested review in the prompt; Codex is run through `codex exec` with read-only sandbox and structured output
 - prints `review still running: <engine> elapsed=<seconds>s pid=<pid>` to stderr at long-running intervals while waiting for the selected review engine, unless streamed output or compact Codex activity has been visible recently
 - prints `autoreview clean: no accepted/actionable findings reported` when the selected review command exits 0

--- a/skills/autoreview/SKILL.md
+++ b/skills/autoreview/SKILL.md
@@ -176,7 +176,7 @@ On current `main`, Droid supports `--model` only; `--thinking` is rejected until
 | **droid** | `droid exec --model X` | `claude-opus-4-8`, Factory model IDs | not supported on `main` | — |
 | **copilot** | `copilot --model X` | `gpt-5.2`, Copilot aliases | not supported | — |
 
-Claude also supports `--fallback-model a,b` for overload/retired-model fallback chains ([model-config](https://code.claude.com/docs/en/model-config)).
+Claude also supports `--fallback-model a,b` for availability-based fallback chains ([model-config](https://code.claude.com/docs/en/model-config)). Current Claude docs note that auth, billing, rate-limit, request-size, and transport errors do not trigger fallback, and the changelog documents interactive-session support in `v2.1.166`.
 
 Examples:
 

--- a/skills/autoreview/SKILL.md
+++ b/skills/autoreview/SKILL.md
@@ -208,7 +208,7 @@ CLI flags take precedence over environment variables.
 | `AUTOREVIEW_<ENGINE>_THINKING` | Per-engine thinking override |
 | `AUTOREVIEW_CLAUDE_FALLBACK_MODEL` | Claude-only fallback chain |
 
-Codex maps thinking to `model_reasoning_effort`. Claude maps thinking to `--effort`. Droid and Copilot reject `--thinking`. Only Claude accepts `--fallback-model`; global CLI fallback requires at least one Claude reviewer, and engine-specific fallback overrides require that reviewer to be selected. Non-Claude fallback overrides, including `AUTOREVIEW_<NONCLAUDE>_FALLBACK_MODEL`, fail closed instead of being silently ignored.
+Codex maps thinking to `model_reasoning_effort`. Claude maps thinking to `--effort`. Droid and Copilot reject `--thinking`. Only Claude accepts `--fallback-model`; global CLI/env fallback requires at least one Claude reviewer, and engine-specific fallback overrides require that reviewer to be selected. Non-Claude fallback overrides, including `AUTOREVIEW_<NONCLAUDE>_FALLBACK_MODEL`, fail closed instead of being silently ignored.
 
 ## Review engine isolation
 

--- a/skills/autoreview/SKILL.md
+++ b/skills/autoreview/SKILL.md
@@ -208,7 +208,7 @@ CLI flags take precedence over environment variables.
 | `AUTOREVIEW_<ENGINE>_THINKING` | Per-engine thinking override |
 | `AUTOREVIEW_CLAUDE_FALLBACK_MODEL` | Claude-only fallback chain |
 
-Codex maps thinking to `model_reasoning_effort`. Claude maps thinking to `--effort`. Droid and Copilot reject `--thinking`. Only Claude accepts `--fallback-model`; non-Claude engine-specific fallback overrides are rejected.
+Codex maps thinking to `model_reasoning_effort`. Claude maps thinking to `--effort`. Droid and Copilot reject `--thinking`. Only Claude accepts `--fallback-model`; non-Claude engine-specific fallback overrides, including `AUTOREVIEW_<NONCLAUDE>_FALLBACK_MODEL`, fail closed instead of being silently ignored.
 
 ## Review engine isolation
 

--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -1022,6 +1022,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--require-finding", action="append", default=[], help="Require finding text to contain this substring.")
     parser.add_argument("--expect-findings", action="store_true", help="Treat findings as success; for harness acceptance tests.")
     parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--self-test-fallback-scope", action="store_true", help=argparse.SUPPRESS)
     args = parser.parse_args()
     if args.engine not in ENGINES:
         raise SystemExit(f"invalid --engine/AUTOREVIEW_ENGINE: {args.engine}")
@@ -1135,17 +1136,21 @@ def reviewer_args(args: argparse.Namespace) -> list[argparse.Namespace]:
             or env_thinking_by_engine.get(engine)
             or env_global_thinking
         )
-        fallback_model = (
-            fallback_by_engine.get(engine)
-            or global_fallback
-            or env_fallback_by_engine.get(engine)
-            or env_global_fallback
-        )
+        if engine == "claude":
+            fallback_model = (
+                fallback_by_engine.get(engine)
+                or global_fallback
+                or env_fallback_by_engine.get(engine)
+                or env_global_fallback
+            )
+        else:
+            engine_specific_fallback = fallback_by_engine.get(engine) or env_fallback_by_engine.get(engine)
+            if engine_specific_fallback:
+                raise SystemExit(f"--fallback-model is only supported for claude, not {engine}")
+            fallback_model = None
         if thinking and thinking not in THINKING_LEVELS_BY_ENGINE[engine]:
             valid = ", ".join(sorted(THINKING_LEVELS_BY_ENGINE[engine])) or "none"
             raise SystemExit(f"invalid thinking level for {engine}: {thinking} (valid: {valid})")
-        if fallback_model and engine != "claude":
-            raise SystemExit(f"--fallback-model is only supported for claude, not {engine}")
         clone = copy.copy(args)
         clone.engine = engine
         clone.model = model
@@ -1230,8 +1235,52 @@ def run_panel(args: argparse.Namespace, reviewers: list[argparse.Namespace], rep
     return report
 
 
+def self_test_fallback_scope() -> None:
+    saved = os.environ.get("AUTOREVIEW_FALLBACK_MODEL")
+    os.environ["AUTOREVIEW_FALLBACK_MODEL"] = "claude-sonnet-4-6"
+    try:
+        base = argparse.Namespace(
+            reviewers="codex,claude",
+            panel=False,
+            engine="codex",
+            model=None,
+            thinking=None,
+            fallback_model=None,
+        )
+        reviewers = reviewer_args(base)
+        codex = next(r for r in reviewers if r.engine == "codex")
+        claude = next(r for r in reviewers if r.engine == "claude")
+        if codex.fallback_model is not None:
+            raise SystemExit("self-test fallback scope failed: codex should ignore AUTOREVIEW_FALLBACK_MODEL")
+        if claude.fallback_model != "claude-sonnet-4-6":
+            raise SystemExit(f"self-test fallback scope failed: claude fallback={claude.fallback_model!r}")
+        explicit = argparse.Namespace(
+            reviewers="codex",
+            panel=False,
+            engine="codex",
+            model=None,
+            thinking=None,
+            fallback_model=["codex=foo"],
+        )
+        try:
+            reviewer_args(explicit)
+            raise SystemExit("self-test fallback scope failed: codex=fallback should be rejected")
+        except SystemExit as exc:
+            if "only supported for claude" not in str(exc):
+                raise
+    finally:
+        if saved is None:
+            os.environ.pop("AUTOREVIEW_FALLBACK_MODEL", None)
+        else:
+            os.environ["AUTOREVIEW_FALLBACK_MODEL"] = saved
+    print("self-test fallback scope: ok")
+
+
 def main() -> int:
     args = parse_args()
+    if args.self_test_fallback_scope:
+        self_test_fallback_scope()
+        return 0
     reviewers = reviewer_args(args)
     repo = repo_root()
     target, target_ref = choose_target(repo, args.mode, args.base)

--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -1358,8 +1358,8 @@ def run_engine(args: argparse.Namespace, repo: Path, prompt: str) -> str:
     raise SystemExit(f"unsupported engine: {args.engine}")
 
 
-def env_defaults_for(option: str) -> tuple[str | None, dict[str, str]]:
-    env_key = option.upper()
+def env_defaults_for(env_suffix: str) -> tuple[str | None, dict[str, str]]:
+    env_key = env_suffix.upper()
     global_value = os.environ.get(f"AUTOREVIEW_{env_key}")
     if global_value is not None:
         global_value = global_value.strip() or None
@@ -1640,6 +1640,14 @@ def self_test_fallback_scope() -> None:
         )[0]
         if cli_engine.fallback_model != "cli-claude":
             raise SystemExit("self-test fallback scope failed: CLI engine fallback should override CLI global")
+        inline = reviewer_args(
+            reviewer_test_args(
+                reviewers="claude:inline-model:high",
+                fallback_model=["cli-global"],
+            )
+        )[0]
+        if inline.fallback_model != "cli-global":
+            raise SystemExit("self-test fallback scope failed: CLI global fallback should apply to inline reviewers")
         explicit = reviewer_test_args(reviewers="codex", fallback_model=["codex=foo"])
         try:
             reviewer_args(explicit)

--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -1438,7 +1438,11 @@ def reviewer_args(args: argparse.Namespace) -> list[argparse.Namespace]:
     if unused_fallback_engines:
         engine_list = ", ".join(sorted(unused_fallback_engines))
         raise SystemExit(f"--fallback-model specified for unselected reviewer: {engine_list}")
-    if (global_fallback or fallback_by_engine) and "claude" not in selected_engines:
+    selected_non_claude_fallback = sorted(engine for engine in fallback_by_engine if engine != "claude")
+    if selected_non_claude_fallback:
+        engine_list = ", ".join(selected_non_claude_fallback)
+        raise SystemExit(f"--fallback-model is only supported for claude, not {engine_list}")
+    if global_fallback and "claude" not in selected_engines:
         raise SystemExit("--fallback-model is only supported for claude; no claude reviewer selected")
 
     seen: set[str] = set()
@@ -1690,8 +1694,14 @@ def self_test_fallback_scope() -> None:
             reviewer_args(explicit)
             raise SystemExit("self-test fallback scope failed: codex=fallback should be rejected")
         except SystemExit as exc:
-            if "only supported for claude" not in str(exc):
+            if "not codex" not in str(exc):
                 raise
+        os.environ.pop("AUTOREVIEW_FALLBACK_MODEL")
+        os.environ["AUTOREVIEW_CLAUDE_FALLBACK_MODEL"] = "env-claude-only"
+        codex_only = reviewer_args(reviewer_test_args(engine="codex"))[0]
+        if codex_only.fallback_model is not None:
+            raise SystemExit("self-test fallback scope failed: Claude fallback env should be ignored without Claude")
+        os.environ["AUTOREVIEW_FALLBACK_MODEL"] = "env-global-fallback"
         os.environ["AUTOREVIEW_CODEX_FALLBACK_MODEL"] = "env-codex-fallback"
         try:
             reviewer_args(reviewer_test_args(engine="codex"))

--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -1442,7 +1442,7 @@ def reviewer_args(args: argparse.Namespace) -> list[argparse.Namespace]:
     if selected_non_claude_fallback:
         engine_list = ", ".join(selected_non_claude_fallback)
         raise SystemExit(f"--fallback-model is only supported for claude, not {engine_list}")
-    if global_fallback and "claude" not in selected_engines:
+    if (global_fallback or env_global_fallback) and "claude" not in selected_engines:
         raise SystemExit("--fallback-model is only supported for claude; no claude reviewer selected")
 
     seen: set[str] = set()
@@ -1656,6 +1656,12 @@ def self_test_fallback_scope() -> None:
         global_only = reviewer_args(reviewer_test_args(engine="claude"))[0]
         if global_only.fallback_model != "env-global-fallback":
             raise SystemExit(f"self-test fallback scope failed: global fallback={global_only.fallback_model!r}")
+        try:
+            reviewer_args(reviewer_test_args(engine="codex"))
+            raise SystemExit("self-test fallback scope failed: env global fallback without Claude should be rejected")
+        except SystemExit as exc:
+            if "no claude reviewer selected" not in str(exc):
+                raise
         cli_global = reviewer_args(reviewer_test_args(engine="claude", fallback_model=["cli-global"]))[0]
         if cli_global.fallback_model != "cli-global":
             raise SystemExit("self-test fallback scope failed: CLI global fallback should override env")

--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -1359,7 +1359,7 @@ def run_engine(args: argparse.Namespace, repo: Path, prompt: str) -> str:
 
 
 def env_defaults_for(env_suffix: str) -> tuple[str | None, dict[str, str]]:
-    env_key = env_suffix.upper()
+    env_key = env_suffix.replace("-", "_").upper()
     global_value = os.environ.get(f"AUTOREVIEW_{env_key}")
     if global_value is not None:
         global_value = global_value.strip() or None
@@ -1417,7 +1417,7 @@ def reviewer_args(args: argparse.Namespace) -> list[argparse.Namespace]:
     global_fallback, fallback_by_engine = parse_keyed_options(args.fallback_model, "fallback-model")
     env_global_model, env_model_by_engine = env_defaults_for("model")
     env_global_thinking, env_thinking_by_engine = env_defaults_for("thinking")
-    env_global_fallback, env_fallback_by_engine = env_defaults_for("fallback_model")
+    env_global_fallback, env_fallback_by_engine = env_defaults_for("fallback-model")
     reviewers: list[tuple[str, str | None, str | None]] = []
     if args.reviewers:
         tokens = [token.strip() for token in args.reviewers.split(",") if token.strip()]
@@ -1433,7 +1433,12 @@ def reviewer_args(args: argparse.Namespace) -> list[argparse.Namespace]:
     else:
         reviewers = [(args.engine, None, None)]
 
-    if global_fallback and not any(engine == "claude" for engine, _, _ in reviewers):
+    selected_engines = {engine for engine, _, _ in reviewers}
+    unused_fallback_engines = set(fallback_by_engine) - selected_engines
+    if unused_fallback_engines:
+        engine_list = ", ".join(sorted(unused_fallback_engines))
+        raise SystemExit(f"--fallback-model specified for unselected reviewer: {engine_list}")
+    if (global_fallback or fallback_by_engine) and "claude" not in selected_engines:
         raise SystemExit("--fallback-model is only supported for claude; no claude reviewer selected")
 
     seen: set[str] = set()
@@ -1572,9 +1577,10 @@ def preserve_env(keys: list[str]):
     saved = {key: os.environ.get(key) for key in keys}
 
     class EnvGuard:
-        def __enter__(self) -> None:
+        def __enter__(self):
             for key in keys:
                 os.environ.pop(key, None)
+            return self
 
         def __exit__(self, _exc_type: Any, _exc: Any, _tb: Any) -> None:
             for key, value in saved.items():
@@ -1664,6 +1670,12 @@ def self_test_fallback_scope() -> None:
             raise SystemExit("self-test fallback scope failed: global fallback without Claude should be rejected")
         except SystemExit as exc:
             if "no claude reviewer selected" not in str(exc):
+                raise
+        try:
+            reviewer_args(reviewer_test_args(engine="codex", fallback_model=["claude=cli-claude"]))
+            raise SystemExit("self-test fallback scope failed: fallback for unselected Claude reviewer should be rejected")
+        except SystemExit as exc:
+            if "unselected reviewer: claude" not in str(exc):
                 raise
         inline = reviewer_args(
             reviewer_test_args(

--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -1336,6 +1336,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--require-finding", action="append", default=[], help="Require finding text to contain this substring.")
     parser.add_argument("--expect-findings", action="store_true", help="Treat findings as success; for harness acceptance tests.")
     parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--self-test-config-defaults", action="store_true", help=argparse.SUPPRESS)
     parser.add_argument("--self-test-fallback-scope", action="store_true", help=argparse.SUPPRESS)
     parser.add_argument("--self-test-engine-isolation", action="store_true", help=argparse.SUPPRESS)
     parser.add_argument("--self-test-json-array-parser", action="store_true", help=argparse.SUPPRESS)
@@ -1551,49 +1552,116 @@ def run_panel(args: argparse.Namespace, reviewers: list[argparse.Namespace], rep
     return report
 
 
+def reviewer_test_args(**overrides: Any) -> argparse.Namespace:
+    defaults = {
+        "reviewers": None,
+        "panel": False,
+        "engine": "codex",
+        "model": None,
+        "thinking": None,
+        "fallback_model": None,
+    }
+    defaults.update(overrides)
+    return argparse.Namespace(**defaults)
+
+
+def preserve_env(keys: list[str]):
+    saved = {key: os.environ.get(key) for key in keys}
+
+    class EnvGuard:
+        def __enter__(self) -> None:
+            for key in keys:
+                os.environ.pop(key, None)
+
+        def __exit__(self, _exc_type: Any, _exc: Any, _tb: Any) -> None:
+            for key, value in saved.items():
+                if value is None:
+                    os.environ.pop(key, None)
+                else:
+                    os.environ[key] = value
+
+    return EnvGuard()
+
+
+def self_test_config_defaults() -> None:
+    keys = [
+        "AUTOREVIEW_MODEL",
+        "AUTOREVIEW_CODEX_MODEL",
+        "AUTOREVIEW_THINKING",
+        "AUTOREVIEW_CODEX_THINKING",
+    ]
+    with preserve_env(keys):
+        os.environ["AUTOREVIEW_MODEL"] = "env-global-model"
+        os.environ["AUTOREVIEW_CODEX_MODEL"] = "env-codex-model"
+        os.environ["AUTOREVIEW_THINKING"] = "low"
+        os.environ["AUTOREVIEW_CODEX_THINKING"] = "high"
+        codex = reviewer_args(reviewer_test_args(engine="codex"))[0]
+        if codex.model != "env-codex-model":
+            raise SystemExit(f"self-test config defaults failed: model={codex.model!r}")
+        if codex.thinking != "high":
+            raise SystemExit(f"self-test config defaults failed: thinking={codex.thinking!r}")
+        cli = reviewer_args(reviewer_test_args(engine="codex", model=["cli-model"], thinking=["medium"]))[0]
+        if cli.model != "cli-model" or cli.thinking != "medium":
+            raise SystemExit("self-test config defaults failed: CLI values should override env")
+        inline = reviewer_args(
+            reviewer_test_args(
+                reviewers="codex:inline-model:minimal",
+                model=["cli-model"],
+                thinking=["medium"],
+            )
+        )[0]
+        if inline.model != "inline-model" or inline.thinking != "minimal":
+            raise SystemExit("self-test config defaults failed: inline reviewer values should override CLI/env")
+    print("self-test config defaults: ok")
+
+
 def self_test_fallback_scope() -> None:
-    saved = os.environ.get("AUTOREVIEW_FALLBACK_MODEL")
-    os.environ["AUTOREVIEW_FALLBACK_MODEL"] = "claude-sonnet-4-6"
-    try:
-        base = argparse.Namespace(
-            reviewers="codex,claude",
-            panel=False,
-            engine="codex",
-            model=None,
-            thinking=None,
-            fallback_model=None,
-        )
+    keys = [
+        "AUTOREVIEW_FALLBACK_MODEL",
+        "AUTOREVIEW_CLAUDE_FALLBACK_MODEL",
+        "AUTOREVIEW_CODEX_FALLBACK_MODEL",
+    ]
+    with preserve_env(keys):
+        os.environ["AUTOREVIEW_FALLBACK_MODEL"] = "env-global-fallback"
+        os.environ["AUTOREVIEW_CLAUDE_FALLBACK_MODEL"] = "env-claude-fallback"
+        base = reviewer_test_args(reviewers="codex,claude")
         reviewers = reviewer_args(base)
         codex = next(r for r in reviewers if r.engine == "codex")
         claude = next(r for r in reviewers if r.engine == "claude")
         if codex.fallback_model is not None:
             raise SystemExit("self-test fallback scope failed: codex should ignore AUTOREVIEW_FALLBACK_MODEL")
-        if claude.fallback_model != "claude-sonnet-4-6":
+        if claude.fallback_model != "env-claude-fallback":
             raise SystemExit(f"self-test fallback scope failed: claude fallback={claude.fallback_model!r}")
-        explicit = argparse.Namespace(
-            reviewers="codex",
-            panel=False,
-            engine="codex",
-            model=None,
-            thinking=None,
-            fallback_model=["codex=foo"],
-        )
+        cli_global = reviewer_args(reviewer_test_args(engine="claude", fallback_model=["cli-global"]))[0]
+        if cli_global.fallback_model != "cli-global":
+            raise SystemExit("self-test fallback scope failed: CLI global fallback should override env")
+        cli_engine = reviewer_args(
+            reviewer_test_args(engine="claude", fallback_model=["cli-global", "claude=cli-claude"])
+        )[0]
+        if cli_engine.fallback_model != "cli-claude":
+            raise SystemExit("self-test fallback scope failed: CLI engine fallback should override CLI global")
+        explicit = reviewer_test_args(reviewers="codex", fallback_model=["codex=foo"])
         try:
             reviewer_args(explicit)
             raise SystemExit("self-test fallback scope failed: codex=fallback should be rejected")
         except SystemExit as exc:
             if "only supported for claude" not in str(exc):
                 raise
-    finally:
-        if saved is None:
-            os.environ.pop("AUTOREVIEW_FALLBACK_MODEL", None)
-        else:
-            os.environ["AUTOREVIEW_FALLBACK_MODEL"] = saved
+        os.environ["AUTOREVIEW_CODEX_FALLBACK_MODEL"] = "env-codex-fallback"
+        try:
+            reviewer_args(reviewer_test_args(engine="codex"))
+            raise SystemExit("self-test fallback scope failed: AUTOREVIEW_CODEX_FALLBACK_MODEL should be rejected")
+        except SystemExit as exc:
+            if "only supported for claude" not in str(exc):
+                raise
     print("self-test fallback scope: ok")
 
 
 def main() -> int:
     args = parse_args()
+    if args.self_test_config_defaults:
+        self_test_config_defaults()
+        return 0
     if args.self_test_fallback_scope:
         self_test_fallback_scope()
         return 0

--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -1433,6 +1433,9 @@ def reviewer_args(args: argparse.Namespace) -> list[argparse.Namespace]:
     else:
         reviewers = [(args.engine, None, None)]
 
+    if global_fallback and not any(engine == "claude" for engine, _, _ in reviewers):
+        raise SystemExit("--fallback-model is only supported for claude; no claude reviewer selected")
+
     seen: set[str] = set()
     result: list[argparse.Namespace] = []
     for engine, inline_model, inline_thinking in reviewers:
@@ -1651,6 +1654,17 @@ def self_test_fallback_scope() -> None:
         )[0]
         if cli_engine.fallback_model != "cli-claude":
             raise SystemExit("self-test fallback scope failed: CLI engine fallback should override CLI global")
+        panel = reviewer_args(reviewer_test_args(reviewers="codex,claude", fallback_model=["cli-global"]))
+        panel_codex = next(r for r in panel if r.engine == "codex")
+        panel_claude = next(r for r in panel if r.engine == "claude")
+        if panel_codex.fallback_model is not None or panel_claude.fallback_model != "cli-global":
+            raise SystemExit("self-test fallback scope failed: CLI global fallback should apply only to Claude panel reviewers")
+        try:
+            reviewer_args(reviewer_test_args(engine="codex", fallback_model=["cli-global"]))
+            raise SystemExit("self-test fallback scope failed: global fallback without Claude should be rejected")
+        except SystemExit as exc:
+            if "no claude reviewer selected" not in str(exc):
+                raise
         inline = reviewer_args(
             reviewer_test_args(
                 reviewers="claude:inline-model:high",

--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -547,6 +547,8 @@ def run_claude(args: argparse.Namespace, repo: Path, prompt: str) -> str:
         cmd.append("--verbose")
     if args.model:
         cmd.extend(["--model", args.model])
+    if getattr(args, "fallback_model", None):
+        cmd.extend(["--fallback-model", args.fallback_model])
     if args.thinking:
         cmd.extend(["--effort", args.thinking])
     result = run_with_heartbeat(
@@ -980,6 +982,11 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--panel", action="store_true", help="Run a Codex/Claude review panel unless --engine changes the first reviewer.")
     parser.add_argument("--model", action="append", help="Model for all reviewers or engine=model. Repeatable.")
     parser.add_argument("--thinking", action="append", help="Thinking/effort for all reviewers or engine=level. Repeatable. Codex: low, medium, high, xhigh. Claude: low, medium, high, xhigh, max.")
+    parser.add_argument(
+        "--fallback-model",
+        action="append",
+        help="Claude fallback model chain for all reviewers or claude=a,b. Repeatable.",
+    )
     parser.add_argument("--allow-partial-panel", action="store_true", help="Continue panel output when one reviewer fails.")
     parser.add_argument("--codex-bin", default=os.environ.get("CODEX_BIN", "codex"))
     parser.add_argument("--claude-bin", default=os.environ.get("CLAUDE_BIN", "claude"))
@@ -1033,6 +1040,22 @@ def run_engine(args: argparse.Namespace, repo: Path, prompt: str) -> str:
     raise SystemExit(f"unsupported engine: {args.engine}")
 
 
+def env_defaults_for(option: str) -> tuple[str | None, dict[str, str]]:
+    env_key = option.upper()
+    global_value = os.environ.get(f"AUTOREVIEW_{env_key}")
+    if global_value is not None:
+        global_value = global_value.strip() or None
+    per_engine: dict[str, str] = {}
+    for engine in ENGINES:
+        value = os.environ.get(f"AUTOREVIEW_{engine.upper()}_{env_key}")
+        if value is None:
+            continue
+        value = value.strip()
+        if value:
+            per_engine[engine] = value
+    return global_value, per_engine
+
+
 def parse_keyed_options(values: list[str] | None, option: str) -> tuple[str | None, dict[str, str]]:
     global_value: str | None = None
     per_engine: dict[str, str] = {}
@@ -1073,6 +1096,10 @@ def parse_reviewer_token(token: str) -> tuple[str, str | None, str | None]:
 def reviewer_args(args: argparse.Namespace) -> list[argparse.Namespace]:
     global_model, model_by_engine = parse_keyed_options(args.model, "model")
     global_thinking, thinking_by_engine = parse_keyed_options(args.thinking, "thinking")
+    global_fallback, fallback_by_engine = parse_keyed_options(args.fallback_model, "fallback-model")
+    env_global_model, env_model_by_engine = env_defaults_for("model")
+    env_global_thinking, env_thinking_by_engine = env_defaults_for("thinking")
+    env_global_fallback, env_fallback_by_engine = env_defaults_for("fallback_model")
     reviewers: list[tuple[str, str | None, str | None]] = []
     if args.reviewers:
         tokens = [token.strip() for token in args.reviewers.split(",") if token.strip()]
@@ -1094,15 +1121,36 @@ def reviewer_args(args: argparse.Namespace) -> list[argparse.Namespace]:
         if engine in seen:
             raise SystemExit(f"reviewer specified more than once: {engine}")
         seen.add(engine)
-        model = inline_model or model_by_engine.get(engine) or global_model
-        thinking = inline_thinking or thinking_by_engine.get(engine) or global_thinking
+        model = (
+            inline_model
+            or model_by_engine.get(engine)
+            or global_model
+            or env_model_by_engine.get(engine)
+            or env_global_model
+        )
+        thinking = (
+            inline_thinking
+            or thinking_by_engine.get(engine)
+            or global_thinking
+            or env_thinking_by_engine.get(engine)
+            or env_global_thinking
+        )
+        fallback_model = (
+            fallback_by_engine.get(engine)
+            or global_fallback
+            or env_fallback_by_engine.get(engine)
+            or env_global_fallback
+        )
         if thinking and thinking not in THINKING_LEVELS_BY_ENGINE[engine]:
             valid = ", ".join(sorted(THINKING_LEVELS_BY_ENGINE[engine])) or "none"
             raise SystemExit(f"invalid thinking level for {engine}: {thinking} (valid: {valid})")
+        if fallback_model and engine != "claude":
+            raise SystemExit(f"--fallback-model is only supported for claude, not {engine}")
         clone = copy.copy(args)
         clone.engine = engine
         clone.model = model
         clone.thinking = thinking
+        clone.fallback_model = fallback_model
         result.append(clone)
     return result
 
@@ -1111,6 +1159,8 @@ def reviewer_label(args: argparse.Namespace) -> str:
     parts = [args.engine]
     if args.model:
         parts.append(f"model={args.model}")
+    if getattr(args, "fallback_model", None):
+        parts.append(f"fallback={args.fallback_model}")
     if args.thinking:
         parts.append(f"thinking={args.thinking}")
     return " ".join(parts)
@@ -1191,6 +1241,8 @@ def main() -> int:
         print(f"engine: {reviewers[0].engine}")
         if reviewers[0].model:
             print(f"model: {reviewers[0].model}")
+        if getattr(reviewers[0], "fallback_model", None):
+            print(f"fallback_model: {reviewers[0].fallback_model}")
         if reviewers[0].thinking:
             print(f"thinking: {reviewers[0].thinking}")
     else:

--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -1434,11 +1434,12 @@ def reviewer_args(args: argparse.Namespace) -> list[argparse.Namespace]:
         reviewers = [(args.engine, None, None)]
 
     selected_engines = {engine for engine, _, _ in reviewers}
-    unused_fallback_engines = (set(fallback_by_engine) | set(env_fallback_by_engine)) - selected_engines
+    fallback_engines = set(fallback_by_engine) | set(env_fallback_by_engine)
+    unused_fallback_engines = fallback_engines - selected_engines
     if unused_fallback_engines:
         engine_list = ", ".join(sorted(unused_fallback_engines))
         raise SystemExit(f"--fallback-model specified for unselected reviewer: {engine_list}")
-    selected_non_claude_fallback = sorted(engine for engine in fallback_by_engine if engine != "claude")
+    selected_non_claude_fallback = sorted(engine for engine in fallback_engines if engine != "claude")
     if selected_non_claude_fallback:
         engine_list = ", ".join(selected_non_claude_fallback)
         raise SystemExit(f"--fallback-model is only supported for claude, not {engine_list}")

--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -1600,6 +1600,13 @@ def self_test_config_defaults() -> None:
             raise SystemExit(f"self-test config defaults failed: model={codex.model!r}")
         if codex.thinking != "high":
             raise SystemExit(f"self-test config defaults failed: thinking={codex.thinking!r}")
+        os.environ.pop("AUTOREVIEW_CODEX_MODEL")
+        os.environ.pop("AUTOREVIEW_CODEX_THINKING")
+        global_only = reviewer_args(reviewer_test_args(engine="codex"))[0]
+        if global_only.model != "env-global-model":
+            raise SystemExit(f"self-test config defaults failed: global model={global_only.model!r}")
+        if global_only.thinking != "low":
+            raise SystemExit(f"self-test config defaults failed: global thinking={global_only.thinking!r}")
         cli = reviewer_args(reviewer_test_args(engine="codex", model=["cli-model"], thinking=["medium"]))[0]
         if cli.model != "cli-model" or cli.thinking != "medium":
             raise SystemExit("self-test config defaults failed: CLI values should override env")
@@ -1632,6 +1639,10 @@ def self_test_fallback_scope() -> None:
             raise SystemExit("self-test fallback scope failed: codex should ignore AUTOREVIEW_FALLBACK_MODEL")
         if claude.fallback_model != "env-claude-fallback":
             raise SystemExit(f"self-test fallback scope failed: claude fallback={claude.fallback_model!r}")
+        os.environ.pop("AUTOREVIEW_CLAUDE_FALLBACK_MODEL")
+        global_only = reviewer_args(reviewer_test_args(engine="claude"))[0]
+        if global_only.fallback_model != "env-global-fallback":
+            raise SystemExit(f"self-test fallback scope failed: global fallback={global_only.fallback_model!r}")
         cli_global = reviewer_args(reviewer_test_args(engine="claude", fallback_model=["cli-global"]))[0]
         if cli_global.fallback_model != "cli-global":
             raise SystemExit("self-test fallback scope failed: CLI global fallback should override env")

--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -1434,7 +1434,7 @@ def reviewer_args(args: argparse.Namespace) -> list[argparse.Namespace]:
         reviewers = [(args.engine, None, None)]
 
     selected_engines = {engine for engine, _, _ in reviewers}
-    unused_fallback_engines = set(fallback_by_engine) - selected_engines
+    unused_fallback_engines = (set(fallback_by_engine) | set(env_fallback_by_engine)) - selected_engines
     if unused_fallback_engines:
         engine_list = ", ".join(sorted(unused_fallback_engines))
         raise SystemExit(f"--fallback-model specified for unselected reviewer: {engine_list}")
@@ -1698,10 +1698,14 @@ def self_test_fallback_scope() -> None:
                 raise
         os.environ.pop("AUTOREVIEW_FALLBACK_MODEL")
         os.environ["AUTOREVIEW_CLAUDE_FALLBACK_MODEL"] = "env-claude-only"
-        codex_only = reviewer_args(reviewer_test_args(engine="codex"))[0]
-        if codex_only.fallback_model is not None:
-            raise SystemExit("self-test fallback scope failed: Claude fallback env should be ignored without Claude")
+        try:
+            reviewer_args(reviewer_test_args(engine="codex"))
+            raise SystemExit("self-test fallback scope failed: Claude fallback env without Claude should be rejected")
+        except SystemExit as exc:
+            if "unselected reviewer: claude" not in str(exc):
+                raise
         os.environ["AUTOREVIEW_FALLBACK_MODEL"] = "env-global-fallback"
+        os.environ.pop("AUTOREVIEW_CLAUDE_FALLBACK_MODEL")
         os.environ["AUTOREVIEW_CODEX_FALLBACK_MODEL"] = "env-codex-fallback"
         try:
             reviewer_args(reviewer_test_args(engine="codex"))

--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -1474,9 +1474,6 @@ def reviewer_args(args: argparse.Namespace) -> list[argparse.Namespace]:
                 or env_global_fallback
             )
         else:
-            engine_specific_fallback = fallback_by_engine.get(engine) or env_fallback_by_engine.get(engine)
-            if engine_specific_fallback:
-                raise SystemExit(f"--fallback-model is only supported for claude, not {engine}")
             fallback_model = None
         if thinking and thinking not in THINKING_LEVELS_BY_ENGINE[engine]:
             valid = ", ".join(sorted(THINKING_LEVELS_BY_ENGINE[engine])) or "none"


### PR DESCRIPTION
## Summary
- add environment defaults for model, thinking, and Claude fallback chains
- forward Claude `--fallback-model` from autoreview
- expand `skills/autoreview/SKILL.md` with a models/thinking matrix, Claude aliases, and env-var table

## Why
Model selection is already wired via `--model` / `--thinking`, but discoverability and zero-flag defaults were missing. Claude Code docs also expose `--fallback-model` for overload/retired models ([model-config](https://code.claude.com/docs/en/model-config)).

## Environment precedence
CLI flag > per-engine CLI (`engine=value`) > global CLI > per-engine env > global env.

Supported env vars:
- `AUTOREVIEW_MODEL`, `AUTOREVIEW_THINKING`, `AUTOREVIEW_FALLBACK_MODEL`
- `AUTOREVIEW_<ENGINE>_MODEL`, `AUTOREVIEW_<ENGINE>_THINKING`, `AUTOREVIEW_CLAUDE_FALLBACK_MODEL`

## Validation (doc-backed / dry-run; no live Claude subscription)
```bash
$ ruby scripts/validate-skills
validated 5 skills

$ AUTOREVIEW_MODEL=gpt-5.4 AUTOREVIEW_CLAUDE_FALLBACK_MODEL=sonnet,haiku \
  python3 skills/autoreview/scripts/autoreview --mode local --engine claude --dry-run
engine: claude
model: gpt-5.4
fallback_model: sonnet,haiku

$ python3 skills/autoreview/scripts/autoreview --mode local --engine claude --fallback-model haiku --dry-run
fallback_model: haiku

$ python3 skills/autoreview/scripts/autoreview --mode local --engine codex --fallback-model x --dry-run
--fallback-model is only supported for claude, not codex
```

## Notes
- Supersedes/extends the docs-only scope of #17 with runtime env + fallback support.
- Droid thinking docs remain model-only until #16 lands.

Made with [Cursor](https://cursor.com)