### PR TITLE
fix: harden agent-skills validation on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+skills/autoreview/scripts/test-review-harness text eol=lf

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -7,7 +7,11 @@ on:
 
 jobs:
   validate:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -20,24 +24,24 @@ jobs:
         with:
           python-version: '3.x'
       - name: Validate skill frontmatter
-        run: scripts/validate-skills
+        run: ruby scripts/validate-skills
       - name: Check Ruby scripts
         run: ruby -c scripts/install-skills && ruby -c scripts/validate-skills && ruby scripts/install-skills.test.rb
       - name: Check shell scripts
         run: bash -n skills/autoreview/scripts/test-review-harness
       - name: Check Python scripts
-        run: python3 -m py_compile skills/autoreview/scripts/autoreview skills/autoreview/scripts/test-review-harness.py skills/autoreview/scripts/autoreview_test.py
+        run: python -m py_compile skills/autoreview/scripts/autoreview skills/autoreview/scripts/test-review-harness.py skills/autoreview/scripts/autoreview_test.py
       - name: Run autoreview self-tests
         run: |
-          python3 skills/autoreview/scripts/autoreview --self-test-config-defaults
-          python3 skills/autoreview/scripts/autoreview --self-test-fallback-scope
-          python3 skills/autoreview/scripts/autoreview --self-test-engine-isolation
-          python3 skills/autoreview/scripts/autoreview --self-test-json-array-parser
-          python3 skills/autoreview/scripts/autoreview --self-test-opencode-jsonl-parser
-          python3 skills/autoreview/scripts/autoreview --self-test-opencode-isolation
-          python3 skills/autoreview/scripts/autoreview --self-test-cursor-jsonl-parser
+          python skills/autoreview/scripts/autoreview --self-test-config-defaults
+          python skills/autoreview/scripts/autoreview --self-test-fallback-scope
+          python skills/autoreview/scripts/autoreview --self-test-engine-isolation
+          python skills/autoreview/scripts/autoreview --self-test-json-array-parser
+          python skills/autoreview/scripts/autoreview --self-test-opencode-jsonl-parser
+          python skills/autoreview/scripts/autoreview --self-test-opencode-isolation
+          python skills/autoreview/scripts/autoreview --self-test-cursor-jsonl-parser
       - name: Run Python tests
-        run: python3 -m unittest skills/autoreview/scripts/autoreview_test.py
+        run: python -m unittest skills/autoreview/scripts/autoreview_test.py
       - name: Check Node scripts
         run: node --check skills/agent-transcript/scripts/agent-transcript
       - name: Run Node tests

--- a/scripts/install-skills.test.rb
+++ b/scripts/install-skills.test.rb
@@ -7,6 +7,12 @@ require "open3"
 require "tmpdir"
 
 class InstallSkillsTest < Minitest::Test
+  def create_symlink_or_skip(source, target)
+    FileUtils.ln_s(source, target)
+  rescue NotImplementedError, Errno::EACCES
+    skip "symlink creation is not available for this user"
+  end
+
   def test_force_skips_target_that_is_source
     Dir.mktmpdir do |dir|
       FileUtils.mkdir_p(File.join(dir, "scripts"))
@@ -37,7 +43,7 @@ class InstallSkillsTest < Minitest::Test
       FileUtils.mkdir_p(File.join(dir, "target"))
       FileUtils.cp(File.join(__dir__, "install-skills"), File.join(dir, "repo", "scripts", "install-skills"))
       File.write(File.join(dir, "repo", "skills", "sample", "SKILL.md"), "---\nname: sample\ndescription: sample\n---\n")
