### PR TITLE
fix: normalize session viewer metadata

### DIFF
--- a/skills/session-viewer/agents/openai.yaml
+++ b/skills/session-viewer/agents/openai.yaml
@@ -1,3 +1,4 @@
-display_name: Session Viewer
-short_description: Render agent session JSONL as searchable one-file HTML.
-default_prompt: View this session log in a browser.
+interface:
+  display_name: "Session Viewer"
+  short_description: "Render session JSONL as searchable HTML"
+  default_prompt: "Use $session-viewer to render this agent session as searchable, shareable HTML."


### PR DESCRIPTION
## Summary

- move Session Viewer UI metadata under the current `interface` key
- make the default prompt explicitly invoke `$session-viewer`

## Proof

- YAML-parsed all skill frontmatter and `agents/openai.yaml` files
- `scripts/validate-skills`: 6 skills
- Session Viewer tests: 27 passed
