### PR TITLE
docs: document shared skill vision

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Shared skills for coding agents that work on OpenClaw projects.
 This repo is the public canonical source for common workflows such as review
 closeout and remote validation. The goal is simple: write a workflow once,
 reuse it everywhere, and avoid hand-copying long `SKILL.md` files across every
-repo.
+repo. See [VISION.md](VISION.md) for catalog boundaries and admission principles.
 
 ## Included Skills
 

--- a/VISION.md
+++ b/VISION.md
@@ -1,0 +1,48 @@
+# Vision
+
+OpenClaw Agent Skills is the curated public source for small, reusable agent
+workflows. A skill belongs here when several repositories or agents benefit
+from one shared operational contract.
+
+## What Belongs Here
+
+- A distinct recurring workflow, tool boundary, or evidence contract—not
+  generic engineering judgment restated as instructions.
+- Portable behavior that is useful across projects and agent runtimes.
+- A narrow responsibility with explicit inputs, outputs, failure modes, and
+  safety boundaries.
+- Proportionate implementation and proof. Dependencies, privileges, and new
+  automation must be necessary for the workflow itself.
+- Public, vendor-neutral guidance where practical. Provider-specific behavior
+  is acceptable when its real contract is documented and tested directly.
+
+Examples include review closeout, source-blind behavior validation, remote
+validation, transcript handling, and focused handoff workflows.
+
+## Boundaries
+
+- Product-specific skills, generated API catalogs, and service-owned workflows
+  stay with their source project or a community catalog such as ClawHub.
+- Repository instructions and callers own product policy, durable memory, and
+  task context. Shared helpers should consume bounded explicit inputs rather
+  than create parallel policy or persistence systems.
+- Do not hide materially different provider cost, quality, eligibility, or
+  failure semantics behind one portable convenience flag. Prefer explicit
+  controls; require exact runtime proof for provider-specific tiers or modes.
+- Repository-relative, bounded, read-only inputs are the default. Broader host
+  paths, external repositories, credentials, publishing, or privileged
+  automation require a narrow ownership model and end-to-end isolation proof.
+- Distribution infrastructure is not bundled merely to publish one skill.
+  Prefer existing source-repository and community publication paths.
+
+## Evolution
+
+- Solve one coherent user problem at a time; split unrelated policy,
+  persistence, provider, and publishing surfaces.
+- Validate the installed or built workflow through the real affected boundary.
+  Dry runs, fixtures, and command-construction tests support but do not replace
+  runtime proof for claims about external tools or services.
+- Keep public CLI and artifact contracts predictable. Add compatibility only
+  for explicit shipped contracts, not speculative future use.
+- Prefer a smaller catalog with clear ownership and strong proof over broad
+  coverage with duplicated judgment or hidden operational risk.


### PR DESCRIPTION
## Summary

- add a durable `VISION.md` for shared-skill admission, ownership, safety, and proof boundaries
- link the policy from the README
- keep ticket-specific outcomes in their issues/PRs while recording only reusable catalog rules

## Policy provenance

- product-specific and generated catalogs: https://github.com/openclaw/agent-skills/pull/10 and https://github.com/openclaw/agent-skills/pull/27
- bounded explicit inputs and caller-owned durable policy: https://github.com/openclaw/agent-skills/pull/23 and https://github.com/openclaw/agent-skills/pull/25
- explicit provider semantics instead of a portable fast abstraction: https://github.com/openclaw/agent-skills/issues/33 and https://github.com/openclaw/agent-skills/pull/34
- distinct reusable workflow boundary accepted for source-blind validation: https://github.com/openclaw/agent-skills/pull/39

## Verification

- `git diff --check`
- `scripts/validate-skills` (6 skills)
- installer tests (6), validator tests (9), AutoReview unit tests (11), Node tests (32)
- all seven AutoReview self-tests in the validation workflow
- Python compile checks, shell syntax check, Node syntax check
- `scripts/install-skills --list` and `scripts/install-skills --dry-run`
- `skills/autoreview/scripts/autoreview --mode local --engine codex --model gpt-5.5 --thinking high --stream-engine-output`: clean, no accepted/actionable findings

No external runtime boundary applies: this is repository policy documentation with a README link.

## Risk

Low. Documentation only; no installed skill, helper, dependency, workflow, or release behavior changes.
