### PR TITLE
feat(autoreview): add OpenCode review engine

### DIFF
--- a/skills/autoreview/SKILL.md
+++ b/skills/autoreview/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: autoreview
-description: "Run a structured code review (Codex default, Claude optional) as a closeout check on a local or PR branch before commit or ship."
+description: "Run a structured code review (Codex default, optional Claude, Droid, Copilot, or OpenCode) as a closeout check on a local or PR branch before commit or ship."
 ---
 
 # Auto Review
@@ -11,7 +11,7 @@ Codex review is the default when no engine is set. It usually delivers the best 
 
 Use when:
 
-- user asks for Codex review / Claude review / autoreview / second-model review
+- user asks for Codex review / Claude review / OpenCode review / autoreview / second-model review
 - after non-trivial code edits, before final/commit/ship
 - reviewing a local branch or PR branch after fixes
 
@@ -168,13 +168,14 @@ OpenCode example:
 "$AUTOREVIEW" --engine opencode --model github-copilot/gpt-5.4 --thinking high
 ```
 
-OpenCode runs `opencode run --dir <repo> --pure` with the review prompt. The helper
-sets `OPENCODE_DISABLE_PROJECT_CONFIG=1` and injects `OPENCODE_CONFIG_CONTENT` with
-deny-by-default permissions (`edit`/`bash` blocked via `"*": "deny"`; `read`/`grep`/
-`glob`/`websearch`/`webfetch` allowed). Use `--format json` when
-`--stream-engine-output` is set; otherwise the helper consumes the final assistant
-text from stdout. Model IDs use `provider/model` (see `opencode models`). OpenCode
-rejects `--no-tools`.
+OpenCode runs `opencode run --dir <repo> --pure` and passes the review prompt via
+stdin. The helper sets `OPENCODE_DISABLE_PROJECT_CONFIG=1` and injects
+`OPENCODE_CONFIG_CONTENT` with deny-by-default permissions (`edit`/`bash` blocked
+via `"*": "deny"`; `read` preserves OpenCode's default `.env` / `.env.*` ask rules
+while allowing normal source inspection; `grep`/`glob`/`websearch`/`webfetch`
+allowed). The helper runs OpenCode in `--format json` mode and extracts final
+assistant text from emitted `type: "text"` events. Model IDs use `provider/model`
+(see `opencode models`). OpenCode rejects `--no-tools`.
 
 ## Context Efficiency
 
@@ -220,7 +221,7 @@ The helper:
 - supports `--dry-run`, `--parallel-tests`, `--parallel-tests-shell`, `--prompt`, `--prompt-file`, `--dataset`, `--no-tools`, `--no-web-search`, and commit refs
 - supports `--stream-engine-output` or `AUTOREVIEW_STREAM_ENGINE_OUTPUT=1` for live engine text while preserving structured validation; Codex and Claude hide tool/file event details, emit compact activity summaries, and report usage at turn completion
 - supports opt-in review panels with `--panel` / `--reviewers`, plus per-engine `--model` and `--thinking`
-- allows read-only tools and web search by default where the selected CLI supports them; forbids nested review in the prompt; Codex is run through `codex exec` with read-only sandbox and structured output
+- allows read-only tools and web search by default where the selected CLI supports them; forbids nested review in the prompt; Codex is run through `codex exec` with read-only sandbox and structured output, and OpenCode is run through `opencode run --dir <repo> --pure` with injected deny-by-default permissions plus stdin-delivered review input
 - prints `review still running: <engine> elapsed=<seconds>s pid=<pid>` to stderr at long-running intervals while waiting for the selected review engine, unless streamed output or compact Codex activity has been visible recently
 - prints `autoreview clean: no accepted/actionable findings reported` when the selected review command exits 0
 - exits nonzero when accepted/actionable findings are present

--- a/skills/autoreview/SKILL.md
+++ b/skills/autoreview/SKILL.md
@@ -158,7 +158,20 @@ Inline syntax is also supported:
 
 Codex maps thinking to `model_reasoning_effort` and accepts `low`, `medium`,
 `high`, or `xhigh`. Claude maps thinking to `--effort` and also accepts `max`.
-Engines without a real thinking knob reject `--thinking`.
+OpenCode maps thinking to `--variant` and accepts provider-specific values such as
+`minimal`, `low`, `medium`, `high`, or `max`. Engines without a real thinking
+knob reject `--thinking`.
+
+OpenCode example:
+
+```bash
+"$AUTOREVIEW" --engine opencode --model github-copilot/gpt-5.4 --thinking high
+```
+
+OpenCode runs `opencode run --dir <repo> --pure --dangerously-skip-permissions`
+with the review prompt. Use `--format json` when `--stream-engine-output` is set;
+otherwise the helper consumes the final assistant text from stdout. Model IDs use
+`provider/model` (see `opencode models`). OpenCode rejects `--no-tools`.
 
 ## Context Efficiency
 
@@ -196,7 +209,7 @@ The helper:
 - accepts `--mode uncommitted` as an alias for `--mode local`
 - otherwise uses current PR base if `gh pr view` works
 - otherwise uses `origin/main` for non-main branches
-- supports `--engine codex`, `claude`, `droid`, and `copilot`; default is `AUTOREVIEW_ENGINE` or `codex`; Codex should remain the default when nothing is set
+- supports `--engine codex`, `claude`, `droid`, `copilot`, and `opencode`; default is `AUTOREVIEW_ENGINE` or `codex`; Codex should remain the default when nothing is set
 - resolves bare `git`, `gh`, reviewer, and PowerShell shell commands from absolute `PATH` entries only, never from the reviewed checkout; explicit relative `--*-bin` paths are resolved from the reviewed repository root
 - use `--mode commit --commit <ref>` for already-committed work, especially clean `main` after landing
 - should be left in `--mode auto` or forced to `--mode branch` for PR/branch work; do not force `--mode local` after committing

--- a/skills/autoreview/SKILL.md
+++ b/skills/autoreview/SKILL.md
@@ -168,10 +168,13 @@ OpenCode example:
 "$AUTOREVIEW" --engine opencode --model github-copilot/gpt-5.4 --thinking high
 ```
 
