### PR TITLE
ci: update validation actions

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -13,14 +13,14 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
         with:
           node-version: '22'
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.3'
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.x'
       - name: Validate skill frontmatter


### PR DESCRIPTION
## Summary

- update `actions/checkout` from v4 to v7
- update `actions/setup-node` from v4 to v6
- update `actions/setup-python` from v5 to v6

## Proof

- `scripts/validate-skills`
- Python installer tests: 6 passed
- AutoReview self-tests and unit tests: 11 passed
- Node tests: 32 passed
- local workflow-equivalent validation passed

GitHub-hosted runners satisfy the Node 24 action requirement (runner v2.327.1 or newer). No package-manager cache behavior applies because the repository has no package manifest.
