### PR TITLE
Add AutoReview fast review profile

### DIFF
--- a/scripts/validate-skills
+++ b/scripts/validate-skills
@@ -46,4 +46,25 @@ if errors.any?
   exit 1
 end
 
+def run_check(label, *command)
+  return if system(*command)
+
+  warn "#{label} failed"
+  exit 1
+end
+
+autoreview = File.join(root, "skills", "autoreview", "scripts", "autoreview")
+autoreview_harness = File.join(root, "skills", "autoreview", "scripts", "test-review-harness.py")
+autoreview_tests = File.join(root, "skills", "autoreview", "tests")
+
+if File.exist?(autoreview)
+  run_check("autoreview py_compile", "python3", "-m", "py_compile", autoreview, autoreview_harness)
+  run_check("autoreview config defaults self-test", autoreview, "--self-test-config-defaults")
+  run_check("autoreview fallback scope self-test", autoreview, "--self-test-fallback-scope")
+  run_check("autoreview fast profile self-test", autoreview, "--self-test-fast-profile")
+  if Dir.exist?(autoreview_tests)
+    run_check("autoreview unit tests", "python3", "-m", "unittest", "discover", "-s", autoreview_tests, "-p", "test_*.py")
+  end
+end
+
 puts "validated #{skill_files.length} skills"

--- a/scripts/validate-skills
+++ b/scripts/validate-skills
@@ -53,17 +53,21 @@ def run_check(label, *command)
   exit 1
 end
 
+def run_python_check(label, *args)
+  run_check(label, { "PYTHONDONTWRITEBYTECODE" => "1" }, "python3", *args)
+end
+
 autoreview = File.join(root, "skills", "autoreview", "scripts", "autoreview")
 autoreview_harness = File.join(root, "skills", "autoreview", "scripts", "test-review-harness.py")
 autoreview_tests = File.join(root, "skills", "autoreview", "tests")
 
 if File.exist?(autoreview)
-  run_check("autoreview py_compile", "python3", "-m", "py_compile", autoreview, autoreview_harness)
+  run_python_check("autoreview py_compile", "-m", "py_compile", autoreview, autoreview_harness)
   run_check("autoreview config defaults self-test", autoreview, "--self-test-config-defaults")
   run_check("autoreview fallback scope self-test", autoreview, "--self-test-fallback-scope")
   run_check("autoreview fast profile self-test", autoreview, "--self-test-fast-profile")
   if Dir.exist?(autoreview_tests)
-    run_check("autoreview unit tests", "python3", "-m", "unittest", "discover", "-s", autoreview_tests, "-p", "test_*.py")
+    run_python_check("autoreview unit tests", "-m", "unittest", "discover", "-s", autoreview_tests, "-p", "test_*.py")
   end
 end
 

