### PR TITLE
feat(autoreview): default to latest review models

### DIFF
--- a/skills/autoreview/SKILL.md
+++ b/skills/autoreview/SKILL.md
@@ -7,7 +7,7 @@ description: "Run a structured code review (Codex default, Claude optional) as a
 
 Run the bundled structured review helper as a closeout check. This is code review, not Guardian `auto_review` approval routing.
 
-Codex review is the default when no engine is set. It usually delivers the best review results and should remain the normal final closeout engine.
+Codex review is the default when no engine is set. It uses `gpt-5.5` by default, usually delivers the best review results, and should remain the normal final closeout engine. Claude review is optional and uses `claude-fable-5` by default.
 
 Use when:
 
@@ -147,30 +147,39 @@ Run multiple reviewers against one frozen bundle:
 Set reviewer models and thinking/effort explicitly:
 
 ```bash
-"$AUTOREVIEW" --reviewers codex,claude --model codex=gpt-5.1 --thinking codex=high --model claude=sonnet --thinking claude=max
+"$AUTOREVIEW" --reviewers codex,claude --model codex=gpt-5.5 --thinking codex=high --model claude=claude-fable-5 --thinking claude=max
 ```
 
 Inline syntax is also supported for simple model IDs:
 
 ```bash
-"$AUTOREVIEW" --reviewers codex:gpt-5.1:high,claude:sonnet:max
+"$AUTOREVIEW" --reviewers codex:gpt-5.5:high,claude:claude-fable-5:max
 ```
 
 For models with slashes or extra colons, prefer keyed form:
 
 ```bash
 "$AUTOREVIEW" --engine droid --model claude-opus-4-8
-"$AUTOREVIEW" --reviewers codex,droid --model codex=gpt-5.1 --model droid=claude-opus-4-8
+"$AUTOREVIEW" --reviewers codex,droid --model codex=gpt-5.5 --model droid=claude-opus-4-8
 ```
 
 ## Models and thinking
 
 The helper accepts `--model` globally or per engine (`engine=model`) and `--thinking` globally or per engine (`engine=level`). Repeat either flag for multiple reviewers.
 
+Recommended model defaults:
+
+| Engine | Default model | Source note |
+|--------|---------------|-------------|
+| **codex** (default) | `gpt-5.5` | OpenAI's current GPT-5.5 alias |
+| **claude** | `claude-fable-5` | Anthropic's most capable widely released Claude model |
+
+CLI flags and environment variables override these defaults. Droid and Copilot do not get built-in model defaults here because their provider catalogs are external to the Codex/Claude closeout path and may vary by installation.
+
 | Engine | Model flag | Example model IDs | Thinking flag | Accepted levels |
 |--------|------------|-------------------|---------------|-----------------|
-| **codex** (default) | `codex --model X exec ...` | `gpt-5.1`, `o3` | `-c model_reasoning_effort=Y` | `none`, `minimal`, `low`, `medium`, `high`, `xhigh` |
-| **claude** | `claude --model X` | `sonnet`, `opus`, `haiku`, full Anthropic IDs | `--effort Y` | `low`, `medium`, `high`, `xhigh`, `max` |
+| **codex** (default) | `codex --model X exec ...` | `gpt-5.5`, `gpt-5.5-2026-04-23` | `-c model_reasoning_effort=Y` | `none`, `minimal`, `low`, `medium`, `high`, `xhigh` |
+| **claude** | `claude --model X` | `claude-fable-5`, `claude-opus-4-8`, `claude-sonnet-4-6`, `claude-haiku-4-5` | `--effort Y` | `low`, `medium`, `high`, `xhigh`, `max` |
 | **droid** | `droid exec --model X` | `claude-opus-4-8`, Factory model IDs | `-r, --reasoning-effort Y` | `off`, `none`, `low`, `medium`, `high` |
 | **copilot** | `copilot --model X` | `gpt-5.2`, Copilot model aliases | not supported | n/a |
 
