### PR TITLE
feat(autoreview): default Codex reviews to gpt-5.6-sol

### DIFF
--- a/skills/autoreview/AGENTS.md
+++ b/skills/autoreview/AGENTS.md
@@ -1,0 +1,6 @@
+# Autoreview Skill
+
+- Canonical source: `openclaw/agent-skills`, under `skills/autoreview`.
+- Before editing any copy, fast-forward a checkout of `openclaw/agent-skills` from `origin/main`.
+- Make and validate shared changes in canonical `skills/autoreview` first, then sync the complete directory into downstream repos.
+- Never create repo-local behavior variants; downstream differences belong in repo-level validation, not the skill.

--- a/skills/autoreview/CLAUDE.md
+++ b/skills/autoreview/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/skills/autoreview/SKILL.md
+++ b/skills/autoreview/SKILL.md
@@ -7,7 +7,7 @@ description: "Pre-commit/ship code review: Codex default; optional Claude, Pi, D
 
 Run the bundled structured review helper as a closeout check. This is code review, not Guardian `auto_review` approval routing.
 
-Codex review is the default when no engine is set. It uses `gpt-5.5` by default, usually delivers the best review results, and should remain the normal final closeout engine. Claude review is optional and uses `claude-fable-5` by default.
+Codex review is the default when no engine is set. It uses `gpt-5.6-sol` with `high` reasoning by default, then retries once with `gpt-5.6-terra` only when the account cannot access Sol. Claude review is optional and uses `claude-fable-5` by default.
 
 For user-visible behavior, pair autoreview with `behavior-validator`. Autoreview is source-aware and judges the change bundle; behavior validation is source-blind and judges the running product or tool against a behavior contract. A clean autoreview is not proof that a UI, CLI, API, or generated artifact works from the user's perspective.
 
@@ -35,6 +35,7 @@ Use when:
 - Do not kill a review just because it has been quiet for 2-5 minutes, or because it is still running under the 30-minute window. Inspect the process only after missing multiple expected heartbeats, after 30 minutes, or after an obviously failed subprocess; prefer letting the same helper command finish.
 - Tools are useful in review mode. The helper allows read-only inspection tools and web search by default so reviewers can check dependency contracts, upstream docs, and current behavior.
 - Security perspective is always included, but it should not cripple legitimate functionality. Report security findings only when the change creates a concrete, actionable risk or removes an important safety check.
+- Reviewer subprocesses preserve authentication and proxy variables needed by headless or restricted-network environments while stripping process-injection and Git override variables.
 - Review bundles fail closed before engine invocation when tracked or untracked paths look sensitive, patch text looks secret-like, or a Git diff exceeds the bundle limit. Redact/split the change; never accept a truncated patch as complete review proof.
 - For regression provenance, keep roles separate: blamed code author, blamed PR author, PR merger/committer, current PR author, and PR/date. If no blamed PR is traceable, use the blamed commit as the provenance: commit SHA, date, and author username. Do not guess a merger or frame missing PR metadata as a separate finding.
 - If the blamed PR was merged by `clawsweeper[bot]` or another automation, identify the human trigger when practical. Check timeline/comments first; if rate-limited, use gitcrawl/cache or public PR HTML. Look for maintainer commands such as `@clawsweeper automerge`, `/landpr`, or labels/status comments that armed automerge. Report `automerge triggered by @login`; if not found, say trigger unknown.
@@ -186,13 +187,13 @@ Run multiple reviewers against one frozen bundle:
 Set reviewer models and thinking/effort explicitly:
 
 ```bash
-"$AUTOREVIEW" --reviewers codex,claude --model codex=gpt-5.5 --thinking codex=high --model claude=claude-fable-5 --thinking claude=max
+"$AUTOREVIEW" --reviewers codex,claude --model codex=gpt-5.6-sol --thinking codex=high --model claude=claude-fable-5 --thinking claude=max
 ```
 
 Inline syntax is also supported for simple model IDs:
 
 ```bash
-"$AUTOREVIEW" --reviewers codex:gpt-5.5:high,claude:claude-fable-5:max
+"$AUTOREVIEW" --reviewers codex:gpt-5.6-sol:high,claude:claude-fable-5:max
 ```
 
 For models with slashes or extra colons, prefer keyed form:
@@ -201,9 +202,9 @@ For models with slashes or extra colons, prefer keyed form:
 "$AUTOREVIEW" --engine pi --model anthropic/claude-sonnet-4 --thinking high
 "$AUTOREVIEW" --engine opencode --model opencode/north-mini-code-free --thinking high
 "$AUTOREVIEW" --engine cursor --model auto --cursor-allow-workspace-instructions
-"$AUTOREVIEW" --reviewers codex,pi --model codex=gpt-5.5 --model pi=anthropic/claude-sonnet-4
-"$AUTOREVIEW" --reviewers codex,opencode --model codex=gpt-5.5 --model opencode=opencode/north-mini-code-free
-"$AUTOREVIEW" --reviewers codex,cursor --model codex=gpt-5.5 --model cursor=auto --cursor-allow-workspace-instructions
+"$AUTOREVIEW" --reviewers codex,pi --model codex=gpt-5.6-sol --model pi=anthropic/claude-sonnet-4
+"$AUTOREVIEW" --reviewers codex,opencode --model codex=gpt-5.6-sol --model opencode=opencode/north-mini-code-free
+"$AUTOREVIEW" --reviewers codex,cursor --model codex=gpt-5.6-sol --model cursor=auto --cursor-allow-workspace-instructions
 ```
 
 `--reviewers all` covers Codex, Claude, Copilot, Pi, and OpenCode. Cursor requires both explicit selection (`--engine cursor` or named in `--reviewers`) and `--cursor-allow-workspace-instructions` because the current Cursor CLI does not document a per-run flag that ignores project-local instructions/config. Droid selection currently fails closed because its CLI cannot disable both project instructions and all tools.
@@ -216,14 +217,14 @@ Recommended model defaults:
 
 | Engine | Default model | Source note |
 |--------|---------------|-------------|
-| **codex** (default) | `gpt-5.5` | OpenAI's current GPT-5.5 alias |
+| **codex** (default) | `gpt-5.6-sol` -> `gpt-5.6-terra` on access failure | OpenClaw org review default |
 | **claude** | `claude-fable-5` | Anthropic's most capable widely released Claude model |
 
 CLI flags and environment variables override these defaults. Droid, Copilot, Pi, Cursor, and OpenCode do not get built-in model defaults here because their provider catalogs are external to the Codex/Claude closeout path and may vary by installation.
 
 | Engine | Model flag | Example model IDs | Thinking flag | Accepted levels |
 |--------|------------|-------------------|---------------|-----------------|
-| **codex** (default) | `codex --model X exec ...` | `gpt-5.5`, `gpt-5.5-2026-04-23` | `-c model_reasoning_effort=Y` | `none`, `minimal`, `low`, `medium`, `high`, `xhigh` |
+| **codex** (default) | `codex --model X exec ...` | `gpt-5.6-sol`, then `gpt-5.6-terra` on Sol access failure | `-c model_reasoning_effort=Y` | `none`, `minimal`, `low`, `medium`, `high`, `xhigh` |
 | **claude** | `claude --model X` | `claude-fable-5`, `claude-opus-4-8`, `claude-sonnet-4-6`, `claude-haiku-4-5` | `--effort Y` | `low`, `medium`, `high`, `xhigh`, `max` |
 | **droid** | currently refused | Factory model IDs | `-r, --reasoning-effort Y` | `off`, `none`, `low`, `medium`, `high`, `xhigh`, `max` |
 | **copilot** | `copilot --model X` | `gpt-5.2`, Copilot model aliases | not supported | n/a |
@@ -237,7 +238,7 @@ Examples matching current `main` behavior:
 
 ```bash
 # Codex with explicit model and reasoning
-"$AUTOREVIEW" --engine codex --model gpt-5.5 --thinking high
+"$AUTOREVIEW" --engine codex --model gpt-5.6-sol --thinking high
 
 # Codex fast mode (priority service tier); needs a model whose catalog lists the tier, silently standard otherwise
 "$AUTOREVIEW" --engine codex --codex-speed fast
@@ -278,7 +279,7 @@ loader such as an untracked `.envrc`; the helper does not write a config file.
 | `AUTOREVIEW_MODEL` | Override the built-in default `--model` for all engines |
 | `AUTOREVIEW_THINKING` | Default `--thinking` for all engines |
 | `AUTOREVIEW_FALLBACK_MODEL` | Default Claude `--fallback-model` chain |