--- a/skills/autoreview/SKILL.md
+++ b/skills/autoreview/SKILL.md
@@ -250,6 +250,55 @@ Examples matching current `main` behavior:
 "$AUTOREVIEW" --engine opencode --model opencode/north-mini-code-free --thinking high
 ```
 
+## Fast review profile
+
+Use `--fast` when a closeout review should prefer lower-latency provider behavior without changing the default review path. Fast mode is opt-in and never persists provider settings.
+
+```bash
+# Preview the default Codex fast profile without spending provider calls
+"$AUTOREVIEW" --engine codex --fast --dry-run
+
+# Preview a mixed panel; Copilot remains model-only and receives no thinking value
+"$AUTOREVIEW" --reviewers codex,claude,copilot --fast --dry-run
+
+# Use a lower effort than the default fast `low` where the engine supports it
+"$AUTOREVIEW" --engine codex --fast --fast-thinking minimal
+
+# Use provider/model aliases only when no explicit model is set
+"$AUTOREVIEW" --reviewers droid,opencode,copilot --fast \
+  --fast-model droid=claude-opus-4-8-fast \
+  --fast-model opencode=github-copilot/gpt-5.4 \
+  --fast-model copilot=gpt-5.2
+```
+
+Precedence is strict: inline reviewer spec > CLI `--model` / `--thinking` > environment model/thinking > fast defaults > built-ins. For example, `--reviewers codex:gpt-5.5:high --fast` keeps `gpt-5.5:high`.
+
+Fast strategy controls how much provider-native behavior is requested:
+
+| Strategy | Behavior |
+|----------|----------|
+| `auto` | Default. Uses proven provider-native fast for Codex and fast thinking/model aliases for other engines. |
+| `service-tier` | Requests provider-native fast where this helper has verified a non-persistent syntax. Currently this is Codex only. Other engines still use documented thinking/model alias behavior. |
+| `thinking-only` | Does not request provider-native fast tier/model behavior; only applies fast thinking/effort where supported and not explicitly set. |
+
+Provider limits:
+
+| Engine | Fast behavior |
+|--------|---------------|
+| **codex** | Adds the per-run config override `-c service_tier="fast"` before `exec` when strategy is `auto` or `service-tier`; never edits `config.toml` and does not force `features.fast_mode=true`, which can violate managed requirements when fast mode is pinned off. |
+| **claude** | Effort-only in headless print mode: `--effort low` when no explicit thinking is set. The installed help does not expose a non-persistent Claude Fast mode flag for `--print`. |
+| **droid** | Uses `-r, --reasoning-effort low` when no explicit thinking is set. Fast model IDs are opt-in aliases via `--fast-model droid=...` or env. |
+| **opencode** | Uses `--variant low` when no explicit thinking is set. Fast provider/model IDs are opt-in aliases via `--fast-model opencode=...` or env. |
+| **pi** | Uses `--thinking low` when no explicit thinking is set. Fast model IDs are opt-in aliases via `--fast-model pi=...` or env. |
+| **copilot** | Model-only. Fast model aliases may set `--model`, but the helper never passes thinking or effort flags to Copilot. |
+
+Use `--fast-strategy thinking-only` if a provider-native fast tier is unsupported, quota-gated, or not desired for the review. Use `--dry-run` to prove the resolved engine/model/thinking/fast metadata before live review:
+
+```bash
+"$AUTOREVIEW" --engine codex --fast --fast-strategy thinking-only --dry-run
+"$AUTOREVIEW" --reviewers codex,claude,copilot --fast --dry-run
+```
+
 ### Environment defaults
 
 CLI flags take precedence over environment variables.
@@ -262,6 +311,12 @@ CLI flags take precedence over environment variables.
 | `AUTOREVIEW_<ENGINE>_MODEL` | Per-engine model override, for example `AUTOREVIEW_CODEX_MODEL=gpt-5.5` |
 | `AUTOREVIEW_<ENGINE>_THINKING` | Per-engine thinking override |
 | `AUTOREVIEW_CLAUDE_FALLBACK_MODEL` | Claude-only fallback chain |
+| `AUTOREVIEW_FAST` | Enable fast mode when set to `1`, `true`, `yes`, or `on`; disable with `--no-fast` |
+| `AUTOREVIEW_FAST_STRATEGY` | Default fast strategy: `auto`, `service-tier`, or `thinking-only` |
+| `AUTOREVIEW_FAST_THINKING` | Default fast thinking/effort for all engines that support thinking |
+| `AUTOREVIEW_<ENGINE>_FAST_THINKING` | Per-engine fast thinking/effort |
+| `AUTOREVIEW_FAST_MODEL` | Default fast model alias for all engines when no explicit model is set |
+| `AUTOREVIEW_<ENGINE>_FAST_MODEL` | Per-engine fast model alias |
 
 Codex maps thinking to `model_reasoning_effort`. Claude maps thinking to `--effort`. Droid maps thinking to `-r, --reasoning-effort`. Pi maps thinking to `--thinking`. OpenCode maps thinking to `--variant`. Copilot rejects `--thinking`. Only Claude accepts `--fallback-model`; global CLI/env fallback requires at least one Claude reviewer, and engine-specific fallback overrides require that reviewer to be selected. Non-Claude fallback overrides, including `AUTOREVIEW_<NONCLAUDE>_FALLBACK_MODEL`, fail closed instead of being silently ignored.
 

--- a/skills/autoreview/SKILL.md
+++ b/skills/autoreview/SKILL.md
@@ -279,7 +279,7 @@ Fast strategy controls how much provider-native behavior is requested:
 |----------|----------|
 | `auto` | Default. Uses proven provider-native fast for Codex and fast thinking/model aliases for other engines. |
 | `service-tier` | Requests provider-native fast where this helper has verified a non-persistent syntax. Currently this is Codex only. Other engines still use documented thinking/model alias behavior. |
-| `thinking-only` | Does not request provider-native fast tier/model behavior; only applies fast thinking/effort where supported and not explicitly set. |
+| `thinking-only` | Does not request provider-native fast tier/model behavior and ignores fast model aliases; only applies fast thinking/effort where supported and not explicitly set. |
 
 Provider limits:
 

--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -2690,6 +2690,7 @@ def reviewer_args(args: argparse.Namespace) -> list[argparse.Namespace]:
     fast_strategy = args.fast_strategy or os.environ.get("AUTOREVIEW_FAST_STRATEGY", "auto").strip() or "auto"
     if fast_strategy not in FAST_STRATEGIES:
         raise SystemExit(f"invalid --fast-strategy/AUTOREVIEW_FAST_STRATEGY: {fast_strategy}")
+    fast_model_enabled = fast_enabled and fast_strategy != "thinking-only"
     reviewers: list[tuple[str, str | None, str | None]] = []
     if args.reviewers:
         tokens = [token.strip() for token in args.reviewers.split(",") if token.strip()]
@@ -2734,10 +2735,10 @@ def reviewer_args(args: argparse.Namespace) -> list[argparse.Namespace]:
             or global_model
             or env_model_by_engine.get(engine)
             or env_global_model
-            or (fast_enabled and fast_model_by_engine.get(engine))
-            or (fast_enabled and fast_model_global)
-            or (fast_enabled and env_fast_model_by_engine.get(engine))
-            or (fast_enabled and env_global_fast_model)
+            or (fast_model_enabled and fast_model_by_engine.get(engine))
+            or (fast_model_enabled and fast_model_global)
+            or (fast_model_enabled and env_fast_model_by_engine.get(engine))
+            or (fast_model_enabled and env_global_fast_model)
             or DEFAULT_MODEL_BY_ENGINE.get(engine)
         )
         model_source = "none"
@@ -2751,13 +2752,13 @@ def reviewer_args(args: argparse.Namespace) -> list[argparse.Namespace]:
             model_source = "env-engine"
         elif env_global_model:
             model_source = "env-global"
-        elif fast_enabled and fast_model_by_engine.get(engine):
+        elif fast_model_enabled and fast_model_by_engine.get(engine):
             model_source = "fast-cli-engine"
-        elif fast_enabled and fast_model_global:
+        elif fast_model_enabled and fast_model_global:
             model_source = "fast-cli-global"
-        elif fast_enabled and env_fast_model_by_engine.get(engine):
+        elif fast_model_enabled and env_fast_model_by_engine.get(engine):
             model_source = "fast-env-engine"
-        elif fast_enabled and env_global_fast_model:
+        elif fast_model_enabled and env_global_fast_model:
             model_source = "fast-env-global"
         elif DEFAULT_MODEL_BY_ENGINE.get(engine):
             model_source = "built-in"
@@ -3156,10 +3157,17 @@ def self_test_fast_profile() -> None:
         if service_tier.fast_strategy != "service-tier" or not service_tier.provider_fast_requested:
             raise SystemExit("self-test fast profile failed: service-tier should request provider fast")
         thinking_only = reviewer_args(
-            reviewer_test_args(engine="codex", fast=True, fast_strategy="thinking-only")
+            reviewer_test_args(
+                engine="codex",
+                fast=True,
+                fast_strategy="thinking-only",
+                fast_model=["codex=fast-codex"],
+            )
         )[0]
         if thinking_only.provider_fast_requested:
             raise SystemExit("self-test fast profile failed: thinking-only should not request provider fast")
+        if thinking_only.model == "fast-codex" or thinking_only.fast_model_source is not None:
+            raise SystemExit("self-test fast profile failed: thinking-only should not apply fast model aliases")
         claude = reviewer_args(reviewer_test_args(engine="claude", fast=True, fast_strategy="service-tier"))[0]
         if claude.provider_fast_requested:
             raise SystemExit("self-test fast profile failed: claude should not claim provider-native fast")

--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -87,6 +87,8 @@ DEFAULT_MODEL_BY_ENGINE = {
     "codex": "gpt-5.5",
     "claude": "claude-fable-5",
 }
+DEFAULT_FAST_THINKING = "low"
+FAST_STRATEGIES = ("auto", "service-tier", "thinking-only")
 THINKING_LEVELS_BY_ENGINE = {
     "codex": {"none", "minimal", "low", "medium", "high", "xhigh"},
     "claude": {"low", "medium", "high", "xhigh", "max"},
@@ -2492,6 +2494,35 @@ def parse_args() -> argparse.Namespace:
         action="append",
         help="Claude fallback model chain for all reviewers or claude=a,b. Repeatable.",
     )
+    fast_group = parser.add_mutually_exclusive_group()
+    fast_group.add_argument(
+        "--fast",
+        dest="fast",
+        action="store_true",
+        default=None,
+        help="Enable the AutoReview fast profile. AUTOREVIEW_FAST=1 also enables it.",
+    )
+    fast_group.add_argument(
+        "--no-fast",
+        dest="fast",
+        action="store_false",
+        help="Disable the AutoReview fast profile even when AUTOREVIEW_FAST=1 is set.",
+    )
+    parser.add_argument(
+        "--fast-thinking",
+        action="append",
+        help="Fast-profile thinking/effort for all supported reviewers or engine=level. Repeatable.",
+    )
+    parser.add_argument(
+        "--fast-model",
+        action="append",
+        help="Fast-profile model for all reviewers or engine=model. Repeatable.",
+    )
+    parser.add_argument(
+        "--fast-strategy",
+        choices=FAST_STRATEGIES,
+        help="Fast-profile provider intent. auto requests provider fast behavior when available, service-tier requests provider-native fast intent, thinking-only only lowers model thinking.",
+    )
     parser.add_argument("--allow-partial-panel", action="store_true", help="Continue panel output when one reviewer fails.")
     parser.add_argument("--codex-bin", default=os.environ.get("CODEX_BIN", "codex"))
     parser.add_argument("--claude-bin", default=os.environ.get("CLAUDE_BIN", "claude"))
@@ -2534,6 +2565,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--dry-run", action="store_true")
     parser.add_argument("--self-test-config-defaults", action="store_true", help=argparse.SUPPRESS)
     parser.add_argument("--self-test-fallback-scope", action="store_true", help=argparse.SUPPRESS)
+    parser.add_argument("--self-test-fast-profile", action="store_true", help=argparse.SUPPRESS)
     parser.add_argument("--self-test-engine-isolation", action="store_true", help=argparse.SUPPRESS)
     parser.add_argument("--self-test-json-array-parser", action="store_true", help=argparse.SUPPRESS)
     parser.add_argument("--self-test-heartbeat-metrics", action="store_true", help=argparse.SUPPRESS)
@@ -2573,6 +2605,18 @@ def env_defaults_for(env_suffix: str) -> tuple[str | None, dict[str, str]]:
         if value:
             per_engine[engine] = value
     return global_value, per_engine
+
+
+def env_bool(name: str) -> bool | None:
+    raw = os.environ.get(name)
+    if raw is None:
+        return None
+    value = raw.strip().lower()
+    if value in {"1", "true", "yes", "on"}:
+        return True
+    if value in {"0", "false", "no", "off", ""}:
+        return False
+    raise SystemExit(f"invalid {name}: expected 1/0, true/false, yes/no, or on/off")
 
 
 def parse_keyed_options(values: list[str] | None, option: str) -> tuple[str | None, dict[str, str]]:
@@ -2616,9 +2660,18 @@ def reviewer_args(args: argparse.Namespace) -> list[argparse.Namespace]:
     global_model, model_by_engine = parse_keyed_options(args.model, "model")
     global_thinking, thinking_by_engine = parse_keyed_options(args.thinking, "thinking")
     global_fallback, fallback_by_engine = parse_keyed_options(args.fallback_model, "fallback-model")
+    fast_model_global, fast_model_by_engine = parse_keyed_options(args.fast_model, "fast-model")
+    fast_thinking_global, fast_thinking_by_engine = parse_keyed_options(args.fast_thinking, "fast-thinking")
     env_global_model, env_model_by_engine = env_defaults_for("model")
     env_global_thinking, env_thinking_by_engine = env_defaults_for("thinking")
     env_global_fallback, env_fallback_by_engine = env_defaults_for("fallback-model")
+    env_global_fast_model, env_fast_model_by_engine = env_defaults_for("fast-model")
+    env_global_fast_thinking, env_fast_thinking_by_engine = env_defaults_for("fast-thinking")
+    env_fast = env_bool("AUTOREVIEW_FAST")
+    fast_enabled = bool(args.fast if args.fast is not None else env_fast)
+    fast_strategy = args.fast_strategy or os.environ.get("AUTOREVIEW_FAST_STRATEGY", "auto").strip() or "auto"
+    if fast_strategy not in FAST_STRATEGIES:
+        raise SystemExit(f"invalid --fast-strategy/AUTOREVIEW_FAST_STRATEGY: {fast_strategy}")
     reviewers: list[tuple[str, str | None, str | None]] = []
     if args.reviewers:
         tokens = [token.strip() for token in args.reviewers.split(",") if token.strip()]
@@ -2653,21 +2706,82 @@ def reviewer_args(args: argparse.Namespace) -> list[argparse.Namespace]:
         if engine in seen:
             raise SystemExit(f"reviewer specified more than once: {engine}")
         seen.add(engine)
+        if fast_enabled and engine in fast_thinking_by_engine and not THINKING_LEVELS_BY_ENGINE[engine]:
+            raise SystemExit(f"--fast-thinking is not supported for {engine}")
+        if fast_enabled and engine in env_fast_thinking_by_engine and not THINKING_LEVELS_BY_ENGINE[engine]:
+            raise SystemExit(f"AUTOREVIEW_{engine.upper()}_FAST_THINKING is not supported for {engine}")
         model = (
             inline_model
             or model_by_engine.get(engine)
             or global_model
             or env_model_by_engine.get(engine)
             or env_global_model
+            or (fast_enabled and fast_model_by_engine.get(engine))
+            or (fast_enabled and fast_model_global)
+            or (fast_enabled and env_fast_model_by_engine.get(engine))
+            or (fast_enabled and env_global_fast_model)
             or DEFAULT_MODEL_BY_ENGINE.get(engine)
         )
+        model_source = "none"
+        if inline_model:
+            model_source = "inline"
+        elif model_by_engine.get(engine):
+            model_source = "cli-engine"
+        elif global_model:
+            model_source = "cli-global"
+        elif env_model_by_engine.get(engine):
+            model_source = "env-engine"
+        elif env_global_model:
+            model_source = "env-global"
+        elif fast_enabled and fast_model_by_engine.get(engine):
+            model_source = "fast-cli-engine"
+        elif fast_enabled and fast_model_global:
+            model_source = "fast-cli-global"
+        elif fast_enabled and env_fast_model_by_engine.get(engine):
+            model_source = "fast-env-engine"
+        elif fast_enabled and env_global_fast_model:
+            model_source = "fast-env-global"
+        elif DEFAULT_MODEL_BY_ENGINE.get(engine):
+            model_source = "built-in"
         thinking = (
             inline_thinking
             or thinking_by_engine.get(engine)
             or global_thinking
             or env_thinking_by_engine.get(engine)
             or env_global_thinking
+            or ((
+                    fast_thinking_by_engine.get(engine)
+                    or fast_thinking_global
+                    or env_fast_thinking_by_engine.get(engine)
+                    or env_global_fast_thinking
+                    or DEFAULT_FAST_THINKING
+                )
+                if fast_enabled and THINKING_LEVELS_BY_ENGINE[engine]
+                else None
+            )
         )
+        thinking_source = "none"
+        if inline_thinking:
+            thinking_source = "inline"
+        elif thinking_by_engine.get(engine):
+            thinking_source = "cli-engine"
+        elif global_thinking:
+            thinking_source = "cli-global"
+        elif env_thinking_by_engine.get(engine):
+            thinking_source = "env-engine"
+        elif env_global_thinking:
+            thinking_source = "env-global"
+        elif fast_enabled and THINKING_LEVELS_BY_ENGINE[engine]:
+            if fast_thinking_by_engine.get(engine):
+                thinking_source = "fast-cli-engine"
+            elif fast_thinking_global:
+                thinking_source = "fast-cli-global"
+            elif env_fast_thinking_by_engine.get(engine):
+                thinking_source = "fast-env-engine"
+            elif env_global_fast_thinking:
+                thinking_source = "fast-env-global"
+            else:
+                thinking_source = "fast-default"
         if engine == "claude":
             fallback_model = (
                 fallback_by_engine.get(engine)
@@ -2685,6 +2799,13 @@ def reviewer_args(args: argparse.Namespace) -> list[argparse.Namespace]:
         clone.model = model
         clone.thinking = thinking
         clone.fallback_model = fallback_model
+        clone.fast_enabled = fast_enabled
+        clone.fast_strategy = fast_strategy
+        clone.fast_model_source = model_source if model_source.startswith("fast-") else None
+        clone.fast_thinking_source = thinking_source if thinking_source.startswith("fast-") else None
+        clone.model_source = model_source
+        clone.thinking_source = thinking_source
+        clone.provider_fast_requested = fast_enabled and fast_strategy in {"auto", "service-tier"}
         result.append(clone)
     return result
 
@@ -2697,6 +2818,16 @@ def reviewer_label(args: argparse.Namespace) -> str:
         parts.append(f"fallback={args.fallback_model}")
     if args.thinking:
         parts.append(f"thinking={args.thinking}")
+    if getattr(args, "fast_enabled", False):
+        fast_parts = [f"strategy={args.fast_strategy}"]
+        if getattr(args, "fast_model_source", None):
+            fast_parts.append(f"model={args.fast_model_source}")
+        if getattr(args, "fast_thinking_source", None):
+            fast_parts.append(f"thinking={args.fast_thinking_source}")
+        fast_parts.append(
+            f"provider-fast={'requested' if getattr(args, 'provider_fast_requested', False) else 'off'}"
+        )
+        parts.append(f"fast({', '.join(fast_parts)})")
     return " ".join(parts)
 
 
@@ -2772,6 +2903,10 @@ def reviewer_test_args(**overrides: Any) -> argparse.Namespace:
         "model": None,
         "thinking": None,
         "fallback_model": None,
+        "fast": None,
+        "fast_model": None,
+        "fast_thinking": None,
+        "fast_strategy": None,
     }
     defaults.update(overrides)
     return argparse.Namespace(**defaults)
@@ -2930,6 +3065,102 @@ def self_test_fallback_scope() -> None:
     print("self-test fallback scope: ok")
 
 
+def self_test_fast_profile() -> None:
+    keys = [
+        "AUTOREVIEW_FAST",
+        "AUTOREVIEW_FAST_MODEL",
+        "AUTOREVIEW_CODEX_FAST_MODEL",
+        "AUTOREVIEW_CLAUDE_FAST_MODEL",
+        "AUTOREVIEW_FAST_THINKING",
+        "AUTOREVIEW_CODEX_FAST_THINKING",
+        "AUTOREVIEW_COPILOT_FAST_THINKING",
+        "AUTOREVIEW_FAST_STRATEGY",
+        "AUTOREVIEW_MODEL",
+        "AUTOREVIEW_CODEX_MODEL",
+        "AUTOREVIEW_THINKING",
+        "AUTOREVIEW_CODEX_THINKING",
+    ]
+    with preserve_env(keys):
+        normal = reviewer_args(reviewer_test_args(engine="codex"))[0]
+        if normal.fast_enabled or normal.thinking is not None:
+            raise SystemExit("self-test fast profile failed: normal codex should not be fast")
+
+        fast = reviewer_args(reviewer_test_args(engine="codex", fast=True))[0]
+        if not fast.fast_enabled or fast.fast_strategy != "auto":
+            raise SystemExit("self-test fast profile failed: --fast did not enable auto strategy")
+        if fast.model != "gpt-5.5" or fast.model_source != "built-in":
+            raise SystemExit(f"self-test fast profile failed: fast model={fast.model!r}")
+        if fast.thinking != DEFAULT_FAST_THINKING or fast.fast_thinking_source != "fast-default":
+            raise SystemExit(f"self-test fast profile failed: fast thinking={fast.thinking!r}")
+        if not fast.provider_fast_requested:
+            raise SystemExit("self-test fast profile failed: provider fast should be requested by auto")
+
+        os.environ["AUTOREVIEW_FAST"] = "1"
+        os.environ["AUTOREVIEW_CODEX_FAST_MODEL"] = "env-fast-codex"
+        os.environ["AUTOREVIEW_FAST_THINKING"] = "medium"
+        env_fast = reviewer_args(reviewer_test_args(engine="codex"))[0]
+        if env_fast.model != "env-fast-codex" or env_fast.fast_model_source != "fast-env-engine":
+            raise SystemExit("self-test fast profile failed: env fast model did not apply")
+        if env_fast.thinking != "medium" or env_fast.fast_thinking_source != "fast-env-global":
+            raise SystemExit("self-test fast profile failed: env fast thinking did not apply")
+
+        no_fast = reviewer_args(reviewer_test_args(engine="codex", fast=False))[0]
+        if no_fast.fast_enabled or no_fast.model != "gpt-5.5" or no_fast.thinking is not None:
+            raise SystemExit("self-test fast profile failed: --no-fast did not override env fast")
+
+        os.environ["AUTOREVIEW_CODEX_MODEL"] = "env-codex"
+        os.environ["AUTOREVIEW_CODEX_THINKING"] = "high"
+        env_normal = reviewer_args(reviewer_test_args(engine="codex"))[0]
+        if env_normal.model != "env-codex" or env_normal.thinking != "high":
+            raise SystemExit("self-test fast profile failed: env normal values should override fast defaults")
+
+        cli_normal = reviewer_args(
+            reviewer_test_args(engine="codex", model=["cli-codex"], thinking=["low"])
+        )[0]
+        if cli_normal.model != "cli-codex" or cli_normal.thinking != "low":
+            raise SystemExit("self-test fast profile failed: CLI values should override env and fast")
+
+        inline = reviewer_args(
+            reviewer_test_args(
+                reviewers="codex:inline-codex:minimal",
+                model=["cli-codex"],
+                thinking=["low"],
+            )
+        )[0]
+        if inline.model != "inline-codex" or inline.thinking != "minimal":
+            raise SystemExit("self-test fast profile failed: inline reviewer values should override fast")
+
+        os.environ.pop("AUTOREVIEW_CODEX_MODEL")
+        os.environ.pop("AUTOREVIEW_CODEX_THINKING")
+        service_tier = reviewer_args(
+            reviewer_test_args(engine="claude", fast=True, fast_strategy="service-tier")
+        )[0]
+        if service_tier.fast_strategy != "service-tier" or not service_tier.provider_fast_requested:
+            raise SystemExit("self-test fast profile failed: service-tier should request provider fast")
+        thinking_only = reviewer_args(
+            reviewer_test_args(engine="claude", fast=True, fast_strategy="thinking-only")
+        )[0]
+        if thinking_only.provider_fast_requested:
+            raise SystemExit("self-test fast profile failed: thinking-only should not request provider fast")
+
+        copilot = reviewer_args(reviewer_test_args(engine="copilot", fast=True))[0]
+        if copilot.thinking is not None or copilot.fast_thinking_source is not None:
+            raise SystemExit("self-test fast profile failed: copilot should not receive fast thinking")
+        try:
+            reviewer_args(reviewer_test_args(engine="copilot", fast=True, fast_thinking=["copilot=low"]))
+            raise SystemExit("self-test fast profile failed: copilot fast thinking should be rejected")
+        except SystemExit as exc:
+            if "not supported for copilot" not in str(exc):
+                raise
+        try:
+            reviewer_args(reviewer_test_args(engine="droid", fast=True, fast_thinking=["max"]))
+            raise SystemExit("self-test fast profile failed: invalid fast thinking should be rejected")
+        except SystemExit as exc:
+            if "invalid thinking level for droid" not in str(exc):
+                raise
+    print("self-test fast profile: ok")
+
+
 def main() -> int:
     args = parse_args()
     if args.self_test_opencode_jsonl_parser:
@@ -2946,6 +3177,9 @@ def main() -> int:
         return 0
     if args.self_test_fallback_scope:
         self_test_fallback_scope()
+        return 0
+    if args.self_test_fast_profile:
+        self_test_fast_profile()
         return 0
     if args.self_test_heartbeat_metrics:
         self_test_heartbeat_metrics()
@@ -2967,6 +3201,14 @@ def main() -> int:
             print(f"fallback_model: {reviewers[0].fallback_model}")
         if reviewers[0].thinking:
             print(f"thinking: {reviewers[0].thinking}")
+        if getattr(reviewers[0], "fast_enabled", False):
+            print(
+                "fast: enabled "
+                f"strategy={reviewers[0].fast_strategy} "
+                f"model_source={reviewers[0].model_source} "
+                f"thinking_source={reviewers[0].thinking_source} "
+                f"provider_fast={'requested' if reviewers[0].provider_fast_requested else 'off'}"
+            )
     else:
         print(f"reviewers: {', '.join(reviewer_label(reviewer) for reviewer in reviewers)}")
     print(f"tools: {'on' if args.tools else 'off'}")

--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -1160,6 +1160,23 @@ def codex_exec_isolation_flags() -> list[str]:
     return ["--ignore-user-config", "--ignore-rules"]
 
 
+def provider_native_fast_supported(args: argparse.Namespace) -> bool:
+    return (
+        getattr(args, "engine", None) == "codex"
+        and getattr(args, "fast_enabled", False)
+        and getattr(args, "fast_strategy", "auto") in {"auto", "service-tier"}
+    )
+
+
+def codex_fast_config_flags(args: argparse.Namespace) -> list[str]:
+    if not provider_native_fast_supported(args):
+        return []
+    return [
+        "-c",
+        'service_tier="fast"',
+    ]
+
+
 def claude_review_isolation_flags() -> list[str]:
     return [
         "--safe-mode",
@@ -1263,6 +1280,7 @@ def run_codex(args: argparse.Namespace, repo: Path, prompt: str) -> str:
         cmd.extend(["-c", f'model_reasoning_effort="{args.thinking}"'])
     cmd.extend(codex_config_isolation_flags(repo))
     cmd.extend(codex_auth_config_flags())
+    cmd.extend(codex_fast_config_flags(args))
     cmd.append("exec")
     if args.stream_engine_output:
         cmd.append("--json")
@@ -2805,7 +2823,7 @@ def reviewer_args(args: argparse.Namespace) -> list[argparse.Namespace]:
         clone.fast_thinking_source = thinking_source if thinking_source.startswith("fast-") else None
         clone.model_source = model_source
         clone.thinking_source = thinking_source
-        clone.provider_fast_requested = fast_enabled and fast_strategy in {"auto", "service-tier"}
+        clone.provider_fast_requested = fast_enabled and fast_strategy in {"auto", "service-tier"} and engine == "codex"
         result.append(clone)
     return result
 
@@ -3133,19 +3151,24 @@ def self_test_fast_profile() -> None:
         os.environ.pop("AUTOREVIEW_CODEX_MODEL")
         os.environ.pop("AUTOREVIEW_CODEX_THINKING")
         service_tier = reviewer_args(
-            reviewer_test_args(engine="claude", fast=True, fast_strategy="service-tier")
+            reviewer_test_args(engine="codex", fast=True, fast_strategy="service-tier")
         )[0]
         if service_tier.fast_strategy != "service-tier" or not service_tier.provider_fast_requested:
             raise SystemExit("self-test fast profile failed: service-tier should request provider fast")
         thinking_only = reviewer_args(
-            reviewer_test_args(engine="claude", fast=True, fast_strategy="thinking-only")
+            reviewer_test_args(engine="codex", fast=True, fast_strategy="thinking-only")
         )[0]
         if thinking_only.provider_fast_requested:
             raise SystemExit("self-test fast profile failed: thinking-only should not request provider fast")
+        claude = reviewer_args(reviewer_test_args(engine="claude", fast=True, fast_strategy="service-tier"))[0]
+        if claude.provider_fast_requested:
+            raise SystemExit("self-test fast profile failed: claude should not claim provider-native fast")
 
         copilot = reviewer_args(reviewer_test_args(engine="copilot", fast=True))[0]
         if copilot.thinking is not None or copilot.fast_thinking_source is not None:
             raise SystemExit("self-test fast profile failed: copilot should not receive fast thinking")
+        if copilot.provider_fast_requested:
+            raise SystemExit("self-test fast profile failed: copilot should not claim provider-native fast")
         try:
             reviewer_args(reviewer_test_args(engine="copilot", fast=True, fast_thinking=["copilot=low"]))
             raise SystemExit("self-test fast profile failed: copilot fast thinking should be rejected")

--- a/skills/autoreview/tests/test_autoreview_hardening.py
+++ b/skills/autoreview/tests/test_autoreview_hardening.py
@@ -305,6 +305,22 @@ class AutoreviewHardeningTests(unittest.TestCase):
         self.assertIsNone(copilot.fast_thinking_source)
         self.assertFalse(copilot.provider_fast_requested)
 
+    def test_fast_profile_thinking_only_ignores_fast_model_aliases(self) -> None:
+        reviewer = self.helper["reviewer_args"](
+            self.helper["reviewer_test_args"](
+                engine="droid",
+                fast=True,
+                fast_strategy="thinking-only",
+                fast_model=["droid=claude-opus-4-8-fast"],
+            )
+        )[0]
+
+        self.assertIsNone(reviewer.model)
+        self.assertEqual(reviewer.thinking, self.helper["DEFAULT_FAST_THINKING"])
+        self.assertEqual(reviewer.thinking_source, "fast-default")
+        self.assertIsNone(reviewer.fast_model_source)
+        self.assertFalse(reviewer.provider_fast_requested)
+
     def test_fast_profile_rejects_unsupported_engine_specific_thinking(self) -> None:
         with self.assertRaisesRegex(SystemExit, "not supported for copilot"):
             self.helper["reviewer_args"](

--- a/skills/autoreview/tests/test_autoreview_hardening.py
+++ b/skills/autoreview/tests/test_autoreview_hardening.py
@@ -52,6 +52,55 @@ class AutoreviewHardeningTests(unittest.TestCase):
     def setUp(self) -> None:
         self.helper = load_helper()
 
+    def resolved_reviewer(self, **overrides: object) -> argparse.Namespace:
+        reviewer = self.helper["reviewer_args"](self.helper["reviewer_test_args"](**overrides))[0]
+        defaults = {
+            "codex_bin": "codex",
+            "claude_bin": "claude",
+            "droid_bin": "droid",
+            "copilot_bin": "copilot",
+            "opencode_bin": "opencode",
+            "pi_bin": "pi",
+            "tools": True,
+            "web_search": False,
+            "stream_engine_output": False,
+            "claude_allowed_tools": "Read,Grep,Glob,WebSearch,WebFetch",
+        }
+        for key, value in defaults.items():
+            setattr(reviewer, key, value)
+        return reviewer
+
+    def capture_engine_commands(self) -> list[list[str]]:
+        captured: list[list[str]] = []
+
+        def fake_run_with_heartbeat(
+            cmd: list[str],
+            cwd: Path,
+            **kwargs: object,
+        ) -> subprocess.CompletedProcess[str]:
+            captured.append(cmd)
+            return subprocess.CompletedProcess(cmd, 0, '{"findings":[]}', "")
+
+        for name in (
+            "run_codex",
+            "run_claude",
+            "run_droid",
+            "run_copilot",
+            "run_opencode",
+            "run_pi",
+        ):
+            self.helper[name].__globals__["run_with_heartbeat"] = fake_run_with_heartbeat
+            self.helper[name].__globals__["resolve_command"] = (
+                lambda command, repo: f"/resolved/{command}"
+            )
+        self.helper["run_claude"].__globals__["ensure_claude_isolation_supported"] = (
+            lambda args, repo: None
+        )
+        self.helper["run_pi"].__globals__["ensure_pi_isolation_supported"] = (
+            lambda args, repo: f"/resolved/{args.pi_bin}"
+        )
+        return captured
+
     def test_local_bundle_blocks_sensitive_untracked_file(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:
             repo = init_repo(Path(tempdir))
@@ -254,7 +303,7 @@ class AutoreviewHardeningTests(unittest.TestCase):
         self.assertEqual(codex.fast_thinking_source, "fast-default")
         self.assertIsNone(copilot.thinking)
         self.assertIsNone(copilot.fast_thinking_source)
-        self.assertTrue(copilot.provider_fast_requested)
+        self.assertFalse(copilot.provider_fast_requested)
 
     def test_fast_profile_rejects_unsupported_engine_specific_thinking(self) -> None:
         with self.assertRaisesRegex(SystemExit, "not supported for copilot"):
@@ -265,6 +314,86 @@ class AutoreviewHardeningTests(unittest.TestCase):
                     fast_thinking=["copilot=low"],
                 )
             )
+
+    def test_fast_provider_wiring_adds_codex_per_run_config_only_when_allowed(self) -> None:
+        captured = self.capture_engine_commands()
+        repo = Path("/repo")
+
+        fast = self.resolved_reviewer(engine="codex", fast=True)
+        self.helper["run_codex"](fast, repo, "prompt")
+        self.assertIn('service_tier="fast"', captured[-1])
+        self.assertIn('model_reasoning_effort="low"', captured[-1])
+        self.assertLess(captured[-1].index('service_tier="fast"'), captured[-1].index("exec"))
+
+        captured.clear()
+        thinking_only = self.resolved_reviewer(
+            engine="codex",
+            fast=True,
+            fast_strategy="thinking-only",
+        )
+        self.helper["run_codex"](thinking_only, repo, "prompt")
+        self.assertNotIn('service_tier="fast"', captured[-1])
+        self.assertIn('model_reasoning_effort="low"', captured[-1])
+
+    def test_fast_provider_wiring_uses_existing_effort_knobs_for_non_codex_engines(self) -> None:
+        captured = self.capture_engine_commands()
+        repo = Path("/repo")
+
+        claude = self.resolved_reviewer(engine="claude", fast=True)
+        self.helper["run_claude"](claude, repo, "prompt")
+        self.assertIn("--effort", captured[-1])
+        self.assertEqual(captured[-1][captured[-1].index("--effort") + 1], "low")
+        self.assertFalse(any("fastMode" in arg or "fast_mode" in arg for arg in captured[-1]))
+
+        droid = self.resolved_reviewer(
+            engine="droid",
+            fast=True,
+            fast_model=["droid=claude-opus-4-8-fast"],
+        )
+        self.helper["run_droid"](droid, repo, "prompt")
+        self.assertIn("--model", captured[-1])
+        self.assertEqual(captured[-1][captured[-1].index("--model") + 1], "claude-opus-4-8-fast")
+        self.assertIn("-r", captured[-1])
+        self.assertEqual(captured[-1][captured[-1].index("-r") + 1], "low")
+
+        opencode = self.resolved_reviewer(
+            engine="opencode",
+            fast=True,
+            fast_model=["opencode=github-copilot/gpt-5.4"],
+        )
+        self.helper["run_opencode"](opencode, repo, "prompt")
+        self.assertIn("-m", captured[-1])
+        self.assertEqual(captured[-1][captured[-1].index("-m") + 1], "github-copilot/gpt-5.4")
+        self.assertIn("--variant", captured[-1])
+        self.assertEqual(captured[-1][captured[-1].index("--variant") + 1], "low")
+
+        pi = self.resolved_reviewer(
+            engine="pi",
+            fast=True,
+            fast_model=["pi=openai/gpt-5.5"],
+        )
+        self.helper["run_pi"](pi, repo, "prompt")
+        self.assertIn("--model", captured[-1])
+        self.assertEqual(captured[-1][captured[-1].index("--model") + 1], "openai/gpt-5.5")
+        self.assertIn("--thinking", captured[-1])
+        self.assertEqual(captured[-1][captured[-1].index("--thinking") + 1], "low")
+
+    def test_fast_provider_wiring_keeps_copilot_model_only(self) -> None:
+        captured = self.capture_engine_commands()
+        repo = Path("/repo")
+        copilot = self.resolved_reviewer(
+            engine="copilot",
+            fast=True,
+            fast_model=["copilot=gpt-5.2"],
+        )
+
+        self.helper["run_copilot"](copilot, repo, "prompt")
+
+        self.assertIn("--model", captured[-1])
+        self.assertEqual(captured[-1][captured[-1].index("--model") + 1], "gpt-5.2")
+        self.assertNotIn("--effort", captured[-1])
+        self.assertNotIn("--reasoning-effort", captured[-1])
+        self.assertNotIn("--thinking", captured[-1])
 
 
 if __name__ == "__main__":

--- a/skills/autoreview/tests/test_autoreview_hardening.py
+++ b/skills/autoreview/tests/test_autoreview_hardening.py
@@ -204,6 +204,68 @@ class AutoreviewHardeningTests(unittest.TestCase):
         self.assertIn("--allow-tool=web_fetch", captured[-1])
         self.assertIn("--allow-all-urls", captured[-1])
 
+    def test_fast_profile_preserves_explicit_precedence(self) -> None:
+        old = os.environ.copy()
+        try:
+            os.environ.clear()
+            os.environ.update(
+                {
+                    "AUTOREVIEW_FAST": "1",
+                    "AUTOREVIEW_CODEX_FAST_MODEL": "env-fast-codex",
+                    "AUTOREVIEW_FAST_THINKING": "medium",
+                    "AUTOREVIEW_CODEX_MODEL": "env-codex",
+                    "AUTOREVIEW_CODEX_THINKING": "high",
+                }
+            )
+
+            reviewer = self.helper["reviewer_args"](
+                self.helper["reviewer_test_args"](
+                    reviewers="codex:inline-codex:minimal",
+                    model=["codex=cli-codex"],
+                    thinking=["codex=low"],
+                )
+            )[0]
+
+            self.assertTrue(reviewer.fast_enabled)
+            self.assertEqual(reviewer.model, "inline-codex")
+            self.assertEqual(reviewer.thinking, "minimal")
+            self.assertEqual(reviewer.model_source, "inline")
+            self.assertEqual(reviewer.thinking_source, "inline")
+            self.assertIsNone(reviewer.fast_model_source)
+            self.assertIsNone(reviewer.fast_thinking_source)
+        finally:
+            os.environ.clear()
+            os.environ.update(old)
+
+    def test_fast_profile_applies_gap_defaults_and_skips_copilot_thinking(self) -> None:
+        reviewers = self.helper["reviewer_args"](
+            self.helper["reviewer_test_args"](
+                reviewers="codex,copilot",
+                fast=True,
+                fast_model=["codex=fast-codex"],
+            )
+        )
+        codex = next(reviewer for reviewer in reviewers if reviewer.engine == "codex")
+        copilot = next(reviewer for reviewer in reviewers if reviewer.engine == "copilot")
+
+        self.assertEqual(codex.model, "fast-codex")
+        self.assertEqual(codex.thinking, self.helper["DEFAULT_FAST_THINKING"])
+        self.assertEqual(codex.fast_model_source, "fast-cli-engine")
+        self.assertEqual(codex.fast_thinking_source, "fast-default")
+        self.assertIsNone(copilot.thinking)
+        self.assertIsNone(copilot.fast_thinking_source)
+        self.assertTrue(copilot.provider_fast_requested)
+
+    def test_fast_profile_rejects_unsupported_engine_specific_thinking(self) -> None:
+        with self.assertRaisesRegex(SystemExit, "not supported for copilot"):
+            self.helper["reviewer_args"](
+                self.helper["reviewer_test_args"](
+                    engine="copilot",
+                    fast=True,
+                    fast_thinking=["copilot=low"],
+                )
+            )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Closes #33

## Summary

Adds a first-class fast review profile to `skills/autoreview/scripts/autoreview`.

The new profile introduces `--fast`, `--no-fast`, `--fast-thinking`, `--fast-model`, and `--fast-strategy`, with resolver metadata visible in dry-run output. Explicit inline reviewer specs, CLI `--model` / `--thinking`, and environment overrides keep precedence over fast defaults.

Provider behavior is deliberately conservative:

- Codex requests the fast service tier per run with `-c service_tier="fast"` and does not persist user config or force `features.fast_mode=true`.
- Claude uses `--effort low` when no explicit thinking value is set.
- Droid, OpenCode, and Pi use their existing reasoning/variant/thinking knobs and optional fast model aliases.
- Copilot remains model-only and never receives thinking/effort flags.
- `thinking-only` ignores fast model aliases and only applies fast thinking/effort.

## Notes

The issue sketch mentioned `features.fast_mode=true` as an implementation possibility for Codex. During review, that was intentionally avoided because managed Codex configs can reject the feature override when fast mode is pinned off. The PR keeps the non-persistent service-tier request and low-reasoning behavior instead.

## Validation

- `scripts/validate-skills`
- `find . \( -name __pycache__ -o -name '*.pyc' -o -name '.pytest_cache' \) -print`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile skills/autoreview/scripts/autoreview skills/autoreview/scripts/test-review-harness.py`
- `python3 -m pytest -q skills/autoreview/tests/test_autoreview_hardening.py`
- `skills/autoreview/scripts/autoreview --self-test-config-defaults`
- `skills/autoreview/scripts/autoreview --self-test-fallback-scope`
- `skills/autoreview/scripts/autoreview --self-test-fast-profile`
- `skills/autoreview/scripts/autoreview --mode branch --base upstream/main --engine codex --fast --dry-run`
- `skills/autoreview/scripts/autoreview --mode branch --base upstream/main --reviewers codex,claude,copilot --fast --dry-run`
- `skills/autoreview/scripts/autoreview --help`

`validate-skills` output after the bytecode-cache fix:

```text
self-test config defaults: ok
self-test fallback scope: ok
self-test fast profile: ok
..................
----------------------------------------------------------------------
Ran 18 tests in 0.623s

OK
validated 5 skills
```

The artifact scan immediately after `scripts/validate-skills` produced no output, confirming the validation entrypoint did not leave `__pycache__`, `.pyc`, or `.pytest_cache` artifacts in the checkout.

Fast single-reviewer dry-run proof against the PR branch diff:

```text
autoreview target: branch
branch: main
engine: codex
model: gpt-5.5
thinking: low
fast: enabled strategy=auto model_source=built-in thinking_source=fast-default provider_fast=requested
tools: on
web_search: on
ref: upstream/main
```

Fast panel dry-run proof against the PR branch diff:

```text
autoreview target: branch
branch: main
reviewers: codex model=gpt-5.5 thinking=low fast(strategy=auto, thinking=fast-default, provider-fast=requested), claude model=claude-fable-5 thinking=low fast(strategy=auto, thinking=fast-default, provider-fast=off), copilot fast(strategy=auto, provider-fast=off)
tools: on
web_search: on
ref: upstream/main
```

Final local branch review reported: `autoreview clean: no accepted/actionable findings reported`.