-      FileUtils.ln_s(File.join(dir, "repo", "skills", "sample"), File.join(dir, "target", "sample"))
+      create_symlink_or_skip(File.join(dir, "repo", "skills", "sample"), File.join(dir, "target", "sample"))
 
       stdout, stderr, status = Open3.capture3(
         RbConfig.ruby,

--- a/scripts/install-skills.test.rb
+++ b/scripts/install-skills.test.rb
@@ -9,8 +9,10 @@ require "tmpdir"
 class InstallSkillsTest < Minitest::Test
   def create_symlink_or_skip(source, target)
     FileUtils.ln_s(source, target)
-  rescue NotImplementedError, Errno::EACCES
-    skip "symlink creation is not available for this user"
+  rescue NotImplementedError, SystemCallError => e
+    raise unless Gem.win_platform?
+
+    skip "symlink creation is not available for this Windows user: #{e.class}"
   end
 
   def test_force_skips_target_that_is_source

--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -102,6 +102,8 @@ CLAUDE_SAFE_MODE_MIN_VERSION = (2, 1, 169)
 # @earendil-works/pi-coding-agent 0.79.0 CLI line. Older legacy binaries can
 # ignore unknown flags, so the Pi engine must fail closed below this floor.
 PI_TRUST_ISOLATION_MIN_VERSION = (0, 79, 0)
+SUBPROCESS_TEXT_ENCODING = "utf-8"
+SUBPROCESS_TEXT_ERRORS = "replace"
 
 
 SCHEMA: dict[str, Any] = {
@@ -171,6 +173,8 @@ def run(
         cwd=cwd,
         input=input_text,
         text=True,
+        encoding=SUBPROCESS_TEXT_ENCODING,
+        errors=SUBPROCESS_TEXT_ERRORS,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         env=env,
@@ -209,9 +213,9 @@ def safe_engine_path(repo: Path, extra_paths: list[Path] | None = None) -> str:
 
     def add(path: str | Path) -> None:
         candidate = Path(path).expanduser()
-        if not candidate.is_absolute() or not candidate.exists():
-            return
         try:
+            if not candidate.is_absolute() or not candidate.exists():
+                return
             resolved = candidate.resolve()
         except OSError:
             return
@@ -288,6 +292,8 @@ def process_pids(repo: Path, pid: int) -> list[str]:
     result = subprocess.run(
         [ps, "-A", "-o", "pid=", "-o", "ppid="],
         text=True,
+        encoding=SUBPROCESS_TEXT_ENCODING,
+        errors=SUBPROCESS_TEXT_ERRORS,
         stdout=subprocess.PIPE,
         stderr=subprocess.DEVNULL,
         check=False,
@@ -320,6 +326,8 @@ def sample_process_metrics(repo: Path, pid: int) -> tuple[float, float, int, str
                 ",".join(process_pids(repo, pid)),
             ],
             text=True,
+            encoding=SUBPROCESS_TEXT_ENCODING,
+            errors=SUBPROCESS_TEXT_ERRORS,
             stdout=subprocess.PIPE,
             stderr=subprocess.DEVNULL,
             check=False,
@@ -457,6 +465,8 @@ def run_with_heartbeat(
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         text=True,
+        encoding=SUBPROCESS_TEXT_ENCODING,
+        errors=SUBPROCESS_TEXT_ERRORS,
         env=env,
     )
     first_communicate = True
@@ -492,6 +502,8 @@ def run_with_stream(
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         text=True,
+        encoding=SUBPROCESS_TEXT_ENCODING,
+        errors=SUBPROCESS_TEXT_ERRORS,
         bufsize=1,
         env=env,
     )
@@ -574,6 +586,8 @@ def repo_root() -> Path:
     result = subprocess.run(
         [git_bin, "--no-optional-locks", *SAFE_GIT_CONFIG_ARGS, "rev-parse", "--show-toplevel"],
         text=True,
+        encoding=SUBPROCESS_TEXT_ENCODING,
+        errors=SUBPROCESS_TEXT_ERRORS,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         env=safe_git_env(),
@@ -2010,9 +2024,14 @@ def is_structured_output_failure(message: str) -> bool:
     )
 
 
-def write_executable(path: Path, text: str) -> None:
-    path.write_text(text)
+def write_executable(path: Path, text: str) -> Path:
+    path.write_text(text, encoding="utf-8")
     path.chmod(0o755)
+    if os.name != "nt":
+        return path
+    wrapper = path.with_name(f"{path.name}.cmd")
+    wrapper.write_text(f'@echo off\r\n"{sys.executable}" "{path}" %*\r\n', encoding="utf-8")
+    return wrapper
 
 
 def create_hostile_repo(repo: Path) -> None:
@@ -2290,12 +2309,12 @@ def self_test_engine_isolation() -> int:
         pi_invocations_path = root / "pi-invocations.jsonl"
         hostile_ps_path = root / "hostile-ps-ran"
         cursor_invocations_path = root / "cursor-invocations.jsonl"
-        write_executable(codex_bin, fake_codex_script())
-        write_executable(claude_bin, fake_claude_script())
-        write_executable(pi_bin, fake_pi_script())
-        write_executable(opencode_bin, fake_opencode_script())
+        codex_bin = write_executable(codex_bin, fake_codex_script())
+        claude_bin = write_executable(claude_bin, fake_claude_script())
+        pi_bin = write_executable(pi_bin, fake_pi_script())
+        opencode_bin = write_executable(opencode_bin, fake_opencode_script())
         write_executable(repo / "ps", f"#!/usr/bin/env python3\nfrom pathlib import Path\nPath({str(hostile_ps_path)!r}).write_text('ran')\n")
-        write_executable(cursor_bin, fake_cursor_script())
+        cursor_bin = write_executable(cursor_bin, fake_cursor_script())
 
         args = argparse.Namespace(
             codex_bin=str(codex_bin),
@@ -2740,6 +2759,8 @@ def self_test_opencode_real_project_isolation(args: argparse.Namespace) -> None:
             [opencode_bin, "debug", "config", "--pure"],
             cwd=repo,
             text=True,
+            encoding=SUBPROCESS_TEXT_ENCODING,
+            errors=SUBPROCESS_TEXT_ERRORS,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             env=subprocess_env(opencode_review_env(False)),

--- a/skills/autoreview/tests/test_autoreview_hardening.py
+++ b/skills/autoreview/tests/test_autoreview_hardening.py
@@ -5,8 +5,10 @@ import argparse
 import os
 import runpy
 import subprocess
+import sys
 import tempfile
 import unittest
+from unittest import mock
 from pathlib import Path
 
 
@@ -82,6 +84,8 @@ class AutoreviewHardeningTests(unittest.TestCase):
                 self.helper["branch_bundle"](repo, "origin/main")
 
     def test_git_path_list_preserves_newline_filenames(self) -> None:
+        if os.name == "nt":
+            self.skipTest("Windows filesystems do not support newline path components")
         with tempfile.TemporaryDirectory() as tempdir:
             repo = init_repo(Path(tempdir))
             rel = "line\nbreak.txt"
@@ -120,7 +124,12 @@ class AutoreviewHardeningTests(unittest.TestCase):
             target = repo / "notes.md"
             target.write_text("notes\n", encoding="utf-8")
             link = repo / "link.md"
-            link.symlink_to(target)
+            try:
+                link.symlink_to(target)
+            except OSError as exc:
+                if os.name == "nt" and getattr(exc, "winerror", None) == 1314:
+                    self.skipTest("Windows symlink privilege is not available")
+                raise
             with self.assertRaisesRegex(SystemExit, "symlinked"):
                 self.helper["validate_evidence_file"](repo, "link.md", "--dataset")
 
@@ -158,6 +167,44 @@ class AutoreviewHardeningTests(unittest.TestCase):
                 os.environ["PATH"] = old_path
 
             self.assertNotIn(str(repo.resolve()), env["PATH"].split(os.pathsep))
+
+    def test_safe_engine_env_ignores_inaccessible_path_entries(self) -> None:
+        old_path = os.environ.get("PATH", "")
+        with tempfile.TemporaryDirectory() as tempdir:
+            root = Path(tempdir)
+            repo = init_repo(root)
+            blocked = root / "blocked"
+            os.environ["PATH"] = f"{blocked}{os.pathsep}{old_path}"
+            original_exists = Path.exists
+
+            def fake_exists(path: Path) -> bool:
+                if str(path) == str(blocked):
+                    raise PermissionError("access denied")
+                return original_exists(path)
+
+            try:
+                with mock.patch.object(Path, "exists", fake_exists):
+                    env = self.helper["safe_engine_env"](repo)
+            finally:
+                os.environ["PATH"] = old_path
+
+            self.assertNotIn(str(blocked), env["PATH"].split(os.pathsep))
+
+    def test_run_with_heartbeat_replaces_undecodable_engine_output(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            result = self.helper["run_with_heartbeat"](
+                [
+                    sys.executable,
+                    "-c",
+                    "import sys; sys.stdout.buffer.write(b'\\x90\\n')",
+                ],
+                Path(tempdir),
+                label="decode-test",
+                heartbeat_seconds=1,
+            )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("\ufffd", result.stdout)
 
     def test_large_repo_relative_evidence_file_is_truncated(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:
@@ -205,8 +252,11 @@ class AutoreviewHardeningTests(unittest.TestCase):
         self.assertIn("--allow-all-urls", captured[-1])
 
     def test_self_test_shortcut_runs_deterministic_checks(self) -> None:
+        command = [str(SCRIPT), "--self-test"]
+        if os.name == "nt":
+            command = [sys.executable, str(SCRIPT), "--self-test"]
         result = subprocess.run(
-            [str(SCRIPT), "--self-test"],
+            command,
             check=False,
             text=True,
             stdout=subprocess.PIPE,


### PR DESCRIPTION
Fixes #36.

## Summary

This PR makes the shared `agent-skills` validation path work from native Windows contributor setups and adds a repository Windows CI lane so the same validation is no longer only contributor-provided live output.

It fixes a small cluster of Windows portability failures:

- skip inaccessible `PATH` entries inside the existing guarded path-resolution block instead of letting `Path.exists()` raise before the guard;
- decode text-mode subprocess output as UTF-8 with replacement, so reviewer/tool output with invalid bytes is preserved instead of crashing the helper;
- make `--self-test-engine-isolation` fake engines runnable on Windows by returning `.cmd` wrappers for generated fake engine scripts;
- skip hardening assertions that require POSIX-only newline filenames or unavailable Windows symlink privilege;
- skip the Ruby install-skills symlink replacement test only when Windows cannot create symlinks for the current user;
- force LF checkout for the `test-review-harness` shell wrapper so `bash -n` works under Git for Windows with `core.autocrlf=true`;
- run the existing validate workflow on both `ubuntu-latest` and `windows-latest`.

## Why

On Windows, contributors can fail before they reach the behavior under review:

- inaccessible path entries can raise `PermissionError` during engine PATH filtering;
- Windows default text decoding can raise `UnicodeDecodeError` for arbitrary subprocess output;
- extensionless shebang scripts are not executable through Windows `CreateProcess`;
- newline path components and symlink creation are not reliable Windows test capabilities;
- CRLF shell wrappers can fail `bash -n` even though CI checks the same wrapper on Linux;
- without a Windows CI lane, Windows proof remains contributor-provided rather than repository-reproduced.

The fix keeps unsupported platform capabilities explicit through skips, keeps actual helper behavior deterministic across platforms, and promotes the Windows proof surface into the repo workflow.

## Changed files

- `.github/workflows/validate.yml`
- `.gitattributes`
- `scripts/install-skills.test.rb`
- `skills/autoreview/scripts/autoreview`
- `skills/autoreview/tests/test_autoreview_hardening.py`

## Validation

Local validation on Windows 11 Release Preview / 25H2 build `26200.8728`, PowerShell `7.6.2`, Python `3.12.10`, RubyInstaller with DevKit `3.3.11`, Node `24.16.0`, Git for Windows `core.autocrlf=true`:

- `ruby scripts/validate-skills`: passed, `validated 5 skills`
- `ruby -c scripts/install-skills`: passed, `Syntax OK`
- `ruby -c scripts/validate-skills`: passed, `Syntax OK`
- `ruby scripts/install-skills.test.rb`: passed, `2 runs`, `6 assertions`, `0 failures`, `0 errors`, `1 skips`
- `bash -n skills/autoreview/scripts/test-review-harness`: passed
- `python -m py_compile skills/autoreview/scripts/autoreview skills/autoreview/scripts/test-review-harness.py skills/autoreview/scripts/autoreview_test.py`: passed
- `python skills/autoreview/scripts/autoreview --self-test-config-defaults`: passed
- `python skills/autoreview/scripts/autoreview --self-test-fallback-scope`: passed
- `python skills/autoreview/scripts/autoreview --self-test-engine-isolation`: passed
- `python skills/autoreview/scripts/autoreview --self-test-json-array-parser`: passed
- `python skills/autoreview/scripts/autoreview --self-test-opencode-jsonl-parser`: passed
- `python skills/autoreview/scripts/autoreview --self-test-opencode-isolation`: passed
- `python skills/autoreview/scripts/autoreview --self-test-cursor-jsonl-parser`: passed
- `python -m unittest skills/autoreview/scripts/autoreview_test.py`: passed, `11 tests`
- `python -m unittest skills/autoreview/tests/test_autoreview_hardening.py`: passed, `14 tests`, `2 skips`
- `node --check skills/agent-transcript/scripts/agent-transcript`: passed
- `node --test skills/agent-transcript/scripts/agent-transcript.test.mjs skills/session-viewer/scripts/session-viewer.test.ts`: passed, `32 tests`
- `git diff --check`: passed
- `python skills/autoreview/scripts/autoreview --mode local --engine codex --thinking high --no-web-search --parallel-tests "python -m unittest skills/autoreview/tests/test_autoreview_hardening.py" --parallel-tests-shell pwsh`: clean, no accepted/actionable findings; `overall: patch is correct (0.86)`
- after adding the Windows CI lane: `python skills/autoreview/scripts/autoreview --mode local --engine codex --thinking high --no-web-search --parallel-tests "ruby scripts/install-skills.test.rb; python -m unittest skills/autoreview/tests/test_autoreview_hardening.py" --parallel-tests-shell pwsh`: clean, no accepted/actionable findings; `overall: patch is correct (0.86)`

## CI note

The workflow now runs the same validation job on both `ubuntu-latest` and `windows-latest` with cross-platform `ruby` and `python` invocations. Because this PR comes from a fork, the upstream GitHub Actions run may still require maintainer approval before executing; the Windows lane is part of this PR and should run once that approval is granted.

## Notes

- The Ruby symlink test skip is intentional and Windows-scoped: Unix-like hosts still fail on symlink creation errors.
- The hardening test skips are platform-capability skips, not behavior relaxations.
- The generated Windows `.cmd` wrappers are limited to temporary fake engines used by the self-test.
