### PR TITLE
feat: add repository-gardener skill (report-first entropy reduction, ClawHub publishable)

### DIFF
--- a/.github/workflows/clawhub-skill-publish.yml
+++ b/.github/workflows/clawhub-skill-publish.yml
@@ -1,0 +1,40 @@
+name: clawhub-skill-publish
+
+on:
+  pull_request:
+    paths:
+      - "skills/**"
+      - "skills.sh.json"
+      - "README.md"
+      - ".github/workflows/clawhub-skill-publish.yml"
+  workflow_dispatch:
+    inputs:
+      skill_path:
+        description: Optional single skill folder to publish, for example skills/repository-gardener.
+        required: false
+        type: string
+        default: ""
+
+jobs:
+  dry-run:
+    if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
+      id-token: write
+    uses: openclaw/clawhub/.github/workflows/skill-publish.yml@v0.21.0
+    with:
+      owner: openclaw
+      dry_run: true
+
+  publish:
+    if: github.event_name == 'workflow_dispatch'
+    permissions:
+      contents: read
+      id-token: write
+    uses: openclaw/clawhub/.github/workflows/skill-publish.yml@v0.21.0
+    with:
+      owner: openclaw
+      dry_run: false
+      skill_path: ${{ inputs.skill_path }}
+    secrets:
+      clawhub_token: ${{ secrets.CLAWHUB_TOKEN }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,5 +15,9 @@ Public shared skills for agent workflows.
 
 ## Layout
 
+- `skills/agent-transcript`: local-only redacted transcript provenance helper.
 - `skills/autoreview`: shared closeout/code-review helper.
 - `skills/crabbox`: shared Crabbox/Testbox remote validation workflow.
+- `skills/handoff`: path-free prompt handoff for delegating tasks across agents.
+- `skills/repository-gardener`: report-first entropy reduction with guarded fixes (ClawHub publishable).
+- `skills/session-viewer`: local JSONL session to searchable HTML renderer.

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ repo.
   proof.
 - `handoff`: path-free prompt handoff workflow for delegating a task to another
   agent.
+- `repository-gardener`: report-first repository entropy reduction workflow
+  with guarded fix rules.
 - `session-viewer`: local searchable HTML viewer for agent session JSONL.
 
 Repo-specific product skills should stay in the repo they describe. For example,
@@ -138,6 +140,8 @@ skills/
   crabbox/
     SKILL.md
   handoff/
+    SKILL.md
+  repository-gardener/
     SKILL.md
   session-viewer/
     SKILL.md

--- a/README.md
+++ b/README.md
@@ -167,6 +167,25 @@ node --check skills/agent-transcript/scripts/agent-transcript
 node --test skills/agent-transcript/scripts/agent-transcript.test.mjs skills/session-viewer/scripts/session-viewer.test.ts
 ```
 
+## Publishing to ClawHub
+
+This repo is the *source of truth* for shared agent skills. ClawHub (clawhub.ai + the `clawhub` CLI) is the *registry and distribution surface*.
+
+To make a skill (including `repository-gardener`) appear in `clawhub search`, `clawhub install openclaw/<slug>`, and the ClawHub site:
+
+1. Add or update the skill under `skills/<name>/SKILL.md` (plus any `scripts/`).
+2. Update `README.md`, `skills.sh.json` (grouping), and this repo's `AGENTS.md` Layout if needed.
+3. Open a PR. The `clawhub-skill-publish.yml` workflow automatically runs a dry-run publish (via the reusable ClawHub action) for changes under `skills/**`, the manifest, README, or the workflow itself. This validates packaging without mutating the registry.
+4. After merge to `main`, a maintainer (or authorized user with the `CLAWHUB_TOKEN` secret) triggers publication:
+   - GitHub UI: Actions → "clawhub-skill-publish" → "Run workflow" (optionally pass `skill_path: skills/repository-gardener` for a single skill).
+   - Or locally: `clawhub login`, then `clawhub skill publish skills/<name>` (or `clawhub sync` for the catalog).
+
+The workflow lives at `.github/workflows/clawhub-skill-publish.yml` and calls `openclaw/clawhub/.github/workflows/skill-publish.yml@v0.21.0`.
+
+Never commit raw `SKILL.md` sources directly into the `openclaw/clawhub` repo — it deliberately ignores skill folders. Publish through the supported path instead.
+
+See also the `publish` mode in individual skills (e.g. `skills/repository-gardener/SKILL.md`).
+
 The validator checks every `skills/*/SKILL.md` for YAML frontmatter plus required
 `name` and `description`.
 

--- a/skills.sh.json
+++ b/skills.sh.json
@@ -3,6 +3,11 @@
   "notGrouped": "bottom",
   "groupings": [
     {
+      "title": "Maintenance",
+      "description": "Skills for bounded repository health reports and entropy reduction.",
+      "skills": ["repository-gardener"]
+    },
+    {
       "title": "Review",
       "description": "Skills for code review closeout and remote validation.",
       "skills": ["autoreview", "crabbox"]

--- a/skills/repository-gardener/SKILL.md
+++ b/skills/repository-gardener/SKILL.md
@@ -1,0 +1,175 @@
+---
+name: repository-gardener
+description: "Run a conservative report-first repository garden: inspect code, docs, tests, and proof drift, then propose or apply only narrow guarded fixes."
+metadata:
+  version: "2026-06-13"
+---
+
+# Repository Gardener
+
+Run a bounded repository health pass that reduces entropy instead of creating
+drive-by cleanup noise.
+
+Use when the user asks for repository gardener, repo garden, weekly repo health,
+entropy reduction, code health maintenance, stale docs/tests/examples review, or
+a guarded cleanup PR.
+
+## Contract
+
+- Default to report-only mode.
+- Enter fix mode only when the user explicitly asks for guarded fixes.
+- Follow the local repo instructions before inspecting or editing files.
+- Keep every conclusion tied to source, commands, tests, logs, CI, docs, issues,
+  or PR evidence.
+- Do not invent repository policy, artifact paths, schedules, or ownership.
+- Do not create hidden memory, ambient state, broad refactors, mass formatting,
+  or speculative rewrites.
+- Do not post GitHub comments, open issues, open PRs, schedule jobs, or publish
+  artifacts unless the user explicitly asks.
+- Redact secrets, private URLs, private account data, raw logs, and large copied
+  source blobs from reports.
+- Keep output bounded enough for a maintainer to review in one pass.
+
+## Modes
+
+Use these names in your own plan and report:
+
+- `report`: inspect, run proof, and produce findings/actions only.
+- `guarded-fix`: make narrow edits only after report evidence shows a safe,
+  local fix class.
+- `schedule`: prepare an explicit OpenClaw cron or repository automation prompt
+  that runs this skill later; do not install it silently.
+- `publish`: prepare ClawHub publishing steps for this skill or repo-owned
+  gardening policy; do not publish silently.
+
+If the user does not specify a mode, use `report`.
+
+## Workflow
+
+1. Resolve the repository and scope.
+   - Run `git status -sb`.
+   - Confirm the current repo, branch, dirty files, issue/PR links, and target
+     branch.
+   - Read root and scoped agent instructions before touching files.
+   - If the request came from GitHub, fetch the live issue/PR state with `gh`.
+2. Define the garden boundary.
+   - Name the repo areas in scope: code, docs, tests, examples, CI, packaging,
+     release readiness, or proof artifacts.
+   - Exclude generated, vendored, build, lockfile, migration, snapshot, and
+     ownership-sensitive paths unless the repo instructions say otherwise.
+   - Prefer repo-local policy. If none exists, use report-only and recommend a
+     policy follow-up instead of inventing one.
+3. Collect evidence.
+   - Inspect recent changes, failing or skipped checks, stale docs/examples,
+     TODO/FIXME clusters, repeated review findings, flaky or quarantined tests,
+     old CI failures, and proof gaps.
+   - Use structured tools (`rg`, package scripts, test runners, docs linters,
+     type checks, CI logs, `gh`) rather than ad hoc guesses.
+   - For dependency-backed behavior, read current upstream docs/source/types
+     before calling a finding confirmed.
+4. Run proof.
+   - Prefer the repo's targeted checks first.
+   - Use broad or remote proof only when the repo policy calls for it or the
+     risk justifies it.
+   - Record commands exactly, including skipped checks and why they were
+     skipped.
+5. Classify findings.
+   - `entropy`: duplicate docs, stale examples, dead paths, obsolete TODOs,
+     noisy generated output, brittle scripts.
+   - `readability`: confusing APIs, missing examples, comments contradicting
+     code, unclear invariants.
+   - `proof`: missing tests, stale E2E coverage, unproven provider paths,
+     missing artifacts.
+   - `correctness`: repeated review findings, weak invariants, unhandled edge
+     cases, regression or performance signals.
+   - `ownership`: work that belongs in another repo, plugin, skill, docs site,
+     or maintainer decision.
+6. Recommend actions.
+   - Choose one of: no-op, file follow-up, update docs, add small test, run a
+     targeted proof command, open a narrow PR, request maintainer decision.
+   - Prefer one or two high-signal actions over a long cleanup backlog.
+7. If in `guarded-fix` mode, edit only after the report justifies it.
+   - Keep changes narrow and reviewable.
+   - Fix one demonstrated bug class at the right ownership boundary.
+   - Update matching docs/tests only when the behavior or public workflow
+     changes.
+   - Rerun focused proof and summarize before/after evidence.
+
+## Report Shape
+
+Use this structure unless the repo provides its own artifact format:
+
+```markdown
+# Repository Garden Report
+
+Scope:
+- Repository:
+- Mode:
+- Target branch/commit:
+- Areas inspected:
+- Areas excluded:
+
+Evidence:
+- Commands/checks run:
+- Skipped checks:
+- Source/docs/issue/PR evidence:
+
+Findings:
+- Entropy:
+- Readability:
+- Proof:
+- Correctness:
+- Ownership:
+
+Proposed actions:
+- No-op:
+- Follow-up issue:
+- Docs/test/code fix:
+- Maintainer decision:
+
+Guardrails:
+- Secrets/raw private data omitted:
+- Broad refactors avoided:
+- GitHub/public mutations performed:
+```
+
+Keep empty sections as `None found` or omit them if the final report stays
+clearer.
+
+## Guarded Fix Rules
+
+Allowed fix classes:
+
+- Correct a stale doc/example that directly contradicts current behavior.
+- Add or repair a focused test for a demonstrated proof gap.
+- Remove an obsolete TODO only when current code and issue history prove it is
+  obsolete.
+- Tighten a small script/check when it has a failing or missing proof path.
+- Update repo-local gardening policy when maintainers already requested it.
+
+Disallowed fix classes:
+
+- broad cleanup, churn, mass formatting, or style-only rewrites
+- renaming public APIs or files without owner approval
+- changing release, security, auth, or migration behavior without maintainer
+  review
+- adding new global config, env vars, state stores, background jobs, or core
+  commands just to support gardening
+- opening multiple low-confidence issues or PRs
+
+## ClawHub And Scheduling
+
+For OpenClaw ecosystem work, prefer this route:
+
+1. Keep the reusable gardening workflow as an installable skill.
+2. Publish or sync the skill through ClawHub.
+3. Use OpenClaw cron to schedule a prompt that invokes the skill in `report`
+   mode.
+4. Use repo-local policy to decide checks, exclusions, thresholds, and allowed
+   fix classes.
+5. Open a core or product issue only after a real gardening run proves a
+   missing OpenClaw, ClawHub, Lobster, Crabbox, AutoReview, or ClawSweeper
+   extension primitive.
+
+Do not propose a bundled OpenClaw core command unless you can name the concrete
+missing extension primitive and show why a ClawHub skill cannot express it.

--- a/skills/repository-gardener/SKILL.md
+++ b/skills/repository-gardener/SKILL.md
@@ -161,10 +161,15 @@ Disallowed fix classes:
 
 For OpenClaw ecosystem work, prefer this route:
 
-1. Keep the reusable gardening workflow as an installable skill.
-2. Publish or sync the skill through ClawHub.
-3. Use OpenClaw cron to schedule a prompt that invokes the skill in `report`
-   mode.
+1. Keep the reusable gardening workflow as an installable skill (source lives in
+   `openclaw/agent-skills`).
+2. Publish the skill through ClawHub using this repo's
+   `.github/workflows/clawhub-skill-publish.yml` (PR dry-run + manual dispatch
+   with `CLAWHUB_TOKEN`) or `clawhub skill publish skills/repository-gardener`.
+   This makes it discoverable via `clawhub search` / `clawhub install` and the
+   ClawHub site without ever checking SKILL.md sources into the clawhub repo.
+3. Use OpenClaw cron / Lobster / repo automation to schedule a prompt that
+   invokes the skill in `report` mode.
 4. Use repo-local policy to decide checks, exclusions, thresholds, and allowed
    fix classes.
 5. Open a core or product issue only after a real gardening run proves a


### PR DESCRIPTION
## Summary

Adds `repository-gardener`: a conservative, **report-first** reusable skill for repository entropy reduction.

- Inspects code, docs, tests, examples, CI, and proof drift.
- Produces a bounded, evidence-backed garden report.
- Only enters guarded-fix mode when the user explicitly requests it.
- Follows local AGENTS.md / repo policy; never invents ownership or policy.
- Includes a ClawHub publish workflow (PR dry-run + manual dispatch) so this skill (and future shared ones) can be published to ClawHub without committing SKILL.md sources into the clawhub repo.

This directly implements the maintainer feedback on the original issue: route to ClawHub / community skill path instead of a new OpenClaw core command.

Closes https://github.com/openclaw/openclaw/issues/92472 (as the scoped implementation path requested in the closure comment).

## Changes

- `skills/repository-gardener/SKILL.md`: full contract, workflow, report shape, guarded-fix rules, ClawHub scheduling guidance.
- `.github/workflows/clawhub-skill-publish.yml`: re-usable publish bridge (dry-run on relevant PR paths using the official ClawHub reusable action @v0.21.0, real publish on `workflow_dispatch` with `CLAWHUB_TOKEN`).
- Updated `README.md` (listing + new "Publishing to ClawHub" section with exact steps), `skills.sh.json` (Maintenance grouping), and `AGENTS.md` (Layout section — was stale).

## Verification (local)

- `scripts/validate-skills` → validated 6 skills (clean)
- `scripts/install-skills --list` includes `repository-gardener`
- `scripts/install-skills --dry-run repository-gardener` → succeeds
- `git diff --check`
- Ruby + JSON syntax checks on scripts/manifest
- Two focused commits on the feature branch; all changes are inside the `agent-skills` tree (parent openclaw checkout left clean via local exclude only)

The PR itself will exercise the dry-run half of the new publish workflow.

## Next steps after merge (to actually appear on ClawHub)

1. Maintainer (or authorized) triggers the publish workflow on `main` (optionally with `skill_path: skills/repository-gardener`).
2. Or locally: `clawhub login && clawhub skill publish skills/repository-gardener`
3. Skill becomes installable/discoverable via ClawHub CLI and https://clawhub.ai/

All links and the publish automation are documented in the added README section and the skill itself.

