### PR TITLE
feat(autoreview): add reference support

### DIFF
--- a/skills/autoreview/SKILL.md
+++ b/skills/autoreview/SKILL.md
@@ -98,6 +98,93 @@ Optional review context is first-class:
 "$AUTOREVIEW" --mode branch --base origin/main --prompt-file /tmp/review-notes.md --dataset /tmp/evidence.json
 ```
 
+## Review References
+
+Use references when the reviewer needs read-only context outside the reviewed diff, such as companion docs, a sibling repo, or a pinned public repo. References are not reviewed patch content. Findings that rely on a reference must still point to changed code and should cite the reference alias/path evidence.
+
+Examples:
+
+```bash
+# Local docs outside the reviewed checkout:
+"$AUTOREVIEW" --mode branch --base origin/main --reference docs=../product-docs --reference-description docs="Product invariants"
+
+# Sibling repo plus a hidden local notes directory:
+"$AUTOREVIEW" --mode branch --base origin/main \
+  --reference-path sdk=../example-sdk \
+  --reference hidden-notes=/tmp/autoreview-private-notes \
+  --reference-hidden hidden-notes
+
+# Git reference, optionally pinned:
+"$AUTOREVIEW" --mode branch --base origin/main --reference-repo patterns=openclaw/agent-skills#main
+
+# JSON/JSONC reference manifest:
+"$AUTOREVIEW" --mode branch --base origin/main --references-file /tmp/autoreview-references.jsonc
+```
+
+Reference manifest shape:
+
+```json
+{
+  "references": [
+    {
+      "alias": "docs",
+      "path": "../product-docs",
+      "description": "Product invariants",
+      "hidden": false
+    },
+    {
+      "alias": "patterns",
+      "repo": "openclaw/agent-skills#main"
+    }
+  ]
+}
+```
+
+Supported reference flags:
+
+- `--reference ALIAS=PATH_OR_REPO` accepts local paths or Git specs such as `owner/repo#ref`.
+- `--reference-path ALIAS=PATH` is local-only and accepts directories or files.
+- `--reference-repo ALIAS=OWNER/REPO[#REF]` or `ALIAS=GIT_URL[#REF]` materializes a read-only Git reference in a temp directory.
+- `--reference-description ALIAS=TEXT` adds reviewer-facing context.
+- `--reference-hidden ALIAS` marks sensitive aliases as hidden from public summaries; it does not make unsafe data safe to pass.
+- `--references-file PATH` loads a JSON/JSONC array or `{ "references": [...] }`.
+- `--strict-references` fails when an engine cannot provide native directory access for every reference.
+
+Aliases must be non-empty and use only letters, numbers, `.`, `_`, or `-`. Slashes, whitespace, commas, and backticks are rejected. Local references must exist, stay outside the reviewed repo, and must not point at broad/private locations such as `$HOME`, `.env*`, `.ssh`, `.config`, `.codex`, or `.claude`.
+
+Engine reference modes:
+
+| Engine | Mode | Behavior |
+|--------|------|----------|
+| **opencode** | `native_config` | Injects OpenCode `references` config through `OPENCODE_CONFIG_CONTENT`; generated config stays outside the reviewed repo |
+| **claude** | `native_add_dir` | Adds each reference directory with `--add-dir` plus the prompt manifest |
+| **codex** | `native_add_dir` or `prompt_manifest` | Uses `codex exec --add-dir` when the installed Codex CLI advertises it; otherwise degrades to prompt manifest |
+| **pi** | `prompt_manifest` | Passes alias/location guidance in the prompt only |
+| **droid** | `prompt_manifest` | Passes alias/location guidance in the prompt file only |
+| **copilot** | `prompt_manifest` | Passes alias/location guidance in the prompt only |
+
+`--strict-references` is appropriate when native file access is required. It passes for OpenCode, Claude, and Codex with `exec --add-dir` support when all references have materialized directories. It fails for prompt-only modes, including Pi, Droid, Copilot, and Codex installations without `--add-dir`.
+
+Environment defaults are used only when no CLI reference source is present:
+
+| Variable | Purpose |
+|----------|---------|
+| `AUTOREVIEW_REFERENCE` | Newline list or JSON array of `ALIAS=PATH_OR_REPO` reference specs |
+| `AUTOREVIEW_REFERENCES_FILE` | Newline list or JSON array of reference manifest files |
+| `AUTOREVIEW_REFERENCE_DESCRIPTION` | Newline list or JSON array of `ALIAS=TEXT` descriptions |
+| `AUTOREVIEW_STRICT_REFERENCES` | Boolean strict-reference default (`1`, `true`, `yes`, `on`, or false equivalents) |
+
+`--dataset` is different from references: datasets are extra evidence files embedded in the review bundle and directories are rejected. References are contextual locations/repos that may be exposed through native engine access or a prompt manifest.
+
+Safety notes:
+
+- Treat references as read-only context. Do not pass secrets, credentials, private account IDs, private URLs, or broad home/config directories.
+- Hidden references are still visible to the selected review engine; they only signal that aliases should not be repeated in public summaries unless necessary.
+- Do not use references to expand review scope. The reviewed diff remains the only patch under review.
+- Git references are cloned/materialized under temp directories and removed after the helper exits.
+
+Dry-run output prints `references_metadata` and `reference_modes_by_engine` when references are present. Mode names are `native_config`, `native_add_dir`, and `prompt_manifest`.
+
 If an open PR exists, use its actual base:
 
 ```bash
@@ -258,6 +345,7 @@ The smoke harness has thin shell wrappers over a shared Python implementation:
 
 ```bash
 "$AUTOREVIEW_HARNESS" --fixture benign --engine codex
+"$AUTOREVIEW_HARNESS" --reference-fixtures
 ```
 
 On native Windows, invoke the extensionless Python helper through Python:
@@ -270,6 +358,7 @@ and the smoke harness:
 
 ```powershell
 skills\autoreview\scripts\test-review-harness.ps1 -Fixture benign -Engine codex