-| `AUTOREVIEW_<ENGINE>_MODEL` | Per-engine model override, for example `AUTOREVIEW_CODEX_MODEL=gpt-5.5` |
+| `AUTOREVIEW_<ENGINE>_MODEL` | Per-engine model override, for example `AUTOREVIEW_CODEX_MODEL=gpt-5.6-sol` |
 | `AUTOREVIEW_<ENGINE>_THINKING` | Per-engine thinking override |
 | `AUTOREVIEW_CODEX_CONFIG` | Default Codex `-c key=value` overrides, semicolon-separated, e.g. `service_tier="fast"`; isolation flags still win |
 | `AUTOREVIEW_CODEX_SPEED` | Default Codex service tier: `fast` (priority), `flex`, or `default`; silently standard when the model does not list the tier |
@@ -347,7 +348,7 @@ The helper:
 - supports `--dry-run`, `--parallel-tests`, `--parallel-tests-shell`, `--prompt`, repo-relative `--prompt-file`, repo-relative `--dataset`, `--no-tools`, `--no-web-search`, repeatable Codex-only `--codex-config key=value`, Codex-only `--codex-speed fast|flex|default`, and commit refs
 - supports `--stream-engine-output` or `AUTOREVIEW_STREAM_ENGINE_OUTPUT=1` for live engine text while preserving structured validation; Codex, Claude, and Cursor hide tool/file event details, emit compact activity summaries, and report usage at turn completion
 - supports opt-in review panels with `--panel` / `--reviewers`, plus per-engine `--model`, `--thinking`, and Claude `--fallback-model`
-- uses built-in model defaults `codex=gpt-5.5` and `claude=claude-fable-5`; honors `AUTOREVIEW_MODEL`, `AUTOREVIEW_THINKING`, `AUTOREVIEW_FALLBACK_MODEL`, and per-engine `AUTOREVIEW_<ENGINE>_MODEL` / `AUTOREVIEW_<ENGINE>_THINKING` environment overrides when CLI flags are omitted
+- uses built-in defaults `codex=gpt-5.6-sol` with `high` reasoning and an access-only `gpt-5.6-terra` retry, plus `claude=claude-fable-5`; honors `AUTOREVIEW_MODEL`, `AUTOREVIEW_THINKING`, `AUTOREVIEW_FALLBACK_MODEL`, and per-engine `AUTOREVIEW_<ENGINE>_MODEL` / `AUTOREVIEW_<ENGINE>_THINKING` environment overrides when CLI flags are omitted
 - allows read-only tools and web search by default where the selected CLI supports them; forbids nested review in the prompt; Codex is run through `codex exec` with auth-only user settings, read-only sandbox, reviewed-repo instruction/config/rule isolation flags, and structured output
 - runs Claude with `--safe-mode` (`v2.1.169+`), `--setting-sources user`, MCP disabled, explicit allowed tools, and `--fallback-model` when set, so reviewed-repo hooks/skills/MCP do not affect the review run while normal auth still works; managed settings policy can still apply
 - refuses Droid reviews until the CLI exposes a complete project-instruction and tool-isolation contract

--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -115,10 +115,16 @@ SECRET_VALUE_PATTERNS = [
     re.compile(r"\bya29\.[0-9A-Za-z_-]{20,}\b"),
 ]
 MAX_BUNDLE_TEXT_BYTES = 180_000
