### PR TITLE
Add behavior validator skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ repo.
 
 - `agent-transcript`: local-only, redacted PR/issue transcript provenance.
 - `autoreview`: structured closeout/code-review workflow plus helper script.
+- `behavior-validator`: source-blind validation of user-visible behavior against
+  a contract.
 - `crabbox`: Crabbox/Testbox remote validation workflow for broad or CI-parity
   proof.
 - `handoff`: path-free prompt handoff workflow for delegating a task to another
@@ -135,6 +137,9 @@ skills/
   autoreview/
     SKILL.md
     scripts/
+  behavior-validator/
+    SKILL.md
+    references/
   crabbox/
     SKILL.md
   handoff/

--- a/skills.sh.json
+++ b/skills.sh.json
@@ -5,7 +5,7 @@
     {
       "title": "Review",
       "description": "Skills for code review closeout and remote validation.",
-      "skills": ["autoreview", "crabbox"]
+      "skills": ["autoreview", "behavior-validator", "crabbox"]
     },
     {
       "title": "Handoff",

--- a/skills/autoreview/SKILL.md
+++ b/skills/autoreview/SKILL.md
@@ -9,6 +9,8 @@ Run the bundled structured review helper as a closeout check. This is code revie
 
 Codex review is the default when no engine is set. It uses `gpt-5.5` by default, usually delivers the best review results, and should remain the normal final closeout engine. Claude review is optional and uses `claude-fable-5` by default.
 
+For user-visible behavior, pair autoreview with `behavior-validator`. Autoreview is source-aware and judges the change bundle; behavior validation is source-blind and judges the running product or tool against a behavior contract. A clean autoreview is not proof that a UI, CLI, API, or generated artifact works from the user's perspective.
+
 Use when:
 
 - user asks for Codex review / Claude review / Pi review / Droid review / Cursor review / OpenCode review / autoreview / second-model review

--- a/skills/behavior-validator/SKILL.md
+++ b/skills/behavior-validator/SKILL.md
@@ -21,12 +21,13 @@ Validate observable behavior without inspecting source. Use this as the black-bo
 Prefer a source-blind workspace:
 
 ```sh
-mkdir -p /tmp/behavior-validator-run
-cp behavior-contract.md /tmp/behavior-validator-run/
-cd /tmp/behavior-validator-run
+validator_dir="$(mktemp -d "${TMPDIR:-/tmp}/behavior-validator-run.XXXXXX")"
+chmod 700 "$validator_dir"
+cp behavior-contract.md "$validator_dir/"
+cd "$validator_dir"
 ```
 
-Launch or connect to the target from the contract. Keep only the contract, allowed fixtures, credentials explicitly provided for testing, and captured evidence in the validator workspace. If the app must be started from the source checkout, start it from a separate terminal and do not read source while validating.
+Launch or connect to the target from the contract. Keep only the contract, allowed fixtures, credentials explicitly provided for testing, and captured evidence in the private validator workspace. Do not use fixed shared paths for contracts, credentials, or captured evidence. If the app must be started from the source checkout, start it from a separate terminal and do not read source while validating.
 
 ## Workflow
 

--- a/skills/behavior-validator/SKILL.md
+++ b/skills/behavior-validator/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: behavior-validator
+description: "Source-blind user behavior validation against a prewritten contract for apps, CLIs, APIs, and generated artifacts."
+---
+
+# Behavior Validator
+
+Validate observable behavior without inspecting source. Use this as the black-box companion to code-aware review: `autoreview` judges the change bundle, while `behavior-validator` judges the running product, CLI, API, or generated artifact against a behavior contract.
+
+## Contract
+
+- Read the behavior contract first. If none exists, write a short one from the user request before testing. See `references/contract-template.md`.
+- Stay source-blind. Do not inspect source files, diffs, tests, git history, implementation notes, build internals, or review bundles.
+- Interact only through user-visible or operator-visible surfaces: browser, CLI, API, generated files, public logs, screenshots, accessibility trees, or documented runtime output.
+- Treat implementation-looking evidence as contamination. If source access is required to continue, stop and report `blocked_source_required`.
+- Report findings against contract clauses and observable steps, not code locations.
+- Do not mark a workflow as passing until each relevant contract clause is pass, fail, blocked, or out of scope.
+
+## Isolation
+
+Prefer a source-blind workspace:
+
+```sh
+mkdir -p /tmp/behavior-validator-run
+cp behavior-contract.md /tmp/behavior-validator-run/
+cd /tmp/behavior-validator-run
+```
+
+Launch or connect to the target from the contract. Keep only the contract, allowed fixtures, credentials explicitly provided for testing, and captured evidence in the validator workspace. If the app must be started from the source checkout, start it from a separate terminal and do not read source while validating.
+
+## Workflow
+
+1. Parse the contract into user tasks, expected behavior, anti-cheat probes, setup, and evidence requirements.
+2. Prepare runtime access: target URL, CLI command, API endpoint, fixture data, credentials, or generated artifact path.
+3. Exercise each user task as a real user or operator would.
+4. Run anti-cheat probes: vary fixture data, refresh/retry, test empty and invalid inputs, verify persistence, inspect generated output, and confirm buttons/commands perform real work rather than only displaying success text.
+5. Capture evidence as compact notes, screenshots, terminal excerpts, response bodies, file summaries, or accessibility observations.
+6. Emit a structured report. Use `references/report-schema.md` when a machine-readable report is useful.
+7. If the orchestrator fixes a finding, rerun only the affected contract clauses plus any nearby regression probes.
+
+## Finding Rules
+
+- Fail when observable behavior violates the contract, a task cannot be completed, expected state is fake/static, or evidence is insufficient for a claimed pass.
+- Block when required runtime access, credentials, fixtures, network, or tools are missing.
+- Mark out of scope only when the contract explicitly excludes the behavior or the task depends on a user-owned product decision.
+- Reject purely aesthetic, code-quality, or implementation-style concerns; those belong to code-aware review.
+
+## Final Report
+
+Include:
+
+- target exercised
+- contract file or inline contract used
+- pass/fail/blocked/out-of-scope summary
+- accepted behavioral findings with reproduction steps and evidence
+- anti-cheat probes run
+- remaining blockers, if any

--- a/skills/behavior-validator/SKILL.md
+++ b/skills/behavior-validator/SKILL.md
@@ -27,7 +27,7 @@ cp behavior-contract.md "$validator_dir/"
 cd "$validator_dir"
 ```
 
-Launch or connect to the target from the contract. Keep only the contract, allowed fixtures, credentials explicitly provided for testing, and captured evidence in the private validator workspace. Do not use fixed shared paths for contracts, credentials, or captured evidence. If the app must be started from the source checkout, start it from a separate terminal and do not read source while validating.
+Launch or connect to the target from the contract. Keep only the contract, allowed fixtures, and redacted captured evidence in the private validator workspace. Supply credentials through approved secret tooling or exact environment variables; never copy credential values into the workspace, report, screenshots, or logs. Do not use fixed shared paths for contracts or captured evidence. If the app must be started from the source checkout, start it from a separate terminal and do not read source while validating.
 
 ## Workflow
 
@@ -35,7 +35,7 @@ Launch or connect to the target from the contract. Keep only the contract, allow
 2. Prepare runtime access: target URL, CLI command, API endpoint, fixture data, credentials, or generated artifact path.
 3. Exercise each user task as a real user or operator would.
 4. Run anti-cheat probes: vary fixture data, refresh/retry, test empty and invalid inputs, verify persistence, inspect generated output, and confirm buttons/commands perform real work rather than only displaying success text.
-5. Capture evidence as compact notes, screenshots, terminal excerpts, response bodies, file summaries, or accessibility observations.
+5. Capture evidence as compact redacted notes, screenshots, terminal excerpts, response summaries, file summaries, or accessibility observations. Omit credentials, tokens, cookies, private user data, and unrelated log content.
 6. Emit a structured report. Use `references/report-schema.md` when a machine-readable report is useful.
 7. If the orchestrator fixes a finding, rerun only the affected contract clauses plus any nearby regression probes.
 

--- a/skills/behavior-validator/agents/openai.yaml
+++ b/skills/behavior-validator/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Behavior Validator"
+  short_description: "Black-box validation against behavior contracts."
+  default_prompt: "Use $behavior-validator to validate this workflow against a source-blind behavior contract."

--- a/skills/behavior-validator/references/contract-template.md
+++ b/skills/behavior-validator/references/contract-template.md
@@ -1,0 +1,36 @@
+# Behavior Contract Template
+
+Use this shape when the user has not provided a behavior contract. Keep it short enough that a source-blind validator can execute it without reading implementation notes.
+
+```md
+# Behavior Contract
+
+## User-Visible Goal
+<What must be true from the user's point of view.>
+
+## Target
+- Type: web app | CLI | API | generated artifact | other
+- Launch or access: <URL, command, endpoint, artifact path, or setup command>
+- Allowed fixtures or credentials: <only what the validator may use>
+
+## User Tasks
+1. <Concrete task a real user/operator performs.>
+2. <Concrete task a real user/operator performs.>
+
+## Expected Observable Behavior
+- <Screen, CLI output, API response, file content, state change, or persistence rule.>
+- <Failure behavior for invalid input or unavailable data.>
+
+## Anti-Cheat Probes
+- <Change fixture/input data and verify output changes accordingly.>
+- <Refresh/retry/reopen and verify expected persistence or reset behavior.>
+- <Try invalid/empty/boundary input and verify the promised handling.>
+
+## Evidence Required
+- <Screenshots, terminal excerpts, response snippets, file summaries, accessibility observations, or logs.>
+
+## Out Of Scope
+- <Anything the validator must not judge.>
+```
+
+Completion criterion: every user task and anti-cheat probe has an expected observable result and evidence type.

--- a/skills/behavior-validator/references/contract-template.md
+++ b/skills/behavior-validator/references/contract-template.md
@@ -11,7 +11,7 @@ Use this shape when the user has not provided a behavior contract. Keep it short
 ## Target
 - Type: web app | CLI | API | generated artifact | other
 - Launch or access: <URL, command, endpoint, artifact path, or setup command>
-- Allowed fixtures or credentials: <only what the validator may use>
+- Allowed fixtures and credential source: <fixtures plus approved secret-tool or exact environment-variable names; never values>
 
 ## User Tasks
 1. <Concrete task a real user/operator performs.>

--- a/skills/behavior-validator/references/report-schema.md
+++ b/skills/behavior-validator/references/report-schema.md
@@ -1,0 +1,51 @@
+# Behavior Validator Report Schema
+
+Use this JSON shape when the orchestrator needs machine-readable behavior validation output.
+
+```json
+{
+  "overall_behavior": "satisfies_contract",
+  "overall_confidence": 0.9,
+  "target": {
+    "type": "web app",
+    "access": "http://localhost:3000"
+  },
+  "checks": [
+    {
+      "contract_clause": "User task 1",
+      "status": "pass",
+      "severity": "P2",
+      "evidence": "Created an invoice, refreshed the page, and saw it remain in the invoice list.",
+      "reproduction_steps": [
+        "Open /invoices",
+        "Click Create",
+        "Submit valid invoice fields",
+        "Refresh /invoices"
+      ],
+      "confidence": 0.9
+    }
+  ],
+  "anti_cheat_probes": [
+    {
+      "probe": "Changed fixture amount and refreshed dashboard",
+      "result": "Dashboard total updated from 120 to 180"
+    }
+  ],
+  "blockers": []
+}
+```
+
+Allowed `overall_behavior` values:
+
+- `satisfies_contract`
+- `violates_contract`
+- `blocked`
+
+Allowed check `status` values:
+
+- `pass`
+- `fail`
+- `blocked`
+- `out_of_scope`
+
+Use `fail` for observable contract violations, including static or fake behavior. Use `blocked` only when runtime access or required test inputs are unavailable.

--- a/skills/behavior-validator/references/report-schema.md
+++ b/skills/behavior-validator/references/report-schema.md
@@ -14,7 +14,7 @@ Use this JSON shape when the orchestrator needs machine-readable behavior valida
     {
       "contract_clause": "User task 1",
       "status": "pass",
-      "severity": "P2",
+      "severity": null,
       "evidence": "Created an invoice, refreshed the page, and saw it remain in the invoice list.",
       "reproduction_steps": [
         "Open /invoices",
@@ -48,4 +48,4 @@ Allowed check `status` values:
 - `blocked`
 - `out_of_scope`
 
-Use `fail` for observable contract violations, including static or fake behavior. Use `blocked` only when runtime access or required test inputs are unavailable.
+Use `severity` only for `fail` checks; use `null` otherwise. Use `fail` for observable contract violations, including static or fake behavior. Use `blocked` only when runtime access or required test inputs are unavailable. Redact credentials, tokens, cookies, private user data, and unrelated log content from every evidence field.


### PR DESCRIPTION
Closes #38

## Summary

- add `behavior-validator` as a source-blind behavior validation skill
- add contract and report-schema references for black-box validation
- mention the behavior-validator pairing from `autoreview`
- list the new skill in the README and `skills.sh.json`
- update the isolation guidance to use a unique private temp workspace with restrictive permissions for contracts, credentials, and captured evidence

## Verification

Redacted terminal proof from the PR branch:

```text
$ scripts/validate-skills
validated 6 skills

$ scripts/install-skills --list
agent-transcript
autoreview
behavior-validator
crabbox
handoff
session-viewer

$ python3 ~/.codex/skills/.system/skill-creator/scripts/quick_validate.py skills/behavior-validator
Skill is valid!

$ ruby -c scripts/install-skills && ruby -c scripts/validate-skills
Syntax OK
Syntax OK

$ bash -n skills/autoreview/scripts/test-review-harness
# passed with no output

$ python3 -m py_compile skills/autoreview/scripts/autoreview skills/autoreview/scripts/test-review-harness.py
# passed with no output

$ node --check skills/agent-transcript/scripts/agent-transcript
# passed with no output

$ node --test skills/agent-transcript/scripts/agent-transcript.test.mjs skills/session-viewer/scripts/session-viewer.test.ts
✔ render redacts common secrets and local identifiers (86.712083ms)
✔ render drops raw tool outputs but keeps a compact tool summary (68.083041ms)
✔ append-body replaces an existing transcript section (67.687667ms)
✔ find scans CLAUDE_CONFIG_DIR projects and labels them as Claude (65.474917ms)
✔ find labels explicit roots under trailing-slash CLAUDE_CONFIG_DIR as Claude (65.307417ms)
...
ℹ tests 32
ℹ suites 0
ℹ pass 32
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 445.088583

$ skills/autoreview/scripts/autoreview --mode local
autoreview target: local
branch: feat/behavior-validator
engine: codex
model: gpt-5.5
tools: on
web_search: on
bundle: 6661 chars
autoreview clean: no accepted/actionable findings reported
overall: patch is correct (0.93)
The change replaces a fixed shared /tmp validator workspace with a per-run mktemp directory, tightens permissions, and updates the guidance to avoid fixed shared paths for contracts, credentials, and evidence. I found no actionable defects introduced by this documentation-only patch.
```