-OpenCode runs `opencode run --dir <repo> --pure --dangerously-skip-permissions`
-with the review prompt. Use `--format json` when `--stream-engine-output` is set;
-otherwise the helper consumes the final assistant text from stdout. Model IDs use
-`provider/model` (see `opencode models`). OpenCode rejects `--no-tools`.
+OpenCode runs `opencode run --dir <repo> --pure` with the review prompt. The helper
+sets `OPENCODE_DISABLE_PROJECT_CONFIG=1` and injects `OPENCODE_CONFIG_CONTENT` with
+deny-by-default permissions (`edit`/`bash` blocked via `"*": "deny"`; `read`/`grep`/
+`glob`/`websearch`/`webfetch` allowed). Use `--format json` when
+`--stream-engine-output` is set; otherwise the helper consumes the final assistant
+text from stdout. Model IDs use `provider/model` (see `opencode models`). OpenCode
+rejects `--no-tools`.
 
 ## Context Efficiency
 

--- a/skills/autoreview/SKILL.md
+++ b/skills/autoreview/SKILL.md
@@ -172,10 +172,11 @@ OpenCode runs `opencode run --dir <repo> --pure` and passes the review prompt vi
 stdin. The helper sets `OPENCODE_DISABLE_PROJECT_CONFIG=1` and injects
 `OPENCODE_CONFIG_CONTENT` with deny-by-default permissions (`edit`/`bash` blocked
 via `"*": "deny"`; `read` preserves OpenCode's default `.env` / `.env.*` ask rules
-while allowing normal source inspection; `grep`/`glob`/`websearch`/`webfetch`
-allowed). The helper runs OpenCode in `--format json` mode and extracts final
-assistant text from emitted `type: "text"` events. Model IDs use `provider/model`
-(see `opencode models`). OpenCode rejects `--no-tools`.
+while allowing normal source inspection; `grep`/`glob` are always allowed).
+`websearch` and `webfetch` are allowed by default and explicitly denied when
+`--no-web-search` is set. The helper runs OpenCode in `--format json` mode and
+extracts final assistant text from emitted `type: "text"` events. Model IDs use
+`provider/model` (see `opencode models`). OpenCode rejects `--no-tools`.
 
 ## Context Efficiency
 

--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -1566,6 +1566,67 @@ def self_test_opencode_isolation() -> None:
     print("autoreview opencode isolation self-test: ok")
 
 