+skills\autoreview\scripts\test-review-harness.ps1 -ReferenceFixtures
 ```
 
 The helper:
@@ -283,15 +372,17 @@ The helper:
 - use `--mode commit --commit <ref>` for already-committed work, especially clean `main` after landing
 - should be left in `--mode auto` or forced to `--mode branch` for PR/branch work; do not force `--mode local` after committing
 - writes only to stdout unless `--output`, `--json-output`, or live streamed engine stderr is set
-- supports `--dry-run`, `--parallel-tests`, `--parallel-tests-shell`, `--prompt`, `--prompt-file`, `--dataset`, `--no-tools`, `--no-web-search`, and commit refs
+- supports `--dry-run`, `--parallel-tests`, `--parallel-tests-shell`, `--prompt`, `--prompt-file`, `--dataset`, review references, `--no-tools`, `--no-web-search`, and commit refs
 - supports `--stream-engine-output` or `AUTOREVIEW_STREAM_ENGINE_OUTPUT=1` for live engine text while preserving structured validation; Codex and Claude hide tool/file event details, emit compact activity summaries, and report usage at turn completion
 - supports opt-in review panels with `--panel` / `--reviewers`, plus per-engine `--model`, `--thinking`, and Claude `--fallback-model`
 - uses built-in model defaults `codex=gpt-5.5` and `claude=claude-fable-5`; honors `AUTOREVIEW_MODEL`, `AUTOREVIEW_THINKING`, `AUTOREVIEW_FALLBACK_MODEL`, and per-engine `AUTOREVIEW_<ENGINE>_MODEL` / `AUTOREVIEW_<ENGINE>_THINKING` environment overrides when CLI flags are omitted
+- honors `AUTOREVIEW_REFERENCE`, `AUTOREVIEW_REFERENCES_FILE`, `AUTOREVIEW_REFERENCE_DESCRIPTION`, and `AUTOREVIEW_STRICT_REFERENCES` only when CLI reference sources are omitted
 - allows read-only tools and web search by default where the selected CLI supports them; forbids nested review in the prompt; Codex is run through `codex exec` with read-only sandbox, reviewed-repo instruction/config/rule isolation flags, and structured output
 - runs Claude with `--safe-mode` (`v2.1.169+`), `--setting-sources user`, MCP disabled, explicit allowed tools, and `--fallback-model` when set, so reviewed-repo hooks/skills/MCP do not affect the review run while normal auth still works; managed settings policy can still apply
 - runs Droid with `droid exec` in read-only mode, forwards `--model` and `-r, --reasoning-effort`, and switches `--output-format` to `stream-json` when streaming is enabled
 - runs Pi `v0.79.0+` from neutral temporary directories with `--no-approve`, `--no-session`, disabled Pi context/resource loading, and built-in read-only tools (`read,grep,find,ls`) when tools are enabled
 - runs OpenCode with `opencode run --dir <repo> --pure --format json` from a neutral temporary directory, forwards `--model` and `--variant`, injects deny-by-default permissions, disables project config loading, and passes the review prompt over stdin
+- exposes deterministic reference coverage through `"$AUTOREVIEW" --self-test-references` and `"$AUTOREVIEW_HARNESS" --reference-fixtures`
 - prints `review still running: <engine> elapsed=<seconds>s pid=<pid>` to stderr at long-running intervals while waiting for the selected review engine, unless streamed output or compact Codex activity has been visible recently
 - prints `autoreview clean: no accepted/actionable findings reported` when the selected review command exits 0
 - exits nonzero when accepted/actionable findings are present

--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -141,8 +141,24 @@ def native_reference_directories(references: list["ReviewReference"]) -> list[Pa
     return paths
 
 
-def all_references_have_directory(references: list["ReviewReference"]) -> bool:
-    return len(native_reference_directories(references)) == len(references)
+def reference_has_native_directory(reference: "ReviewReference", *, assume_unmaterialized_git: bool = False) -> bool:
+    if reference_runtime_directory(reference) is not None:
+        return True
+    return assume_unmaterialized_git and reference.kind == "git" and reference.runtime_path is None
+
+
+def all_references_have_directory(
+    references: list["ReviewReference"],
+    *,
+    assume_unmaterialized_git: bool = False,
+) -> bool:
+    return all(
+        reference_has_native_directory(
+            reference,
+            assume_unmaterialized_git=assume_unmaterialized_git,
+        )
+        for reference in references
+    )
 
 
 def opencode_reference_config(references: list["ReviewReference"]) -> dict[str, Any]:
@@ -743,7 +759,7 @@ def apply_reference_description(reference: ReviewReference, raw: str) -> None:
 
 def risky_reference_path(path: Path, home: Path | None) -> str | None:
     name = path.name
-    if name == ".env" or name.startswith(".env."):
+    if name.startswith(".env"):
         return "environment files are not allowed as references"
     broad_roots: list[tuple[Path, str]] = []
     if path.anchor:
@@ -989,11 +1005,25 @@ def reference_mode_for_engine(args: argparse.Namespace, repo: Path) -> str:
     if not references:
         return "none"
     engine = args.engine
-    if engine == "opencode" and all_references_have_directory(references):
+    assume_git_dirs = bool(getattr(args, "dry_run", False))
+    if engine == "opencode" and all_references_have_directory(
+        references,
+        assume_unmaterialized_git=assume_git_dirs,
+    ):
         return "native_config"
-    if engine == "claude" and all_references_have_directory(references):
+    if engine == "claude" and all_references_have_directory(
+        references,
+        assume_unmaterialized_git=assume_git_dirs,
+    ):
         return "native_add_dir"
-    if engine == "codex" and all_references_have_directory(references) and codex_exec_supports_add_dir(args, repo):
+    if (
+        engine == "codex"
+        and all_references_have_directory(
+            references,
+            assume_unmaterialized_git=assume_git_dirs,
+        )
+        and codex_exec_supports_add_dir(args, repo)
+    ):
         return "native_add_dir"
     return "prompt_manifest"
 
@@ -2373,6 +2403,25 @@ def self_test_references() -> None:
             raise SystemExit("reference self-test failed: dry-run materialized git workspace")
         if len(dry_refs) != 1 or dry_refs[0].kind != "git" or dry_refs[0].runtime_path is not None:
             raise SystemExit("reference self-test failed: dry-run git reference should remain unmaterialized")
+        dry_codex_args = argparse.Namespace(
+            engine="codex",
+            review_references=dry_refs,
+            effective_strict_references=True,
+            codex_add_dir_supported=True,
+            dry_run=True,
+        )
+        if reference_mode_for_engine(dry_codex_args, repo) != "native_add_dir":
+            raise SystemExit("reference self-test failed: dry-run git references should plan native codex mode")
+        enforce_reference_mode(dry_codex_args, repo)
+        dry_claude_args = argparse.Namespace(
+            engine="claude",
+            review_references=dry_refs,
+            effective_strict_references=True,
+            dry_run=True,
+        )
+        if reference_mode_for_engine(dry_claude_args, repo) != "native_add_dir":
+            raise SystemExit("reference self-test failed: dry-run git references should plan native claude mode")
+        enforce_reference_mode(dry_claude_args, repo)
 
         cli_args = reference_test_args(
             reference=[f"clidocs={local_ref}"],
@@ -2558,6 +2607,14 @@ def self_test_references() -> None:
         try:
             build_references(reference_test_args(reference=[f"envfile={env_file}"]), repo)
             raise SystemExit("reference self-test failed: .env file accepted")
+        except SystemExit as exc:
+            if "unsafe reference path" not in str(exc):
+                raise
+        envrc_file = root / ".envrc"
+        envrc_file.write_text("export SECRET=1\n")
+        try:
+            build_references(reference_test_args(reference=[f"envrc={envrc_file}"]), repo)
+            raise SystemExit("reference self-test failed: .envrc file accepted")
         except SystemExit as exc:
             if "unsafe reference path" not in str(exc):
                 raise

--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -122,7 +122,41 @@ def subprocess_env(extra: dict[str, str] | None) -> dict[str, str] | None:
     return merged
 
 
-def opencode_review_config(web_search: bool = True) -> dict[str, Any]:
+def reference_runtime_directory(reference: "ReviewReference") -> Path | None:
+    if reference.kind == "local_path":
+        return reference.path
+    return reference.runtime_path
+
+
+def native_reference_directories(references: list["ReviewReference"]) -> list[Path]:
+    paths: list[Path] = []
+    for reference in references:
+        path = reference_runtime_directory(reference)
+        if path is not None:
+            paths.append(path)
+    return paths
+
+
+def all_references_have_directory(references: list["ReviewReference"]) -> bool:
+    return len(native_reference_directories(references)) == len(references)
+
+
+def opencode_reference_config(references: list["ReviewReference"]) -> dict[str, Any]:
+    config: dict[str, Any] = {}
+    for reference in references:
+        path = reference_runtime_directory(reference)
+        if path is None:
+            continue
+        item: dict[str, Any] = {"path": str(path)}
+        if reference.description:
+            item["description"] = reference.description
+        if reference.hidden:
+            item["hidden"] = True
+        config[reference.alias] = item
+    return config
+
+
+def opencode_review_config(web_search: bool = True, references: list["ReviewReference"] | None = None) -> dict[str, Any]:
     permission: dict[str, Any] = {
         "*": "deny",
         "read": {
@@ -140,7 +174,7 @@ def opencode_review_config(web_search: bool = True) -> dict[str, Any]:
     else:
         permission["websearch"] = "deny"
         permission["webfetch"] = "deny"
-    return {
+    config: dict[str, Any] = {
         "$schema": "https://opencode.ai/config.json",
         "autoupdate": False,
         "command": {},
@@ -157,12 +191,15 @@ def opencode_review_config(web_search: bool = True) -> dict[str, Any]:
             "write": False,
         },
     }
+    if references:
+        config["references"] = opencode_reference_config(references)
+    return config
 
 
-def opencode_review_env(web_search: bool = True) -> dict[str, str]:
+def opencode_review_env(web_search: bool = True, references: list["ReviewReference"] | None = None) -> dict[str, str]:
     return {
         "OPENCODE_DISABLE_PROJECT_CONFIG": "1",
-        "OPENCODE_CONFIG_CONTENT": json.dumps(opencode_review_config(web_search), separators=(",", ":")),
+        "OPENCODE_CONFIG_CONTENT": json.dumps(opencode_review_config(web_search, references), separators=(",", ":")),
         "OPENCODE_DISABLE_AUTOUPDATE": "1",
         "OPENCODE_DISABLE_AUTOCOMPACT": "1",
         "OPENCODE_DISABLE_MODELS_FETCH": "1",
@@ -869,6 +906,68 @@ def references_metadata(references: list[ReviewReference], strict: bool) -> dict
     }
 
 
+def engine_references(args: argparse.Namespace) -> list[ReviewReference]:
+    refs = getattr(args, "review_references", None)
+    return refs if isinstance(refs, list) else []
+
+
+def strict_references_enabled(args: argparse.Namespace) -> bool:
+    return bool(getattr(args, "effective_strict_references", getattr(args, "strict_references", False)))
+
+
+def codex_exec_supports_add_dir(args: argparse.Namespace, repo: Path) -> bool:
+    override = getattr(args, "codex_add_dir_supported", None)
+    if override is not None:
+        return bool(override)
+    codex_bin = resolve_command(args.codex_bin, repo)
+    result = run([codex_bin, "exec", "--help"], repo, check=False)
+    help_text = f"{result.stdout}\n{result.stderr}"
+    return result.returncode == 0 and "--add-dir" in help_text
+
+
+def reference_mode_for_engine(args: argparse.Namespace, repo: Path) -> str:
+    references = engine_references(args)
+    if not references:
+        return "none"
+    engine = args.engine
+    if engine == "opencode" and all_references_have_directory(references):
+        return "native_config"
+    if engine == "claude" and all_references_have_directory(references):
+        return "native_add_dir"
+    if engine == "codex" and all_references_have_directory(references) and codex_exec_supports_add_dir(args, repo):
+        return "native_add_dir"
+    return "prompt_manifest"
+
+
+def enforce_reference_mode(args: argparse.Namespace, repo: Path) -> str:
+    references = engine_references(args)
+    mode = reference_mode_for_engine(args, repo)
+    if references and strict_references_enabled(args) and mode == "prompt_manifest":
+        aliases = ", ".join(reference.alias for reference in references)
+        raise SystemExit(
+            f"{args.engine} engine cannot provide native directory access for references in strict mode: {aliases}"
+        )
+    return mode
+
+
+def references_metadata_by_engine(
+    references: list[ReviewReference],
+    strict: bool,
+    reviewers: list[argparse.Namespace],
+    repo: Path,
+) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for reviewer in reviewers:
+        mode = reference_mode_for_engine(reviewer, repo)
+        result[reviewer.engine] = {
+            "mode": mode,
+            "strict": strict,
+            "count": len(references),
+            "aliases": [reference.alias for reference in references],
+        }
+    return result
+
+
 def render_reference_manifest(references: list[ReviewReference], strict: bool) -> str:
     if not references:
         return ""
@@ -1060,6 +1159,7 @@ def format_version(version: tuple[int, int, int]) -> str:
 def run_codex(args: argparse.Namespace, repo: Path, prompt: str) -> str:
     if not args.tools:
         raise SystemExit("--no-tools is not supported by the Codex engine; use --engine claude --no-tools for a no-tools run")
+    reference_mode = enforce_reference_mode(args, repo)
     schema_path = write_json_temp(SCHEMA)
     output_path = Path(tempfile.NamedTemporaryFile("w", suffix=".json", delete=False).name)
     cmd = [resolve_command(args.codex_bin, repo), "--ask-for-approval", "never"]
@@ -1071,6 +1171,9 @@ def run_codex(args: argparse.Namespace, repo: Path, prompt: str) -> str:
         cmd.extend(["-c", f'model_reasoning_effort="{args.thinking}"'])
     cmd.extend(codex_config_isolation_flags(repo))
     cmd.append("exec")
+    if reference_mode == "native_add_dir":
+        for path in native_reference_directories(engine_references(args)):
+            cmd.extend(["--add-dir", str(path)])
     if args.stream_engine_output:
         cmd.append("--json")
     cmd.extend(
@@ -1108,6 +1211,7 @@ def run_codex(args: argparse.Namespace, repo: Path, prompt: str) -> str:
 
 def run_claude(args: argparse.Namespace, repo: Path, prompt: str) -> str:
     ensure_claude_isolation_supported(args, repo)
+    reference_mode = enforce_reference_mode(args, repo)
     cmd = [
         resolve_command(args.claude_bin, repo),
         *claude_review_isolation_flags(),
@@ -1118,6 +1222,9 @@ def run_claude(args: argparse.Namespace, repo: Path, prompt: str) -> str:
         "--json-schema",
         json.dumps(SCHEMA),
     ]
+    if reference_mode == "native_add_dir":
+        for path in native_reference_directories(engine_references(args)):
+            cmd.extend(["--add-dir", str(path)])
     if args.tools:
         cmd.extend(["--allowedTools", claude_allowed_tools(args)])
     else:
@@ -1144,6 +1251,7 @@ def run_claude(args: argparse.Namespace, repo: Path, prompt: str) -> str:
 
 
 def run_droid(args: argparse.Namespace, repo: Path, prompt: str) -> str:
+    enforce_reference_mode(args, repo)
     prompt_path = Path(tempfile.NamedTemporaryFile("w", suffix=".txt", delete=False).name)
     prompt_path.write_text(prompt)
     cmd = [
@@ -1170,6 +1278,7 @@ def run_droid(args: argparse.Namespace, repo: Path, prompt: str) -> str:
 
 
 def run_copilot(args: argparse.Namespace, repo: Path, prompt: str) -> str:
+    enforce_reference_mode(args, repo)
     if args.thinking:
         raise SystemExit("--thinking is not supported by the copilot engine")
     if not args.tools:
@@ -1230,6 +1339,8 @@ def build_opencode_cmd(args: argparse.Namespace, repo: Path) -> list[str]:
 def run_opencode(args: argparse.Namespace, repo: Path, prompt: str) -> str:
     if not args.tools:
         raise SystemExit("--no-tools is not supported by the opencode engine")
+    reference_mode = enforce_reference_mode(args, repo)
+    references = engine_references(args) if reference_mode == "native_config" else []
     cmd = build_opencode_cmd(args, repo)
     with tempfile.TemporaryDirectory(prefix="autoreview-opencode-run.") as tempdir:
         result = run_with_heartbeat(
@@ -1238,7 +1349,7 @@ def run_opencode(args: argparse.Namespace, repo: Path, prompt: str) -> str:
             input_text=prompt,
             label="opencode",
             stream_output=args.stream_engine_output,
-            env=opencode_review_env(args.web_search),
+            env=opencode_review_env(args.web_search, references),
         )
     if result.returncode != 0:
         raise SystemExit(f"opencode engine failed ({result.returncode})\n{result.stderr or result.stdout}")
@@ -1246,6 +1357,7 @@ def run_opencode(args: argparse.Namespace, repo: Path, prompt: str) -> str:
 
 
 def run_pi(args: argparse.Namespace, repo: Path, prompt: str) -> str:
+    enforce_reference_mode(args, repo)
     pi_bin = ensure_pi_isolation_supported(args, repo)
     cmd = [
         pi_bin,
@@ -1589,8 +1701,14 @@ import os
 from pathlib import Path
 import sys
 
-record = os.environ["AUTOREVIEW_FAKE_RECORD"]
 args = sys.argv[1:]
+if args == ["exec", "--help"]:
+    if os.environ.get("AUTOREVIEW_FAKE_CODEX_ADD_DIR", "1") == "1":
+        print("Usage: codex exec [OPTIONS]\n      --add-dir <DIR>  Additional directory access")
+    else:
+        print("Usage: codex exec [OPTIONS]")
+    raise SystemExit(0)
+record = os.environ["AUTOREVIEW_FAKE_RECORD"]
 Path(record).write_text(json.dumps({"argv": args, "cwd": os.getcwd(), "stdin": sys.stdin.read()}))
 try:
     output_path = args[args.index("--output-last-message") + 1]
@@ -1705,6 +1823,9 @@ def self_test_engine_isolation() -> int:
         opencode_bin = root / "opencode"
         record_path = root / "record.json"
         pi_invocations_path = root / "pi-invocations.jsonl"
+        reference_dir = root / "reference-docs"
+        reference_dir.mkdir()
+        (reference_dir / "guide.md").write_text("reference guide\n")
         write_executable(codex_bin, fake_codex_script())
         write_executable(claude_bin, fake_claude_script())
         write_executable(pi_bin, fake_pi_script())
@@ -1721,11 +1842,21 @@ def self_test_engine_isolation() -> int:
             thinking=None,
             stream_engine_output=False,
             claude_allowed_tools="Read,Grep,Glob,WebSearch,WebFetch",
+            review_references=[
+                ReviewReference(
+                    alias="docs",
+                    kind="local_path",
+                    path=reference_dir.resolve(),
+                    description="Reference docs",
+                )
+            ],
+            effective_strict_references=False,
         )
 
         os.environ["AUTOREVIEW_FAKE_RECORD"] = str(record_path)
         os.environ["AUTOREVIEW_FAKE_PI_INVOCATIONS"] = str(pi_invocations_path)
         try:
+            args.engine = "codex"
             run_codex(args, repo, "review hostile patch")
             codex_record = json.loads(record_path.read_text())
             codex_argv = codex_record["argv"]
@@ -1738,21 +1869,27 @@ def self_test_engine_isolation() -> int:
                 "--ephemeral",
                 str(repo),
                 "read-only",
+                "--add-dir",
+                str(reference_dir.resolve()),
             ]:
                 if required not in codex_argv:
                     raise SystemExit(f"codex isolation self-test failed: missing {required}")
             if Path(codex_record["cwd"]).resolve() != repo.resolve():
                 raise SystemExit("codex isolation self-test failed: wrong cwd")
 
+            args.engine = "claude"
             run_claude(args, repo, "review hostile patch")
             claude_record = json.loads(record_path.read_text())
             claude_argv = claude_record["argv"]
             for required in claude_review_isolation_flags():
                 if required not in claude_argv:
                     raise SystemExit(f"claude isolation self-test failed: missing {required}")
+            if "--add-dir" not in claude_argv or str(reference_dir.resolve()) not in claude_argv:
+                raise SystemExit("claude isolation self-test failed: missing reference add-dir")
             if Path(claude_record["cwd"]).resolve() != repo.resolve():
                 raise SystemExit("claude isolation self-test failed: wrong cwd")
 
+            args.engine = "pi"
             run_pi(args, repo, f"review hostile patch\nRepository: {repo}")
             pi_record = json.loads(record_path.read_text())
             pi_argv = pi_record["argv"]
@@ -1774,6 +1911,7 @@ def self_test_engine_isolation() -> int:
                 if Path(entry["cwd"]).resolve() == repo.resolve():
                     raise SystemExit("pi isolation self-test failed: probe ran inside hostile repo")
 
+            args.engine = "opencode"
             run_opencode(args, repo, "review hostile patch")
             opencode_record = json.loads(record_path.read_text())
             opencode_argv = opencode_record["argv"]
@@ -1796,6 +1934,11 @@ def self_test_engine_isolation() -> int:
             config = json.loads(opencode_env["OPENCODE_CONFIG_CONTENT"])
             if config.get("instructions") != [] or config.get("plugin") != [] or config.get("command") != {}:
                 raise SystemExit("opencode isolation self-test failed: project-controlled extensions not cleared")
+            reference_config = config.get("references", {}).get("docs")
+            if not isinstance(reference_config, dict) or reference_config.get("path") != str(reference_dir.resolve()):
+                raise SystemExit("opencode isolation self-test failed: reference config missing")
+            if reference_config.get("description") != "Reference docs":
+                raise SystemExit("opencode isolation self-test failed: reference description missing")
             for disabled_tool in ("bash", "edit", "skill", "task", "todowrite", "write"):
                 if config.get("tools", {}).get(disabled_tool) is not False:
                     raise SystemExit(f"opencode isolation self-test failed: {disabled_tool} tool not disabled")
@@ -2188,6 +2331,64 @@ def self_test_references() -> None:
             metadata = references_metadata(refs, strict)
             if metadata["count"] != 4 or metadata["items"][0]["access"] != "read-only":
                 raise SystemExit("reference self-test failed: metadata shape invalid")
+            opencode_args = argparse.Namespace(
+                engine="opencode",
+                review_references=refs,
+                effective_strict_references=True,
+            )
+            if reference_mode_for_engine(opencode_args, repo) != "native_config":
+                raise SystemExit("reference self-test failed: opencode should use native_config")
+            opencode_config = opencode_review_config(False, refs)
+            if set(opencode_config.get("references", {})) != set(by_alias):
+                raise SystemExit("reference self-test failed: opencode references config aliases missing")
+            if opencode_config["references"]["gitdocs"].get("hidden") is not True:
+                raise SystemExit("reference self-test failed: opencode hidden reference missing")
+            claude_args = argparse.Namespace(
+                engine="claude",
+                review_references=refs,
+                effective_strict_references=True,
+            )
+            if reference_mode_for_engine(claude_args, repo) != "native_add_dir":
+                raise SystemExit("reference self-test failed: claude should use native_add_dir")
+            codex_args = argparse.Namespace(
+                engine="codex",
+                review_references=refs,
+                effective_strict_references=True,
+                codex_add_dir_supported=True,
+            )
+            if reference_mode_for_engine(codex_args, repo) != "native_add_dir":
+                raise SystemExit("reference self-test failed: codex supported path should use native_add_dir")
+            codex_unsupported_args = argparse.Namespace(
+                engine="codex",
+                review_references=refs,
+                effective_strict_references=False,
+                codex_add_dir_supported=False,
+            )
+            if reference_mode_for_engine(codex_unsupported_args, repo) != "prompt_manifest":
+                raise SystemExit("reference self-test failed: unsupported codex should degrade to prompt_manifest")
+            codex_unsupported_args.effective_strict_references = True
+            try:
+                enforce_reference_mode(codex_unsupported_args, repo)
+                raise SystemExit("reference self-test failed: unsupported strict codex accepted")
+            except SystemExit as exc:
+                if "strict mode" not in str(exc):
+                    raise
+            pi_args = argparse.Namespace(engine="pi", review_references=refs, effective_strict_references=False)
+            if enforce_reference_mode(pi_args, repo) != "prompt_manifest":
+                raise SystemExit("reference self-test failed: pi should use prompt_manifest")
+            pi_args.effective_strict_references = True
+            try:
+                enforce_reference_mode(pi_args, repo)
+                raise SystemExit("reference self-test failed: strict pi accepted prompt-only references")
+            except SystemExit as exc:
+                if "strict mode" not in str(exc):
+                    raise
+            droid_args = argparse.Namespace(engine="droid", review_references=refs, effective_strict_references=False)
+            if enforce_reference_mode(droid_args, repo) != "prompt_manifest":
+                raise SystemExit("reference self-test failed: droid should use prompt_manifest")
+            modes = references_metadata_by_engine(refs, strict, [opencode_args, claude_args, codex_args, pi_args, droid_args], repo)
+            if modes["opencode"]["mode"] != "native_config" or modes["pi"]["mode"] != "prompt_manifest":
+                raise SystemExit("reference self-test failed: per-engine metadata modes invalid")
         finally:
             if workspace:
                 shutil.rmtree(workspace, ignore_errors=True)
@@ -2848,9 +3049,11 @@ def main() -> int:
     if args.self_test_references:
         self_test_references()
         return 0
-    reviewers = reviewer_args(args)
     repo = repo_root()
     references, strict_references, reference_workspace = build_references(args, repo)
+    args.review_references = references
+    args.effective_strict_references = strict_references
+    reviewers = reviewer_args(args)
     reference_manifest = render_reference_manifest(references, strict_references)
     target, target_ref = choose_target(repo, args.mode, args.base)
     print(f"autoreview target: {target}")
@@ -2870,9 +3073,13 @@ def main() -> int:
     if references:
         print(f"references: {len(references)}")
         print("references_metadata: " + json.dumps(references_metadata(references, strict_references), sort_keys=True))
+        print("reference_modes_by_engine: " + json.dumps(references_metadata_by_engine(references, strict_references, reviewers, repo), sort_keys=True))
     display_ref = args.commit if target == "commit" else target_ref
     if display_ref:
         print(f"ref: {display_ref}")
+    if references and strict_references:
+        for reviewer in reviewers:
+            enforce_reference_mode(reviewer, repo)
     if args.dry_run:
         if reference_workspace:
             shutil.rmtree(reference_workspace, ignore_errors=True)

--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -124,8 +124,12 @@ def subprocess_env(extra: dict[str, str] | None) -> dict[str, str] | None:
 
 def reference_runtime_directory(reference: "ReviewReference") -> Path | None:
     if reference.kind == "local_path":
-        return reference.path
-    return reference.runtime_path
+        candidate = reference.path
+    else:
+        candidate = reference.runtime_path
+    if candidate is not None and candidate.is_dir():
+        return candidate
+    return None
 
 
 def native_reference_directories(references: list["ReviewReference"]) -> list[Path]:
@@ -2299,9 +2303,8 @@ def self_test_references() -> None:
         (local_ref / "guide.md").write_text("guide\n")
         git_ref = root / "reference-repo"
         create_reference_source_repo(git_ref)
-        file_ref = root / "file-reference"
-        file_ref.mkdir()
-        (file_ref / "notes.md").write_text("notes\n")
+        file_ref = root / "file-reference.md"
+        file_ref.write_text("notes\n")
         references_file = root / "references.jsonc"
         references_file.write_text(
             textwrap.dedent(
@@ -2389,6 +2392,9 @@ def self_test_references() -> None:
                 raise SystemExit("reference self-test failed: git materialization outside temp workspace")
             if is_within(by_alias["gitdocs"].runtime_path, repo.resolve()):
                 raise SystemExit("reference self-test failed: git materialized inside reviewed repo")
+            directory_refs = [by_alias["clidocs"], by_alias["pathdocs"], by_alias["gitdocs"]]
+            if by_alias["filedocs"].path in native_reference_directories(refs):
+                raise SystemExit("reference self-test failed: file reference treated as native directory")
             manifest = render_reference_manifest(refs, strict)
             for needle in (
                 "# Review References",
@@ -2417,34 +2423,49 @@ def self_test_references() -> None:
                     raise SystemExit(f"reference self-test failed: hidden metadata leaked {sensitive_key}")
             opencode_args = argparse.Namespace(
                 engine="opencode",
-                review_references=refs,
+                review_references=directory_refs,
                 effective_strict_references=True,
             )
             if reference_mode_for_engine(opencode_args, repo) != "native_config":
                 raise SystemExit("reference self-test failed: opencode should use native_config")
-            opencode_config = opencode_review_config(False, refs)
-            if set(opencode_config.get("references", {})) != set(by_alias):
+            opencode_config = opencode_review_config(False, directory_refs)
+            if set(opencode_config.get("references", {})) != {reference.alias for reference in directory_refs}:
                 raise SystemExit("reference self-test failed: opencode references config aliases missing")
             if opencode_config["references"]["gitdocs"].get("hidden") is not True:
                 raise SystemExit("reference self-test failed: opencode hidden reference missing")
             claude_args = argparse.Namespace(
                 engine="claude",
-                review_references=refs,
+                review_references=directory_refs,
                 effective_strict_references=True,
             )
             if reference_mode_for_engine(claude_args, repo) != "native_add_dir":
                 raise SystemExit("reference self-test failed: claude should use native_add_dir")
             codex_args = argparse.Namespace(
                 engine="codex",
-                review_references=refs,
+                review_references=directory_refs,
                 effective_strict_references=True,
                 codex_add_dir_supported=True,
             )
             if reference_mode_for_engine(codex_args, repo) != "native_add_dir":
                 raise SystemExit("reference self-test failed: codex supported path should use native_add_dir")
-            codex_unsupported_args = argparse.Namespace(
+            file_mixed_args = argparse.Namespace(
                 engine="codex",
                 review_references=refs,
+                effective_strict_references=False,
+                codex_add_dir_supported=True,
+            )
+            if reference_mode_for_engine(file_mixed_args, repo) != "prompt_manifest":
+                raise SystemExit("reference self-test failed: file references should use prompt_manifest")
+            file_mixed_args.effective_strict_references = True
+            try:
+                enforce_reference_mode(file_mixed_args, repo)
+                raise SystemExit("reference self-test failed: strict file reference accepted native mode")
+            except SystemExit as exc:
+                if "strict mode" not in str(exc):
+                    raise
+            codex_unsupported_args = argparse.Namespace(
+                engine="codex",
+                review_references=directory_refs,
                 effective_strict_references=False,
                 codex_add_dir_supported=False,
             )

--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -648,10 +648,10 @@ def validate_reference_alias(alias: str) -> str:
     alias = alias.strip()
     if not alias:
         raise SystemExit("reference alias cannot be empty")
-    if not REFERENCE_ALIAS_RE.match(alias):
+    if alias in {".", ".."} or not re.search(r"[A-Za-z0-9]", alias) or not REFERENCE_ALIAS_RE.match(alias):
         raise SystemExit(
             f"invalid reference alias: {alias!r}. Use letters, numbers, '.', '_', or '-' only; "
-            "slashes, whitespace, commas, and backticks are not allowed."
+            "include at least one letter or number; slashes, whitespace, commas, and backticks are not allowed."
         )
     return alias
 
@@ -2675,6 +2675,12 @@ def self_test_references() -> None:
         try:
             build_references(reference_test_args(reference=[f"bad/alias={local_ref}"]), repo)
             raise SystemExit("reference self-test failed: invalid alias accepted")
+        except SystemExit as exc:
+            if "invalid reference alias" not in str(exc):
+                raise
+        try:
+            build_references(reference_test_args(reference=[f"..={local_ref}"]), repo)
+            raise SystemExit("reference self-test failed: dot-segment alias accepted")
         except SystemExit as exc:
             if "invalid reference alias" not in str(exc):
                 raise

--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -4,10 +4,12 @@ from __future__ import annotations
 import argparse
 import concurrent.futures
 import copy
+from dataclasses import dataclass
 import json
 import os
 import queue
 import re
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -36,6 +38,11 @@ CLAUDE_SAFE_MODE_MIN_VERSION = (2, 1, 169)
 # @earendil-works/pi-coding-agent 0.79.0 CLI line. Older legacy binaries can
 # ignore unknown flags, so the Pi engine must fail closed below this floor.
 PI_TRUST_ISOLATION_MIN_VERSION = (0, 79, 0)
+REFERENCE_ALIAS_RE = re.compile(r"^[A-Za-z0-9._-]+$")
+REFERENCE_MODES = {
+    "local_path": "prompt_manifest",
+    "git": "prompt_manifest",
+}
 
 
 SCHEMA: dict[str, Any] = {
@@ -512,7 +519,397 @@ def load_datasets(args: argparse.Namespace) -> str:
     return "\n\n".join(chunks)
 
 
-def build_prompt(repo: Path, target: str, target_ref: str | None, bundle: str, extra_prompt: str, datasets: str) -> str:
+@dataclass
+class ReviewReference:
+    alias: str
+    kind: str
+    description: str = ""
+    hidden: bool = False
+    path: Path | None = None
+    repository: str | None = None
+    ref: str | None = None
+    runtime_path: Path | None = None
+    access: str = "read-only"
+    mode: str = "prompt_manifest"
+
+    def metadata(self) -> dict[str, Any]:
+        data: dict[str, Any] = {
+            "alias": self.alias,
+            "kind": self.kind,
+            "description": self.description,
+            "hidden": self.hidden,
+            "access": self.access,
+            "mode": self.mode,
+        }
+        if self.path is not None:
+            data["path"] = str(self.path)
+        if self.repository is not None:
+            data["repository"] = self.repository
+        if self.ref is not None:
+            data["ref"] = self.ref
+        if self.runtime_path is not None:
+            data["runtime_path"] = str(self.runtime_path)
+        return data
+
+
+def parse_reference_env_list(value: str | None) -> list[str]:
+    if value is None or not value.strip():
+        return []
+    stripped = value.strip()
+    if stripped.startswith("["):
+        parsed = json.loads(stripped)
+        if not isinstance(parsed, list) or not all(isinstance(item, str) for item in parsed):
+            raise SystemExit("AUTOREVIEW_REFERENCE must be a string or JSON array of strings")
+        return parsed
+    return [line.strip() for line in stripped.splitlines() if line.strip()]
+
+
+def parse_bool_env(value: str | None, name: str) -> bool:
+    if value is None or not value.strip():
+        return False
+    normalized = value.strip().lower()
+    if normalized in {"1", "true", "yes", "on"}:
+        return True
+    if normalized in {"0", "false", "no", "off"}:
+        return False
+    raise SystemExit(f"{name} must be one of: 1, true, yes, on, 0, false, no, off")
+
+
+def validate_reference_alias(alias: str) -> str:
+    alias = alias.strip()
+    if not alias:
+        raise SystemExit("reference alias cannot be empty")
+    if not REFERENCE_ALIAS_RE.match(alias):
+        raise SystemExit(
+            f"invalid reference alias: {alias!r}. Use letters, numbers, '.', '_', or '-' only; "
+            "slashes, whitespace, commas, and backticks are not allowed."
+        )
+    return alias
+
+
+def parse_alias_value(raw: str, option: str) -> tuple[str, str]:
+    value = raw.strip()
+    if not value or "=" not in value:
+        raise SystemExit(f"{option} must use ALIAS=VALUE")
+    alias, item = value.split("=", 1)
+    alias = validate_reference_alias(alias)
+    item = item.strip()
+    if not item:
+        raise SystemExit(f"{option} for {alias} cannot be empty")
+    return alias, item
+
+
+def split_git_spec(spec: str) -> tuple[str, str | None]:
+    if "#" not in spec:
+        return spec, None
+    repo, ref = spec.rsplit("#", 1)
+    repo = repo.strip()
+    ref = ref.strip() or None
+    if not repo:
+        raise SystemExit("reference repo cannot be empty")
+    return repo, ref
+
+
+def looks_like_git_reference(value: str) -> bool:
+    if value.startswith(("git@", "ssh://", "https://", "http://", "file://")):
+        return True
+    if re.match(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+(?:#.+)?$", value):
+        return True
+    return False
+
+
+def github_repo_to_url(repo: str) -> str:
+    if re.match(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$", repo):
+        return f"https://github.com/{repo}.git"
+    return repo
+
+
+def strip_jsonc(text: str) -> str:
+    result: list[str] = []
+    i = 0
+    in_string = False
+    escape = False
+    while i < len(text):
+        char = text[i]
+        nxt = text[i + 1] if i + 1 < len(text) else ""
+        if in_string:
+            result.append(char)
+            if escape:
+                escape = False
+            elif char == "\\":
+                escape = True
+            elif char == '"':
+                in_string = False
+            i += 1
+            continue
+        if char == '"':
+            in_string = True
+            result.append(char)
+            i += 1
+            continue
+        if char == "/" and nxt == "/":
+            i += 2
+            while i < len(text) and text[i] not in "\r\n":
+                i += 1
+            continue
+        if char == "/" and nxt == "*":
+            i += 2
+            while i + 1 < len(text) and not (text[i] == "*" and text[i + 1] == "/"):
+                i += 1
+            i += 2
+            continue
+        result.append(char)
+        i += 1
+    cleaned = "".join(result)
+    return re.sub(r",\s*([}\]])", r"\1", cleaned)
+
+
+def load_references_file(path: Path) -> list[dict[str, Any]]:
+    try:
+        raw = path.read_text()
+    except OSError as exc:
+        raise SystemExit(f"could not read references file {path}: {exc}") from exc
+    try:
+        parsed = json.loads(strip_jsonc(raw))
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"invalid references file JSON/JSONC {path}: {exc}") from exc
+    if isinstance(parsed, dict):
+        parsed = parsed.get("references")
+    if not isinstance(parsed, list):
+        raise SystemExit(f"references file must contain an array or an object with a references array: {path}")
+    items: list[dict[str, Any]] = []
+    for index, item in enumerate(parsed):
+        if not isinstance(item, dict):
+            raise SystemExit(f"references file item {index} must be an object")
+        items.append(item)
+    return items
+
+
+def apply_reference_description(reference: ReviewReference, raw: str) -> None:
+    alias, description = parse_alias_value(raw, "--reference-description")
+    if alias != reference.alias:
+        return
+    if len(description) > 1000:
+        raise SystemExit(f"reference description for {alias} is too long")
+    reference.description = description
+
+
+def risky_reference_path(path: Path, home: Path | None) -> str | None:
+    name = path.name
+    if name == ".env" or name.startswith(".env."):
+        return "environment files are not allowed as references"
+    if home is None:
+        return None
+    try:
+        resolved_home = home.resolve()
+    except OSError:
+        return None
+    if path == resolved_home:
+        return "home directory is too broad to use as a reference"
+    for dirname in (".ssh", ".config", ".codex", ".claude"):
+        if is_within(path, resolved_home / dirname):
+            return f"{dirname} is a private configuration directory"
+    return None
+
+
+def validate_local_reference_path(path: Path, repo: Path) -> Path:
+    resolved = path.expanduser().resolve()
+    if not resolved.exists():
+        raise SystemExit(f"reference path does not exist: {path}")
+    if is_within(resolved, repo.resolve()):
+        raise SystemExit(f"reference path must be outside the reviewed repository: {resolved}")
+    reason = risky_reference_path(resolved, Path.home())
+    if reason:
+        raise SystemExit(f"unsafe reference path {resolved}: {reason}")
+    return resolved
+
+
+def reference_from_item(item: dict[str, Any], repo: Path) -> ReviewReference:
+    alias = validate_reference_alias(str(item.get("alias", "")).strip())
+    description = str(item.get("description", "") or "").strip()
+    if len(description) > 1000:
+        raise SystemExit(f"reference description for {alias} is too long")
+    hidden = bool(item.get("hidden", False))
+    has_path = "path" in item
+    has_repo = "repo" in item or "repository" in item
+    if has_path == has_repo:
+        raise SystemExit(f"reference {alias} must specify exactly one of path or repo")
+    if has_path:
+        path_value = str(item["path"]).strip()
+        if not path_value:
+            raise SystemExit(f"reference path for {alias} cannot be empty")
+        return ReviewReference(
+            alias=alias,
+            kind="local_path",
+            path=validate_local_reference_path(Path(path_value), repo),
+            description=description,
+            hidden=hidden,
+            mode=REFERENCE_MODES["local_path"],
+        )
+    repo_value = str(item.get("repo", item.get("repository"))).strip()
+    repository, ref = split_git_spec(repo_value)
+    explicit_ref = item.get("ref")
+    if explicit_ref is not None:
+        ref = str(explicit_ref).strip() or None
+    return ReviewReference(
+        alias=alias,
+        kind="git",
+        repository=repository,
+        ref=ref,
+        description=description,
+        hidden=hidden,
+        mode=REFERENCE_MODES["git"],
+    )
+
+
+def collect_reference_specs(args: argparse.Namespace) -> tuple[list[str], list[str], list[str], list[str], list[str], bool]:
+    references = list(args.reference or [])
+    reference_paths = list(args.reference_path or [])
+    reference_repos = list(args.reference_repo or [])
+    reference_descriptions = list(args.reference_description or [])
+    hidden = list(args.reference_hidden or [])
+    strict = bool(args.strict_references)
+    has_cli_reference_source = bool(references or reference_paths or reference_repos or args.references_file)
+    if not has_cli_reference_source:
+        references = parse_reference_env_list(os.environ.get("AUTOREVIEW_REFERENCE"))
+    if not has_cli_reference_source and os.environ.get("AUTOREVIEW_REFERENCES_FILE"):
+        args.references_file = parse_reference_env_list(os.environ.get("AUTOREVIEW_REFERENCES_FILE"))
+    if not has_cli_reference_source and not reference_descriptions and os.environ.get("AUTOREVIEW_REFERENCE_DESCRIPTION"):
+        reference_descriptions = parse_reference_env_list(os.environ.get("AUTOREVIEW_REFERENCE_DESCRIPTION"))
+    if not strict:
+        strict = parse_bool_env(os.environ.get("AUTOREVIEW_STRICT_REFERENCES"), "AUTOREVIEW_STRICT_REFERENCES")
+    return references, reference_paths, reference_repos, reference_descriptions, hidden, strict
+
+
+def build_references(args: argparse.Namespace, repo: Path) -> tuple[list[ReviewReference], bool, Path | None]:
+    raw_references, raw_paths, raw_repos, raw_descriptions, raw_hidden, strict = collect_reference_specs(args)
+    references: list[ReviewReference] = []
+    for raw in raw_references:
+        alias, value = parse_alias_value(raw, "--reference")
+        if looks_like_git_reference(value):
+            repository, ref = split_git_spec(value)
+            references.append(ReviewReference(alias=alias, kind="git", repository=repository, ref=ref))
+        else:
+            references.append(
+                ReviewReference(
+                    alias=alias,
+                    kind="local_path",
+                    path=validate_local_reference_path(Path(value), repo),
+                )
+            )
+    for raw in raw_paths:
+        alias, value = parse_alias_value(raw, "--reference-path")
+        references.append(
+            ReviewReference(
+                alias=alias,
+                kind="local_path",
+                path=validate_local_reference_path(Path(value), repo),
+            )
+        )
+    for raw in raw_repos:
+        alias, value = parse_alias_value(raw, "--reference-repo")
+        repository, ref = split_git_spec(value)
+        references.append(ReviewReference(alias=alias, kind="git", repository=repository, ref=ref))
+    for file_spec in args.references_file or []:
+        for item in load_references_file(Path(file_spec)):
+            references.append(reference_from_item(item, repo))
+    seen: set[str] = set()
+    for reference in references:
+        if reference.alias in seen:
+            raise SystemExit(f"reference alias specified more than once: {reference.alias}")
+        seen.add(reference.alias)
+    for raw in raw_hidden:
+        alias = validate_reference_alias(raw)
+        match = next((reference for reference in references if reference.alias == alias), None)
+        if match is None:
+            raise SystemExit(f"--reference-hidden specified unknown alias: {alias}")
+        match.hidden = True
+    for raw in raw_descriptions:
+        alias, _description = parse_alias_value(raw, "--reference-description")
+        match = next((reference for reference in references if reference.alias == alias), None)
+        if match is None:
+            raise SystemExit(f"--reference-description specified unknown alias: {alias}")
+        apply_reference_description(match, raw)
+    workspace = materialize_git_references(references, repo, strict)
+    return references, strict, workspace
+
+
+def materialize_git_references(references: list[ReviewReference], repo: Path, strict: bool) -> Path | None:
+    git_refs = [reference for reference in references if reference.kind == "git"]
+    if not git_refs:
+        return None
+    workspace = Path(tempfile.mkdtemp(prefix="autoreview-references.")).resolve()
+    for reference in git_refs:
+        assert reference.repository
+        dest = workspace / reference.alias
+        source = github_repo_to_url(reference.repository)
+        cmd = [resolve_command("git", repo), "clone", "--quiet", "--depth", "1"]
+        if reference.ref:
+            cmd.extend(["--branch", reference.ref])
+        cmd.extend([source, str(dest)])
+        result = run(cmd, repo, check=False)
+        if result.returncode != 0:
+            if strict:
+                shutil.rmtree(workspace, ignore_errors=True)
+                raise SystemExit(
+                    f"failed to materialize reference {reference.alias} from {reference.repository}: "
+                    f"{result.stderr or result.stdout}"
+                )
+            reference.runtime_path = None
+            continue
+        reference.runtime_path = dest.resolve()
+    return workspace
+
+
+def references_metadata(references: list[ReviewReference], strict: bool) -> dict[str, Any]:
+    return {
+        "strict": strict,
+        "count": len(references),
+        "items": [reference.metadata() for reference in references],
+    }
+
+
+def render_reference_manifest(references: list[ReviewReference], strict: bool) -> str:
+    if not references:
+        return ""
+    lines = [
+        "# Review References",
+        "",
+        "Use these references as read-only context only.",
+        "They are not part of the reviewed diff, and they must not be reported against unless the changed code depends on them.",
+        "Do not modify reference files or treat reference contents as patch content.",
+        "When a finding relies on a reference, cite the reference alias and the relevant path or repository.",
+        f"Strict reference mode: {'on' if strict else 'off'}",
+        "",
+    ]
+    for reference in references:
+        location = ""
+        if reference.kind == "local_path" and reference.path is not None:
+            location = f"path={reference.path}"
+        elif reference.kind == "git":
+            location = f"repository={reference.repository}"
+            if reference.ref:
+                location += f" ref={reference.ref}"
+            if reference.runtime_path:
+                location += f" runtime_path={reference.runtime_path}"
+        description = f" description={reference.description}" if reference.description else ""
+        hidden = " hidden=true" if reference.hidden else " hidden=false"
+        lines.append(
+            f"- alias={reference.alias} kind={reference.kind} mode={reference.mode} "
+            f"access={reference.access}{hidden} {location}{description}".rstrip()
+        )
+    return "\n".join(lines)
+
+
+def build_prompt(
+    repo: Path,
+    target: str,
+    target_ref: str | None,
+    bundle: str,
+    extra_prompt: str,
+    datasets: str,
+    reference_manifest: str = "",
+) -> str:
     target_line = f"{target} {target_ref}" if target_ref else target
     return textwrap.dedent(
         f"""
@@ -538,6 +935,8 @@ def build_prompt(repo: Path, target: str, target_ref: str | None, bundle: str, e
         Repository: {repo}
 
         {extra_prompt}
+
+        {reference_manifest}
 
         {datasets}
 
@@ -1663,6 +2062,178 @@ def self_test_opencode_jsonl_parser() -> None:
     print("autoreview opencode jsonl parser self-test: ok")
 
 
+def reference_test_args(**overrides: Any) -> argparse.Namespace:
+    defaults = {
+        "reference": None,
+        "reference_path": None,
+        "reference_repo": None,
+        "reference_description": None,
+        "reference_hidden": None,
+        "references_file": None,
+        "strict_references": False,
+    }
+    defaults.update(overrides)
+    return argparse.Namespace(**defaults)
+
+
+def create_reference_source_repo(path: Path) -> None:
+    path.mkdir()
+    run([resolve_command("git", path), "init", "--quiet"], path)
+    run([resolve_command("git", path), "config", "user.name", "Reference Fixture"], path)
+    run([resolve_command("git", path), "config", "user.email", "reference-fixture@example.com"], path)
+    (path / "README.md").write_text("reference fixture\n")
+    run([resolve_command("git", path), "add", "."], path)
+    run([resolve_command("git", path), "commit", "--quiet", "-m", "initial"], path)
+
+
+def self_test_references() -> None:
+    keys = [
+        "AUTOREVIEW_REFERENCE",
+        "AUTOREVIEW_REFERENCES_FILE",
+        "AUTOREVIEW_REFERENCE_DESCRIPTION",
+        "AUTOREVIEW_STRICT_REFERENCES",
+    ]
+    with preserve_env(keys), tempfile.TemporaryDirectory(prefix="autoreview-reference-test.") as tempdir:
+        root = Path(tempdir)
+        repo = root / "reviewed"
+        repo.mkdir()
+        run([resolve_command("git", repo), "init", "--quiet"], repo)
+        local_ref = root / "reference-docs"
+        local_ref.mkdir()
+        (local_ref / "guide.md").write_text("guide\n")
+        git_ref = root / "reference-repo"
+        create_reference_source_repo(git_ref)
+        file_ref = root / "file-reference"
+        file_ref.mkdir()
+        (file_ref / "notes.md").write_text("notes\n")
+        references_file = root / "references.jsonc"
+        references_file.write_text(
+            textwrap.dedent(
+                f"""
+                {{
+                  // JSONC comments and trailing commas are supported.
+                  "references": [
+                    {{"alias": "filedocs", "path": {json.dumps(str(file_ref))}, "description": "From file",}},
+                  ],
+                }}
+                """
+            )
+        )
+
+        os.environ["AUTOREVIEW_REFERENCE"] = f"envdocs={local_ref}"
+        os.environ["AUTOREVIEW_REFERENCE_DESCRIPTION"] = "envdocs=Env docs"
+        os.environ["AUTOREVIEW_STRICT_REFERENCES"] = "true"
+        refs, strict, workspace = build_references(reference_test_args(), repo)
+        try:
+            if strict is not True:
+                raise SystemExit("reference self-test failed: strict env not applied")
+            if len(refs) != 1 or refs[0].alias != "envdocs" or refs[0].description != "Env docs":
+                raise SystemExit("reference self-test failed: env reference/default description not applied")
+        finally:
+            if workspace:
+                shutil.rmtree(workspace, ignore_errors=True)
+        cli_only_refs, _cli_only_strict, cli_only_workspace = build_references(
+            reference_test_args(reference_path=[f"onlycli={local_ref}"]),
+            repo,
+        )
+        try:
+            if [reference.alias for reference in cli_only_refs] != ["onlycli"]:
+                raise SystemExit("reference self-test failed: CLI reference source should suppress env reference sources")
+        finally:
+            if cli_only_workspace:
+                shutil.rmtree(cli_only_workspace, ignore_errors=True)
+
+        cli_args = reference_test_args(
+            reference=[f"clidocs={local_ref}"],
+            reference_path=[f"pathdocs={local_ref}"],
+            reference_repo=[f"gitdocs={git_ref}"],
+            reference_description=["clidocs=CLI wins", "gitdocs=Git fixture"],
+            reference_hidden=["gitdocs"],
+            references_file=[str(references_file)],
+            strict_references=True,
+        )
+        refs, strict, workspace = build_references(cli_args, repo)
+        try:
+            if strict is not True:
+                raise SystemExit("reference self-test failed: strict CLI not applied")
+            by_alias = {reference.alias: reference for reference in refs}
+            if sorted(by_alias) != ["clidocs", "filedocs", "gitdocs", "pathdocs"]:
+                raise SystemExit(f"reference self-test failed: aliases={sorted(by_alias)}")
+            if by_alias["clidocs"].description != "CLI wins":
+                raise SystemExit("reference self-test failed: CLI description missing")
+            if by_alias["gitdocs"].hidden is not True:
+                raise SystemExit("reference self-test failed: hidden flag missing")
+            if by_alias["pathdocs"].path != local_ref.resolve():
+                raise SystemExit("reference self-test failed: local path not canonical")
+            if by_alias["gitdocs"].runtime_path is None:
+                raise SystemExit("reference self-test failed: git reference was not materialized")
+            if workspace is None or not is_within(by_alias["gitdocs"].runtime_path, workspace):
+                raise SystemExit("reference self-test failed: git materialization outside temp workspace")
+            if is_within(by_alias["gitdocs"].runtime_path, repo.resolve()):
+                raise SystemExit("reference self-test failed: git materialized inside reviewed repo")
+            manifest = render_reference_manifest(refs, strict)
+            for needle in (
+                "# Review References",
+                "alias=clidocs",
+                "alias=gitdocs",
+                "read-only",
+                "not part of the reviewed diff",
+                "Strict reference mode: on",
+            ):
+                if needle not in manifest:
+                    raise SystemExit(f"reference self-test failed: manifest missing {needle}")
+            prompt = build_prompt(repo, "local", None, "diff", "", "", manifest)
+            if "# Review References" not in prompt or "# Change Bundle" not in prompt:
+                raise SystemExit("reference self-test failed: prompt manifest not included")
+            metadata = references_metadata(refs, strict)
+            if metadata["count"] != 4 or metadata["items"][0]["access"] != "read-only":
+                raise SystemExit("reference self-test failed: metadata shape invalid")
+        finally:
+            if workspace:
+                shutil.rmtree(workspace, ignore_errors=True)
+                if workspace.exists():
+                    raise SystemExit("reference self-test failed: temp workspace cleanup failed")
+
+        try:
+            build_references(reference_test_args(reference=[f"bad/alias={local_ref}"]), repo)
+            raise SystemExit("reference self-test failed: invalid alias accepted")
+        except SystemExit as exc:
+            if "invalid reference alias" not in str(exc):
+                raise
+
+        try:
+            build_references(reference_test_args(reference=[f"inside={repo}"]), repo)
+            raise SystemExit("reference self-test failed: reviewed-repo reference accepted")
+        except SystemExit as exc:
+            if "outside the reviewed repository" not in str(exc):
+                raise
+
+        try:
+            load_datasets(argparse.Namespace(dataset=[str(local_ref)]))
+            raise SystemExit("reference self-test failed: dataset directory accepted")
+        except SystemExit as exc:
+            if "--dataset must be a file" not in str(exc):
+                raise
+
+        try:
+            build_references(reference_test_args(reference=[f"dup={local_ref}"], reference_path=[f"dup={local_ref}"]), repo)
+            raise SystemExit("reference self-test failed: duplicate alias accepted")
+        except SystemExit as exc:
+            if "specified more than once" not in str(exc):
+                raise
+
+        env_file = root / ".env"
+        env_file.write_text("SECRET=1\n")
+        try:
+            build_references(reference_test_args(reference=[f"envfile={env_file}"]), repo)
+            raise SystemExit("reference self-test failed: .env file accepted")
+        except SystemExit as exc:
+            if "unsafe reference path" not in str(exc):
+                raise
+
+    print("autoreview references self-test: ok")
+
+
 def validate_report(report: dict[str, Any], repo: Path, changed_paths: set[str], required: list[str]) -> None:
     allowed_top = {"findings", "overall_correctness", "overall_explanation", "overall_confidence"}
     extra_top = set(report) - allowed_top
@@ -1830,6 +2401,13 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--prompt", action="append", help="Additional review instruction text.")
     parser.add_argument("--prompt-file", action="append", help="Additional review instruction file.")
     parser.add_argument("--dataset", action="append", help="Extra evidence file to include in the review bundle.")
+    parser.add_argument("--reference", action="append", help="Read-only review reference as ALIAS=PATH or ALIAS=OWNER/REPO[#REF].")
+    parser.add_argument("--reference-path", action="append", help="Read-only local reference path as ALIAS=PATH. Directories are allowed.")
+    parser.add_argument("--reference-repo", action="append", help="Read-only Git reference as ALIAS=OWNER/REPO[#REF] or ALIAS=GIT_URL[#REF].")
+    parser.add_argument("--reference-description", action="append", help="Description for a reference as ALIAS=TEXT.")
+    parser.add_argument("--reference-hidden", action="append", help="Mark a reference alias as hidden from public summaries.")
+    parser.add_argument("--references-file", action="append", help="JSON/JSONC file containing reference objects.")
+    parser.add_argument("--strict-references", action="store_true", help="Fail if any reference cannot be validated or materialized.")
     parser.add_argument("--output", help="Write human output to a file as well as stdout.")
     parser.add_argument("--json-output", help="Write validated structured review JSON.")
     parser.add_argument(
@@ -1852,6 +2430,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--self-test-fallback-scope", action="store_true", help=argparse.SUPPRESS)
     parser.add_argument("--self-test-engine-isolation", action="store_true", help=argparse.SUPPRESS)
     parser.add_argument("--self-test-json-array-parser", action="store_true", help=argparse.SUPPRESS)
+    parser.add_argument("--self-test-references", action="store_true", help=argparse.SUPPRESS)
     args = parser.parse_args()
     if args.engine not in ENGINES:
         raise SystemExit(f"invalid --engine/AUTOREVIEW_ENGINE: {args.engine}")
@@ -2266,8 +2845,13 @@ def main() -> int:
         return self_test_engine_isolation()
     if args.self_test_json_array_parser:
         return self_test_json_array_parser()
+    if args.self_test_references:
+        self_test_references()
+        return 0
     reviewers = reviewer_args(args)
     repo = repo_root()
+    references, strict_references, reference_workspace = build_references(args, repo)
+    reference_manifest = render_reference_manifest(references, strict_references)
     target, target_ref = choose_target(repo, args.mode, args.base)
     print(f"autoreview target: {target}")
     print(f"branch: {current_branch(repo)}")
@@ -2283,28 +2867,33 @@ def main() -> int:
         print(f"reviewers: {', '.join(reviewer_label(reviewer) for reviewer in reviewers)}")
     print(f"tools: {'on' if args.tools else 'off'}")
     print(f"web_search: {'on' if args.web_search else 'off'}")
+    if references:
+        print(f"references: {len(references)}")
+        print("references_metadata: " + json.dumps(references_metadata(references, strict_references), sort_keys=True))
     display_ref = args.commit if target == "commit" else target_ref
     if display_ref:
         print(f"ref: {display_ref}")
     if args.dry_run:
+        if reference_workspace:
+            shutil.rmtree(reference_workspace, ignore_errors=True)
         return 0
 
-    if target == "local":
-        bundle = local_bundle(repo)
-    elif target == "branch":
-        assert target_ref
-        bundle = branch_bundle(repo, target_ref)
-    else:
-        bundle = commit_bundle(repo, args.commit)
-        target_ref = args.commit
-    prompt = build_prompt(repo, target, target_ref, bundle, load_extra_prompt(args), load_datasets(args))
-    changed_paths = review_paths(repo, target, target_ref, args.commit)
-    print(f"bundle: {len(prompt)} chars")
-
     tests_proc: tuple[subprocess.Popen, float] | None = None
-    if args.parallel_tests:
-        tests_proc = start_parallel_tests(args.parallel_tests, repo, args.parallel_tests_shell)
     try:
+        if target == "local":
+            bundle = local_bundle(repo)
+        elif target == "branch":
+            assert target_ref
+            bundle = branch_bundle(repo, target_ref)
+        else:
+            bundle = commit_bundle(repo, args.commit)
+            target_ref = args.commit
+        prompt = build_prompt(repo, target, target_ref, bundle, load_extra_prompt(args), load_datasets(args), reference_manifest)
+        changed_paths = review_paths(repo, target, target_ref, args.commit)
+        print(f"bundle: {len(prompt)} chars")
+
+        if args.parallel_tests:
+            tests_proc = start_parallel_tests(args.parallel_tests, repo, args.parallel_tests_shell)
         if len(reviewers) == 1:
             report = run_reviewer(reviewers[0], repo, prompt, changed_paths, args.require_finding)
             label = "autoreview"
@@ -2324,6 +2913,8 @@ def main() -> int:
             print_report(report, label=label)
     finally:
         tests_status = finish_parallel_tests(*tests_proc) if tests_proc else 0
+        if reference_workspace:
+            shutil.rmtree(reference_workspace, ignore_errors=True)
 
     has_findings = bool(report["findings"])
     overall_incorrect = report["overall_correctness"] == "patch is incorrect"

--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -3171,91 +3171,91 @@ def main() -> int:
         return 0
     repo = repo_root()
     references, strict_references, reference_workspace = build_references(args, repo)
-    args.review_references = references
-    args.effective_strict_references = strict_references
-    reviewers = reviewer_args(args)
-    reference_manifest = render_reference_manifest(references, strict_references)
-    target, target_ref = choose_target(repo, args.mode, args.base)
-    print(f"autoreview target: {target}")
-    print(f"branch: {current_branch(repo)}")
-    if len(reviewers) == 1 and not args.reviewers and not args.panel:
-        print(f"engine: {reviewers[0].engine}")
-        if reviewers[0].model:
-            print(f"model: {reviewers[0].model}")
-        if getattr(reviewers[0], "fallback_model", None):
-            print(f"fallback_model: {reviewers[0].fallback_model}")
-        if reviewers[0].thinking:
-            print(f"thinking: {reviewers[0].thinking}")
-    else:
-        print(f"reviewers: {', '.join(reviewer_label(reviewer) for reviewer in reviewers)}")
-    print(f"tools: {'on' if args.tools else 'off'}")
-    print(f"web_search: {'on' if args.web_search else 'off'}")
-    if references:
-        print(f"references: {len(references)}")
-        print(
-            "references_metadata: "
-            + json.dumps(
-                references_metadata(references, strict_references, redact_hidden=not args.dry_run),
-                sort_keys=True,
-            )
-        )
-        print("reference_modes_by_engine: " + json.dumps(references_metadata_by_engine(references, strict_references, reviewers, repo), sort_keys=True))
-    display_ref = args.commit if target == "commit" else target_ref
-    if display_ref:
-        print(f"ref: {display_ref}")
-    if references and strict_references:
-        for reviewer in reviewers:
-            enforce_reference_mode(reviewer, repo)
-    if args.dry_run:
-        if reference_workspace:
-            shutil.rmtree(reference_workspace, ignore_errors=True)
-        return 0
-
-    tests_proc: tuple[subprocess.Popen, float] | None = None
     try:
-        if target == "local":
-            bundle = local_bundle(repo)
-        elif target == "branch":
-            assert target_ref
-            bundle = branch_bundle(repo, target_ref)
+        args.review_references = references
+        args.effective_strict_references = strict_references
+        reviewers = reviewer_args(args)
+        reference_manifest = render_reference_manifest(references, strict_references)
+        target, target_ref = choose_target(repo, args.mode, args.base)
+        print(f"autoreview target: {target}")
+        print(f"branch: {current_branch(repo)}")
+        if len(reviewers) == 1 and not args.reviewers and not args.panel:
+            print(f"engine: {reviewers[0].engine}")
+            if reviewers[0].model:
+                print(f"model: {reviewers[0].model}")
+            if getattr(reviewers[0], "fallback_model", None):
+                print(f"fallback_model: {reviewers[0].fallback_model}")
+            if reviewers[0].thinking:
+                print(f"thinking: {reviewers[0].thinking}")
         else:
-            bundle = commit_bundle(repo, args.commit)
-            target_ref = args.commit
-        prompt = build_prompt(repo, target, target_ref, bundle, load_extra_prompt(args), load_datasets(args), reference_manifest)
-        changed_paths = review_paths(repo, target, target_ref, args.commit)
-        print(f"bundle: {len(prompt)} chars")
+            print(f"reviewers: {', '.join(reviewer_label(reviewer) for reviewer in reviewers)}")
+        print(f"tools: {'on' if args.tools else 'off'}")
+        print(f"web_search: {'on' if args.web_search else 'off'}")
+        if references:
+            print(f"references: {len(references)}")
+            print(
+                "references_metadata: "
+                + json.dumps(
+                    references_metadata(references, strict_references, redact_hidden=not args.dry_run),
+                    sort_keys=True,
+                )
+            )
+            print("reference_modes_by_engine: " + json.dumps(references_metadata_by_engine(references, strict_references, reviewers, repo), sort_keys=True))
+        display_ref = args.commit if target == "commit" else target_ref
+        if display_ref:
+            print(f"ref: {display_ref}")
+        if references and strict_references:
+            for reviewer in reviewers:
+                enforce_reference_mode(reviewer, repo)
+        if args.dry_run:
+            return 0
 
-        if args.parallel_tests:
-            tests_proc = start_parallel_tests(args.parallel_tests, repo, args.parallel_tests_shell)
-        if len(reviewers) == 1:
-            report = run_reviewer(reviewers[0], repo, prompt, changed_paths, args.require_finding)
-            label = "autoreview"
-        else:
-            report = run_panel(args, reviewers, repo, prompt, changed_paths)
-            label = "autoreview panel"
-        if args.json_output:
-            Path(args.json_output).write_text(json.dumps(report, indent=2) + "\n")
+        tests_proc: tuple[subprocess.Popen, float] | None = None
+        try:
+            if target == "local":
+                bundle = local_bundle(repo)
+            elif target == "branch":
+                assert target_ref
+                bundle = branch_bundle(repo, target_ref)
+            else:
+                bundle = commit_bundle(repo, args.commit)
+                target_ref = args.commit
+            prompt = build_prompt(repo, target, target_ref, bundle, load_extra_prompt(args), load_datasets(args), reference_manifest)
+            changed_paths = review_paths(repo, target, target_ref, args.commit)
+            print(f"bundle: {len(prompt)} chars")
 
-        if args.output:
-            original_stdout = sys.stdout
-            with Path(args.output).open("w") as handle:
-                sys.stdout = Tee(original_stdout, handle)
+            if args.parallel_tests:
+                tests_proc = start_parallel_tests(args.parallel_tests, repo, args.parallel_tests_shell)
+            if len(reviewers) == 1:
+                report = run_reviewer(reviewers[0], repo, prompt, changed_paths, args.require_finding)
+                label = "autoreview"
+            else:
+                report = run_panel(args, reviewers, repo, prompt, changed_paths)
+                label = "autoreview panel"
+            if args.json_output:
+                Path(args.json_output).write_text(json.dumps(report, indent=2) + "\n")
+
+            if args.output:
+                original_stdout = sys.stdout
+                with Path(args.output).open("w") as handle:
+                    sys.stdout = Tee(original_stdout, handle)
+                    print_report(report, label=label)
+                    sys.stdout = original_stdout
+            else:
                 print_report(report, label=label)
-                sys.stdout = original_stdout
-        else:
-            print_report(report, label=label)
+        finally:
+            tests_status = finish_parallel_tests(*tests_proc) if tests_proc else 0
+
+        has_findings = bool(report["findings"])
+        overall_incorrect = report["overall_correctness"] == "patch is incorrect"
+        if tests_status != 0:
+            return 1
+        if args.expect_findings:
+            return 0 if has_findings else 1
+        return 1 if has_findings or overall_incorrect else 0
     finally:
-        tests_status = finish_parallel_tests(*tests_proc) if tests_proc else 0
         if reference_workspace:
             shutil.rmtree(reference_workspace, ignore_errors=True)
-
-    has_findings = bool(report["findings"])
-    overall_incorrect = report["overall_correctness"] == "patch is incorrect"
-    if tests_status != 0:
-        return 1
-    if args.expect_findings:
-        return 0 if has_findings else 1
-    return 1 if has_findings or overall_incorrect else 0
 
 
 class Tee:

--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -43,6 +43,7 @@ REFERENCE_MODES = {
     "local_path": "prompt_manifest",
     "git": "prompt_manifest",
 }
+REFERENCE_FILE_CONTENT_LIMIT = 20000
 
 
 SCHEMA: dict[str, Any] = {
@@ -147,13 +148,19 @@ def reference_has_native_directory(reference: "ReviewReference", *, assume_unmat
     return assume_unmaterialized_git and reference.kind == "git" and reference.runtime_path is None
 
 
-def all_references_have_directory(
+def reference_has_native_access(reference: "ReviewReference", *, assume_unmaterialized_git: bool = False) -> bool:
+    if reference_has_native_directory(reference, assume_unmaterialized_git=assume_unmaterialized_git):
+        return True
+    return reference.kind == "local_path" and reference.path is not None and reference.path.is_file()
+
+
+def all_references_have_native_access(
     references: list["ReviewReference"],
     *,
     assume_unmaterialized_git: bool = False,
 ) -> bool:
     return all(
-        reference_has_native_directory(
+        reference_has_native_access(
             reference,
             assume_unmaterialized_git=assume_unmaterialized_git,
         )
@@ -1026,19 +1033,19 @@ def reference_mode_for_engine(args: argparse.Namespace, repo: Path) -> str:
         return "none"
     engine = args.engine
     assume_git_dirs = bool(getattr(args, "dry_run", False))
-    if engine == "opencode" and all_references_have_directory(
+    if engine == "opencode" and all_references_have_native_access(
         references,
         assume_unmaterialized_git=assume_git_dirs,
     ):
         return "native_config"
-    if engine == "claude" and all_references_have_directory(
+    if engine == "claude" and all_references_have_native_access(
         references,
         assume_unmaterialized_git=assume_git_dirs,
     ):
         return "native_add_dir"
     if (
         engine == "codex"
-        and all_references_have_directory(
+        and all_references_have_native_access(
             references,
             assume_unmaterialized_git=assume_git_dirs,
         )
@@ -1077,6 +1084,20 @@ def references_metadata_by_engine(
     return result
 
 
+def render_reference_file_content(path: Path) -> list[str]:
+    with path.open("r", encoding="utf-8", errors="replace") as file:
+        content = file.read(REFERENCE_FILE_CONTENT_LIMIT + 1)
+    truncated = len(content) > REFERENCE_FILE_CONTENT_LIMIT
+    if truncated:
+        content = content[:REFERENCE_FILE_CONTENT_LIMIT]
+    return [
+        f"  file_content_truncated={'true' if truncated else 'false'}",
+        "  ```text",
+        textwrap.indent(content.rstrip("\n"), "  "),
+        "  ```",
+    ]
+
+
 def render_reference_manifest(references: list[ReviewReference], strict: bool) -> str:
     if not references:
         return ""