@@ -180,11 +189,11 @@ Examples matching current `main` behavior:
 
 ```bash
 # Codex with explicit model and reasoning
-"$AUTOREVIEW" --engine codex --model gpt-5.1 --thinking high
+"$AUTOREVIEW" --engine codex --model gpt-5.5 --thinking high
 
 # Claude Code aliases or full model names, with optional availability fallback
-"$AUTOREVIEW" --engine claude --model sonnet --thinking max
-"$AUTOREVIEW" --engine claude --model opus --fallback-model sonnet,haiku
+"$AUTOREVIEW" --engine claude --model claude-fable-5 --thinking max
+"$AUTOREVIEW" --engine claude --model claude-fable-5 --fallback-model claude-opus-4-8,claude-sonnet-4-6
 
 # Factory Droid with explicit model and reasoning effort
 "$AUTOREVIEW" --engine droid --model claude-opus-4-8 --thinking low
@@ -199,10 +208,10 @@ CLI flags take precedence over environment variables.
 
 | Variable | Purpose |
 |----------|---------|
-| `AUTOREVIEW_MODEL` | Default `--model` for all engines |
+| `AUTOREVIEW_MODEL` | Override the built-in default `--model` for all engines |
 | `AUTOREVIEW_THINKING` | Default `--thinking` for all engines |
 | `AUTOREVIEW_FALLBACK_MODEL` | Default Claude `--fallback-model` chain |
-| `AUTOREVIEW_<ENGINE>_MODEL` | Per-engine model override |
+| `AUTOREVIEW_<ENGINE>_MODEL` | Per-engine model override, for example `AUTOREVIEW_CODEX_MODEL=gpt-5.5` |
 | `AUTOREVIEW_<ENGINE>_THINKING` | Per-engine thinking override |
 | `AUTOREVIEW_CLAUDE_FALLBACK_MODEL` | Claude-only fallback chain |
 
@@ -263,7 +272,7 @@ The helper:
 - supports `--dry-run`, `--parallel-tests`, `--parallel-tests-shell`, `--prompt`, `--prompt-file`, `--dataset`, `--no-tools`, `--no-web-search`, and commit refs
 - supports `--stream-engine-output` or `AUTOREVIEW_STREAM_ENGINE_OUTPUT=1` for live engine text while preserving structured validation; Codex and Claude hide tool/file event details, emit compact activity summaries, and report usage at turn completion
 - supports opt-in review panels with `--panel` / `--reviewers`, plus per-engine `--model`, `--thinking`, and Claude `--fallback-model`
-- honors `AUTOREVIEW_MODEL`, `AUTOREVIEW_THINKING`, `AUTOREVIEW_FALLBACK_MODEL`, and per-engine `AUTOREVIEW_<ENGINE>_MODEL` / `AUTOREVIEW_<ENGINE>_THINKING` environment defaults when CLI flags are omitted
+- uses built-in model defaults `codex=gpt-5.5` and `claude=claude-fable-5`; honors `AUTOREVIEW_MODEL`, `AUTOREVIEW_THINKING`, `AUTOREVIEW_FALLBACK_MODEL`, and per-engine `AUTOREVIEW_<ENGINE>_MODEL` / `AUTOREVIEW_<ENGINE>_THINKING` environment overrides when CLI flags are omitted
 - allows read-only tools and web search by default where the selected CLI supports them; forbids nested review in the prompt; Codex is run through `codex exec` with read-only sandbox, reviewed-repo instruction/config/rule isolation flags, and structured output
 - runs Claude with `--safe-mode` (`v2.1.169+`), `--setting-sources user`, MCP disabled, explicit allowed tools, and `--fallback-model` when set, so reviewed-repo hooks/skills/MCP do not affect the review run while normal auth still works; managed settings policy can still apply
 - runs Droid with `droid exec` in read-only mode, forwards `--model` and `-r, --reasoning-effort`, and switches `--output-format` to `stream-json` when streaming is enabled

--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -19,6 +19,10 @@ from typing import Any, Callable
 
 
 ENGINES = ("codex", "claude", "droid", "copilot")
+DEFAULT_MODEL_BY_ENGINE = {
+    "codex": "gpt-5.5",
+    "claude": "claude-fable-5",
+}
 THINKING_LEVELS_BY_ENGINE = {
     "codex": {"none", "minimal", "low", "medium", "high", "xhigh"},
     "claude": {"low", "medium", "high", "xhigh", "max"},
@@ -1305,9 +1309,13 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--base")
     parser.add_argument("--commit", default="HEAD")
     parser.add_argument("--engine", choices=ENGINES, default=os.environ.get("AUTOREVIEW_ENGINE", "codex"))
-    parser.add_argument("--reviewers", help="Comma-separated review panel, e.g. codex,claude or codex:gpt-5:high.")
+    parser.add_argument("--reviewers", help="Comma-separated review panel, e.g. codex,claude or codex:gpt-5.5:high.")
     parser.add_argument("--panel", action="store_true", help="Run a Codex/Claude review panel unless --engine changes the first reviewer.")
-    parser.add_argument("--model", action="append", help="Model for all reviewers or engine=model. Repeatable.")
+    parser.add_argument(
+        "--model",
+        action="append",
+        help="Model for all reviewers or engine=model. Repeatable. Defaults: codex=gpt-5.5, claude=claude-fable-5.",
+    )
     parser.add_argument("--thinking", action="append", help="Thinking/effort for all reviewers or engine=level. Repeatable. Codex: none, minimal, low, medium, high, xhigh. Claude: low, medium, high, xhigh, max. Droid: off, none, low, medium, high.")
     parser.add_argument(
         "--fallback-model",
@@ -1471,6 +1479,7 @@ def reviewer_args(args: argparse.Namespace) -> list[argparse.Namespace]:
             or global_model
             or env_model_by_engine.get(engine)
             or env_global_model
+            or DEFAULT_MODEL_BY_ENGINE.get(engine)
         )
         thinking = (
             inline_thinking
@@ -1611,10 +1620,18 @@ def self_test_config_defaults() -> None:
     keys = [
         "AUTOREVIEW_MODEL",
         "AUTOREVIEW_CODEX_MODEL",
+        "AUTOREVIEW_CLAUDE_MODEL",
         "AUTOREVIEW_THINKING",
         "AUTOREVIEW_CODEX_THINKING",
+        "AUTOREVIEW_CLAUDE_THINKING",
     ]
     with preserve_env(keys):
+        default_codex = reviewer_args(reviewer_test_args(engine="codex"))[0]
+        if default_codex.model != "gpt-5.5":
+            raise SystemExit(f"self-test config defaults failed: default codex model={default_codex.model!r}")
+        default_claude = reviewer_args(reviewer_test_args(engine="claude"))[0]
+        if default_claude.model != "claude-fable-5":
+            raise SystemExit(f"self-test config defaults failed: default claude model={default_claude.model!r}")
         os.environ["AUTOREVIEW_MODEL"] = "env-global-model"
         os.environ["AUTOREVIEW_CODEX_MODEL"] = "env-codex-model"
         os.environ["AUTOREVIEW_THINKING"] = "low"


### PR DESCRIPTION
## Summary
- Set explicit built-in autoreview model defaults for the first-class engines: Codex now defaults to `gpt-5.5`, Claude now defaults to `claude-fable-5`.
- Preserve override precedence so inline reviewer specs, CLI `--model`, and `AUTOREVIEW_*_MODEL` environment values still win over built-in defaults.
- Refresh autoreview docs/examples so the recommended paths no longer show stale `gpt-5.1` / Claude alias examples, while preserving current Droid reasoning support.

## Source checks
- OpenAI GPT-5.5 docs list `gpt-5.5` as the current alias and `gpt-5.5-2026-04-23` as the dated snapshot.
- Anthropic Claude model docs list `claude-fable-5` as the most capable widely released model and include current Claude 4.x IDs for alternatives.

## Verification
- `scripts/validate-skills`
- `ruby -c scripts/install-skills && ruby -c scripts/validate-skills`
- `bash -n skills/autoreview/scripts/test-review-harness`
- `python3 -m py_compile skills/autoreview/scripts/autoreview skills/autoreview/scripts/test-review-harness.py`
- `python3 skills/autoreview/scripts/autoreview --self-test-config-defaults`
- `python3 skills/autoreview/scripts/autoreview --self-test-fallback-scope`
- `python3 skills/autoreview/scripts/autoreview --mode branch --base origin/main --dry-run`
- `python3 skills/autoreview/scripts/autoreview --mode branch --base origin/main` (clean: no accepted/actionable findings reported)