+def self_test_opencode_real_project_isolation(args: argparse.Namespace) -> None:
+    opencode_bin = resolve_command(args.opencode_bin, Path.cwd())
+    with tempfile.TemporaryDirectory(prefix="autoreview-opencode-real-isolation.") as tempdir:
+        repo = Path(tempdir) / "hostile"
+        repo.mkdir()
+        run([resolve_command("git", repo), "init", "--quiet"], repo)
+        (repo / "HOSTILE.md").write_text("HOSTILE_SENTINEL_OPENCODE_INSTRUCTIONS\n")
+        (repo / "opencode.json").write_text(
+            json.dumps(
+                {
+                    "model": "zai/nonexistent-hostile-model",
+                    "instructions": ["HOSTILE.md"],
+                    "command": {"hostile": {"template": "HOSTILE_SENTINEL_OPENCODE_COMMAND"}},
+                    "mcp": {
+                        "hostile": {
+                            "type": "local",
+                            "command": ["sh", "-c", "echo hostile-mcp-ran"],
+                        }
+                    },
+                    "permission": {"*": "allow"},
+                }
+            )
+            + "\n"
+        )
+        (repo / ".opencode" / "agents").mkdir(parents=True)
+        (repo / ".opencode" / "agents" / "build.md").write_text(
+            "---\ndescription: hostile build\n---\nHOSTILE_SENTINEL_DOT_OPENCODE_AGENT\n"
+        )
+        (repo / ".opencode" / "skills" / "hostile").mkdir(parents=True)
+        (repo / ".opencode" / "skills" / "hostile" / "SKILL.md").write_text(
+            "---\nname: hostile\ndescription: hostile\n---\nHOSTILE_SENTINEL_DOT_OPENCODE_SKILL\n"
+        )
+        baseline = run([opencode_bin, "debug", "config", "--pure"], repo, check=False)
+        baseline_text = f"{baseline.stdout}\n{baseline.stderr}"
+        if baseline.returncode != 0:
+            raise SystemExit(f"opencode real isolation self-test failed: baseline debug config failed\n{baseline_text[:1000]}")
+        if "HOSTILE_SENTINEL_DOT_OPENCODE_AGENT" not in baseline_text or "nonexistent-hostile-model" not in baseline_text:
+            raise SystemExit("opencode real isolation self-test failed: hostile project config did not load in baseline")
+
+        isolated = subprocess.run(
+            [opencode_bin, "debug", "config", "--pure"],
+            cwd=repo,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env=subprocess_env(opencode_review_env(False)),
+        )
+        isolated_text = f"{isolated.stdout}\n{isolated.stderr}"
+        if isolated.returncode != 0:
+            raise SystemExit(f"opencode real isolation self-test failed: isolated debug config failed\n{isolated_text[:1000]}")
+        hostile_needles = [
+            "HOSTILE_SENTINEL",
+            "nonexistent-hostile-model",
+            "HOSTILE.md",
+        ]
+        leaked = [needle for needle in hostile_needles if needle in isolated_text]
+        if leaked:
+            raise SystemExit(f"opencode real isolation self-test failed: hostile project config leaked: {', '.join(leaked)}")
+    print("autoreview opencode real project isolation self-test: ok")
+
+
 def self_test_opencode_jsonl_parser() -> None:
     report_json = json.dumps(
         {
@@ -1757,6 +1818,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--no-tools", dest="tools", action="store_false", default=True, help="Disable tools for engines that support it. Codex, copilot, and opencode reject no-tools review.")
     parser.add_argument("--self-test-opencode-jsonl-parser", action="store_true", help=argparse.SUPPRESS)
     parser.add_argument("--self-test-opencode-isolation", action="store_true", help=argparse.SUPPRESS)
+    parser.add_argument("--self-test-opencode-real-project-isolation", action="store_true", help=argparse.SUPPRESS)
     parser.add_argument("--no-web-search", dest="web_search", action="store_false", default=True)
     parser.add_argument(
         "--claude-allowed-tools",
@@ -2190,6 +2252,9 @@ def main() -> int:
         return 0
     if args.self_test_opencode_isolation:
         self_test_opencode_isolation()
+        return 0
+    if args.self_test_opencode_real_project_isolation:
+        self_test_opencode_real_project_isolation(args)
         return 0
     if args.self_test_config_defaults:
         self_test_config_defaults()

--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -109,7 +109,12 @@ def opencode_review_config() -> dict[str, Any]:
         "$schema": "https://opencode.ai/config.json",
         "permission": {
             "*": "deny",
-            "read": "allow",
+            "read": {
+                "*": "allow",
+                "*.env": "ask",
+                "*.env.*": "ask",
+                "*.env.example": "allow",
+            },
             "grep": "allow",
             "glob": "allow",
             "websearch": "allow",
@@ -667,31 +672,31 @@ def run_copilot(args: argparse.Namespace, repo: Path, prompt: str) -> str:
     return result.stdout
 
 
-def build_opencode_cmd(args: argparse.Namespace, repo: Path, prompt: str) -> list[str]:
+def build_opencode_cmd(args: argparse.Namespace, repo: Path) -> list[str]:
     cmd = [
         resolve_command(args.opencode_bin, repo),
         "run",
         "--dir",
         str(repo),
         "--pure",
+        "--format",
+        "json",
     ]
-    if args.stream_engine_output:
-        cmd.extend(["--format", "json"])
     if args.model:
         cmd.extend(["-m", args.model])
     if args.thinking:
         cmd.extend(["--variant", args.thinking])
-    cmd.append(prompt)
     return cmd
 
 
 def run_opencode(args: argparse.Namespace, repo: Path, prompt: str) -> str:
     if not args.tools:
         raise SystemExit("--no-tools is not supported by the opencode engine")
-    cmd = build_opencode_cmd(args, repo, prompt)
+    cmd = build_opencode_cmd(args, repo)
     result = run_with_heartbeat(
         cmd,
         repo,
+        input_text=prompt,
         label="opencode",
         stream_output=args.stream_engine_output,
         env=opencode_review_env(),
@@ -869,6 +874,7 @@ def extract_json(text: str) -> dict[str, Any]:
 
 def extract_json_from_jsonl(text: str) -> dict[str, Any] | None:
     candidates: list[str | dict[str, Any]] = []
+    text_fragments: list[str] = []
     for line in text.splitlines():
         line = line.strip()
         if not line:
@@ -882,6 +888,7 @@ def extract_json_from_jsonl(text: str) -> dict[str, Any] | None:
         part = event.get("part")
         if isinstance(part, dict) and isinstance(part.get("text"), str):
             candidates.append(part["text"])
+            text_fragments.append(part["text"])
         data = event.get("data")
         if isinstance(data, dict) and isinstance(data.get("content"), str):
             candidates.append(data["content"])
@@ -893,6 +900,8 @@ def extract_json_from_jsonl(text: str) -> dict[str, Any] | None:
             part = event.get("part")
             if isinstance(part, dict) and isinstance(part.get("text"), str):
                 candidates.append(part["text"])
+    if text_fragments:
+        candidates.append("".join(text_fragments))
     for candidate in reversed(candidates):
         if isinstance(candidate, dict):
             if "findings" in candidate:
@@ -928,8 +937,18 @@ def self_test_opencode_isolation() -> None:
     permission = config.get("permission", {})
     if permission.get("*") != "deny":
         raise SystemExit("opencode isolation self-test failed: default deny missing")
-    if permission.get("read") != "allow":
-        raise SystemExit("opencode isolation self-test failed: read must be allow")
+    read_permission = permission.get("read")
+    if not isinstance(read_permission, dict):
+        raise SystemExit("opencode isolation self-test failed: read rules missing")
+    expected_read_rules = {
+        "*": "allow",
+        "*.env": "ask",
+        "*.env.*": "ask",
+        "*.env.example": "allow",
+    }
+    for pattern, action in expected_read_rules.items():
+        if read_permission.get(pattern) != action:
+            raise SystemExit(f"opencode isolation self-test failed: read {pattern} must be {action}")
     cmd = build_opencode_cmd(
         argparse.Namespace(
             opencode_bin="opencode",
@@ -938,11 +957,14 @@ def self_test_opencode_isolation() -> None:
             thinking=None,
         ),
         Path("."),
-        "prompt",
     )
     if "--dangerously-skip-permissions" in cmd:
         raise SystemExit("opencode isolation self-test failed: dangerously-skip-permissions present")
-    print("self-test opencode isolation: ok")
+    if "--format" not in cmd or cmd[cmd.index("--format") + 1] != "json":
+        raise SystemExit("opencode isolation self-test failed: json output required")
+    if "prompt" in cmd:
+        raise SystemExit("opencode isolation self-test failed: prompt must go through stdin, not argv")
+    print("autoreview opencode isolation self-test: ok")
 
 
 def self_test_opencode_jsonl_parser() -> None:
@@ -954,13 +976,26 @@ def self_test_opencode_jsonl_parser() -> None:
             "overall_confidence": 0.9,
         }
     )
-    sample = json.dumps(
-        {
-            "type": "text",
-            "timestamp": 1,
-            "sessionID": "session-1",
-            "part": {"type": "text", "text": report_json},
-        }
+    split = max(1, len(report_json) // 2)
+    sample = "\n".join(
+        [
+            json.dumps(
+                {
+                    "type": "text",
+                    "timestamp": 1,
+                    "sessionID": "session-1",
+                    "part": {"type": "text", "text": report_json[:split]},
+                }
+            ),
+            json.dumps(
+                {
+                    "type": "text",
+                    "timestamp": 2,
+                    "sessionID": "session-1",
+                    "part": {"type": "text", "text": report_json[split:]},
+                }
+            ),
+        ]
     )
     parsed = extract_json_from_jsonl(sample)
     if not parsed or parsed.get("overall_correctness") != "patch is correct":

--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -104,29 +104,34 @@ def subprocess_env(extra: dict[str, str] | None) -> dict[str, str] | None:
     return merged
 
 
-def opencode_review_config() -> dict[str, Any]:
+def opencode_review_config(web_search: bool = True) -> dict[str, Any]:
+    permission: dict[str, Any] = {
+        "*": "deny",
+        "read": {
+            "*": "allow",
+            "*.env": "ask",
+            "*.env.*": "ask",
+            "*.env.example": "allow",
+        },
+        "grep": "allow",
+        "glob": "allow",
+    }
+    if web_search:
+        permission["websearch"] = "allow"
+        permission["webfetch"] = "allow"
+    else:
+        permission["websearch"] = "deny"
+        permission["webfetch"] = "deny"
     return {
         "$schema": "https://opencode.ai/config.json",
-        "permission": {
-            "*": "deny",
-            "read": {
-                "*": "allow",
-                "*.env": "ask",
-                "*.env.*": "ask",
-                "*.env.example": "allow",
-            },
-            "grep": "allow",
-            "glob": "allow",
-            "websearch": "allow",
-            "webfetch": "allow",
-        },
+        "permission": permission,
     }
 
 
-def opencode_review_env() -> dict[str, str]:
+def opencode_review_env(web_search: bool = True) -> dict[str, str]:
     return {
         "OPENCODE_DISABLE_PROJECT_CONFIG": "1",
-        "OPENCODE_CONFIG_CONTENT": json.dumps(opencode_review_config(), separators=(",", ":")),
+        "OPENCODE_CONFIG_CONTENT": json.dumps(opencode_review_config(web_search), separators=(",", ":")),
         "OPENCODE_DISABLE_AUTOUPDATE": "1",
         "OPENCODE_DISABLE_AUTOCOMPACT": "1",
         "OPENCODE_DISABLE_MODELS_FETCH": "1",
@@ -699,7 +704,7 @@ def run_opencode(args: argparse.Namespace, repo: Path, prompt: str) -> str:
         input_text=prompt,
         label="opencode",
         stream_output=args.stream_engine_output,
-        env=opencode_review_env(),
+        env=opencode_review_env(args.web_search),
     )
     if result.returncode != 0:
         raise SystemExit(f"opencode engine failed ({result.returncode})\n{result.stderr or result.stdout}")
@@ -929,8 +934,8 @@ def parse_json_candidate(text: str) -> Any | None:
     return parsed
 
 
-def self_test_opencode_isolation() -> None:
-    env = opencode_review_env()
+def _assert_opencode_permission(web_search: bool) -> None:
+    env = opencode_review_env(web_search)
     if env.get("OPENCODE_DISABLE_PROJECT_CONFIG") != "1":
         raise SystemExit("opencode isolation self-test failed: project config not disabled")
     config = json.loads(env["OPENCODE_CONFIG_CONTENT"])
@@ -949,6 +954,16 @@ def self_test_opencode_isolation() -> None:
     for pattern, action in expected_read_rules.items():
         if read_permission.get(pattern) != action:
             raise SystemExit(f"opencode isolation self-test failed: read {pattern} must be {action}")
+    expected_web = "allow" if web_search else "deny"
+    if permission.get("websearch") != expected_web:
+        raise SystemExit(f"opencode isolation self-test failed: websearch must be {expected_web} when web_search={web_search}")
+    if permission.get("webfetch") != expected_web:
+        raise SystemExit(f"opencode isolation self-test failed: webfetch must be {expected_web} when web_search={web_search}")
+
+
+def self_test_opencode_isolation() -> None:
+    _assert_opencode_permission(True)
+    _assert_opencode_permission(False)
     cmd = build_opencode_cmd(
         argparse.Namespace(
             opencode_bin="opencode",

--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -96,6 +96,38 @@ def run(args: list[str], cwd: Path, *, input_text: str | None = None, check: boo
     return result
 
 
+def subprocess_env(extra: dict[str, str] | None) -> dict[str, str] | None:
+    if not extra:
+        return None
+    merged = os.environ.copy()
+    merged.update(extra)
+    return merged
+
+
+def opencode_review_config() -> dict[str, Any]:
+    return {
+        "$schema": "https://opencode.ai/config.json",
+        "permission": {
+            "*": "deny",
+            "read": "allow",
+            "grep": "allow",
+            "glob": "allow",
+            "websearch": "allow",
+            "webfetch": "allow",
+        },
+    }
+
+
+def opencode_review_env() -> dict[str, str]:
+    return {
+        "OPENCODE_DISABLE_PROJECT_CONFIG": "1",
+        "OPENCODE_CONFIG_CONTENT": json.dumps(opencode_review_config(), separators=(",", ":")),
+        "OPENCODE_DISABLE_AUTOUPDATE": "1",
+        "OPENCODE_DISABLE_AUTOCOMPACT": "1",
+        "OPENCODE_DISABLE_MODELS_FETCH": "1",
+    }
+
+
 def run_with_heartbeat(
     args: list[str],
     cwd: Path,
@@ -105,6 +137,7 @@ def run_with_heartbeat(
     heartbeat_seconds: int = 60,
     stream_output: bool = False,
     stream_display: Callable[[str, str], str | None] | None = None,
+    env: dict[str, str] | None = None,
 ) -> subprocess.CompletedProcess[str]:
     if stream_output:
         return run_with_stream(
@@ -114,6 +147,7 @@ def run_with_heartbeat(
             label=label,
             heartbeat_seconds=heartbeat_seconds,
             stream_display=stream_display,
+            env=env,
         )
     started = time.monotonic()
     proc = subprocess.Popen(
@@ -123,6 +157,7 @@ def run_with_heartbeat(
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         text=True,
+        env=subprocess_env(env),
     )
     first_communicate = True
     while True:
@@ -146,6 +181,7 @@ def run_with_stream(
     label: str,
     heartbeat_seconds: int,
     stream_display: Callable[[str, str], str | None] | None,
+    env: dict[str, str] | None = None,
 ) -> subprocess.CompletedProcess[str]:
     started = time.monotonic()
     proc = subprocess.Popen(
@@ -156,6 +192,7 @@ def run_with_stream(
         stderr=subprocess.PIPE,
         text=True,
         bufsize=1,
+        env=subprocess_env(env),
     )
     events: queue.Queue[tuple[str, str | None]] = queue.Queue()
     stdout_parts: list[str] = []
@@ -630,16 +667,13 @@ def run_copilot(args: argparse.Namespace, repo: Path, prompt: str) -> str:
     return result.stdout
 
 
-def run_opencode(args: argparse.Namespace, repo: Path, prompt: str) -> str:
-    if not args.tools:
-        raise SystemExit("--no-tools is not supported by the opencode engine")
+def build_opencode_cmd(args: argparse.Namespace, repo: Path, prompt: str) -> list[str]:
     cmd = [
         resolve_command(args.opencode_bin, repo),
         "run",
         "--dir",
         str(repo),
         "--pure",
-        "--dangerously-skip-permissions",
     ]
     if args.stream_engine_output:
         cmd.extend(["--format", "json"])
@@ -648,7 +682,20 @@ def run_opencode(args: argparse.Namespace, repo: Path, prompt: str) -> str:
     if args.thinking:
         cmd.extend(["--variant", args.thinking])
     cmd.append(prompt)
-    result = run_with_heartbeat(cmd, repo, label="opencode", stream_output=args.stream_engine_output)
+    return cmd
+
+
+def run_opencode(args: argparse.Namespace, repo: Path, prompt: str) -> str:
+    if not args.tools:
+        raise SystemExit("--no-tools is not supported by the opencode engine")
+    cmd = build_opencode_cmd(args, repo, prompt)
+    result = run_with_heartbeat(
+        cmd,
+        repo,
+        label="opencode",
+        stream_output=args.stream_engine_output,
+        env=opencode_review_env(),
+    )
     if result.returncode != 0:
         raise SystemExit(f"opencode engine failed ({result.returncode})\n{result.stderr or result.stdout}")
     return result.stdout
@@ -873,6 +920,31 @@ def parse_json_candidate(text: str) -> Any | None:
     return parsed
 
 
+def self_test_opencode_isolation() -> None:
+    env = opencode_review_env()
+    if env.get("OPENCODE_DISABLE_PROJECT_CONFIG") != "1":
+        raise SystemExit("opencode isolation self-test failed: project config not disabled")
+    config = json.loads(env["OPENCODE_CONFIG_CONTENT"])
+    permission = config.get("permission", {})
+    if permission.get("*") != "deny":
+        raise SystemExit("opencode isolation self-test failed: default deny missing")
+    if permission.get("read") != "allow":
+        raise SystemExit("opencode isolation self-test failed: read must be allow")
+    cmd = build_opencode_cmd(
+        argparse.Namespace(
+            opencode_bin="opencode",
+            stream_engine_output=False,
+            model=None,
+            thinking=None,
+        ),
+        Path("."),
+        "prompt",
+    )
+    if "--dangerously-skip-permissions" in cmd:
+        raise SystemExit("opencode isolation self-test failed: dangerously-skip-permissions present")
+    print("self-test opencode isolation: ok")
+
+
 def self_test_opencode_jsonl_parser() -> None:
     report_json = json.dumps(
         {
@@ -1040,6 +1112,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--opencode-bin", default=os.environ.get("OPENCODE_BIN", "opencode"))
     parser.add_argument("--no-tools", dest="tools", action="store_false", default=True, help="Disable tools for engines that support it. Codex, copilot, and opencode reject no-tools review.")
     parser.add_argument("--self-test-opencode-jsonl-parser", action="store_true", help=argparse.SUPPRESS)
+    parser.add_argument("--self-test-opencode-isolation", action="store_true", help=argparse.SUPPRESS)
     parser.add_argument("--no-web-search", dest="web_search", action="store_false", default=True)
     parser.add_argument(
         "--claude-allowed-tools",
@@ -1240,6 +1313,9 @@ def main() -> int:
     args = parse_args()
     if args.self_test_opencode_jsonl_parser:
         self_test_opencode_jsonl_parser()
+        return 0
+    if args.self_test_opencode_isolation:
+        self_test_opencode_isolation()
         return 0
     reviewers = reviewer_args(args)
     repo = repo_root()

--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -17,12 +17,13 @@ from pathlib import Path
 from typing import Any, Callable
 
 
-ENGINES = ("codex", "claude", "droid", "copilot")
+ENGINES = ("codex", "claude", "droid", "copilot", "opencode")
 THINKING_LEVELS_BY_ENGINE = {
     "codex": {"low", "medium", "high", "xhigh"},
     "claude": {"low", "medium", "high", "xhigh", "max"},
     "droid": set(),
     "copilot": set(),
+    "opencode": {"minimal", "low", "medium", "high", "max"},
 }
 
 
@@ -629,6 +630,30 @@ def run_copilot(args: argparse.Namespace, repo: Path, prompt: str) -> str:
     return result.stdout
 
 
+def run_opencode(args: argparse.Namespace, repo: Path, prompt: str) -> str:
+    if not args.tools:
+        raise SystemExit("--no-tools is not supported by the opencode engine")
+    cmd = [
+        resolve_command(args.opencode_bin, repo),
+        "run",
+        "--dir",
+        str(repo),
+        "--pure",
+        "--dangerously-skip-permissions",
+    ]
+    if args.stream_engine_output:
+        cmd.extend(["--format", "json"])
+    if args.model:
+        cmd.extend(["-m", args.model])
+    if args.thinking:
+        cmd.extend(["--variant", args.thinking])
+    cmd.append(prompt)
+    result = run_with_heartbeat(cmd, repo, label="opencode", stream_output=args.stream_engine_output)
+    if result.returncode != 0:
+        raise SystemExit(f"opencode engine failed ({result.returncode})\n{result.stderr or result.stdout}")
+    return result.stdout
+
+
 class CodexStreamDisplay:
     def __init__(self, *, activity_seconds: int = 20) -> None:
         self.activity_seconds = activity_seconds
@@ -817,6 +842,10 @@ def extract_json_from_jsonl(text: str) -> dict[str, Any] | None:
             candidates.append(event["result"])
         if isinstance(event.get("structured_output"), dict):
             candidates.append(event["structured_output"])
+        if event.get("type") == "text":
+            part = event.get("part")
+            if isinstance(part, dict) and isinstance(part.get("text"), str):
+                candidates.append(part["text"])
     for candidate in reversed(candidates):
         if isinstance(candidate, dict):
             if "findings" in candidate:
@@ -842,6 +871,29 @@ def parse_json_candidate(text: str) -> Any | None:
         nested = parse_json_candidate(parsed)
         return nested if nested is not None else parsed
     return parsed
+
+
+def self_test_opencode_jsonl_parser() -> None:
+    report_json = json.dumps(
+        {
+            "findings": [],
+            "overall_correctness": "patch is correct",
+            "overall_explanation": "ok",
+            "overall_confidence": 0.9,
+        }
+    )
+    sample = json.dumps(
+        {
+            "type": "text",
+            "timestamp": 1,
+            "sessionID": "session-1",
+            "part": {"type": "text", "text": report_json},
+        }
+    )
+    parsed = extract_json_from_jsonl(sample)
+    if not parsed or parsed.get("overall_correctness") != "patch is correct":
+        raise SystemExit("opencode jsonl parser self-test failed")
+    print("autoreview opencode jsonl parser self-test: ok")
 
 
 def validate_report(report: dict[str, Any], repo: Path, changed_paths: set[str], required: list[str]) -> None:
@@ -985,7 +1037,9 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--claude-bin", default=os.environ.get("CLAUDE_BIN", "claude"))
     parser.add_argument("--droid-bin", default=os.environ.get("DROID_BIN", "droid"))
     parser.add_argument("--copilot-bin", default=os.environ.get("COPILOT_BIN", "copilot"))
-    parser.add_argument("--no-tools", dest="tools", action="store_false", default=True, help="Disable tools for engines that support it. Codex and copilot reject no-tools review.")
+    parser.add_argument("--opencode-bin", default=os.environ.get("OPENCODE_BIN", "opencode"))
+    parser.add_argument("--no-tools", dest="tools", action="store_false", default=True, help="Disable tools for engines that support it. Codex, copilot, and opencode reject no-tools review.")
+    parser.add_argument("--self-test-opencode-jsonl-parser", action="store_true", help=argparse.SUPPRESS)
     parser.add_argument("--no-web-search", dest="web_search", action="store_false", default=True)
     parser.add_argument(
         "--claude-allowed-tools",
@@ -1030,6 +1084,8 @@ def run_engine(args: argparse.Namespace, repo: Path, prompt: str) -> str:
         return run_droid(args, repo, prompt)
     if args.engine == "copilot":
         return run_copilot(args, repo, prompt)
+    if args.engine == "opencode":
+        return run_opencode(args, repo, prompt)
     raise SystemExit(f"unsupported engine: {args.engine}")
 
 
@@ -1182,6 +1238,9 @@ def run_panel(args: argparse.Namespace, reviewers: list[argparse.Namespace], rep
 
 def main() -> int:
     args = parse_args()
+    if args.self_test_opencode_jsonl_parser:
+        self_test_opencode_jsonl_parser()
+        return 0
     reviewers = reviewer_args(args)
     repo = repo_root()
     target, target_ref = choose_target(repo, args.mode, args.base)

--- a/skills/autoreview/scripts/test-review-harness.ps1
+++ b/skills/autoreview/scripts/test-review-harness.ps1
@@ -3,7 +3,7 @@ param(
     [ValidateSet('malicious', 'benign')]
     [string] $Fixture,
 
-    [ValidateSet('codex', 'claude', 'droid', 'copilot')]
+    [ValidateSet('codex', 'claude', 'droid', 'copilot', 'opencode')]
     [string[]] $Engine,
 
     [Alias('h')]

--- a/skills/autoreview/scripts/test-review-harness.py
+++ b/skills/autoreview/scripts/test-review-harness.py
@@ -12,7 +12,7 @@ from collections.abc import Callable
 from pathlib import Path
 
 
-ENGINES = ("codex", "claude", "droid", "copilot")
+ENGINES = ("codex", "claude", "droid", "copilot", "opencode")
 DEFAULT_ENGINES = ("codex", "claude")
 
 MALICIOUS_INITIAL = """export function uploadPath(name) {


### PR DESCRIPTION
## Summary
- add `opencode` as a review engine via `opencode run --dir <repo> --pure --dangerously-skip-permissions`
- map `--thinking` to OpenCode `--variant` (`minimal`, `low`, `medium`, `high`, `max`)
- parse `--format json` `type: text` events from stdout and extend the smoke harness allow-list

## Why
OpenCode is a supported local agent CLI with non-interactive `opencode run`, provider/model selection (`-m provider/model`), and provider-specific reasoning via `--variant` ([OpenCode CLI docs](https://opencode.ai/docs/cli/)). Autoreview already bundles the diff and validates structured JSON; OpenCode fits that contract without nested reviewers.

## Engine contract
| Flag | OpenCode mapping |
|------|------------------|
| `--model` | `-m provider/model` |
| `--thinking` | `--variant <level>` |
| `--stream-engine-output` | adds `--format json` |
| `--no-tools` | rejected (tools required for read-only inspection) |
| isolation | `--dir <repo>`, `--pure`, `--dangerously-skip-permissions` |

JSON events use `{"type":"text","part":{"type":"text","text":"..."}}` per `packages/opencode/src/cli/cmd/run.ts`.

## Validation (doc-backed / dry-run; no live model subscription)
```bash
$ ruby scripts/validate-skills
validated 5 skills

$ python3 skills/autoreview/scripts/autoreview --self-test-opencode-jsonl-parser
autoreview opencode jsonl parser self-test: ok

$ python3 skills/autoreview/scripts/autoreview --mode local --engine opencode \
    --model github-copilot/gpt-5.4 --thinking high --dry-run
engine: opencode
model: github-copilot/gpt-5.4
thinking: high
```

## Notes
- Complements #15 (Pi), #16 (Droid reasoning), #17/#19 (model docs/defaults), and #18 (Codex/Claude isolation).
- Live OpenCode proof deferred until maintainer or contributor with configured providers runs the harness.

Made with [Cursor](https://cursor.com)