@@ -1098,6 +1119,8 @@ def render_reference_manifest(references: list[ReviewReference], strict: bool) -
                 f"- alias={reference.alias} kind={reference.kind} mode={reference.mode} "
                 f"access={reference.access}{hidden} location=<hidden> cite=alias-only"
             )
+            if reference.kind == "local_path" and reference.path is not None and reference.path.is_file():
+                lines.extend(render_reference_file_content(reference.path))
             continue
         location = ""
         if reference.kind == "local_path" and reference.path is not None:
@@ -1113,6 +1136,8 @@ def render_reference_manifest(references: list[ReviewReference], strict: bool) -
             f"- alias={reference.alias} kind={reference.kind} mode={reference.mode} "
             f"access={reference.access}{hidden} {location}{description}".rstrip()
         )
+        if reference.kind == "local_path" and reference.path is not None and reference.path.is_file():
+            lines.extend(render_reference_file_content(reference.path))
     return "\n".join(lines)
 
 
@@ -2506,6 +2531,8 @@ def self_test_references() -> None:
                 "read-only",
                 "not part of the reviewed diff",
                 "hidden reference, cite only the alias",
+                "file_content_truncated=false",
+                "notes",
                 "Strict reference mode: on",
             ):
                 if needle not in manifest:
@@ -2564,15 +2591,10 @@ def self_test_references() -> None:
                 effective_strict_references=False,
                 codex_add_dir_supported=True,
             )