+SECRET_SCAN_CHUNK_CHARS = 64_000
+SECRET_SCAN_OVERLAP_CHARS = 512
 DEFAULT_ENGINE_PATHS = ("/usr/local/bin", "/usr/bin", "/bin")
 DEFAULT_MODEL_BY_ENGINE = {
-    "codex": "gpt-5.5",
+    "codex": "gpt-5.6-sol",
     "claude": "claude-fable-5",
+}
+DEFAULT_CODEX_ACCESS_FALLBACK_MODEL = "gpt-5.6-terra"
+DEFAULT_THINKING_BY_ENGINE = {
+    "codex": "high",
 }
 THINKING_LEVELS_BY_ENGINE = {
     "codex": {"none", "minimal", "low", "medium", "high", "xhigh"},
@@ -275,6 +281,14 @@ def safe_engine_path(repo: Path, extra_paths: list[Path] | None = None) -> str:
     return os.pathsep.join(entries)
 
 
+def codex_tool_git_env() -> dict[str, str]:
+    env = {"GIT_CONFIG_COUNT": str(len(ENGINE_GIT_CONFIG_OVERRIDES))}
+    for index, (key, value) in enumerate(ENGINE_GIT_CONFIG_OVERRIDES):
+        env[f"GIT_CONFIG_KEY_{index}"] = key
+        env[f"GIT_CONFIG_VALUE_{index}"] = value
+    return env
+
+
 def safe_engine_env(
     repo: Path,
     extra_paths: list[Path] | None = None,
@@ -301,10 +315,7 @@ def safe_engine_env(
         if key not in blocked_exact and not any(key.startswith(prefix) for prefix in blocked_prefixes)
     }
     env["PATH"] = safe_engine_path(repo, extra_paths)
-    env["GIT_CONFIG_COUNT"] = str(len(ENGINE_GIT_CONFIG_OVERRIDES))
-    for index, (key, value) in enumerate(ENGINE_GIT_CONFIG_OVERRIDES):
-        env[f"GIT_CONFIG_KEY_{index}"] = key
-        env[f"GIT_CONFIG_VALUE_{index}"] = value
+    env.update(codex_tool_git_env())
     env.update(extra or {})
     return env
 
@@ -825,6 +836,20 @@ def secret_text_risk(text: str) -> bool:
     return any(pattern.search(text) for pattern in SECRET_VALUE_PATTERNS)
 
 
+def file_secret_text_risk(path: Path) -> bool:
+    overlap = ""
+    try:
+        with path.open("r", encoding="utf-8", errors="replace") as handle:
+            while chunk := handle.read(SECRET_SCAN_CHUNK_CHARS):
+                text = overlap + chunk
+                if secret_text_risk(text):
+                    return True
+                overlap = text[-SECRET_SCAN_OVERLAP_CHARS:]
+    except OSError as exc:
+        raise SystemExit(f"unreadable file: {path}: {exc}") from exc
+    return False
+
+
 def require_no_secret_values(label: str, text: str) -> None:
     if secret_text_risk(text):
         raise SystemExit(
@@ -950,10 +975,14 @@ def file_bundle_risk(
         data, _ = read_prefix(path, MAX_BUNDLE_TEXT_BYTES)
     except SystemExit as exc:
         return str(exc)
+    try:
+        sensitive_value_found = file_secret_text_risk(path)
+    except SystemExit as exc:
+        return str(exc)
+    if sensitive_value_found:
+        return "secret-like content"
     if b"\0" in data:
         return None if allow_binary_omission else "binary file"
-    if secret_text_risk(data.decode("utf-8", errors="replace")):
-        return "secret-like content"
     return None
 
 
@@ -1265,12 +1294,28 @@ def toml_quoted_key_segment(value: str) -> str:
     return json.dumps(value)
 
 
+def toml_inline_string_table(values: dict[str, str]) -> str:
+    entries = ", ".join(f"{key}={json.dumps(value)}" for key, value in sorted(values.items()))
+    return "{" + entries + "}"
+
+
 def codex_config_isolation_flags(repo: Path) -> list[str]:
+    tool_env = toml_inline_string_table(codex_tool_git_env())
     return [
         "-c",
         "project_doc_max_bytes=0",
         "-c",
         f"projects.{toml_quoted_key_segment(str(repo.resolve()))}.trust_level=\"untrusted\"",
+        "-c",
+        'shell_environment_policy.inherit="core"',
+        "-c",
+        "shell_environment_policy.ignore_default_excludes=false",
+        "-c",
+        f"shell_environment_policy.set={tool_env}",
+        "-c",
+        "shell_environment_policy.experimental_use_profile=false",
+        "-c",
+        "allow_login_shell=false",
     ]
 
 
@@ -1484,16 +1529,36 @@ def codex_speed_override(args: argparse.Namespace) -> str | None:
     return f'service_tier="{speed}"'
 
 
-def run_codex(args: argparse.Namespace, repo: Path, prompt: str) -> str:
-    if not args.tools:
-        raise SystemExit("--no-tools is not supported by the Codex engine; use --engine claude --no-tools for a no-tools run")
-    schema_path = write_json_temp(SCHEMA)
-    output_path = Path(tempfile.NamedTemporaryFile("w", suffix=".json", delete=False).name)
+def codex_model_access_failure(result: subprocess.CompletedProcess[str], model: str) -> bool:
+    text = f"{result.stderr}\n{result.stdout}".lower()
+    if model.lower() not in text:
+        return False
+    return any(
+        marker in text
+        for marker in (
+            "does not exist or you do not have access",
+            "do not have access to",
+            "don't have access to",
+            "not supported when using codex",
+            "model_not_found",
+            "model_not_available",
+            "unsupported_model",
+        )
+    )
+
+
+def codex_command(
+    args: argparse.Namespace,
+    repo: Path,
+    schema_path: Path,
+    output_path: Path,
+    model: str | None,
+) -> list[str]:
     cmd = [resolve_command(args.codex_bin, repo), "--ask-for-approval", "never"]
     if args.web_search:
         cmd.append("--search")
-    if args.model:
-        cmd.extend(["--model", args.model])
+    if model:
+        cmd.extend(["--model", model])
     # User overrides go before the isolation flags so isolation stays authoritative on conflicts.
     for override in codex_config_overrides(args):
         cmd.extend(["-c", override])
@@ -1524,23 +1589,60 @@ def run_codex(args: argparse.Namespace, repo: Path, prompt: str) -> str:
             "-",
         ]
     )
-    result = run_with_heartbeat(
-        cmd,
-        repo,
-        input_text=prompt,
-        label="codex",
-        stream_output=args.stream_engine_output,
-        stream_display=CodexStreamDisplay() if args.stream_engine_output else None,
-        env=safe_engine_env(repo, [Path(cmd[0]).parent]),
-    )
+    return cmd
+
+
+def run_codex(args: argparse.Namespace, repo: Path, prompt: str) -> str:
+    if not args.tools:
+        raise SystemExit("--no-tools is not supported by the Codex engine; use --engine claude --no-tools for a no-tools run")
+    schema_path = write_json_temp(SCHEMA)
+    with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as output_file:
+        output_path = Path(output_file.name)
+    models = [args.model]
+    fallback_model = getattr(args, "fallback_model", None)
+    if fallback_model and fallback_model != args.model:
+        models.append(fallback_model)
+    primary_failure: subprocess.CompletedProcess[str] | None = None
     try:
-        output = output_path.read_text()
+        for index, model in enumerate(models):
+            output_path.write_text("")
+            cmd = codex_command(args, repo, schema_path, output_path, model)
+            result = run_with_heartbeat(
+                cmd,
+                repo,
+                input_text=prompt,
+                label="codex",
+                stream_output=args.stream_engine_output,
+                stream_display=CodexStreamDisplay() if args.stream_engine_output else None,
+                env=safe_engine_env(repo, [Path(cmd[0]).parent]),
+            )
+            output = output_path.read_text()
+            if result.returncode == 0:
+                return output or result.stdout
+            if (
+                index == 0
+                and len(models) > 1
+                and model
+                and codex_model_access_failure(result, model)
+            ):
+                primary_failure = result
+                print(
+                    f"codex model {model} is unavailable for this account; retrying with {models[1]}",
+                    file=sys.stderr,
+                )
+                continue
+            detail = result.stderr or result.stdout
+            if primary_failure is not None:
+                primary_detail = primary_failure.stderr or primary_failure.stdout
+                raise SystemExit(
+                    f"codex engine failed with primary model ({primary_failure.returncode})\n{primary_detail}\n"
+                    f"codex fallback model failed ({result.returncode})\n{detail}"
+                )
+            raise SystemExit(f"codex engine failed ({result.returncode})\n{detail}")
     finally:
         schema_path.unlink(missing_ok=True)
         output_path.unlink(missing_ok=True)
-    if result.returncode != 0:
-        raise SystemExit(f"codex engine failed ({result.returncode})\n{result.stderr or result.stdout}")
-    return output or result.stdout
+    raise AssertionError("unreachable")
 
 
 def run_claude(args: argparse.Namespace, repo: Path, prompt: str) -> str:
@@ -3281,12 +3383,12 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--base")
     parser.add_argument("--commit", default="HEAD")
     parser.add_argument("--engine", choices=ENGINE_CHOICES, default=os.environ.get("AUTOREVIEW_ENGINE", "codex"))
-    parser.add_argument("--reviewers", help="Comma-separated review panel, e.g. codex,claude,cursor or codex:gpt-5.5:high.")
+    parser.add_argument("--reviewers", help="Comma-separated review panel, e.g. codex,claude,cursor or codex:gpt-5.6-sol:high.")
     parser.add_argument("--panel", action="store_true", help="Run a Codex/Claude review panel unless --engine changes the first reviewer.")
     parser.add_argument(
         "--model",
         action="append",
-        help="Model for all reviewers or engine=model. Repeatable. Defaults: codex=gpt-5.5, claude=claude-fable-5.",
+        help="Model for all reviewers or engine=model. Repeatable. Defaults: codex=gpt-5.6-sol with an access-only gpt-5.6-terra retry, claude=claude-fable-5.",
     )
     parser.add_argument("--thinking", action="append", help="Thinking/effort for all reviewers or engine=level. Repeatable. Codex: none, minimal, low, medium, high, xhigh. Claude: low, medium, high, xhigh, max. Droid: off, none, low, medium, high. Pi: off, minimal, low, medium, high, xhigh. OpenCode: minimal, low, medium, high, max. Cursor: none.")
     parser.add_argument(
@@ -3519,6 +3621,7 @@ def reviewer_args(args: argparse.Namespace) -> list[argparse.Namespace]:
             or global_thinking
             or env_thinking_by_engine.get(engine)
             or env_global_thinking
+            or DEFAULT_THINKING_BY_ENGINE.get(engine)
         )
         if engine == "claude":
             fallback_model = (
@@ -3527,6 +3630,8 @@ def reviewer_args(args: argparse.Namespace) -> list[argparse.Namespace]:
                 or env_fallback_by_engine.get(engine)
                 or env_global_fallback
             )
+        elif engine == "codex" and model == DEFAULT_MODEL_BY_ENGINE["codex"]:
+            fallback_model = DEFAULT_CODEX_ACCESS_FALLBACK_MODEL
         else:
             fallback_model = None
         if thinking and thinking not in THINKING_LEVELS_BY_ENGINE[engine]:
@@ -3691,8 +3796,14 @@ def self_test_config_defaults() -> None:
     ]
     with preserve_env(keys):
         default_codex = reviewer_args(reviewer_test_args(engine="codex"))[0]
-        if default_codex.model != "gpt-5.5":
+        if default_codex.model != "gpt-5.6-sol":
             raise SystemExit(f"self-test config defaults failed: default codex model={default_codex.model!r}")
+        if default_codex.fallback_model != "gpt-5.6-terra":
+            raise SystemExit(
+                f"self-test config defaults failed: default codex fallback={default_codex.fallback_model!r}"
+            )
+        if default_codex.thinking != "high":
+            raise SystemExit(f"self-test config defaults failed: default codex thinking={default_codex.thinking!r}")
         default_claude = reviewer_args(reviewer_test_args(engine="claude"))[0]
         if default_claude.model != "claude-fable-5":
             raise SystemExit(f"self-test config defaults failed: default claude model={default_claude.model!r}")
@@ -3786,8 +3897,10 @@ def self_test_fallback_scope() -> None:
         reviewers = reviewer_args(base)
         codex = next(r for r in reviewers if r.engine == "codex")
         claude = next(r for r in reviewers if r.engine == "claude")
-        if codex.fallback_model is not None:
-            raise SystemExit("self-test fallback scope failed: codex should ignore AUTOREVIEW_FALLBACK_MODEL")
+        if codex.fallback_model != "gpt-5.6-terra":
+            raise SystemExit(
+                f"self-test fallback scope failed: codex access fallback={codex.fallback_model!r}"
+            )
         if claude.fallback_model != "env-claude-fallback":
             raise SystemExit(f"self-test fallback scope failed: claude fallback={claude.fallback_model!r}")
         os.environ.pop("AUTOREVIEW_CLAUDE_FALLBACK_MODEL")
@@ -3811,7 +3924,7 @@ def self_test_fallback_scope() -> None:
         panel = reviewer_args(reviewer_test_args(reviewers="codex,claude", fallback_model=["cli-global"]))
         panel_codex = next(r for r in panel if r.engine == "codex")
         panel_claude = next(r for r in panel if r.engine == "claude")
-        if panel_codex.fallback_model is not None or panel_claude.fallback_model != "cli-global":
+        if panel_codex.fallback_model != "gpt-5.6-terra" or panel_claude.fallback_model != "cli-global":
             raise SystemExit("self-test fallback scope failed: CLI global fallback should apply only to Claude panel reviewers")
         try:
             reviewer_args(reviewer_test_args(engine="codex", fallback_model=["cli-global"]))

--- a/skills/autoreview/scripts/autoreview_test.py
+++ b/skills/autoreview/scripts/autoreview_test.py
@@ -178,6 +178,80 @@ class AutoreviewCompatibilityTests(unittest.TestCase):
         args = argparse.Namespace(codex_config=['model_provider="private-value"'])
         self.assertEqual(AUTOREVIEW.codex_config_keys(args), ["model_provider"])
 
+    def test_codex_retries_terra_after_sol_access_failure(self) -> None:
+        args = argparse.Namespace(
+            codex_bin="codex",
+            codex_config=None,
+            codex_speed=None,
+            fallback_model="gpt-5.6-terra",
+            model="gpt-5.6-sol",
+            stream_engine_output=False,
+            thinking="high",
+            tools=True,
+            web_search=False,
+        )
+        models: list[str] = []
+
+        def fake_run(command: list[str], *_args: object, **_kwargs: object) -> subprocess.CompletedProcess[str]:
+            model = command[command.index("--model") + 1]
+            models.append(model)
+            if model == "gpt-5.6-sol":
+                return subprocess.CompletedProcess(
+                    command,
+                    1,
+                    "",
+                    "The model `gpt-5.6-sol` does not exist or you do not have access to it.",
+                )
+            output_path = Path(command[command.index("--output-last-message") + 1])
+            output_path.write_text(json.dumps(FINAL_REPORT))
+            return subprocess.CompletedProcess(command, 0, "", "")
+
+        with tempfile.TemporaryDirectory(prefix="autoreview-codex-fallback.") as tmpdir, mock.patch.object(
+            AUTOREVIEW,
+            "resolve_command",
+            return_value="/usr/bin/codex",
+        ), mock.patch.object(AUTOREVIEW, "codex_auth_config_flags", return_value=[]), mock.patch.object(
+            AUTOREVIEW,
+            "run_with_heartbeat",
+            side_effect=fake_run,
+        ):
+            output = AUTOREVIEW.run_codex(args, Path(tmpdir), "review")
+
+        self.assertEqual(json.loads(output), FINAL_REPORT)
+        self.assertEqual(models, ["gpt-5.6-sol", "gpt-5.6-terra"])
+
+    def test_codex_does_not_fallback_after_unrelated_failure(self) -> None:
+        args = argparse.Namespace(
+            codex_bin="codex",
+            codex_config=None,
+            codex_speed=None,
+            fallback_model="gpt-5.6-terra",
+            model="gpt-5.6-sol",
+            stream_engine_output=False,
+            thinking="high",
+            tools=True,
+            web_search=False,
+        )
+        models: list[str] = []
+
+        def fake_run(command: list[str], *_args: object, **_kwargs: object) -> subprocess.CompletedProcess[str]:
+            models.append(command[command.index("--model") + 1])
+            return subprocess.CompletedProcess(command, 1, "", "network timeout")
+
+        with tempfile.TemporaryDirectory(prefix="autoreview-codex-fallback.") as tmpdir, mock.patch.object(
+            AUTOREVIEW,
+            "resolve_command",
+            return_value="/usr/bin/codex",
+        ), mock.patch.object(AUTOREVIEW, "codex_auth_config_flags", return_value=[]), mock.patch.object(
+            AUTOREVIEW,
+            "run_with_heartbeat",
+            side_effect=fake_run,
+        ):
+            with self.assertRaisesRegex(SystemExit, "network timeout"):
+                AUTOREVIEW.run_codex(args, Path(tmpdir), "review")
+
+        self.assertEqual(models, ["gpt-5.6-sol"])
+
     def test_extract_json_accepts_dict_result_payload(self) -> None:
         payload = {
             "type": "result",

--- a/skills/autoreview/tests/test_autoreview_hardening.py
+++ b/skills/autoreview/tests/test_autoreview_hardening.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import argparse
+import json
 import os
 import runpy
 import subprocess
@@ -71,6 +72,29 @@ class AutoreviewHardeningTests(unittest.TestCase):
 
             self.assertIn("## image.bin\n[binary file omitted]", bundle)
             self.assertFalse(truncated)
+
+    def test_full_file_secret_scan_blocks_truncated_tail(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo = init_repo(Path(tempdir))
+            tail_secret = "\ntoken=" + "A" * 24 + "\n"
+            content = "x" * (64_000 * 3 - 4) + tail_secret
+
+            untracked = repo / "untracked.txt"
+            untracked.write_text(content, encoding="utf-8")
+            with self.assertRaisesRegex(SystemExit, "secret-like content"):
+                self.helper["safe_untracked_files"](repo)
+
+            untracked.unlink()
+            binary = repo / "binary.bin"
+            binary.write_bytes(b"\0" + content.encode())
+            with self.assertRaisesRegex(SystemExit, "secret-like content"):
+                self.helper["safe_untracked_files"](repo)
+
+            binary.unlink()
+            evidence = repo / "evidence.txt"
+            evidence.write_text(content, encoding="utf-8")
+            with self.assertRaisesRegex(SystemExit, "secret-like content"):
+                self.helper["validate_evidence_file"](repo, "evidence.txt", "--dataset")
 
     def test_branch_bundle_rejects_unsafe_or_unknown_base_before_diff(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:
@@ -418,6 +442,8 @@ class AutoreviewHardeningTests(unittest.TestCase):
                 os.environ["GIT_CONFIG_COUNT"] = "99"
                 os.environ["DYLD_INSERT_LIBRARIES"] = "/tmp/unsafe.dylib"
                 os.environ["NODE_OPTIONS"] = "--require=/tmp/unsafe.js"
+                os.environ["GITHUB_TOKEN"] = "test-token-placeholder"
+                os.environ["HTTPS_PROXY"] = "http://proxy.example.invalid:8080"
 
                 env = self.helper["safe_engine_env"](repo)
 
@@ -428,9 +454,29 @@ class AutoreviewHardeningTests(unittest.TestCase):
                 )
                 self.assertNotIn("DYLD_INSERT_LIBRARIES", env)
                 self.assertNotIn("NODE_OPTIONS", env)
+                self.assertEqual(env["GITHUB_TOKEN"], "test-token-placeholder")
+                self.assertEqual(env["HTTPS_PROXY"], "http://proxy.example.invalid:8080")
             finally:
                 os.environ.clear()
                 os.environ.update(old)
+
+    def test_codex_isolation_restricts_tool_environment(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo = init_repo(Path(tempdir))
+            flags = self.helper["codex_config_isolation_flags"](repo)
+
+        for required in (
+            'shell_environment_policy.inherit="core"',
+            "shell_environment_policy.ignore_default_excludes=false",
+            "shell_environment_policy.experimental_use_profile=false",
+            "allow_login_shell=false",
+        ):
+            self.assertIn(required, flags)
+        set_flag = next(
+            flag for flag in flags if flag.startswith("shell_environment_policy.set=")
+        )
+        for key, value in self.helper["codex_tool_git_env"]().items():
+            self.assertIn(f"{key}={json.dumps(value)}", set_flag)
 
     def test_safe_engine_env_excludes_repo_local_path_entries(self) -> None:
         old_path = os.environ.get("PATH", "")


### PR DESCRIPTION
## What Problem This Solves

OpenClaw repositories carry drifted copies of the autoreview skill and still default Codex reviews to older models.

## Why This Change Was Made

- default Codex reviews to gpt-5.6-sol at high reasoning
- retry once with gpt-5.6-terra only when Sol is unavailable to the account
- preserve safe Git overrides inside Codex tool subprocesses
- scan complete review files for secret-like content
- add scoped guidance that makes openclaw/agent-skills the canonical source

## User Impact

Autoreview uses the current OpenClaw model policy by default, still works for accounts without Sol access, and gives downstream repositories one canonical directory to sync.

## Evidence

- 56 Python tests passed
- scripts/validate-skills validated 6 skills
- live benign harness passed with gpt-5.6-sol at high
- live benign harness passed with gpt-5.6-terra at high
- simulated Sol access failure retried Terra; unrelated failures did not retry
- fresh autoreview completed with no accepted findings
