### PR TITLE
docs: document complete validation workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 __pycache__/
 *.py[cod]
+.venv/

--- a/README.md
+++ b/README.md
@@ -160,13 +160,23 @@ belong inside that skill's `scripts/` directory.
 Run this after edits:
 
 ```sh
-python3 -m pip install -r requirements-dev.txt
+python3 -m venv .venv
+. .venv/bin/activate
+python -m pip install -r requirements-dev.txt
 scripts/validate-skills
 python3 -m py_compile scripts/install-skills scripts/install-skills.test.py scripts/validate-skills scripts/validate-skills.test.py
 python3 scripts/install-skills.test.py
 python3 scripts/validate-skills.test.py
 bash -n skills/autoreview/scripts/test-review-harness
-python3 -m py_compile skills/autoreview/scripts/autoreview skills/autoreview/scripts/test-review-harness.py
+python3 -m py_compile skills/autoreview/scripts/autoreview skills/autoreview/scripts/test-review-harness.py skills/autoreview/scripts/autoreview_test.py
+python3 skills/autoreview/scripts/autoreview --self-test-config-defaults
+python3 skills/autoreview/scripts/autoreview --self-test-fallback-scope
+python3 skills/autoreview/scripts/autoreview --self-test-engine-isolation
+python3 skills/autoreview/scripts/autoreview --self-test-json-array-parser
+python3 skills/autoreview/scripts/autoreview --self-test-opencode-jsonl-parser
+python3 skills/autoreview/scripts/autoreview --self-test-opencode-isolation
+python3 skills/autoreview/scripts/autoreview --self-test-cursor-jsonl-parser
+python3 -m unittest skills/autoreview/scripts/autoreview_test.py
 node --check skills/agent-transcript/scripts/agent-transcript
 node --test skills/agent-transcript/scripts/agent-transcript.test.mjs skills/session-viewer/scripts/session-viewer.test.ts
 ```


### PR DESCRIPTION
## Summary

- create and ignore a local Python virtual environment before installing validation dependencies
- document the complete AutoReview self-test and unit-test commands already required by CI
- include the AutoReview unit-test module in the documented compile check

## Proof

- replayed every command in the documented validation block under `set -e` from a fresh Python 3.14 virtual environment
- skill validation: 6 skills
- Python tests: installer 6, validator 9, AutoReview 11
- AutoReview self-tests: all seven passed
- Node tests: 32 passed
- shell, Python, Node syntax checks and `git diff --check` passed
- structured AutoReview with Codex `gpt-5.5` / high reasoning: clean, no accepted/actionable findings

No external runtime boundary applies: this only corrects contributor setup and validation documentation. Public Model Identifier Gate: PASS; no model-bearing code or artifact changes.

## Risk

Low. Documentation and local virtual-environment ignore behavior only; no installed skill, helper, dependency, CI, or release behavior changes.