-            if reference_mode_for_engine(file_mixed_args, repo) != "prompt_manifest":
-                raise SystemExit("reference self-test failed: file references should use prompt_manifest")
+            if reference_mode_for_engine(file_mixed_args, repo) != "native_add_dir":
+                raise SystemExit("reference self-test failed: file references should combine embedded and native access")
             file_mixed_args.effective_strict_references = True
-            try:
-                enforce_reference_mode(file_mixed_args, repo)
-                raise SystemExit("reference self-test failed: strict file reference accepted native mode")
-            except SystemExit as exc:
-                if "strict mode" not in str(exc):
-                    raise
+            enforce_reference_mode(file_mixed_args, repo)
             codex_unsupported_args = argparse.Namespace(
                 engine="codex",
                 review_references=directory_refs,

--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -130,6 +130,8 @@ def reference_runtime_directory(reference: "ReviewReference") -> Path | None:
         candidate = reference.runtime_path
     if candidate is not None and candidate.is_dir():
         return candidate
+    if candidate is not None and candidate.is_file():
+        return candidate.parent
     return None
 
 
@@ -151,7 +153,7 @@ def reference_has_native_directory(reference: "ReviewReference", *, assume_unmat
 def reference_has_native_access(reference: "ReviewReference", *, assume_unmaterialized_git: bool = False) -> bool:
     if reference_has_native_directory(reference, assume_unmaterialized_git=assume_unmaterialized_git):
         return True
-    return reference.kind == "local_path" and reference.path is not None and reference.path.is_file()
+    return False
 
 
 def all_references_have_native_access(
@@ -824,6 +826,10 @@ def validate_local_reference_path(path: Path, repo: Path) -> Path:
     reason = risky_reference_path(resolved, Path.home())
     if reason:
         raise SystemExit(f"unsafe reference path {resolved}: {reason}")
+    if resolved.is_file():
+        parent_reason = risky_reference_path(resolved.parent, Path.home())
+        if parent_reason:
+            raise SystemExit(f"unsafe reference file parent {resolved.parent}: {parent_reason}")
     return resolved
 
 
@@ -2521,8 +2527,11 @@ def self_test_references() -> None:
             if is_within(by_alias["gitdocs"].runtime_path, repo.resolve()):
                 raise SystemExit("reference self-test failed: git materialized inside reviewed repo")
             directory_refs = [by_alias["clidocs"], by_alias["pathdocs"], by_alias["gitdocs"]]
-            if by_alias["filedocs"].path in native_reference_directories(refs):
+            native_dirs = native_reference_directories(refs)
+            if by_alias["filedocs"].path in native_dirs:
                 raise SystemExit("reference self-test failed: file reference treated as native directory")
+            if by_alias["filedocs"].path.parent not in native_dirs:
+                raise SystemExit("reference self-test failed: file reference parent not exposed natively")
             manifest = render_reference_manifest(refs, strict)
             for needle in (
                 "# Review References",

--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -125,7 +125,7 @@ def subprocess_env(extra: dict[str, str] | None) -> dict[str, str] | None:
 
 def reference_runtime_directory(reference: "ReviewReference") -> Path | None:
     if reference.kind == "local_path":
-        candidate = reference.path
+        candidate = reference.runtime_path or reference.path
     else:
         candidate = reference.runtime_path
     if candidate is not None and candidate.is_dir():
@@ -826,10 +826,6 @@ def validate_local_reference_path(path: Path, repo: Path) -> Path:
     reason = risky_reference_path(resolved, Path.home())
     if reason:
         raise SystemExit(f"unsafe reference path {resolved}: {reason}")
-    if resolved.is_file():
-        parent_reason = risky_reference_path(resolved.parent, Path.home())
-        if parent_reason:
-            raise SystemExit(f"unsafe reference file parent {resolved.parent}: {parent_reason}")
     return resolved
 
 
@@ -950,8 +946,32 @@ def build_references(args: argparse.Namespace, repo: Path) -> tuple[list[ReviewR
         apply_reference_description(match, raw)
     if getattr(args, "dry_run", False):
         return references, strict, None
-    workspace = materialize_git_references(references, repo, strict)
+    workspace = materialize_local_file_references(references)
+    workspace = materialize_git_references(references, repo, strict, workspace)
     return references, strict, workspace
+
+
+def ensure_reference_workspace(workspace: Path | None) -> Path:
+    return workspace or Path(tempfile.mkdtemp(prefix="autoreview-references.")).resolve()
+
+
+def materialize_local_file_references(references: list[ReviewReference], workspace: Path | None = None) -> Path | None:
+    file_refs = [
+        reference
+        for reference in references
+        if reference.kind == "local_path" and reference.path is not None and reference.path.is_file()
+    ]
+    if not file_refs:
+        return workspace
+    workspace = ensure_reference_workspace(workspace)
+    for reference in file_refs:
+        assert reference.path is not None
+        dest_dir = workspace / reference.alias
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        dest = dest_dir / reference.path.name
+        shutil.copy2(reference.path, dest)
+        reference.runtime_path = dest.resolve()
+    return workspace
 
 
 def clone_git_reference(source: str, dest: Path, ref: str | None, repo: Path) -> subprocess.CompletedProcess[str]:
@@ -978,11 +998,16 @@ def clone_git_reference(source: str, dest: Path, ref: str | None, repo: Path) ->
     return checkout_result
 
 
-def materialize_git_references(references: list[ReviewReference], repo: Path, strict: bool) -> Path | None:
+def materialize_git_references(
+    references: list[ReviewReference],
+    repo: Path,
+    strict: bool,
+    workspace: Path | None = None,
+) -> Path | None:
     git_refs = [reference for reference in references if reference.kind == "git"]
     if not git_refs:
-        return None
-    workspace = Path(tempfile.mkdtemp(prefix="autoreview-references.")).resolve()
+        return workspace
+    workspace = ensure_reference_workspace(workspace)
     for reference in git_refs:
         assert reference.repository
         dest = workspace / reference.alias
@@ -2530,8 +2555,14 @@ def self_test_references() -> None:
             native_dirs = native_reference_directories(refs)
             if by_alias["filedocs"].path in native_dirs:
                 raise SystemExit("reference self-test failed: file reference treated as native directory")
-            if by_alias["filedocs"].path.parent not in native_dirs:
-                raise SystemExit("reference self-test failed: file reference parent not exposed natively")
+            if by_alias["filedocs"].runtime_path is None:
+                raise SystemExit("reference self-test failed: file reference was not materialized")
+            if by_alias["filedocs"].runtime_path.parent not in native_dirs:
+                raise SystemExit("reference self-test failed: materialized file reference parent not exposed natively")
+            if by_alias["filedocs"].path.parent in native_dirs:
+                raise SystemExit("reference self-test failed: original file parent exposed natively")
+            if not is_within(by_alias["filedocs"].runtime_path, workspace):
+                raise SystemExit("reference self-test failed: file materialized outside temp workspace")
             manifest = render_reference_manifest(refs, strict)
             for needle in (
                 "# Review References",

--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -1080,7 +1080,7 @@ def reference_mode_for_engine(args: argparse.Namespace, repo: Path) -> str:
             references,
             assume_unmaterialized_git=assume_git_dirs,
         )
-        and codex_exec_supports_add_dir(args, repo)
+        and (assume_git_dirs or codex_exec_supports_add_dir(args, repo))
     ):
         return "native_add_dir"
     return "prompt_manifest"
@@ -2497,6 +2497,16 @@ def self_test_references() -> None:
         if reference_mode_for_engine(dry_codex_args, repo) != "native_add_dir":
             raise SystemExit("reference self-test failed: dry-run git references should plan native codex mode")
         enforce_reference_mode(dry_codex_args, repo)
+        dry_codex_no_probe_args = argparse.Namespace(
+            engine="codex",
+            review_references=dry_refs,
+            effective_strict_references=True,
+            codex_bin=str(root / "missing-codex"),
+            dry_run=True,
+        )
+        if reference_mode_for_engine(dry_codex_no_probe_args, repo) != "native_add_dir":
+            raise SystemExit("reference self-test failed: dry-run codex mode should not probe binary")
+        enforce_reference_mode(dry_codex_no_probe_args, repo)
         dry_claude_args = argparse.Namespace(
             engine="claude",
             review_references=dry_refs,

--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -569,15 +569,18 @@ class ReviewReference:
     access: str = "read-only"
     mode: str = "prompt_manifest"
 
-    def metadata(self) -> dict[str, Any]:
+    def metadata(self, *, redact_hidden: bool = False) -> dict[str, Any]:
         data: dict[str, Any] = {
             "alias": self.alias,
             "kind": self.kind,
-            "description": self.description,
             "hidden": self.hidden,
             "access": self.access,
             "mode": self.mode,
         }
+        if self.hidden and redact_hidden:
+            data["redacted"] = True
+            return data
+        data["description"] = self.description
         if self.path is not None:
             data["path"] = str(self.path)
         if self.repository is not None:
@@ -738,11 +741,44 @@ def risky_reference_path(path: Path, home: Path | None) -> str | None:
     name = path.name
     if name == ".env" or name.startswith(".env."):
         return "environment files are not allowed as references"
+    broad_roots: list[tuple[Path, str]] = []
+    if path.anchor:
+        broad_roots.append((Path(path.anchor), "filesystem root"))
+    for raw in (
+        "/Users",
+        "/home",
+        "/etc",
+        "/tmp",
+        "/private",
+        "/private/tmp",
+        "/var",
+        "/usr",
+        "/opt",
+        "/System",
+        "/Library",
+        "/Applications",
+    ):
+        broad_roots.append((Path(raw), f"{raw}"))
     if home is None:
-        return None
-    try:
-        resolved_home = home.resolve()
-    except OSError:
+        resolved_home = None
+    else:
+        try:
+            resolved_home = home.resolve()
+            broad_roots.append((resolved_home.parent, "home parent directory"))
+        except OSError:
+            resolved_home = None
+    seen_broad_roots: set[Path] = set()
+    for broad_root, label in broad_roots:
+        try:
+            resolved_broad_root = broad_root.resolve()
+        except OSError:
+            continue
+        if resolved_broad_root in seen_broad_roots:
+            continue
+        seen_broad_roots.add(resolved_broad_root)
+        if path == resolved_broad_root:
+            return f"{label} is too broad to use as a reference"
+    if resolved_home is None:
         return None
     if path == resolved_home:
         return "home directory is too broad to use as a reference"
@@ -910,11 +946,16 @@ def materialize_git_references(references: list[ReviewReference], repo: Path, st
     return workspace
 
 
-def references_metadata(references: list[ReviewReference], strict: bool) -> dict[str, Any]:
+def references_metadata(
+    references: list[ReviewReference],
+    strict: bool,
+    *,
+    redact_hidden: bool = False,
+) -> dict[str, Any]:
     return {
         "strict": strict,
         "count": len(references),
-        "items": [reference.metadata() for reference in references],
+        "items": [reference.metadata(redact_hidden=redact_hidden) for reference in references],
     }
 
 
@@ -2365,6 +2406,15 @@ def self_test_references() -> None:
             metadata = references_metadata(refs, strict)
             if metadata["count"] != 4 or metadata["items"][0]["access"] != "read-only":
                 raise SystemExit("reference self-test failed: metadata shape invalid")
+            redacted_metadata = references_metadata(refs, strict, redact_hidden=True)
+            redacted_gitdocs = next(
+                item for item in redacted_metadata["items"] if item["alias"] == "gitdocs"
+            )
+            if not redacted_gitdocs.get("redacted"):
+                raise SystemExit("reference self-test failed: hidden metadata not marked redacted")
+            for sensitive_key in ("description", "path", "repository", "ref", "runtime_path"):
+                if sensitive_key in redacted_gitdocs:
+                    raise SystemExit(f"reference self-test failed: hidden metadata leaked {sensitive_key}")
             opencode_args = argparse.Namespace(
                 engine="opencode",
                 review_references=refs,
@@ -2441,6 +2491,21 @@ def self_test_references() -> None:
             raise SystemExit("reference self-test failed: reviewed-repo reference accepted")
         except SystemExit as exc:
             if "outside the reviewed repository" not in str(exc):
+                raise
+
+        try:
+            build_references(reference_test_args(reference=[f"root={Path('/')}"]), repo)
+            raise SystemExit("reference self-test failed: filesystem root reference accepted")
+        except SystemExit as exc:
+            if "too broad" not in str(exc):
+                raise
+
+        home_parent = Path.home().resolve().parent
+        try:
+            build_references(reference_test_args(reference=[f"homeparent={home_parent}"]), repo)
+            raise SystemExit("reference self-test failed: home parent reference accepted")
+        except SystemExit as exc:
+            if "too broad" not in str(exc):
                 raise
 
         try:
@@ -3106,7 +3171,13 @@ def main() -> int:
     print(f"web_search: {'on' if args.web_search else 'off'}")
     if references:
         print(f"references: {len(references)}")
-        print("references_metadata: " + json.dumps(references_metadata(references, strict_references), sort_keys=True))
+        print(
+            "references_metadata: "
+            + json.dumps(
+                references_metadata(references, strict_references, redact_hidden=not args.dry_run),
+                sort_keys=True,
+            )
+        )
         print("reference_modes_by_engine: " + json.dumps(references_metadata_by_engine(references, strict_references, reviewers, repo), sort_keys=True))
     display_ref = args.commit if target == "commit" else target_ref
     if display_ref:

--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -919,6 +919,8 @@ def build_references(args: argparse.Namespace, repo: Path) -> tuple[list[ReviewR
         if match is None:
             raise SystemExit(f"--reference-description specified unknown alias: {alias}")
         apply_reference_description(match, raw)
+    if getattr(args, "dry_run", False):
+        return references, strict, None
     workspace = materialize_git_references(references, repo, strict)
     return references, strict, workspace
 
@@ -2363,6 +2365,14 @@ def self_test_references() -> None:
         finally:
             if relative_workspace:
                 shutil.rmtree(relative_workspace, ignore_errors=True)
+        dry_refs, _dry_strict, dry_workspace = build_references(
+            reference_test_args(reference_repo=[f"drygit={git_ref}"], dry_run=True),
+            repo,
+        )
+        if dry_workspace is not None:
+            raise SystemExit("reference self-test failed: dry-run materialized git workspace")
+        if len(dry_refs) != 1 or dry_refs[0].kind != "git" or dry_refs[0].runtime_path is not None:
+            raise SystemExit("reference self-test failed: dry-run git reference should remain unmaterialized")
 
         cli_args = reference_test_args(
             reference=[f"clidocs={local_ref}"],

--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -650,6 +650,9 @@ def split_git_spec(spec: str) -> tuple[str, str | None]:
 def looks_like_git_reference(value: str) -> bool:
     if value.startswith(("git@", "ssh://", "https://", "http://", "file://")):
         return True
+    repo_part = value.split("#", 1)[0]
+    if "/" in repo_part and any(part in {".", ".."} for part in repo_part.split("/")):
+        return False
     if re.match(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+(?:#.+)?$", value):
         return True
     return False
@@ -813,7 +816,7 @@ def collect_reference_specs(args: argparse.Namespace) -> tuple[list[str], list[s
         args.references_file = parse_reference_env_list(os.environ.get("AUTOREVIEW_REFERENCES_FILE"))
     if not has_cli_reference_source and not reference_descriptions and os.environ.get("AUTOREVIEW_REFERENCE_DESCRIPTION"):
         reference_descriptions = parse_reference_env_list(os.environ.get("AUTOREVIEW_REFERENCE_DESCRIPTION"))
-    if not strict:
+    if not strict and not has_cli_reference_source:
         strict = parse_bool_env(os.environ.get("AUTOREVIEW_STRICT_REFERENCES"), "AUTOREVIEW_STRICT_REFERENCES")
     return references, reference_paths, reference_repos, reference_descriptions, hidden, strict
 
@@ -823,7 +826,16 @@ def build_references(args: argparse.Namespace, repo: Path) -> tuple[list[ReviewR
     references: list[ReviewReference] = []
     for raw in raw_references:
         alias, value = parse_alias_value(raw, "--reference")
-        if looks_like_git_reference(value):
+        local_candidate = Path(value).expanduser()
+        if local_candidate.exists():
+            references.append(
+                ReviewReference(
+                    alias=alias,
+                    kind="local_path",
+                    path=validate_local_reference_path(Path(value), repo),
+                )
+            )
+        elif looks_like_git_reference(value):
             repository, ref = split_git_spec(value)
             references.append(ReviewReference(alias=alias, kind="git", repository=repository, ref=ref))
         else:
@@ -2282,9 +2294,31 @@ def self_test_references() -> None:
         try:
             if [reference.alias for reference in cli_only_refs] != ["onlycli"]:
                 raise SystemExit("reference self-test failed: CLI reference source should suppress env reference sources")
+            if _cli_only_strict is not False:
+                raise SystemExit("reference self-test failed: CLI reference source should suppress env strict default")
         finally:
             if cli_only_workspace:
                 shutil.rmtree(cli_only_workspace, ignore_errors=True)
+        relative_parent = root / "relative-parent"
+        relative_parent.mkdir()
+        (relative_parent / "guide.md").write_text("relative parent reference\n")
+        original_cwd = Path.cwd()
+        os.chdir(repo)
+        try:
+            relative_refs, _relative_strict, relative_workspace = build_references(
+                reference_test_args(reference=["reldocs=../relative-parent"]),
+                repo,
+            )
+        finally:
+            os.chdir(original_cwd)
+        try:
+            if len(relative_refs) != 1 or relative_refs[0].kind != "local_path":
+                raise SystemExit("reference self-test failed: relative parent path should be local")
+            if relative_refs[0].path != relative_parent.resolve():
+                raise SystemExit("reference self-test failed: relative parent path not canonical")
+        finally:
+            if relative_workspace:
+                shutil.rmtree(relative_workspace, ignore_errors=True)
 
         cli_args = reference_test_args(
             reference=[f"clidocs={local_ref}"],

--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -941,6 +941,30 @@ def build_references(args: argparse.Namespace, repo: Path) -> tuple[list[ReviewR
     return references, strict, workspace
 
 
+def clone_git_reference(source: str, dest: Path, ref: str | None, repo: Path) -> subprocess.CompletedProcess[str]:
+    git = resolve_command("git", repo)
+    cmd = [git, "clone", "--quiet", "--depth", "1"]
+    if ref:
+        cmd.extend(["--branch", ref])
+    cmd.extend([source, str(dest)])
+    result = run(cmd, repo, check=False)
+    if result.returncode == 0 or not ref:
+        return result
+
+    shutil.rmtree(dest, ignore_errors=True)
+    clone_result = run([git, "clone", "--quiet", "--filter=blob:none", "--no-checkout", source, str(dest)], repo, check=False)
+    if clone_result.returncode != 0:
+        return clone_result
+    fetch_result = run([git, "-C", str(dest), "fetch", "--quiet", "--depth", "1", "origin", ref], repo, check=False)
+    if fetch_result.returncode != 0:
+        shutil.rmtree(dest, ignore_errors=True)
+        return fetch_result
+    checkout_result = run([git, "-C", str(dest), "checkout", "--quiet", "FETCH_HEAD"], repo, check=False)
+    if checkout_result.returncode != 0:
+        shutil.rmtree(dest, ignore_errors=True)
+    return checkout_result
+
+
 def materialize_git_references(references: list[ReviewReference], repo: Path, strict: bool) -> Path | None:
     git_refs = [reference for reference in references if reference.kind == "git"]
     if not git_refs:
@@ -950,11 +974,7 @@ def materialize_git_references(references: list[ReviewReference], repo: Path, st
         assert reference.repository
         dest = workspace / reference.alias
         source = github_repo_to_url(reference.repository)
-        cmd = [resolve_command("git", repo), "clone", "--quiet", "--depth", "1"]
-        if reference.ref:
-            cmd.extend(["--branch", reference.ref])
-        cmd.extend([source, str(dest)])
-        result = run(cmd, repo, check=False)
+        result = clone_git_reference(source, dest, reference.ref, repo)
         if result.returncode != 0:
             if strict:
                 shutil.rmtree(workspace, ignore_errors=True)
@@ -2335,6 +2355,7 @@ def self_test_references() -> None:
         (local_ref / "guide.md").write_text("guide\n")
         git_ref = root / "reference-repo"
         create_reference_source_repo(git_ref)
+        git_ref_sha = run([resolve_command("git", git_ref), "rev-parse", "HEAD"], git_ref).stdout.strip()
         file_ref = root / "file-reference.md"
         file_ref.write_text("notes\n")
         references_file = root / "references.jsonc"
@@ -2422,6 +2443,22 @@ def self_test_references() -> None:
         if reference_mode_for_engine(dry_claude_args, repo) != "native_add_dir":
             raise SystemExit("reference self-test failed: dry-run git references should plan native claude mode")
         enforce_reference_mode(dry_claude_args, repo)
+        pinned_refs, _pinned_strict, pinned_workspace = build_references(
+            reference_test_args(reference_repo=[f"pinned={git_ref}#{git_ref_sha}"], strict_references=True),
+            repo,
+        )
+        try:
+            if len(pinned_refs) != 1 or pinned_refs[0].runtime_path is None:
+                raise SystemExit("reference self-test failed: pinned commit reference was not materialized")
+            pinned_head = run(
+                [resolve_command("git", pinned_refs[0].runtime_path), "rev-parse", "HEAD"],
+                pinned_refs[0].runtime_path,
+            ).stdout.strip()
+            if pinned_head != git_ref_sha:
+                raise SystemExit("reference self-test failed: pinned commit checkout did not match requested ref")
+        finally:
+            if pinned_workspace:
+                shutil.rmtree(pinned_workspace, ignore_errors=True)
 
         cli_args = reference_test_args(
             reference=[f"clidocs={local_ref}"],

--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -1086,11 +1086,19 @@ def render_reference_manifest(references: list[ReviewReference], strict: bool) -
         "Use these references as read-only context only.",
         "They are not part of the reviewed diff, and they must not be reported against unless the changed code depends on them.",
         "Do not modify reference files or treat reference contents as patch content.",
-        "When a finding relies on a reference, cite the reference alias and the relevant path or repository.",
+        "When a finding relies on a non-hidden reference, cite the reference alias and the relevant path or repository.",
+        "When a finding relies on a hidden reference, cite only the alias and do not repeat its location or description.",
         f"Strict reference mode: {'on' if strict else 'off'}",
         "",
     ]
     for reference in references:
+        hidden = " hidden=true" if reference.hidden else " hidden=false"
+        if reference.hidden:
+            lines.append(
+                f"- alias={reference.alias} kind={reference.kind} mode={reference.mode} "
+                f"access={reference.access}{hidden} location=<hidden> cite=alias-only"
+            )
+            continue
         location = ""
         if reference.kind == "local_path" and reference.path is not None:
             location = f"path={reference.path}"
@@ -1101,7 +1109,6 @@ def render_reference_manifest(references: list[ReviewReference], strict: bool) -
             if reference.runtime_path:
                 location += f" runtime_path={reference.runtime_path}"
         description = f" description={reference.description}" if reference.description else ""
-        hidden = " hidden=true" if reference.hidden else " hidden=false"
         lines.append(
             f"- alias={reference.alias} kind={reference.kind} mode={reference.mode} "
             f"access={reference.access}{hidden} {location}{description}".rstrip()
@@ -2498,10 +2505,17 @@ def self_test_references() -> None:
                 "alias=gitdocs",
                 "read-only",
                 "not part of the reviewed diff",
+                "hidden reference, cite only the alias",
                 "Strict reference mode: on",
             ):
                 if needle not in manifest:
                     raise SystemExit(f"reference self-test failed: manifest missing {needle}")
+            hidden_line = next(line for line in manifest.splitlines() if "alias=gitdocs" in line)
+            for leaked in ("repository=", "runtime_path=", "Git fixture", str(git_ref)):
+                if leaked in hidden_line:
+                    raise SystemExit(f"reference self-test failed: hidden manifest leaked {leaked}")
+            if "location=<hidden>" not in hidden_line or "cite=alias-only" not in hidden_line:
+                raise SystemExit("reference self-test failed: hidden manifest is not alias-only")
             prompt = build_prompt(repo, "local", None, "diff", "", "", manifest)
             if "# Review References" not in prompt or "# Change Bundle" not in prompt:
                 raise SystemExit("reference self-test failed: prompt manifest not included")

--- a/skills/autoreview/scripts/test-review-harness.ps1
+++ b/skills/autoreview/scripts/test-review-harness.ps1
@@ -6,6 +6,8 @@ param(
     [ValidateSet('codex', 'claude', 'droid', 'copilot', 'pi', 'opencode')]
     [string[]] $Engine,
 
+    [switch] $ReferenceFixtures,
+
     [Alias('h')]
     [switch] $Help
 )
@@ -27,6 +29,10 @@ if ($PSBoundParameters.ContainsKey('Engine')) {
     foreach ($SelectedEngine in $Engine) {
         $ForwardedArgs += @('--engine', $SelectedEngine)
     }
+}
+
+if ($ReferenceFixtures) {
+    $ForwardedArgs += '--reference-fixtures'
 }
 
 $PyLauncher = Get-Command py -ErrorAction SilentlyContinue

--- a/skills/autoreview/scripts/test-review-harness.py
+++ b/skills/autoreview/scripts/test-review-harness.py
@@ -2,14 +2,18 @@
 from __future__ import annotations
 
 import argparse
+import importlib.machinery
+import json
 import os
 import shutil
 import stat
 import subprocess
 import sys
 import tempfile
+import textwrap
 from collections.abc import Callable
 from pathlib import Path
+from types import ModuleType
 
 
 ENGINES = ("codex", "claude", "droid", "copilot", "pi", "opencode")
@@ -122,6 +126,11 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     )
     parser.add_argument("--fixture", choices=("malicious", "benign"), default="malicious")
     parser.add_argument("--engine", action="append", choices=ENGINES, dest="engines")
+    parser.add_argument(
+        "--reference-fixtures",
+        action="store_true",
+        help="Run deterministic reference parser and fake-engine fixture checks.",
+    )
     return parser.parse_args(argv)
 
 
@@ -180,9 +189,259 @@ def cleanup_repo(repo: Path) -> None:
         print(f"warning: unable to remove temp repo {repo}: {exc}", file=sys.stderr)
 
 
+def load_autoreview_module(script_dir: Path) -> ModuleType:
+    loader = importlib.machinery.SourceFileLoader("autoreview_helper_for_harness", str(script_dir / "autoreview"))
+    return loader.load_module()
+
+
+def write_executable(path: Path, text: str) -> None:
+    path.write_text(text, encoding="utf-8", newline="\n")
+    path.chmod(0o755)
+
+
+def fake_droid_script() -> str:
+    return r'''#!/usr/bin/env python3
+import json
+import os
+from pathlib import Path
+import sys
+
+args = sys.argv[1:]
+prompt = ""
+if "-f" in args:
+    prompt = Path(args[args.index("-f") + 1]).read_text()
+record = os.environ["AUTOREVIEW_FAKE_RECORD"]
+Path(record).write_text(json.dumps({"argv": args, "cwd": os.getcwd(), "prompt": prompt}))
+report = {
+    "findings": [],
+    "overall_correctness": "patch is correct",
+    "overall_explanation": "fake droid clean",
+    "overall_confidence": 0.99,
+}
+print(json.dumps(report))
+'''
+
+
+def harness_args(**overrides: object) -> argparse.Namespace:
+    defaults: dict[str, object] = {
+        "codex_bin": "codex",
+        "claude_bin": "claude",
+        "droid_bin": "droid",
+        "opencode_bin": "opencode",
+        "pi_bin": "pi",
+        "tools": True,
+        "web_search": False,
+        "model": None,
+        "thinking": None,
+        "stream_engine_output": False,
+        "claude_allowed_tools": "Read,Grep,Glob,WebSearch,WebFetch",
+        "review_references": [],
+        "effective_strict_references": False,
+    }
+    defaults.update(overrides)
+    return argparse.Namespace(**defaults)
+
+
+def read_record(path: Path) -> dict[str, object]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def assert_contains(items: list[object], required: object, label: str) -> None:
+    if required not in items:
+        raise SystemExit(f"reference fixture failed: {label} missing {required!r}")
+
+
+def run_reference_fixtures(script_dir: Path) -> None:
+    autoreview = load_autoreview_module(script_dir)
+    keys = [
+        "AUTOREVIEW_FAKE_RECORD",
+        "AUTOREVIEW_FAKE_CODEX_ADD_DIR",
+        "AUTOREVIEW_FAKE_CLAUDE_VERSION",
+        "AUTOREVIEW_FAKE_PI_VERSION",
+        "AUTOREVIEW_FAKE_PI_HELP",
+        "AUTOREVIEW_REFERENCE",
+        "AUTOREVIEW_REFERENCES_FILE",
+        "AUTOREVIEW_REFERENCE_DESCRIPTION",
+        "AUTOREVIEW_STRICT_REFERENCES",
+    ]
+    with autoreview.preserve_env(keys), tempfile.TemporaryDirectory(prefix="autoreview-reference-harness.") as tempdir:
+        root = Path(tempdir)
+        repo = root / "reviewed"
+        repo.mkdir()
+        run(["git", "init", "--quiet"], repo)
+        run(["git", "config", "user.name", "Reference Harness"], repo)
+        run(["git", "config", "user.email", "reference-harness@example.com"], repo)
+        (repo / "app.js").write_text("export const value = 1;\n", encoding="utf-8")
+        run(["git", "add", "app.js"], repo)
+        run(["git", "commit", "--quiet", "-m", "initial"], repo)
+        (repo / "app.js").write_text("export const value = 2;\n", encoding="utf-8")
+
+        local_ref = root / "reference-docs"
+        local_ref.mkdir()
+        (local_ref / "guide.md").write_text("reference guide\n", encoding="utf-8")
+        hidden_ref = root / "hidden-reference"
+        hidden_ref.mkdir()
+        (hidden_ref / "private-notes.md").write_text("hidden reference\n", encoding="utf-8")
+        refs_file = root / "references.jsonc"
+        refs_file.write_text(
+            textwrap.dedent(
+                f"""
+                {{
+                  "references": [
+                    {{
+                      "alias": "hidden",
+                      "path": {json.dumps(str(hidden_ref))},
+                      "description": "Hidden internal notes",
+                      "hidden": true,
+                    }},
+                  ],
+                }}
+                """
+            ),
+            encoding="utf-8",
+        )
+
+        reference_args = autoreview.reference_test_args(
+            reference=[f"docs={local_ref}"],
+            reference_description=["docs=Public reference docs"],
+            references_file=[str(refs_file)],
+        )
+        refs, strict, workspace = autoreview.build_references(reference_args, repo)
+        try:
+            if strict:
+                raise SystemExit("reference fixture failed: strict unexpectedly enabled")
+            aliases = {reference.alias for reference in refs}
+            if aliases != {"docs", "hidden"}:
+                raise SystemExit(f"reference fixture failed: aliases={sorted(aliases)}")
+            manifest = autoreview.render_reference_manifest(refs, strict)
+            for needle in ("# Review References", "alias=docs", "alias=hidden", "hidden=true", "not part of the reviewed diff"):
+                if needle not in manifest:
+                    raise SystemExit(f"reference fixture failed: manifest missing {needle!r}")
+            prompt = autoreview.build_prompt(repo, "local", None, "diff --git a/app.js b/app.js", "", "", manifest)
+            if "Public reference docs" not in prompt or "# Change Bundle" not in prompt:
+                raise SystemExit("reference fixture failed: prompt manifest not included")
+
+            record = root / "record.json"
+            codex_bin = root / "codex"
+            claude_bin = root / "claude"
+            pi_bin = root / "pi"
+            droid_bin = root / "droid"
+            opencode_bin = root / "opencode"
+            write_executable(codex_bin, autoreview.fake_codex_script())
+            write_executable(claude_bin, autoreview.fake_claude_script())
+            write_executable(pi_bin, autoreview.fake_pi_script())
+            write_executable(droid_bin, fake_droid_script())
+            write_executable(opencode_bin, autoreview.fake_opencode_script())
+            os.environ["AUTOREVIEW_FAKE_RECORD"] = str(record)
+
+            codex_args = harness_args(
+                engine="codex",
+                codex_bin=str(codex_bin),
+                review_references=refs,
+                codex_add_dir_supported=True,
+            )
+            autoreview.run_codex(codex_args, repo, prompt)
+            codex_record = read_record(record)
+            codex_argv = codex_record["argv"]
+            assert isinstance(codex_argv, list)
+            assert_contains(codex_argv, "--add-dir", "codex native reference flag")
+            assert_contains(codex_argv, str(local_ref.resolve()), "codex local reference path")
+            assert_contains(codex_argv, str(hidden_ref.resolve()), "codex hidden reference path")
+            if "alias=docs" not in str(codex_record["stdin"]):
+                raise SystemExit("reference fixture failed: codex prompt omitted reference manifest")
+
+            codex_degraded = harness_args(
+                engine="codex",
+                codex_bin=str(codex_bin),
+                review_references=refs,
+                codex_add_dir_supported=False,
+            )
+            if autoreview.reference_mode_for_engine(codex_degraded, repo) != "prompt_manifest":
+                raise SystemExit("reference fixture failed: codex without add-dir should degrade to prompt_manifest")
+            codex_degraded.effective_strict_references = True
+            try:
+                autoreview.enforce_reference_mode(codex_degraded, repo)
+                raise SystemExit("reference fixture failed: strict codex degradation accepted")
+            except SystemExit as exc:
+                if "strict mode" not in str(exc):
+                    raise
+
+            claude_args = harness_args(engine="claude", claude_bin=str(claude_bin), review_references=refs)
+            autoreview.run_claude(claude_args, repo, prompt)
+            claude_record = read_record(record)
+            claude_argv = claude_record["argv"]
+            assert isinstance(claude_argv, list)
+            assert_contains(claude_argv, "--add-dir", "claude native reference flag")
+            assert_contains(claude_argv, str(local_ref.resolve()), "claude local reference path")
+
+            opencode_args = harness_args(engine="opencode", opencode_bin=str(opencode_bin), review_references=refs)
+            autoreview.run_opencode(opencode_args, repo, prompt)
+            opencode_record = read_record(record)
+            opencode_env = opencode_record["env"]
+            assert isinstance(opencode_env, dict)
+            config = json.loads(str(opencode_env["OPENCODE_CONFIG_CONTENT"]))
+            if config.get("references", {}).get("docs", {}).get("path") != str(local_ref.resolve()):
+                raise SystemExit("reference fixture failed: OpenCode reference config missing docs path")
+            if config.get("references", {}).get("hidden", {}).get("hidden") is not True:
+                raise SystemExit("reference fixture failed: OpenCode hidden flag missing")
+            for generated in (".opencode", ".claude", ".factory", ".pi"):
+                if (repo / generated).exists():
+                    raise SystemExit(f"reference fixture failed: generated config wrote into reviewed repo: {generated}")
+
+            pi_args = harness_args(engine="pi", pi_bin=str(pi_bin), review_references=refs)
+            if autoreview.enforce_reference_mode(pi_args, repo) != "prompt_manifest":
+                raise SystemExit("reference fixture failed: Pi should use prompt_manifest")
+            autoreview.run_pi(pi_args, repo, prompt)
+            pi_record = read_record(record)
+            if "alias=docs" not in str(pi_record["stdin"]):
+                raise SystemExit("reference fixture failed: Pi prompt omitted reference manifest")
+            pi_args.effective_strict_references = True
+            try:
+                autoreview.enforce_reference_mode(pi_args, repo)
+                raise SystemExit("reference fixture failed: strict Pi prompt manifest accepted")
+            except SystemExit as exc:
+                if "strict mode" not in str(exc):
+                    raise
+
+            droid_args = harness_args(engine="droid", droid_bin=str(droid_bin), review_references=refs)
+            if autoreview.enforce_reference_mode(droid_args, repo) != "prompt_manifest":
+                raise SystemExit("reference fixture failed: Droid should use prompt_manifest")
+            autoreview.run_droid(droid_args, repo, prompt)
+            droid_record = read_record(record)
+            if "alias=docs" not in str(droid_record["prompt"]):
+                raise SystemExit("reference fixture failed: Droid prompt file omitted reference manifest")
+            droid_args.effective_strict_references = True
+            try:
+                autoreview.enforce_reference_mode(droid_args, repo)
+                raise SystemExit("reference fixture failed: strict Droid prompt manifest accepted")
+            except SystemExit as exc:
+                if "strict mode" not in str(exc):
+                    raise
+
+            metadata_modes = autoreview.references_metadata_by_engine(refs, False, [codex_args, claude_args, opencode_args, pi_args, droid_args], repo)
+            expected_modes = {
+                "codex": "native_add_dir",
+                "claude": "native_add_dir",
+                "opencode": "native_config",
+                "pi": "prompt_manifest",
+                "droid": "prompt_manifest",
+            }
+            for engine, mode in expected_modes.items():
+                if metadata_modes[engine]["mode"] != mode:
+                    raise SystemExit(f"reference fixture failed: {engine} mode={metadata_modes[engine]['mode']!r}")
+        finally:
+            if workspace:
+                shutil.rmtree(workspace, ignore_errors=True)
+
+    print("reference fixtures: ok")
+
+
 def main(argv: list[str]) -> int:
     args = parse_args(argv)
     script_dir = Path(__file__).resolve().parent
+    if args.reference_fixtures:
+        run_reference_fixtures(script_dir)
+        return 0
     engines = args.engines or list(DEFAULT_ENGINES)
     repo = Path(tempfile.mkdtemp(prefix="autoreview-fixture."))
     try:

--- a/skills/autoreview/scripts/test-review-harness.py
+++ b/skills/autoreview/scripts/test-review-harness.py
@@ -195,7 +195,8 @@ def load_autoreview_module(script_dir: Path) -> ModuleType:
 
 
 def write_executable(path: Path, text: str) -> None:
-    path.write_text(text, encoding="utf-8", newline="\n")
+    with path.open("w", encoding="utf-8", newline="\n") as handle:
+        handle.write(text)
     path.chmod(0o755)
 
 


### PR DESCRIPTION
Closes #24

## Summary
- add autoreview reference inputs for local paths, Git repositories, references files, hidden references, and strict reference mode
- wire reference access through Codex, Claude, OpenCode, and prompt-manifest fallback modes
- add reference fixture coverage to the review harness and document the workflow in the autoreview skill
- harden reference handling for local-path safety, hidden metadata redaction, dry-run behavior, pinned Git refs, file reference materialization, and alias validation

## Verification
- `python3 skills/autoreview/scripts/autoreview --help`
- `python3 skills/autoreview/scripts/autoreview --self-test-config-defaults`
- `python3 skills/autoreview/scripts/autoreview --self-test-engine-isolation`
- `python3 skills/autoreview/scripts/autoreview --self-test-opencode-isolation`
- `python3 skills/autoreview/scripts/autoreview --self-test-json-array-parser`
- `python3 skills/autoreview/scripts/autoreview --self-test-references`
- `skills/autoreview/scripts/test-review-harness --reference-fixtures`
- `python3 -m compileall -q skills/autoreview/scripts`
- `scripts/validate-skills`
- `git diff --check -- skills/autoreview/SKILL.md skills/autoreview/scripts/autoreview skills/autoreview/scripts/test-review-harness.py skills/autoreview/scripts/test-review-harness skills/autoreview/scripts/test-review-harness.ps1`
- `python3 skills/autoreview/scripts/autoreview --mode branch --base origin/main --engine codex --model gpt-5.5 --thinking high` reported clean with no accepted/actionable findings

## Notes
- Optional `ruby scripts/install-skills.test.rb` still fails on the pre-existing Ruby 2.6 `assert_path_exists` incompatibility in `scripts/install-skills.test.rb`.

