### PR TITLE
fix(autoreview): confine reviewer inputs

### DIFF
--- a/skills/autoreview/SKILL.md
+++ b/skills/autoreview/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: autoreview
-description: "Pre-commit/ship code review: Codex default; optional Claude, Pi, Droid, Copilot, Cursor, or OpenCode."
+description: "Pre-commit/ship code review: Codex default; optional Claude, Pi, or OpenCode."
 ---
 
 # Auto Review
 
 Run the bundled structured review helper as a closeout check. This is code review, not Guardian `auto_review` approval routing.
 
-Codex review is the default when no engine is set. It uses `gpt-5.6-sol` with `xhigh` reasoning and fast service tier by default. Claude review is optional and uses `claude-fable-5` by default.
+Codex review is the default when no engine is set. It uses `gpt-5.6-sol` with `high` reasoning by default, then retries once with `gpt-5.6-terra` only when the account cannot access Sol. Claude review is optional and uses `claude-fable-5` by default.
 
 For user-visible behavior, pair autoreview with `behavior-validator`. Autoreview is source-aware and judges the change bundle; behavior validation is source-blind and judges the running product or tool against a behavior contract. A clean autoreview is not proof that a UI, CLI, API, or generated artifact works from the user's perspective.
 
@@ -29,7 +29,7 @@ Use when:
 - Keep going until structured review returns no accepted/actionable findings only while the work remains inside the original task scope.
 - If a review-triggered fix changes code, rerun focused tests and rerun the structured review helper.
 - For security-audit suppression changes, verify accepted findings remain auditable: suppressed findings stay in structured output, active output keeps an unsuppressible suppression notice, and aggregate findings cannot hide unrelated active risk.
-- Never switch or override the requested review engine/model. Capacity, access, rate-limit, and unrelated failures keep the same engine/model.
+- Never switch or override the requested review engine/model except for the documented Codex Sol-to-Terra account-access fallback. Capacity, rate-limit, and unrelated failures keep the same engine/model.
 - Be patient with large bundles. Structured review can take up to 30 minutes while the model call is active, especially with Codex tools or web search.
 - Treat heartbeat lines like `review still running: ... elapsed=... pid=...` as healthy progress, not a hang. Let the helper continue while heartbeats are advancing. Pass `--stream-engine-output` when live engine text is useful; Codex, Claude, and Cursor filter tool/file chatter, other engines pass raw output through.
 - Do not kill a review just because it has been quiet for 2-5 minutes, or because it is still running under the 30-minute window. Inspect the process only after missing multiple expected heartbeats, after 30 minutes, or after an obviously failed subprocess; prefer letting the same helper command finish.
@@ -187,13 +187,13 @@ Run multiple reviewers against one frozen bundle:
 Set reviewer models and thinking/effort explicitly:
 
 ```bash
-"$AUTOREVIEW" --reviewers codex,claude --model codex=gpt-5.6-sol --thinking codex=xhigh --model claude=claude-fable-5 --thinking claude=max
+"$AUTOREVIEW" --reviewers codex,claude --model codex=gpt-5.6-sol --thinking codex=high --model claude=claude-fable-5 --thinking claude=max
 ```
 
 Inline syntax is also supported for simple model IDs:
 
 ```bash
-"$AUTOREVIEW" --reviewers codex:gpt-5.6-sol:xhigh,claude:claude-fable-5:max
+"$AUTOREVIEW" --reviewers codex:gpt-5.6-sol:high,claude:claude-fable-5:max
 ```
 
 For models with slashes or extra colons, prefer keyed form:
@@ -201,13 +201,11 @@ For models with slashes or extra colons, prefer keyed form:
 ```bash
 "$AUTOREVIEW" --engine pi --model anthropic/claude-sonnet-4 --thinking high
 "$AUTOREVIEW" --engine opencode --model opencode/north-mini-code-free --thinking high
-"$AUTOREVIEW" --engine cursor --model auto --cursor-allow-workspace-instructions
 "$AUTOREVIEW" --reviewers codex,pi --model codex=gpt-5.6-sol --model pi=anthropic/claude-sonnet-4
 "$AUTOREVIEW" --reviewers codex,opencode --model codex=gpt-5.6-sol --model opencode=opencode/north-mini-code-free
-"$AUTOREVIEW" --reviewers codex,cursor --model codex=gpt-5.6-sol --model cursor=auto --cursor-allow-workspace-instructions
 ```
 
-`--reviewers all` covers Codex, Claude, Copilot, Pi, and OpenCode. Cursor requires both explicit selection (`--engine cursor` or named in `--reviewers`) and `--cursor-allow-workspace-instructions` because the current Cursor CLI does not document a per-run flag that ignores project-local instructions/config. Droid selection currently fails closed because its CLI cannot disable both project instructions and all tools.
+`--reviewers all` covers Codex, Claude, Pi, and OpenCode. Droid, Copilot, and Cursor selections fail closed because their current CLI contracts cannot confine all project instructions and filesystem reads to the review bundle.
 
 ## Models and thinking
 
@@ -217,19 +215,19 @@ Recommended model defaults:
 
 | Engine              | Default model                                      | Source note                                           |
 | ------------------- | -------------------------------------------------- | ----------------------------------------------------- |
-| **codex** (default) | `gpt-5.6-sol`                                      | OpenClaw org review default                           |
+| **codex** (default) | `gpt-5.6-sol` -> `gpt-5.6-terra` on access failure | OpenClaw org review default                           |
 | **claude**          | `claude-fable-5`                                   | Anthropic's most capable widely released Claude model |
 
 CLI flags and environment variables override these defaults. Droid, Copilot, Pi, Cursor, and OpenCode do not get built-in model defaults here because their provider catalogs are external to the Codex/Claude closeout path and may vary by installation.
 
 | Engine              | Model flag                 | Example model IDs                                                            | Thinking flag                 | Accepted levels                                        |
 | ------------------- | -------------------------- | ---------------------------------------------------------------------------- | ----------------------------- | ------------------------------------------------------ |
-| **codex** (default) | `codex --model X exec ...` | `gpt-5.6-sol`, `gpt-5.5`                                                     | `-c model_reasoning_effort=Y` | `none`, `minimal`, `low`, `medium`, `high`, `xhigh`    |
+| **codex** (default) | `codex --model X exec ...` | `gpt-5.6-sol`, then `gpt-5.6-terra` on Sol access failure                    | `-c model_reasoning_effort=Y` | `none`, `minimal`, `low`, `medium`, `high`, `xhigh`    |
 | **claude**          | `claude --model X`         | `claude-fable-5`, `claude-opus-4-8`, `claude-sonnet-4-6`, `claude-haiku-4-5` | `--effort Y`                  | `low`, `medium`, `high`, `xhigh`, `max`                |
 | **droid**           | currently refused          | Factory model IDs                                                            | `-r, --reasoning-effort Y`    | `off`, `none`, `low`, `medium`, `high`, `xhigh`, `max` |
-| **copilot**         | `copilot --model X`        | `gpt-5.2`, Copilot model aliases                                             | not supported                 | n/a                                                    |
+| **copilot**         | currently refused          | Copilot model aliases                                                        | not supported                 | n/a                                                    |
 | **pi**              | `pi --model X`             | `anthropic/claude-sonnet-4`, `openai/gpt-4o`                                 | `--thinking Y`                | `off`, `minimal`, `low`, `medium`, `high`, `xhigh`     |
-| **cursor**          | `cursor-agent --model X`   | `auto`, Cursor model aliases                                                 | not supported                 | n/a                                                    |
+| **cursor**          | currently refused          | Cursor model aliases                                                         | not supported                 | n/a                                                    |
 | **opencode**        | `opencode run -m X`        | `opencode/north-mini-code-free`, OpenCode provider/model IDs                 | `--variant Y`                 | `minimal`, `low`, `medium`, `high`, `max`              |
 
 Claude also supports `--fallback-model a,b` for availability-based fallback chains ([model-config](https://code.claude.com/docs/en/model-config)). Current Claude docs note that auth, billing, rate-limit, request-size, and transport errors do not trigger fallback, and the changelog documents interactive-session support in `v2.1.166`.
@@ -238,7 +236,7 @@ Examples matching current `main` behavior:
 
 ```bash
 # Codex with explicit model and reasoning
-"$AUTOREVIEW" --engine codex --model gpt-5.6-sol --thinking xhigh --codex-speed fast
+"$AUTOREVIEW" --engine codex --model gpt-5.6-sol --thinking high
 
 # Codex fast mode (priority service tier); needs a model whose catalog lists the tier, silently standard otherwise
 "$AUTOREVIEW" --engine codex --codex-speed fast
@@ -250,14 +248,8 @@ Examples matching current `main` behavior:
 "$AUTOREVIEW" --engine claude --model claude-fable-5 --thinking max
 "$AUTOREVIEW" --engine claude --model claude-fable-5 --fallback-model claude-opus-4-8,claude-sonnet-4-6
 
-# GitHub Copilot (model only; no thinking knob)
-"$AUTOREVIEW" --engine copilot --model gpt-5.2
-
 # Pi with explicit model and thinking level
 "$AUTOREVIEW" --engine pi --model anthropic/claude-sonnet-4 --thinking high --pi-bin pi
-
-# Cursor print-mode review (`cursor-agent` remains a compatibility alias)
-"$AUTOREVIEW" --engine cursor --model auto --cursor-bin cursor-agent --cursor-allow-workspace-instructions
 
 # OpenCode with explicit provider/model and variant
 "$AUTOREVIEW" --engine opencode --model opencode/north-mini-code-free --thinking high
@@ -274,36 +266,34 @@ Store persistent personal defaults in your shell startup file or launcher
 environment. For repository-local defaults, use an existing local environment
 loader such as an untracked `.envrc`; the helper does not write a config file.
 
-| Variable                                         | Purpose                                                                                                                      |
-| ------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------- |
-| `AUTOREVIEW_MODEL`                               | Override the built-in default `--model` for all engines                                                                      |
-| `AUTOREVIEW_THINKING`                            | Default `--thinking` for all engines                                                                                         |
-| `AUTOREVIEW_FALLBACK_MODEL`                      | Default Claude `--fallback-model` chain                                                                                      |
-| `AUTOREVIEW_<ENGINE>_MODEL`                      | Per-engine model override, for example `AUTOREVIEW_CODEX_MODEL=gpt-5.6-sol`                                                  |
-| `AUTOREVIEW_<ENGINE>_THINKING`                   | Per-engine thinking override                                                                                                 |
-| `AUTOREVIEW_CODEX_CONFIG`                        | Default Codex `-c key=value` overrides, semicolon-separated, e.g. `service_tier="fast"`; isolation flags still win           |
-| `AUTOREVIEW_CODEX_SPEED`                         | Codex service tier override: `fast` (default), `flex`, or `default`; silently standard when the model does not list the tier |
-| `AUTOREVIEW_CLAUDE_FALLBACK_MODEL`               | Claude-only fallback chain                                                                                                   |
-| `AUTOREVIEW_CURSOR_ALLOW_WORKSPACE_INSTRUCTIONS` | Required `1`/true opt-in for Cursor reviews of trusted repositories                                                          |
+| Variable                           | Purpose                                                                                                                      |
+| ---------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `AUTOREVIEW_MODEL`                 | Override the built-in default `--model` for all engines                                                                      |
+| `AUTOREVIEW_THINKING`              | Default `--thinking` for all engines                                                                                         |
+| `AUTOREVIEW_FALLBACK_MODEL`        | Default Claude `--fallback-model` chain                                                                                      |
+| `AUTOREVIEW_<ENGINE>_MODEL`        | Per-engine model override, for example `AUTOREVIEW_CODEX_MODEL=gpt-5.6-sol`                                                  |
+| `AUTOREVIEW_<ENGINE>_THINKING`     | Per-engine thinking override                                                                                                 |
+| `AUTOREVIEW_CODEX_CONFIG`          | Default Codex `-c key=value` overrides, semicolon-separated, e.g. `service_tier="fast"`; isolation flags still win           |
+| `AUTOREVIEW_CODEX_SPEED`           | Codex service tier override: `fast` (priority), `flex`, or `default`; silently standard when the model does not list the tier |
+| `AUTOREVIEW_CLAUDE_FALLBACK_MODEL` | Claude-only fallback chain                                                                                                   |
 
-Codex maps thinking to `model_reasoning_effort`. Claude maps thinking to `--effort`. Droid maps thinking to `-r, --reasoning-effort`. Pi maps thinking to `--thinking`. OpenCode maps thinking to `--variant`. Copilot and Cursor reject `--thinking`. Only Claude accepts `--fallback-model`; global CLI/env fallback requires at least one Claude reviewer, and engine-specific fallback overrides require that reviewer to be selected. Non-Claude fallback overrides, including `AUTOREVIEW_<NONCLAUDE>_FALLBACK_MODEL`, fail closed instead of being silently ignored.
+Codex maps thinking to `model_reasoning_effort`. Claude maps thinking to `--effort`. Pi maps thinking to `--thinking`. OpenCode maps thinking to `--variant`. Only Claude accepts `--fallback-model`; global CLI/env fallback requires at least one Claude reviewer, and engine-specific fallback overrides require that reviewer to be selected. Non-Claude fallback overrides, including `AUTOREVIEW_<NONCLAUDE>_FALLBACK_MODEL`, fail closed instead of being silently ignored.
 
 ## Review engine isolation
 
 When autoreview runs inside the repository under review, external reviewer CLIs must not load project-local trust or configuration that the branch controls.
 
-| Engine       | Isolation flags                                                                                                                                                                                                       | Reference                                                                                                                                                                                                                                                                      |
-| ------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| **codex**    | Auth-only config overrides, `-c project_doc_max_bytes=0`, repo `trust_level="untrusted"`, `exec --ignore-user-config --ignore-rules`, plus read-only sandbox                                                          | Codex CLI `exec --help`                                                                                                                                                                                                                                                        |
-| **claude**   | `--safe-mode --setting-sources user --strict-mcp-config --disallowedTools mcp__*` plus explicit `--allowedTools` (`--safe-mode` requires Claude Code `v2.1.169+`)                                                     | Claude Code [CLI reference](https://code.claude.com/docs/en/cli-reference)                                                                                                                                                                                                     |
-| **droid**    | Fails closed: current CLI cannot disable both project instructions and all tools                                                                                                                                      | Droid CLI `exec --help` and `--list-tools`                                                                                                                                                                                                                                     |
-| **pi**       | `--no-approve --no-session --no-context-files --no-extensions --no-skills --no-prompt-templates --no-themes --no-tools`                                                                                               | Pi CLI `--help`; requires Pi `v0.79.0+`                                                                                                                                                                                                                                        |
-| **opencode** | `opencode run --dir <repo> --pure --format json`, prompt over stdin, neutral subprocess cwd, injected deny-by-default permissions, project config disabled                                                            | OpenCode CLI `--help`                                                                                                                                                                                                                                                          |
-| **cursor**   | `cursor-agent --print --mode ask --sandbox enabled` with `json` or `stream-json` output, prompt over stdin, temporary read-only permission config, help-probed flags, and mandatory explicit trusted-workspace opt-in | Cursor CLI [headless mode](https://cursor.com/docs/cli/headless), [output format](https://cursor.com/docs/cli/reference/output-format), [permissions](https://cursor.com/docs/cli/reference/permissions), [configuration](https://cursor.com/docs/cli/reference/configuration) |
+| Engine       | Isolation flags                                                                                                                                                        | Reference                                                                   |
+| ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
+| **codex**    | Auth-only config overrides, `-c project_doc_max_bytes=0`, repo `trust_level="untrusted"`, `exec --ignore-user-config --ignore-rules`, plus read-only sandbox           | Codex CLI `exec --help`                                                     |
+| **claude**   | `--safe-mode --setting-sources user --strict-mcp-config --disallowedTools mcp__*`; filesystem/shell tools disabled, optional web tools only (`v2.1.169+`)              | Claude Code [CLI reference](https://code.claude.com/docs/en/cli-reference)  |
+| **droid**    | Fails closed: current CLI cannot disable both project instructions and all tools                                                                                       | Droid CLI `exec --help` and `--list-tools`                                  |
+| **copilot**  | Fails closed: repository read tools also expose ignored files outside the reviewed bundle                                                                              | GitHub Copilot CLI command reference                                        |
+| **pi**       | `--no-approve --no-session --no-context-files --no-extensions --no-skills --no-prompt-templates --no-themes --no-tools`                                                | Pi CLI `--help`; requires Pi `v0.79.0+`                                     |
+| **opencode** | `opencode run --dir <repo> --pure --format json`, prompt over stdin, neutral subprocess cwd, project config disabled, filesystem tools denied, optional web tools only | OpenCode CLI `--help`                                                       |
+| **cursor**   | Fails closed: documented read permissions can target absolute host paths and no proven repository-only filesystem sandbox is exposed                                   | Cursor CLI [permissions](https://cursor.com/docs/cli/reference/permissions) |
 
-Codex `--ignore-user-config` skips config loading for the exec run. Autoreview reconstructs only the documented `cli_auth_credentials_store`, `forced_login_method`, and `forced_chatgpt_workspace_id` settings from `CODEX_HOME/config.toml`, keeping authentication and workspace restrictions usable without forwarding unrelated user configuration. The explicit repo trust override and zero project-doc budget keep reviewed-repo `AGENTS.md` and `.codex/` trust surfaces out of the review prompt. `--ignore-rules` skips user/project execpolicy rules. Claude `--safe-mode` disables project hooks, skills, plugins, MCP servers, and CLAUDE.md while preserving normal authentication, model selection, built-in tools, and permissions; managed settings policy can still apply. `--setting-sources user` avoids project/local settings from the reviewed checkout, and current Claude Code docs note the project-skill blocking behavior was fixed in `v2.1.69`. `--strict-mcp-config` and `--disallowedTools mcp__*` keep MCP unavailable to the review run. `--bare` is not used here because Claude's headless docs say it skips OAuth and keychain reads. Droid fails closed because its CLI cannot disable reviewed-repository `AGENTS.md` loading and all tools in the same run. Pi `--no-approve` ignores project-local files for one run; the helper requires Pi `v0.79.0+` plus help output that advertises every required isolation flag because older legacy binaries can ignore unknown flags. The current package is `@earendil-works/pi-coding-agent`; deprecated `@mariozechner/pi-coding-agent` `0.73.x` is intentionally rejected. Pi version/help probes and the review command run from neutral temporary directories, not the reviewed repo. Pi `--no-context-files` removes `AGENTS.md`/`CLAUDE.md`, the resource-disable flags keep `.pi` extensions, skills, prompts, and themes out of the run, `--no-session` avoids writing review sessions, and `--no-tools` prevents built-in read tools from escaping the repository through absolute paths. OpenCode starts from a neutral temporary directory, points at the reviewed repo with `--dir`, disables project config through `OPENCODE_DISABLE_PROJECT_CONFIG=1`, and injects `OPENCODE_CONFIG_CONTENT`; permissions default to deny, allow read/grep/glob, preserve OpenCode's `.env` ask rules, and gate `websearch`/`webfetch` with `--no-web-search`. The injected config also clears command/instruction/plugin arrays and disables write/edit/bash/task/skill/todowrite tools without changing user auth storage. Cursor's documented headless path is print mode with JSON output and workspace-relative project-resource discovery. Because the CLI exposes no per-run flag that disables every current and future project instruction surface, autoreview requires `--cursor-allow-workspace-instructions` (or its environment equivalent) for every Cursor run. Project-local Cursor/Claude hook settings, project MCP config, and global Cursor MCP config remain hard refusals because hooks execute host commands and MCP tools cannot be constrained to read-only review access. Cursor capability probes run from neutral temporary directories with the sanitized engine environment. Review runs set documented `CURSOR_CONFIG_DIR` to an ephemeral configuration that allows workspace reads while denying shell commands and relative or absolute writes. The helper sends review prompts to OpenCode and Cursor over stdin rather than argv and extracts final structured JSON from terminal result/text events. OpenCode and Cursor reject `--no-tools`; Cursor also rejects `--no-web-search` because the CLI does not expose a documented per-run web-search disable flag.
-
-Claude `--tools` restricts the built-in tool inventory to the configured read/search set, while matching `--allowedTools` entries approve that set. Cursor user-level hooks in `~/.cursor/hooks.json` and Claude-compatible user settings are hard refusals alongside project hooks because they can execute host commands outside the temporary review config.
+Codex `--ignore-user-config` skips config loading for the exec run. Autoreview reconstructs only the documented `cli_auth_credentials_store`, `forced_login_method`, and `forced_chatgpt_workspace_id` settings from `CODEX_HOME/config.toml`, keeping authentication and workspace restrictions usable without forwarding unrelated user configuration. The explicit repo trust override and zero project-doc budget keep reviewed-repo `AGENTS.md` and `.codex/` trust surfaces out of the review prompt. `--ignore-rules` skips user/project execpolicy rules. Claude `--safe-mode` disables project hooks, skills, plugins, MCP servers, and CLAUDE.md; autoreview supplies only WebSearch/WebFetch when web search is enabled and no filesystem or shell tools. Pi runs from a neutral temporary directory with project resources disabled and `--no-tools`. OpenCode runs from a neutral temporary directory with project config disabled, filesystem tools denied, and web tools gated by `--no-web-search`. Droid, Copilot, and Cursor fail closed because their current CLI contracts cannot isolate untrusted review input from host/project trust surfaces.
 
 Codex uses a named permission profile that grants read access only to the active repository workspace root. This is narrower than the legacy `read-only` sandbox, which permits reads across the host filesystem.
 
@@ -344,21 +334,20 @@ The helper:
 - otherwise uses current PR base if `gh pr view` works
 - otherwise uses `origin/main` for non-main branches
 - does not fetch automatically during branch review; the selected base ref must already resolve locally
-- recognizes `--engine droid` only to fail closed with an isolation error; runnable engines are `codex`, `claude`, `copilot`, `pi`, `opencode`, and `cursor`; default is `AUTOREVIEW_ENGINE` or `codex`
+- recognizes `--engine droid`, `copilot`, and `cursor` only to fail closed with isolation errors; runnable engines are `codex`, `claude`, `pi`, and `opencode`; default is `AUTOREVIEW_ENGINE` or `codex`
 - resolves bare `git`, `gh`, reviewer, and PowerShell shell commands from absolute `PATH` entries only, never from the reviewed checkout; explicit relative `--*-bin` paths are resolved from the reviewed repository root
 - use `--mode commit --commit <ref>` for already-committed work, especially clean `main` after landing
 - should be left in `--mode auto` or forced to `--mode branch` for PR/branch work; do not force `--mode local` after committing
 - writes only to stdout unless `--output`, `--json-output`, or live streamed engine stderr is set
 - supports `--dry-run`, `--parallel-tests`, `--parallel-tests-shell`, `--prompt`, repo-relative `--prompt-file`, repo-relative `--dataset`, `--no-tools`, `--no-web-search`, repeatable Codex-only `--codex-config key=value`, Codex-only `--codex-speed fast|flex|default`, and commit refs
-- supports `--stream-engine-output` or `AUTOREVIEW_STREAM_ENGINE_OUTPUT=1` for live engine text while preserving structured validation; Codex, Claude, and Cursor hide tool/file event details, emit compact activity summaries, and report usage at turn completion
+- supports `--stream-engine-output` or `AUTOREVIEW_STREAM_ENGINE_OUTPUT=1` for live engine text while preserving structured validation; Codex and Claude hide tool/file event details, emit compact activity summaries, and report usage at turn completion
 - supports opt-in review panels with `--panel` / `--reviewers`, plus per-engine `--model`, `--thinking`, and Claude `--fallback-model`
-- uses built-in defaults `codex=gpt-5.6-sol` with `xhigh` reasoning and fast service tier, plus `claude=claude-fable-5`; honors `AUTOREVIEW_MODEL`, `AUTOREVIEW_THINKING`, `AUTOREVIEW_FALLBACK_MODEL`, and per-engine `AUTOREVIEW_<ENGINE>_MODEL` / `AUTOREVIEW_<ENGINE>_THINKING` environment overrides when CLI flags are omitted
-- allows read-only tools and web search by default where the selected CLI supports them; forbids nested review in the prompt; Codex is run through `codex exec` with auth-only user settings, read-only sandbox, reviewed-repo instruction/config/rule isolation flags, and structured output
-- runs Claude with `--safe-mode` (`v2.1.169+`), `--setting-sources user`, MCP disabled, explicit allowed tools, and `--fallback-model` when set, so reviewed-repo hooks/skills/MCP do not affect the review run while normal auth still works; managed settings policy can still apply
-- refuses Droid reviews until the CLI exposes a complete project-instruction and tool-isolation contract
+- uses built-in defaults `codex=gpt-5.6-sol` with `high` reasoning and an access-only `gpt-5.6-terra` retry, plus `claude=claude-fable-5`; honors `AUTOREVIEW_MODEL`, `AUTOREVIEW_THINKING`, `AUTOREVIEW_FALLBACK_MODEL`, and per-engine `AUTOREVIEW_<ENGINE>_MODEL` / `AUTOREVIEW_<ENGINE>_THINKING` environment overrides when CLI flags are omitted
+- allows repository-scoped read tools only for Codex; Claude and OpenCode receive the bundle plus optional web tools, and Pi receives the bundle with no tools
+- runs Claude with `--safe-mode` (`v2.1.169+`), `--setting-sources user`, MCP disabled, web-only tools, and `--fallback-model` when set
+- refuses Droid, Copilot, and Cursor reviews until their CLIs expose complete project-instruction and repository-only filesystem isolation
 - runs Pi `v0.79.0+` from neutral temporary directories with `--no-approve`, `--no-session`, disabled Pi context/resource loading, and `--no-tools` because its built-in read tools are not repository-confined
-- runs OpenCode with `opencode run --dir <repo> --pure --format json` from a neutral temporary directory, forwards `--model` and `--variant`, injects deny-by-default permissions, disables project config loading, and passes the review prompt over stdin
-- runs Cursor only with mandatory trusted-workspace opt-in, uses `cursor-agent --print --mode ask --sandbox enabled --output-format json`, forwards `--model`, passes the review prompt over stdin, and always refuses project-local hooks/MCP
+- runs OpenCode with `opencode run --dir <repo> --pure --format json` from a neutral temporary directory, denies filesystem tools, forwards `--model` and `--variant`, disables project config loading, and passes the review prompt over stdin
 - prints `review still running: <engine> elapsed=<seconds>s pid=<pid>` to stderr at long-running intervals while waiting for the selected review engine, unless streamed output or compact Codex activity has been visible recently
 - prints `autoreview clean: no accepted/actionable findings reported` when the selected review command exits 0
 - exits nonzero when accepted/actionable findings are present

--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 import argparse
 import ast
-import base64
 import concurrent.futures
 import copy
 import json
@@ -23,7 +22,7 @@ from typing import Any, Callable
 ENGINES = ("codex", "claude", "droid", "copilot", "pi", "opencode", "cursor")
 ENGINE_ALIASES = {"cursor-agent": "cursor"}
 ENGINE_CHOICES = (*ENGINES, *ENGINE_ALIASES)
-ALL_REVIEWERS = ("codex", "claude", "copilot", "pi", "opencode")
+ALL_REVIEWERS = ("codex", "claude", "pi", "opencode")
 SAFE_GIT_CONFIG_ARGS = (
     "-c",
     "core.fsmonitor=false",
@@ -58,7 +57,6 @@ SENSITIVE_PATH_PARTS = {
     ".gnupg",
     ".ssh",
     "private",
-    "secrets",
 }
 TRACKED_SENSITIVE_PATH_PARTS = SENSITIVE_PATH_PARTS - {
     "private",
@@ -137,16 +135,16 @@ TRACKED_TOKEN_CREDENTIAL_EXTENSIONS = {
     ".yaml",
     ".yml",
 }
+SECRET_ASSIGNMENT_PATTERN = re.compile(
+    r"(?i)(?:"
+    r"[\"'](?:api[_-]?key|client[_-]?secret|refresh[_-]?token|access[_-]?token|auth[_-]?token|id[_-]?token|token|secret|password)[\"']"
+    r"|(?:api[_-]?key|client[_-]?secret|refresh[_-]?token|access[_-]?token|auth[_-]?token|id[_-]?token|token|secret|password)"
+    r")\s*[:=]\s*"
+    r"(?P<value>[\"'][^\"'\r\n]{12,}[\"']|"
+    r"[A-Za-z0-9_./+=:@#$%&*!?-]{20,})"
+)
 SECRET_VALUE_PATTERNS = [
     re.compile(r"-----BEGIN (?:RSA |DSA |EC |OPENSSH |PGP )?PRIVATE KEY-----"),
-    re.compile(
-        r"(?i)(?:"
-        r"[\"'](?:api[_-]?key|client[_-]?secret|refresh[_-]?token|access[_-]?token|auth[_-]?token|id[_-]?token|token|secret|password)[\"']"
-        r"|(?:api[_-]?key|client[_-]?secret|refresh[_-]?token|access[_-]?token|auth[_-]?token|id[_-]?token|token|secret|password)"
-        r")\s*[:=]\s*"
-        r"(?:[\"'][^\"'\r\n]{12,}[\"']|"
-        r"[A-Za-z0-9_./+=:@#$%&*!?-]{20,}(?![A-Za-z0-9_./+=:@#$%&*!?(\-]))"
-    ),
     re.compile(r"(?i)bearer\s+[A-Za-z0-9._-]{20,}"),
     re.compile(r"\b(?:sk|rk|pk|org|proj)-[A-Za-z0-9_-]{20,}\b"),
     re.compile(r"\bgithub_pat_[A-Za-z0-9_]{20,}\b"),
@@ -161,17 +159,88 @@ SECRET_VALUE_PATTERNS = [
 ]
 MAX_BUNDLE_TEXT_BYTES = 180_000
 MAX_REVIEW_PROMPT_BYTES = 512_000
-SECRET_SCAN_CHUNK_CHARS = 64_000
-SECRET_SCAN_OVERLAP_CHARS = 512
+SECRET_PLACEHOLDER_VALUES = {
+    "changeme",
+    "dummy",
+    "example",
+    "fake",
+    "gateway-token",
+    "not-a-real",
+    "placeholder",
+    "redacted",
+    "sample",
+    "secret-token",
+    "test-auth-token",
+    "test-token-placeholder",
+}
 DEFAULT_ENGINE_PATHS = ("/usr/local/bin", "/usr/bin", "/bin")
+MULTI_PROVIDER_CREDENTIAL_SUFFIXES = (
+    "_ACCESS_TOKEN",
+    "_API_KEY",
+    "_API_TOKEN",
+    "_AUTH_TOKEN",
+    "_TOKEN",
+)
+MULTI_PROVIDER_ENV_KEYS = {
+    "AWS_CONTAINER_AUTHORIZATION_TOKEN",
+    "AWS_CONTAINER_CREDENTIALS_FULL_URI",
+    "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI",
+    "AWS_BEDROCK_FORCE_HTTP1",
+    "AWS_BEDROCK_SKIP_AUTH",
+    "AWS_ENDPOINT_URL_BEDROCK_RUNTIME",
+    "AWS_ROLE_ARN",
+    "AWS_ROLE_SESSION_NAME",
+    "AZURE_COGNITIVE_SERVICES_RESOURCE_NAME",
+    "AZURE_OPENAI_API_VERSION",
+    "AZURE_OPENAI_BASE_URL",
+    "AZURE_OPENAI_DEPLOYMENT_NAME_MAP",
+    "AZURE_OPENAI_RESOURCE_NAME",
+    "AZURE_RESOURCE_NAME",
+    "CLOUDFLARE_ACCOUNT_ID",
+    "CLOUDFLARE_GATEWAY_ID",
+    "GCLOUD_PROJECT",
+    "GOOGLE_CLOUD_LOCATION",
+    "GOOGLE_CLOUD_PROJECT",
+    "HF_TOKEN",
+    "SNOWFLAKE_ACCOUNT",
+    "VERTEXAI_LOCATION",
+    "VERTEXAI_PROJECT",
+}
+CLAUDE_CLOUD_CREDENTIAL_ENV_KEYS = {
+    "AWS_CONTAINER_AUTHORIZATION_TOKEN",
+    "AWS_CONTAINER_CREDENTIALS_FULL_URI",
+    "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI",
+    "AWS_ROLE_ARN",
+    "AWS_ROLE_SESSION_NAME",
+    "AZURE_CLIENT_ID",
+    "AZURE_CLIENT_SECRET",
+    "AZURE_TENANT_ID",
+    "GCLOUD_PROJECT",
+    "GOOGLE_CLOUD_PROJECT",
+}
+CODEX_TRUST_PATH_ENV_KEYS = {
+    "CODEX_CA_CERTIFICATE",
+    "SSL_CERT_DIR",
+    "SSL_CERT_FILE",
+}
+PROVIDER_CREDENTIAL_PATH_ENV_KEYS = {
+    "AWS_CONFIG_FILE",
+    "AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE",
+    "AWS_SHARED_CREDENTIALS_FILE",
+    "AWS_WEB_IDENTITY_TOKEN_FILE",
+    "GOOGLE_APPLICATION_CREDENTIALS",
+    "NODE_EXTRA_CA_CERTS",
+    "SSL_CERT_DIR",
+    "SSL_CERT_FILE",
+}
 DEFAULT_MODEL_BY_ENGINE = {
     "codex": "gpt-5.6-sol",
     "claude": "claude-fable-5",
 }
+DEFAULT_CODEX_ACCESS_FALLBACK_MODEL = "gpt-5.6-terra"
 DEFAULT_THINKING_BY_ENGINE = {
-    "codex": "xhigh",
+    "codex": "high",
 }
-DEFAULT_CODEX_SPEED = "fast"
 THINKING_LEVELS_BY_ENGINE = {
     "codex": {"none", "minimal", "low", "medium", "high", "xhigh"},
     "claude": {"low", "medium", "high", "xhigh", "max"},
@@ -335,33 +404,193 @@ def codex_tool_git_env() -> dict[str, str]:
     return env
 
 
+def external_env_path(repo: Path, value: str) -> bool:
+    try:
+        resolved = Path(value).expanduser().resolve()
+    except OSError:
+        return False
+    return not is_within(resolved, repo.resolve())
+
+
+def external_env_path_value(repo: Path, key: str, value: str) -> bool:
+    values = value.split(os.pathsep) if key == "SSL_CERT_DIR" else [value]
+    return bool(values) and all(
+        item and external_env_path(repo, item)
+        for item in values
+    )
+
+
 def safe_engine_env(
     repo: Path,
     extra_paths: list[Path] | None = None,
     extra: dict[str, str] | None = None,
+    *,
+    engine: str | None = None,
 ) -> dict[str, str]:
-    blocked_exact = {
-        "BASH_ENV",
-        "COPILOT_ALLOW_ALL",
-        "ENV",
-        "GIT_CONFIG",
-        "GIT_CONFIG_GLOBAL",
-        "GIT_CONFIG_NOSYSTEM",
-        "GIT_CONFIG_SYSTEM",
-        "GIT_OPTIONAL_LOCKS",
-        "GIT_TERMINAL_PROMPT",
-        "LD_PRELOAD",
-        "NODE_OPTIONS",
-        "PYTHONHOME",
-        "PYTHONPATH",
+    common_allowed_exact = {
+        "ALL_PROXY",
+        "COMSPEC",
+        "DISABLE_AUTOUPDATER",
+        "DISABLE_ERROR_REPORTING",
+        "DISABLE_TELEMETRY",
+        "DO_NOT_TRACK",
+        "HTTP_PROXY",
+        "HTTPS_PROXY",
+        "LANG",
+        "LC_ALL",
+        "LOGNAME",
+        "NO_PROXY",
+        "PATHEXT",
+        "SHELL",
+        "SYSTEMROOT",
+        "TEMP",
+        "TMP",
+        "TMPDIR",
+        "USER",
+        "WINDIR",
+        "all_proxy",
+        "http_proxy",
+        "https_proxy",
+        "no_proxy",
     }
-    blocked_prefixes = ("GIT_", "DYLD_")
+    codex_allowed_exact = {
+        "AZURE_OPENAI_API_KEY",
+        "AZURE_OPENAI_ENDPOINT",
+        "CODEX_API_KEY",
+        "OPENAI_API_KEY",
+        "OPENAI_BASE_URL",
+        "OPENAI_ORGANIZATION",
+        "OPENAI_PROJECT",
+    }
+    claude_allowed_exact = {
+        "ANTHROPIC_API_KEY",
+        "ANTHROPIC_AUTH_TOKEN",
+        "ANTHROPIC_AWS_API_KEY",
+        "ANTHROPIC_AWS_BASE_URL",
+        "ANTHROPIC_AWS_WORKSPACE_ID",
+        "ANTHROPIC_BASE_URL",
+        "ANTHROPIC_BEDROCK_BASE_URL",
+        "ANTHROPIC_BEDROCK_MANTLE_BASE_URL",
+        "ANTHROPIC_BEDROCK_SERVICE_TIER",
+        "ANTHROPIC_CUSTOM_HEADERS",
+        "ANTHROPIC_FOUNDRY_API_KEY",
+        "ANTHROPIC_FOUNDRY_AUTH_TOKEN",
+        "ANTHROPIC_FOUNDRY_BASE_URL",
+        "ANTHROPIC_FOUNDRY_RESOURCE",
+        "ANTHROPIC_SMALL_FAST_MODEL_AWS_REGION",
+        "ANTHROPIC_VERTEX_BASE_URL",
+        "ANTHROPIC_VERTEX_PROJECT_ID",
+        "ANTHROPIC_WORKSPACE_ID",
+        "AWS_ACCESS_KEY_ID",
+        "AWS_BEARER_TOKEN_BEDROCK",
+        "AWS_DEFAULT_REGION",
+        "AWS_PROFILE",
+        "AWS_REGION",
+        "AWS_SECRET_ACCESS_KEY",
+        "AWS_SESSION_TOKEN",
+        "CLAUDE_CODE_API_KEY_HELPER_TTL_MS",
+        "CLAUDE_CODE_CERT_STORE",
+        "CLAUDE_CODE_CLIENT_CERT",
+        "CLAUDE_CODE_CLIENT_KEY",
+        "CLAUDE_CODE_CLIENT_KEY_PASSPHRASE",
+        "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC",
+        "CLAUDE_CODE_OAUTH_REFRESH_TOKEN",
+        "CLAUDE_CODE_OAUTH_SCOPES",
+        "CLAUDE_CODE_OAUTH_TOKEN",
+        "CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST",
+        "CLAUDE_CODE_SKIP_ANTHROPIC_AWS_AUTH",
+        "CLAUDE_CODE_SKIP_BEDROCK_AUTH",
+        "CLAUDE_CODE_SKIP_FOUNDRY_AUTH",
+        "CLAUDE_CODE_SKIP_MANTLE_AUTH",
+        "CLAUDE_CODE_SKIP_VERTEX_AUTH",
+        "CLAUDE_CODE_USE_ANTHROPIC_AWS",
+        "CLAUDE_CODE_USE_BEDROCK",
+        "CLAUDE_CODE_USE_FOUNDRY",
+        "CLAUDE_CODE_USE_MANTLE",
+        "CLAUDE_CODE_USE_VERTEX",
+        "CLOUD_ML_REGION",
+    } | CLAUDE_CLOUD_CREDENTIAL_ENV_KEYS
+    multi_provider_allowed_exact = {
+        "ANTHROPIC_AWS_BASE_URL",
+        "ANTHROPIC_AWS_WORKSPACE_ID",
+        "ANTHROPIC_BASE_URL",
+        "ANTHROPIC_BEDROCK_BASE_URL",
+        "ANTHROPIC_BEDROCK_MANTLE_BASE_URL",
+        "ANTHROPIC_BEDROCK_SERVICE_TIER",
+        "ANTHROPIC_CUSTOM_HEADERS",
+        "ANTHROPIC_FOUNDRY_BASE_URL",
+        "ANTHROPIC_FOUNDRY_RESOURCE",
+        "ANTHROPIC_SMALL_FAST_MODEL_AWS_REGION",
+        "ANTHROPIC_VERTEX_BASE_URL",
+        "ANTHROPIC_VERTEX_PROJECT_ID",
+        "ANTHROPIC_WORKSPACE_ID",
+        "AWS_ACCESS_KEY_ID",
+        "AWS_BEARER_TOKEN_BEDROCK",
+        "AWS_DEFAULT_REGION",
+        "AWS_PROFILE",
+        "AWS_REGION",
+        "AWS_SECRET_ACCESS_KEY",
+        "AWS_SESSION_TOKEN",
+        "AZURE_OPENAI_ENDPOINT",
+        "CLOUD_ML_REGION",
+        "COPILOT_GITHUB_TOKEN",
+        "GITHUB_TOKEN",
+        "GH_TOKEN",
+        "OPENAI_BASE_URL",
+        "OPENAI_ORGANIZATION",
+        "OPENAI_PROJECT",
+    } | MULTI_PROVIDER_ENV_KEYS
+    engine_allowed_exact = {
+        "claude": claude_allowed_exact,
+        "codex": codex_allowed_exact,
+        "opencode": multi_provider_allowed_exact,
+        "pi": multi_provider_allowed_exact,
+    }.get(engine or "", set())
+    allowed_prefixes = ("AUTOREVIEW_FAKE_",)
+    allow_multi_provider_credentials = engine in {"opencode", "pi"}
     env = {
         key: value
         for key, value in os.environ.items()
-        if key not in blocked_exact and not any(key.startswith(prefix) for prefix in blocked_prefixes)
+        if (
+            key in common_allowed_exact
+            or key in engine_allowed_exact
+            or any(key.startswith(prefix) for prefix in allowed_prefixes)
+            or (
+                allow_multi_provider_credentials
+                and (
+                    key in MULTI_PROVIDER_ENV_KEYS
+                    or key.endswith(MULTI_PROVIDER_CREDENTIAL_SUFFIXES)
+                )
+            )
+        )
     }
     env["PATH"] = safe_engine_path(repo, extra_paths)
+    for key in ("HOME", "USERPROFILE"):
+        value = os.environ.get(key)
+        if value and external_env_path(repo, value):
+            env[key] = value
+    engine_config_paths = {
+        "claude": ("CLAUDE_CONFIG_DIR",),
+        "codex": ("CODEX_HOME",),
+        "pi": ("PI_CODING_AGENT_DIR",),
+    }
+    for key in engine_config_paths.get(engine or "", ()):
+        value = os.environ.get(key)
+        if value and external_env_path(repo, value):
+            env[key] = value
+    if engine == "codex":
+        for key in CODEX_TRUST_PATH_ENV_KEYS:
+            value = os.environ.get(key)
+            if value and external_env_path_value(repo, key, value):
+                env[key] = value
+    if engine in {"claude", "opencode", "pi"}:
+        for key in PROVIDER_CREDENTIAL_PATH_ENV_KEYS:
+            value = os.environ.get(key)
+            if value and external_env_path_value(repo, key, value):
+                env[key] = value
+    if engine == "opencode" and (xdg_data_home := os.environ.get("XDG_DATA_HOME")):
+        if external_env_path(repo, xdg_data_home):
+            env["XDG_DATA_HOME"] = xdg_data_home
     env.update(codex_tool_git_env())
     env.update(extra or {})
     return env
@@ -487,14 +716,9 @@ def emit_heartbeat(
 def opencode_review_config(web_search: bool = True) -> dict[str, Any]:
     permission: dict[str, Any] = {
         "*": "deny",
-        "read": {
-            "*": "allow",
-            "*.env": "ask",
-            "*.env.*": "ask",
-            "*.env.example": "allow",
-        },
-        "grep": "allow",
-        "glob": "allow",
+        "read": "deny",
+        "grep": "deny",
+        "glob": "deny",
     }
     if web_search:
         permission["websearch"] = "allow"
@@ -522,13 +746,16 @@ def opencode_review_config(web_search: bool = True) -> dict[str, Any]:
 
 
 def opencode_review_env(web_search: bool = True) -> dict[str, str]:
-    return {
+    env = {
         "OPENCODE_DISABLE_PROJECT_CONFIG": "1",
         "OPENCODE_CONFIG_CONTENT": json.dumps(opencode_review_config(web_search), separators=(",", ":")),
         "OPENCODE_DISABLE_AUTOUPDATE": "1",
         "OPENCODE_DISABLE_AUTOCOMPACT": "1",
         "OPENCODE_DISABLE_MODELS_FETCH": "1",
     }
+    if web_search and (enable_exa := os.environ.get("OPENCODE_ENABLE_EXA")):
+        env["OPENCODE_ENABLE_EXA"] = enable_exa
+    return env
 
 
 def run_with_heartbeat(
@@ -880,20 +1107,19 @@ def raw_repo_path_has_symlink_component(repo: Path, rel_path: Path) -> bool:
 
 
 def secret_text_risk(text: str) -> bool:
-    return any(pattern.search(text) for pattern in SECRET_VALUE_PATTERNS)
-
-
-def file_secret_text_risk(path: Path) -> bool:
-    overlap = ""
-    try:
-        with path.open("r", encoding="utf-8", errors="replace") as handle:
-            while chunk := handle.read(SECRET_SCAN_CHUNK_CHARS):
-                text = overlap + chunk
-                if secret_text_risk(text):
-                    return True
-                overlap = text[-SECRET_SCAN_OVERLAP_CHARS:]
-    except OSError as exc:
-        raise SystemExit(f"unreadable file: {path}: {exc}") from exc
+    if any(pattern.search(text) for pattern in SECRET_VALUE_PATTERNS):
+        return True
+    for match in SECRET_ASSIGNMENT_PATTERN.finditer(text):
+        raw_value = match.group("value")
+        quoted = raw_value.startswith(("\"", "'"))
+        value = raw_value.strip("\"'")
+        lowered = value.lower()
+        if lowered in SECRET_PLACEHOLDER_VALUES:
+            continue
+        call_target = re.fullmatch(r"[A-Za-z_][A-Za-z0-9_.]*", value)
+        if not quoted and call_target and text[match.end() :].startswith("("):
+            continue
+        return True
     return False
 
 
@@ -941,7 +1167,12 @@ def unified_diff_contents(patch: str) -> tuple[str, str]:
 
 def sensitive_repo_path_risk(rel: str) -> str | None:
     normalized = rel.replace(os.sep, "/")
-    if path_has_sensitive_part(normalized) or token_credential_store_path(normalized):
+    if (
+        path_has_sensitive_part(normalized)
+        or credential_store_path(normalized)
+        or secret_directory_path(normalized)
+        or token_credential_store_path(normalized)
+    ):
         return "sensitive path"
     if any(pattern.search(normalized) for pattern in SENSITIVE_NAME_PATTERNS):
         return "sensitive filename"
@@ -958,19 +1189,42 @@ def token_credential_store_path(normalized: str) -> bool:
     )
 
 
+def credential_store_path(normalized: str) -> bool:
+    path = Path(normalized)
+    credential_directory = any(
+        TRACKED_CREDENTIAL_DIR_PATTERN.fullmatch(part)
+        for part in path.parts[:-1]
+    )
+    return credential_directory and not skill_instruction_path(path)
+
+
+def secret_directory_path(normalized: str) -> bool:
+    path = Path(normalized)
+    secret_directory = any(
+        part.lower() == "secrets"
+        for part in path.parts[:-1]
+    )
+    return secret_directory and not skill_instruction_path(path)
+
+
+def skill_instruction_path(path: Path) -> bool:
+    parts = tuple(part.lower() for part in path.parts)
+    skill_root = parts[:1] == ("skills",) or any(
+        parts[index : index + 2] in {(".agents", "skills"), (".claude", "skills")}
+        for index in range(len(parts) - 1)
+    )
+    return skill_root and path.name.lower() in {"agents.md", "claude.md", "skill.md"}
+
+
 def tracked_sensitive_repo_path_risk(rel: str) -> str | None:
     normalized = rel.replace(os.sep, "/")
-    path_parts = Path(normalized).parts
-    parts = {part.lower() for part in path_parts}
-    credential_dir = any(
-        TRACKED_CREDENTIAL_DIR_PATTERN.fullmatch(part)
-        for part in path_parts[:-1]
-    )
+    parts = {part.lower() for part in Path(normalized).parts}
     if (
         "/.config/gcloud/" in f"/{normalized.lower()}/"
         or f"/{normalized.lower()}".endswith("/.docker/config.json")
         or parts & TRACKED_SENSITIVE_PATH_PARTS
-        or credential_dir
+        or credential_store_path(normalized)
+        or secret_directory_path(normalized)
         or token_credential_store_path(normalized)
     ):
         return "sensitive path"
@@ -1030,17 +1284,15 @@ def file_bundle_risk(
     if not path.is_file():
         return "not a regular file"
     try:
-        data, _ = read_prefix(path, MAX_BUNDLE_TEXT_BYTES)
+        data, truncated = read_prefix(path, MAX_BUNDLE_TEXT_BYTES)
     except SystemExit as exc:
         return str(exc)
-    try:
-        sensitive_value_found = file_secret_text_risk(path)
-    except SystemExit as exc:
-        return str(exc)
-    if sensitive_value_found:
-        return "secret-like content"
     if b"\0" in data:
         return None if allow_binary_omission else "binary file"
+    if truncated:
+        return "file too large to scan safely"
+    if secret_text_risk(data.decode("utf-8", errors="replace")):
+        return "secret-like content"
     return None
 
 
@@ -1156,6 +1408,12 @@ def branch_bundle(repo: Path, base_ref: str) -> tuple[str, bool]:
 
 def commit_bundle(repo: Path, commit_ref: str) -> tuple[str, bool]:
     commit_ref = validate_git_ref(repo, commit_ref, "commit")
+    parents = git(repo, "rev-list", "--parents", "-n", "1", commit_ref).split()
+    if len(parents) > 2:
+        raise SystemExit(
+            "commit review does not accept merge commits; review the branch diff "
+            "or an individual parent-relative commit instead"
+        )
     commit_patch = git(
         repo,
         "show",
@@ -1445,8 +1703,10 @@ def load_codex_auth_config(path: Path) -> dict[str, Any]:
     return config if isinstance(config, dict) else {}
 
 
-def codex_auth_config_flags() -> list[str]:
+def codex_auth_config_flags(repo: Path) -> list[str]:
     codex_home = Path(os.environ.get("CODEX_HOME", Path.home() / ".codex"))
+    if not external_env_path(repo, str(codex_home)):
+        return []
     config = load_codex_auth_config(codex_home / "config.toml")
 
     allowed_values = {
@@ -1508,7 +1768,11 @@ def parse_cli_version(text: str) -> tuple[int, int, int] | None:
 
 def ensure_claude_isolation_supported(args: argparse.Namespace, repo: Path) -> None:
     claude_bin = resolve_command(args.claude_bin, repo)
-    engine_env = safe_engine_env(repo, [Path(claude_bin).parent])
+    engine_env = safe_engine_env(
+        repo,
+        [Path(claude_bin).parent],
+        engine="claude",
+    )
     result = run([claude_bin, "--version"], repo, check=False, env=engine_env)
     selected_models = [args.model, *(getattr(args, "fallback_model", "") or "").split(",")]
     uses_fable = "claude-fable-5" in selected_models
@@ -1535,7 +1799,7 @@ def ensure_claude_isolation_supported(args: argparse.Namespace, repo: Path) -> N
 
 def ensure_pi_isolation_supported(args: argparse.Namespace, repo: Path) -> str:
     pi_bin = resolve_command(args.pi_bin, repo)
-    engine_env = safe_engine_env(repo, [Path(pi_bin).parent])
+    engine_env = safe_engine_env(repo, [Path(pi_bin).parent], engine="pi")
     with tempfile.TemporaryDirectory(prefix="autoreview-pi-probe.") as tempdir:
         probe_cwd = Path(tempdir)
         result = run([pi_bin, "--version"], probe_cwd, check=False, env=engine_env)
@@ -1589,17 +1853,65 @@ def codex_config_keys(args: argparse.Namespace) -> list[str]:
 
 
 def codex_speed_override(args: argparse.Namespace) -> str | None:
-    speed = (
-        getattr(args, "codex_speed", None)
-        or os.environ.get("AUTOREVIEW_CODEX_SPEED", "").strip()
-        or DEFAULT_CODEX_SPEED
-    )
+    speed = getattr(args, "codex_speed", None) or os.environ.get("AUTOREVIEW_CODEX_SPEED", "").strip() or None
     if speed is None:
         return None
     speed = speed.strip().lower()
     if speed not in {"fast", "flex", "default"}:
         raise SystemExit(f"invalid Codex speed: {speed} (valid: fast, flex, default)")
     return f'service_tier="{speed}"'
+
+
+def codex_error_messages(result: subprocess.CompletedProcess[str]) -> list[str]:
+    messages: list[str] = []
+    for stream, accept_plain_text in (
+        (result.stderr, True),
+        (result.stdout, False),
+    ):
+        for raw_line in stream.splitlines():
+            line = raw_line.strip()
+            if not line:
+                continue
+            if not line.startswith("{"):
+                if accept_plain_text:
+                    messages.append(line)
+                continue
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(event, dict) or event.get("type") not in {
+                "error",
+                "turn.failed",
+            }:
+                continue
+            message = event.get("message")
+            if isinstance(message, str):
+                messages.append(message)
+            error = event.get("error")
+            if isinstance(error, str):
+                messages.append(error)
+            elif isinstance(error, dict) and isinstance(error.get("message"), str):
+                messages.append(error["message"])
+    return messages
+
+
+def codex_model_access_failure(result: subprocess.CompletedProcess[str], model: str) -> bool:
+    for message in codex_error_messages(result):
+        lowered = message.lower()
+        if model.lower() not in lowered:
+            continue
+        if any(
+            marker in lowered
+            for marker in (
+                "does not exist or you do not have access",
+                "do not have access to",
+                "don't have access to",
+                "not supported when using codex",
+            )
+        ):
+            return True
+    return False
 
 
 def codex_command(
@@ -1625,7 +1937,7 @@ def codex_command(
     if speed_override is not None:
         cmd.extend(["-c", speed_override])
     cmd.extend(codex_config_isolation_flags(repo))
-    cmd.extend(codex_auth_config_flags())
+    cmd.extend(codex_auth_config_flags(repo))
     cmd.append("exec")
     if args.stream_engine_output:
         cmd.append("--json")
@@ -1651,25 +1963,55 @@ def run_codex(args: argparse.Namespace, repo: Path, prompt: str) -> str:
     schema_path = write_json_temp(SCHEMA)
     with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as output_file:
         output_path = Path(output_file.name)
+    models = [args.model]
+    fallback_model = getattr(args, "fallback_model", None)
+    if fallback_model and fallback_model != args.model:
+        models.append(fallback_model)
+    primary_failure: subprocess.CompletedProcess[str] | None = None
     try:
-        cmd = codex_command(args, repo, schema_path, output_path, args.model)
-        result = run_with_heartbeat(
-            cmd,
-            repo,
-            input_text=prompt,
-            label="codex",
-            stream_output=args.stream_engine_output,
-            stream_display=CodexStreamDisplay() if args.stream_engine_output else None,
-            env=safe_engine_env(repo, [Path(cmd[0]).parent]),
-        )
-        output = output_path.read_text()
-        if result.returncode == 0:
-            return output or result.stdout
-        detail = result.stderr or result.stdout
-        raise SystemExit(f"codex engine failed ({result.returncode})\n{detail}")
+        for index, model in enumerate(models):
+            output_path.write_text("")
+            cmd = codex_command(args, repo, schema_path, output_path, model)
+            result = run_with_heartbeat(
+                cmd,
+                repo,
+                input_text=prompt,
+                label="codex",
+                stream_output=args.stream_engine_output,
+                stream_display=CodexStreamDisplay() if args.stream_engine_output else None,
+                env=safe_engine_env(
+                    repo,
+                    [Path(cmd[0]).parent],
+                    engine="codex",
+                ),
+            )
+            output = output_path.read_text()
+            if result.returncode == 0:
+                return output or result.stdout
+            if (
+                index == 0
+                and len(models) > 1
+                and model
+                and codex_model_access_failure(result, model)
+            ):
+                primary_failure = result
+                print(
+                    f"codex model {model} is unavailable for this account; retrying with {models[1]}",
+                    file=sys.stderr,
+                )
+                continue
+            detail = result.stderr or result.stdout
+            if primary_failure is not None:
+                primary_detail = primary_failure.stderr or primary_failure.stdout
+                raise SystemExit(
+                    f"codex engine failed with primary model ({primary_failure.returncode})\n{primary_detail}\n"
+                    f"codex fallback model failed ({result.returncode})\n{detail}"
+                )
+            raise SystemExit(f"codex engine failed ({result.returncode})\n{detail}")
     finally:
         schema_path.unlink(missing_ok=True)
         output_path.unlink(missing_ok=True)
+    raise AssertionError("unreachable")
 
 
 def run_claude(args: argparse.Namespace, repo: Path, prompt: str) -> str:
@@ -1704,7 +2046,11 @@ def run_claude(args: argparse.Namespace, repo: Path, prompt: str) -> str:
         label="claude",
         stream_output=args.stream_engine_output,
         stream_display=ClaudeStreamDisplay() if args.stream_engine_output else None,
-        env=safe_engine_env(repo, [Path(cmd[0]).parent]),
+        env=safe_engine_env(
+            repo,
+            [Path(cmd[0]).parent],
+            engine="claude",
+        ),
     )
     if result.returncode != 0:
         raise SystemExit(f"claude engine failed ({result.returncode})\n{result.stderr or result.stdout}")
@@ -1714,105 +2060,15 @@ def run_claude(args: argparse.Namespace, repo: Path, prompt: str) -> str:
 def run_droid(args: argparse.Namespace, repo: Path, prompt: str) -> str:
     raise SystemExit(
         "droid engine is unavailable: the current Droid CLI cannot disable project instructions and all tools; "
-        "use codex, claude, copilot, pi, opencode, or cursor"
+        "use codex, claude, pi, or opencode"
     )
 
 
 def run_copilot(args: argparse.Namespace, repo: Path, prompt: str) -> str:
-    if args.thinking:
-        raise SystemExit("--thinking is not supported by the copilot engine")
-    if not args.tools:
-        raise SystemExit("--no-tools is not supported by the copilot engine; copilot requires a read-only file view tool to load the review bundle without exposing it in argv")
-    # Copilot child processes can briefly retain this cwd on Windows after a
-    # successful review. Cleanup failure must not replace the review result.
-    with tempfile.TemporaryDirectory(prefix="autoreview-copilot.", ignore_cleanup_errors=True) as tempdir:
-        temp_root = Path(tempdir)
-        repo_alias = temp_root / "repo"
-        try:
-            repo_alias.symlink_to(repo, target_is_directory=True)
-        except OSError as exc:
-            if os.name != "nt":
-                raise SystemExit(f"copilot engine could not create the temporary repository alias: {exc}") from exc
-            import ctypes
-
-            buffer = ctypes.create_unicode_buffer(32_768)
-            length = ctypes.windll.kernel32.GetWindowsDirectoryW(buffer, len(buffer))
-            if length == 0 or length >= len(buffer):
-                raise SystemExit("copilot engine could not resolve the Windows system directory") from exc
-            powershell = Path(buffer.value) / "System32" / "WindowsPowerShell" / "v1.0" / "powershell.exe"
-            if not powershell.is_file() or is_within(powershell.resolve(), repo.resolve()):
-                raise SystemExit("copilot engine could not resolve a trusted Windows PowerShell executable") from exc
-            alias_literal = str(repo_alias).replace("'", "''")
-            repo_literal = str(repo).replace("'", "''")
-            script = (
-                f"New-Item -ItemType Junction -LiteralPath '{alias_literal}' "
-                f"-Target '{repo_literal}' -ErrorAction Stop | Out-Null"
-            )
-            encoded = base64.b64encode(script.encode("utf-16le")).decode("ascii")
-            result = subprocess.run(
-                [
-                    str(powershell),
-                    "-NoLogo",
-                    "-NoProfile",
-                    "-NonInteractive",
-                    "-EncodedCommand",
-                    encoded,
-                ],
-                cwd=temp_root,
-                env=safe_engine_env(repo, [powershell.parent]),
-                check=False,
-                text=True,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-            )
-            if result.returncode != 0 or not repo_alias.is_dir():
-                raise SystemExit(
-                    "copilot engine could not create the temporary repository junction: "
-                    + (result.stderr or result.stdout)
-                )
-        root_marker = "Repository root: ."
-        copilot_prompt = prompt.replace(root_marker, "Repository root: ./repo", 1)
-        if root_marker not in prompt:
-            copilot_prompt = f"Repository root: ./repo\n\n{prompt}"
-        prompt_path = temp_root / "prompt.txt"
-        prompt_path.write_text(copilot_prompt)
-        os.chmod(prompt_path, 0o600)
-        cmd = [
-            resolve_command(args.copilot_bin, repo),
-            "-C",
-            tempdir,
-            "--add-dir=./repo",
-            "-p",
-            "Read ./prompt.txt and follow it exactly. Return only the requested JSON object.",
-            "--output-format",
-            "json",
-            "--stream",
-            "on" if args.stream_engine_output else "off",
-            "--no-ask-user",
-            "--disable-builtin-mcps",
-        ]
-        if args.model:
-            cmd.extend(["--model", args.model])
-        available_tools = ["read_agent", "rg", "view"]
-        allowed_tools = available_tools[:]
-        if args.web_search:
-            available_tools.append("web_fetch")
-            allowed_tools.append("web_fetch")
-            cmd.append("--allow-all-urls")
-        cmd.append(f"--available-tools={','.join(available_tools)}")
-        for tool in allowed_tools:
-            cmd.append(f"--allow-tool={tool}")
-        result = run_with_heartbeat(
-            cmd,
-            Path(tempdir),
-            label="copilot",
-            stream_output=args.stream_engine_output,
-            resolve_root=repo,
-            env=safe_engine_env(repo, [Path(cmd[0]).parent]),
-        )
-    if result.returncode != 0:
-        raise SystemExit(f"copilot engine failed ({result.returncode})\n{result.stderr or result.stdout}")
-    return result.stdout
+    raise SystemExit(
+        "copilot engine is unavailable: its file tools cannot be confined to the reviewed bundle "
+        "without exposing ignored repository secrets; use codex, claude, pi, or opencode"
+    )
 
 
 def build_opencode_cmd(args: argparse.Namespace, repo: Path) -> list[str]:
@@ -1847,6 +2103,7 @@ def run_opencode(args: argparse.Namespace, repo: Path, prompt: str) -> str:
                 repo,
                 [Path(cmd[0]).parent],
                 opencode_review_env(args.web_search),
+                engine="opencode",
             ),
             resolve_root=repo,
         )
@@ -2018,88 +2275,10 @@ def build_cursor_cmd(
 
 
 def run_cursor(args: argparse.Namespace, repo: Path, prompt: str) -> str:
-    if args.thinking:
-        raise SystemExit("--thinking is not supported by the cursor engine")
-    if not args.tools:
-        raise SystemExit("--no-tools is not supported by the cursor engine")
-    if not args.web_search:
-        raise SystemExit("--no-web-search is not supported by the cursor engine; Cursor CLI does not expose a documented per-run web-search disable flag")
-    local_mcp_paths = cursor_local_mcp_paths(repo)
-    global_mcp_paths = cursor_global_mcp_paths()
-    local_hook_paths = cursor_local_hook_paths(repo)
-    global_hook_paths = cursor_global_hook_paths()
-    local_permission_paths = cursor_local_permission_paths(repo)
-    if not args.cursor_allow_workspace_instructions:
-        raise SystemExit(
-            "cursor engine requires --cursor-allow-workspace-instructions for an explicitly trusted repo; "
-            "Cursor CLI does not expose a per-run project-resource disable flag."
-        )
-    if local_hook_paths:
-        raise SystemExit(
-            "cursor engine refused project-local hooks: "
-            + format_repo_paths(repo, local_hook_paths)
-            + ". Cursor hooks execute host commands outside review tool permissions."
-        )
-    if global_hook_paths:
-        raise SystemExit(
-            "cursor engine refused user-level hooks because Cursor can execute them outside the temporary review config."
-        )
-    if local_mcp_paths:
-        raise SystemExit(
-            "cursor engine refused project-local MCP config: "
-            + format_repo_paths(repo, local_mcp_paths)
-            + ". Cursor MCP tools cannot be restricted to read-only review access."
-        )
-    if global_mcp_paths:
-        raise SystemExit(
-            "cursor engine refused global MCP config because Cursor can load it outside the temporary review config."
-        )
-    if local_permission_paths:
-        raise SystemExit(
-            "cursor engine refused project-local permission config: "
-            + format_repo_paths(repo, local_permission_paths)
-            + ". Project permissions can override the read-only review policy."
-        )
-    print(
-        "cursor isolation warning: trusted project-local resources are being allowed explicitly.",
-        file=sys.stderr,
+    raise SystemExit(
+        "cursor engine is unavailable: Cursor read permissions can target absolute host paths "
+        "and the CLI does not expose a proven repository-only filesystem sandbox"
     )
-    cursor_bin = resolve_command(args.cursor_bin, repo)
-    with tempfile.TemporaryDirectory(prefix="autoreview-cursor-config.") as tempdir:
-        config_dir = Path(tempdir)
-        (config_dir / "cli-config.json").write_text(
-            json.dumps(
-                {
-                    "version": 1,
-                    "editor": {"vimMode": False},
-                    "permissions": {
-                        "allow": ["Read(**)"],
-                        "deny": ["Shell(*)", "Write(**)", "Write(/**)"],
-                    },
-                }
-            )
-            + "\n"
-        )
-        engine_env = safe_engine_env(
-            repo,
-            [Path(cursor_bin).parent],
-            {"CURSOR_CONFIG_DIR": str(config_dir)},
-        )
-        cmd = build_cursor_cmd(args, repo, cursor_bin, engine_env)
-        result = run_with_heartbeat(
-            cmd,
-            repo,
-            input_text=prompt,
-            label="cursor",
-            stream_output=args.stream_engine_output,
-            stream_display=CursorStreamDisplay() if args.stream_engine_output else None,
-            env=engine_env,
-            resolve_root=repo,
-        )
-    if result.returncode != 0:
-        raise SystemExit(f"cursor engine failed ({result.returncode})\n{result.stderr or result.stdout}")
-    print_cursor_metadata(result.stdout)
-    return result.stdout
 
 
 def run_pi(args: argparse.Namespace, repo: Path, prompt: str) -> str:
@@ -2124,7 +2303,11 @@ def run_pi(args: argparse.Namespace, repo: Path, prompt: str) -> str:
             label="pi",
             stream_output=args.stream_engine_output,
             resolve_root=repo,
-            env=safe_engine_env(repo, [Path(cmd[0]).parent]),
+            env=safe_engine_env(
+                repo,
+                [Path(cmd[0]).parent],
+                engine="pi",
+            ),
         )
     if result.returncode != 0:
         raise SystemExit(f"pi engine failed ({result.returncode})\n{result.stderr or result.stdout}")
@@ -2353,14 +2536,12 @@ def claude_allowed_tools(args: argparse.Namespace) -> str:
 
 
 def claude_tool_inventory(args: argparse.Namespace) -> str:
-    safe_tools = {"Bash", "Glob", "Grep", "Read", "WebFetch", "WebSearch"}
+    safe_tools = {"WebFetch", "WebSearch"}
     names: list[str] = []
     for rule in claude_tool_rules(args):
         name = claude_tool_name(rule)
         if name not in safe_tools:
             raise SystemExit(f"Claude review tool is not read-only: {name}")
-        if name == "Bash" and not rule.startswith("Bash("):
-            raise SystemExit("Claude review Bash access must use a scoped Bash(...) rule")
         if name not in names:
             names.append(name)
     return ",".join(names)
@@ -2376,7 +2557,7 @@ def extract_json(text: str) -> dict[str, Any]:
         jsonl_report = extract_json_from_jsonl(stripped)
         if jsonl_report:
             return jsonl_report
-        fenced_report = extract_findings_json_from_text(stripped) or parse_json_candidate(stripped)
+        fenced_report = parse_json_candidate(stripped)
         if isinstance(fenced_report, dict) and "findings" in fenced_report:
             return fenced_report
         raise SystemExit(f"review engine returned non-JSON output: {exc}\n{stripped[:2000]}")
@@ -2389,7 +2570,7 @@ def extract_json(text: str) -> dict[str, Any]:
         if "findings" in result_object:
             return result_object
     if isinstance(parsed, dict) and isinstance(parsed.get("result"), str):
-        result_json = extract_findings_json_from_text(parsed["result"]) or parse_json_candidate(parsed["result"])
+        result_json = parse_json_candidate(parsed["result"])
         if isinstance(result_json, dict) and "findings" in result_json:
             return result_json
         raise SystemExit(f"review engine result was not structured JSON:\n{parsed['result'][:2000]}")
@@ -2450,7 +2631,7 @@ def _report_from_events(events: list[Any]) -> dict[str, Any] | None:
             if "findings" in candidate:
                 return candidate
             continue
-        parsed = extract_findings_json_from_text(candidate) or parse_json_candidate(candidate)
+        parsed = parse_json_candidate(candidate)
         if isinstance(parsed, dict) and "findings" in parsed:
             return parsed
     if terminal_candidates:
@@ -2460,11 +2641,11 @@ def _report_from_events(events: list[Any]) -> dict[str, Any] | None:
             if "findings" in candidate:
                 return candidate
             continue
-        parsed = extract_findings_json_from_text(candidate) or parse_json_candidate(candidate)
+        parsed = parse_json_candidate(candidate)
         if isinstance(parsed, dict) and "findings" in parsed:
             return parsed
     for candidate in reversed(assistant_candidates):
-        parsed = extract_findings_json_from_text(candidate) or parse_json_candidate(candidate)
+        parsed = parse_json_candidate(candidate)
         if isinstance(parsed, dict) and "findings" in parsed:
             return parsed
     return None
@@ -2481,22 +2662,6 @@ def extract_json_from_jsonl(text: str) -> dict[str, Any] | None:
         except json.JSONDecodeError:
             continue
     return _report_from_events(events)
-
-
-def extract_findings_json_from_text(text: str) -> dict[str, Any] | None:
-    stripped = text.strip()
-    decoder = json.JSONDecoder()
-    parsed: dict[str, Any] | None = None
-    for index, char in enumerate(stripped):
-        if char != "{":
-            continue
-        try:
-            candidate, _ = decoder.raw_decode(stripped[index:])
-        except json.JSONDecodeError:
-            continue
-        if isinstance(candidate, dict) and "findings" in candidate:
-            parsed = candidate
-    return parsed
 
 
 def is_structured_output_failure(message: str) -> bool:
@@ -2808,7 +2973,7 @@ def self_test_engine_isolation() -> int:
             model=None,
             thinking=None,
             stream_engine_output=False,
-            claude_allowed_tools="Read,Grep,Glob,WebSearch,WebFetch",
+            claude_allowed_tools="WebSearch,WebFetch",
             cursor_allow_workspace_instructions=False,
         )
 
@@ -2935,84 +3100,12 @@ def self_test_engine_isolation() -> int:
             try:
                 run_cursor(args, repo, "review hostile patch")
             except SystemExit as exc:
-                if "requires --cursor-allow-workspace-instructions" not in str(exc):
+                if "Cursor read permissions" not in str(exc):
                     raise
             else:
-                raise SystemExit("cursor isolation self-test failed: hostile project surfaces should be refused")
+                raise SystemExit("cursor isolation self-test failed: unconfined reads were allowed")
             if record_path.exists():
-                raise SystemExit("cursor isolation self-test failed: cursor invoked despite refused project surfaces")
-
-            args.cursor_allow_workspace_instructions = True
-            try:
-                run_cursor(args, repo, "review hostile patch")
-            except SystemExit as exc:
-                if "project-local hooks" not in str(exc):
-                    raise
-            else:
-                raise SystemExit("cursor isolation self-test failed: local hooks should be refused")
-            if record_path.exists():
-                raise SystemExit("cursor isolation self-test failed: cursor invoked despite refused hooks")
-
-            for relative_path in (Path(".claude/settings.json"), Path(".claude/settings.local.json")):
-                (repo / relative_path).unlink(missing_ok=True)
-            try:
-                run_cursor(args, repo, "review hostile patch")
-            except SystemExit as exc:
-                if "project-local MCP config" not in str(exc):
-                    raise
-            else:
-                raise SystemExit("cursor isolation self-test failed: local MCP config should be refused")
-            if record_path.exists():
-                raise SystemExit("cursor isolation self-test failed: cursor invoked despite refused MCP config")
-
-            for relative_path in (
-                Path(".cursor/mcp.json"),
-                Path(".mcp.json"),
-                Path("mcp.json"),
-            ):
-                (repo / relative_path).unlink(missing_ok=True)
-            try:
-                run_cursor(args, repo, "review hostile patch")
-            except SystemExit as exc:
-                if "project-local permission config" not in str(exc):
-                    raise
-            else:
-                raise SystemExit("cursor isolation self-test failed: local permission config should be refused")
-            (repo / ".cursor" / "cli.json").unlink()
-            user_hooks = test_home / ".cursor" / "hooks.json"
-            user_hooks.parent.mkdir()
-            user_hooks.write_text("{}\n")
-            try:
-                run_cursor(args, repo, "review hostile patch")
-            except SystemExit as exc:
-                if "user-level hooks" not in str(exc):
-                    raise
-            else:
-                raise SystemExit("cursor isolation self-test failed: user-level hooks should be refused")
-            user_hooks.unlink()
-            run_cursor(args, repo, "review hostile patch")
-            cursor_record = json.loads(record_path.read_text())
-            cursor_argv = cursor_record["argv"]
-            for required in ["--print", "--output-format", "json"]:
-                if required not in cursor_argv:
-                    raise SystemExit(f"cursor isolation self-test failed: missing {required}")
-            for forbidden in ["--workspace", "--trust"]:
-                if forbidden in cursor_argv:
-                    raise SystemExit(f"cursor isolation self-test failed: unsupported flag present: {forbidden}")
-            for required in ["--mode", "ask", "--sandbox", "enabled"]:
-                if required not in cursor_argv:
-                    raise SystemExit(f"cursor isolation self-test failed: missing {required}")
-            if Path(cursor_record["cwd"]).resolve() != repo.resolve():
-                raise SystemExit("cursor isolation self-test failed: Cursor workspace cwd should be reviewed repo")
-            if cursor_record["stdin"] != "review hostile patch":
-                raise SystemExit("cursor isolation self-test failed: prompt not delivered over stdin")
-            if "review hostile patch" in cursor_argv:
-                raise SystemExit("cursor isolation self-test failed: prompt leaked into argv")
-            cursor_config = json.loads(cursor_record["cursor_config"])
-            if cursor_config.get("permissions", {}).get("allow") != ["Read(**)"]:
-                raise SystemExit("cursor isolation self-test failed: read-only allowlist missing")
-            if cursor_config.get("permissions", {}).get("deny") != ["Shell(*)", "Write(**)", "Write(/**)"]:
-                raise SystemExit("cursor isolation self-test failed: shell/write denylist missing")
+                raise SystemExit("cursor isolation self-test failed: disabled cursor was invoked")
 
             os.environ["AUTOREVIEW_FAKE_CLAUDE_VERSION"] = "2.1.168 (Claude Code)"
             try:
@@ -3166,7 +3259,7 @@ def self_test_cursor_jsonl_parser() -> int:
 
     result_text = {
         "type": "result",
-        "result": "prefix\n```json\n" + json.dumps(report) + "\n```",
+        "result": "```json\n" + json.dumps(report) + "\n```",
         "session_id": "session",
         "request_id": "request",
     }
@@ -3189,8 +3282,12 @@ def self_test_cursor_jsonl_parser() -> int:
     else:
         raise SystemExit("cursor parser self-test failed: assistant draft masked bad result")
 
-    if extract_json("analysis before " + json.dumps(report) + " after") != report:
-        raise SystemExit("cursor parser self-test failed for embedded JSON")
+    try:
+        extract_json("analysis before " + json.dumps(report) + " after")
+    except SystemExit:
+        pass
+    else:
+        raise SystemExit("cursor parser self-test failed: embedded JSON was accepted")
 
     print("autoreview cursor jsonl parser self-test: ok")
     return 0
@@ -3227,18 +3324,11 @@ def _assert_opencode_permission(web_search: bool) -> None:
             raise SystemExit(f"opencode isolation self-test failed: {disabled_tool} tool not disabled")
     if permission.get("*") != "deny":
         raise SystemExit("opencode isolation self-test failed: default deny missing")
-    read_permission = permission.get("read")
-    if not isinstance(read_permission, dict):
-        raise SystemExit("opencode isolation self-test failed: read rules missing")
-    expected_read_rules = {
-        "*": "allow",
-        "*.env": "ask",
-        "*.env.*": "ask",
-        "*.env.example": "allow",
-    }
-    for pattern, action in expected_read_rules.items():
-        if read_permission.get(pattern) != action:
-            raise SystemExit(f"opencode isolation self-test failed: read {pattern} must be {action}")
+    for filesystem_tool in ("read", "grep", "glob"):
+        if permission.get(filesystem_tool) != "deny":
+            raise SystemExit(
+                f"opencode isolation self-test failed: {filesystem_tool} must be denied"
+            )
     expected_web = "allow" if web_search else "deny"
     if permission.get("websearch") != expected_web:
         raise SystemExit(f"opencode isolation self-test failed: websearch must be {expected_web} when web_search={web_search}")
@@ -3544,12 +3634,12 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--base")
     parser.add_argument("--commit", default="HEAD")
     parser.add_argument("--engine", choices=ENGINE_CHOICES, default=os.environ.get("AUTOREVIEW_ENGINE", "codex"))
-    parser.add_argument("--reviewers", help="Comma-separated review panel, e.g. codex,claude,cursor or codex:gpt-5.6-sol:high.")
+    parser.add_argument("--reviewers", help="Comma-separated review panel, e.g. codex,claude,pi or codex:gpt-5.6-sol:high.")
     parser.add_argument("--panel", action="store_true", help="Run a Codex/Claude review panel unless --engine changes the first reviewer.")
     parser.add_argument(
         "--model",
         action="append",
-        help="Model for all reviewers or engine=model. Repeatable. Defaults: codex=gpt-5.6-sol, claude=claude-fable-5.",
+        help="Model for all reviewers or engine=model. Repeatable. Defaults: codex=gpt-5.6-sol with an access-only gpt-5.6-terra retry, claude=claude-fable-5.",
     )
     parser.add_argument("--thinking", action="append", help="Thinking/effort for all reviewers or engine=level. Repeatable. Codex: none, minimal, low, medium, high, xhigh. Claude: low, medium, high, xhigh, max. Droid: off, none, low, medium, high. Pi: off, minimal, low, medium, high, xhigh. OpenCode: minimal, low, medium, high, max. Cursor: none.")
     parser.add_argument(
@@ -3593,7 +3683,7 @@ def parse_args() -> argparse.Namespace:
         "--claude-allowed-tools",
         default=os.environ.get(
             "AUTOREVIEW_CLAUDE_TOOLS",
-            "Read,Grep,Glob,WebSearch,WebFetch",
+            "WebSearch,WebFetch",
         ),
     )
     parser.add_argument("--prompt", action="append", help="Additional review instruction text.")
@@ -3605,20 +3695,20 @@ def parse_args() -> argparse.Namespace:
         "--stream-engine-output",
         action="store_true",
         default=os.environ.get("AUTOREVIEW_STREAM_ENGINE_OUTPUT") == "1",
-        help="Stream review engine output while preserving buffered output for validation. Codex, Claude, and Cursor filter noisy tool/status chatter.",
+        help="Stream review engine output while preserving buffered output for validation. Codex and Claude filter noisy tool/status chatter.",
     )
     parser.add_argument(
         "--cursor-allow-workspace-instructions",
         dest="cursor_allow_workspace_instructions",
         action="store_true",
         default=None,
-        help="Required opt-in for every Cursor review. Confirms the repository and its project-local resources are trusted.",
+        help="Legacy compatibility flag. Cursor review is unavailable because reads cannot be confined to the repository.",
     )
     parser.add_argument(
         "--no-cursor-allow-workspace-instructions",
         dest="cursor_allow_workspace_instructions",
         action="store_false",
-        help="Refuse Cursor review because project-local resource loading cannot be disabled.",
+        help="Legacy compatibility flag. Cursor review remains unavailable.",
     )
     parser.add_argument("--parallel-tests", help="Run a test command concurrently with review; failure fails the helper.")
     parser.add_argument(
@@ -3791,6 +3881,8 @@ def reviewer_args(args: argparse.Namespace) -> list[argparse.Namespace]:
                 or env_fallback_by_engine.get(engine)
                 or env_global_fallback
             )
+        elif engine == "codex" and model == DEFAULT_MODEL_BY_ENGINE["codex"]:
+            fallback_model = DEFAULT_CODEX_ACCESS_FALLBACK_MODEL
         else:
             fallback_model = None
         if thinking and thinking not in THINKING_LEVELS_BY_ENGINE[engine]:
@@ -3957,15 +4049,17 @@ def self_test_config_defaults() -> None:
         default_codex = reviewer_args(reviewer_test_args(engine="codex"))[0]
         if default_codex.model != "gpt-5.6-sol":
             raise SystemExit(f"self-test config defaults failed: default codex model={default_codex.model!r}")
-        if default_codex.fallback_model is not None:
+        if default_codex.fallback_model != "gpt-5.6-terra":
             raise SystemExit(
                 f"self-test config defaults failed: default codex fallback={default_codex.fallback_model!r}"
             )
-        if default_codex.thinking != "xhigh":
+        explicit_sol = reviewer_args(reviewer_test_args(engine="codex", model=["gpt-5.6-sol"]))[0]
+        if explicit_sol.fallback_model != "gpt-5.6-terra":
+            raise SystemExit(
+                f"self-test config defaults failed: explicit Sol access fallback={explicit_sol.fallback_model!r}"
+            )
+        if default_codex.thinking != "high":
             raise SystemExit(f"self-test config defaults failed: default codex thinking={default_codex.thinking!r}")
-        default_speed = codex_speed_override(reviewer_test_args(engine="codex"))
-        if default_speed != 'service_tier="fast"':
-            raise SystemExit(f"self-test config defaults failed: default codex speed={default_speed!r}")
         default_claude = reviewer_args(reviewer_test_args(engine="claude"))[0]
         if default_claude.model != "claude-fable-5":
             raise SystemExit(f"self-test config defaults failed: default claude model={default_claude.model!r}")
@@ -4059,9 +4153,9 @@ def self_test_fallback_scope() -> None:
         reviewers = reviewer_args(base)
         codex = next(r for r in reviewers if r.engine == "codex")
         claude = next(r for r in reviewers if r.engine == "claude")
-        if codex.fallback_model is not None:
+        if codex.fallback_model != "gpt-5.6-terra":
             raise SystemExit(
-                f"self-test fallback scope failed: codex fallback={codex.fallback_model!r}"
+                f"self-test fallback scope failed: codex access fallback={codex.fallback_model!r}"
             )
         if claude.fallback_model != "env-claude-fallback":
             raise SystemExit(f"self-test fallback scope failed: claude fallback={claude.fallback_model!r}")
@@ -4086,7 +4180,7 @@ def self_test_fallback_scope() -> None:
         panel = reviewer_args(reviewer_test_args(reviewers="codex,claude", fallback_model=["cli-global"]))
         panel_codex = next(r for r in panel if r.engine == "codex")
         panel_claude = next(r for r in panel if r.engine == "claude")
-        if panel_codex.fallback_model is not None or panel_claude.fallback_model != "cli-global":
+        if panel_codex.fallback_model != "gpt-5.6-terra" or panel_claude.fallback_model != "cli-global":
             raise SystemExit("self-test fallback scope failed: CLI global fallback should apply only to Claude panel reviewers")
         try:
             reviewer_args(reviewer_test_args(engine="codex", fallback_model=["cli-global"]))

--- a/skills/autoreview/scripts/autoreview_test.py
+++ b/skills/autoreview/scripts/autoreview_test.py
@@ -178,15 +178,89 @@ class AutoreviewCompatibilityTests(unittest.TestCase):
         args = argparse.Namespace(codex_config=['model_provider="private-value"'])
         self.assertEqual(AUTOREVIEW.codex_config_keys(args), ["model_provider"])
 
-    def test_codex_runs_single_model_without_fallback_retry(self) -> None:
+    def test_codex_retries_terra_after_sol_access_failure(self) -> None:
         args = argparse.Namespace(
             codex_bin="codex",
             codex_config=None,
             codex_speed=None,
-            fallback_model=None,
+            fallback_model="gpt-5.6-terra",
             model="gpt-5.6-sol",
             stream_engine_output=False,
-            thinking="xhigh",
+            thinking="high",
+            tools=True,
+            web_search=False,
+        )
+        models: list[str] = []
+
+        def fake_run(command: list[str], *_args: object, **_kwargs: object) -> subprocess.CompletedProcess[str]:
+            model = command[command.index("--model") + 1]
+            models.append(model)
+            if model == "gpt-5.6-sol":
+                return subprocess.CompletedProcess(
+                    command,
+                    1,
+                    "",
+                    "The model `gpt-5.6-sol` does not exist or you do not have access to it.",
+                )
+            output_path = Path(command[command.index("--output-last-message") + 1])
+            output_path.write_text(json.dumps(FINAL_REPORT))
+            return subprocess.CompletedProcess(command, 0, "", "")
+
+        with tempfile.TemporaryDirectory(prefix="autoreview-codex-fallback.") as tmpdir, mock.patch.object(
+            AUTOREVIEW,
+            "resolve_command",
+            return_value="/usr/bin/codex",
+        ), mock.patch.object(AUTOREVIEW, "codex_auth_config_flags", return_value=[]), mock.patch.object(
+            AUTOREVIEW,
+            "run_with_heartbeat",
+            side_effect=fake_run,
+        ):
+            output = AUTOREVIEW.run_codex(args, Path(tmpdir), "review")
+
+        self.assertEqual(json.loads(output), FINAL_REPORT)
+        self.assertEqual(models, ["gpt-5.6-sol", "gpt-5.6-terra"])
+
+    def test_codex_does_not_fallback_after_unrelated_failure(self) -> None:
+        args = argparse.Namespace(
+            codex_bin="codex",
+            codex_config=None,
+            codex_speed=None,
+            fallback_model="gpt-5.6-terra",
+            model="gpt-5.6-sol",
+            stream_engine_output=False,
+            thinking="high",
+            tools=True,
+            web_search=False,
+        )
+        models: list[str] = []
+
+        def fake_run(command: list[str], *_args: object, **_kwargs: object) -> subprocess.CompletedProcess[str]:
+            models.append(command[command.index("--model") + 1])
+            return subprocess.CompletedProcess(command, 1, "", "network timeout")
+
+        with tempfile.TemporaryDirectory(prefix="autoreview-codex-fallback.") as tmpdir, mock.patch.object(
+            AUTOREVIEW,
+            "resolve_command",
+            return_value="/usr/bin/codex",
+        ), mock.patch.object(AUTOREVIEW, "codex_auth_config_flags", return_value=[]), mock.patch.object(
+            AUTOREVIEW,
+            "run_with_heartbeat",
+            side_effect=fake_run,
+        ):
+            with self.assertRaisesRegex(SystemExit, "network timeout"):
+                AUTOREVIEW.run_codex(args, Path(tmpdir), "review")
+
+        self.assertEqual(models, ["gpt-5.6-sol"])
+
+    def test_codex_does_not_fallback_after_model_capacity_failure(self) -> None:
+        args = argparse.Namespace(
+            codex_bin="codex",
+            codex_config=None,
+            codex_speed=None,
+            fallback_model="gpt-5.6-terra",
+            model="gpt-5.6-sol",
+            stream_engine_output=False,
+            thinking="high",
             tools=True,
             web_search=False,
         )
@@ -198,10 +272,10 @@ class AutoreviewCompatibilityTests(unittest.TestCase):
                 command,
                 1,
                 "",
-                "The model `gpt-5.6-sol` does not exist or you do not have access to it.",
+                "model_not_available: gpt-5.6-sol is temporarily unavailable due to capacity",
             )
 
-        with tempfile.TemporaryDirectory(prefix="autoreview-codex-single.") as tmpdir, mock.patch.object(
+        with tempfile.TemporaryDirectory(prefix="autoreview-codex-fallback.") as tmpdir, mock.patch.object(
             AUTOREVIEW,
             "resolve_command",
             return_value="/usr/bin/codex",
@@ -210,10 +284,46 @@ class AutoreviewCompatibilityTests(unittest.TestCase):
             "run_with_heartbeat",
             side_effect=fake_run,
         ):
-            with self.assertRaisesRegex(SystemExit, "codex engine failed"):
+            with self.assertRaisesRegex(SystemExit, "temporarily unavailable"):
                 AUTOREVIEW.run_codex(args, Path(tmpdir), "review")
 
         self.assertEqual(models, ["gpt-5.6-sol"])
+
+    def test_codex_access_fallback_ignores_structured_output_text(self) -> None:
+        result = subprocess.CompletedProcess(
+            ["codex"],
+            1,
+            '{"type":"agent_message","text":"gpt-5.6-sol does not exist or you do not have access"}',
+            '{"type":"agent_message","message":"gpt-5.6-sol does not exist or you do not have access"}',
+        )
+
+        self.assertFalse(
+            AUTOREVIEW.codex_model_access_failure(result, "gpt-5.6-sol")
+        )
+
+    def test_codex_access_fallback_accepts_terminal_error_event(self) -> None:
+        result = subprocess.CompletedProcess(
+            ["codex"],
+            1,
+            '{"type":"error","message":"gpt-5.6-sol does not exist or you do not have access"}',
+            "",
+        )
+
+        self.assertTrue(
+            AUTOREVIEW.codex_model_access_failure(result, "gpt-5.6-sol")
+        )
+
+    def test_codex_access_fallback_ignores_plain_stdout(self) -> None:
+        message = "gpt-5.6-sol does not exist or you do not have access"
+        stdout_result = subprocess.CompletedProcess(["codex"], 1, message, "")
+        stderr_result = subprocess.CompletedProcess(["codex"], 1, "", message)
+
+        self.assertFalse(
+            AUTOREVIEW.codex_model_access_failure(stdout_result, "gpt-5.6-sol")
+        )
+        self.assertTrue(
+            AUTOREVIEW.codex_model_access_failure(stderr_result, "gpt-5.6-sol")
+        )
 
     def test_extract_json_accepts_dict_result_payload(self) -> None:
         payload = {
@@ -225,32 +335,14 @@ class AutoreviewCompatibilityTests(unittest.TestCase):
         }
         self.assertEqual(AUTOREVIEW.extract_json(json.dumps(payload)), FINAL_REPORT)
 
-    def test_extract_json_accepts_result_string_with_preamble(self) -> None:
+    def test_extract_json_rejects_result_string_with_preamble(self) -> None:
         payload = {
             "type": "result",
             "subtype": "success",
             "result": "Inspecting the diff first.\n" + json.dumps(FINAL_REPORT),
         }
-        self.assertEqual(AUTOREVIEW.extract_json(json.dumps(payload)), FINAL_REPORT)
-
-    def test_extract_findings_json_from_text_prefers_last_findings_object(self) -> None:
-        later_report = {
-            "findings": [
-                {
-                    "title": "Later finding",
-                    "body": "later",
-                    "priority": "P2",
-                    "confidence": 0.8,
-                    "category": "bug",
-                    "code_location": {"file_path": "later.js", "line": 2},
-                }
-            ],
-            "overall_correctness": "patch is incorrect",
-            "overall_explanation": "later",
-            "overall_confidence": 0.8,
-        }
-        text = f"{json.dumps(FINAL_REPORT)} separator {json.dumps(later_report)}"
-        self.assertEqual(AUTOREVIEW.extract_findings_json_from_text(text), later_report)
+        with self.assertRaisesRegex(SystemExit, "result was not structured JSON"):
+            AUTOREVIEW.extract_json(json.dumps(payload))
 
     def test_retry_filter_only_matches_parse_failures(self) -> None:
         self.assertTrue(AUTOREVIEW.is_structured_output_failure("review engine returned non-JSON output: nope"))
@@ -272,7 +364,7 @@ class AutoreviewCompatibilityTests(unittest.TestCase):
             )
             with self.assertRaises(SystemExit) as exc_info:
                 AUTOREVIEW.run_cursor(args, repo, "prompt")
-            self.assertIn("requires --cursor-allow-workspace-instructions", str(exc_info.exception))
+            self.assertIn("cursor engine is unavailable", str(exc_info.exception))
 
     def test_cursor_local_mcp_requires_explicit_approval(self) -> None:
         with tempfile.TemporaryDirectory(prefix="autoreview-cursor-test.") as tmpdir:
@@ -290,7 +382,7 @@ class AutoreviewCompatibilityTests(unittest.TestCase):
             )
             with self.assertRaises(SystemExit) as exc_info:
                 AUTOREVIEW.run_cursor(args, repo, "prompt")
-            self.assertIn("cursor engine refused project-local MCP config", str(exc_info.exception))
+            self.assertIn("cursor engine is unavailable", str(exc_info.exception))
 
     def test_cursor_local_hooks_are_always_refused(self) -> None:
         with tempfile.TemporaryDirectory(prefix="autoreview-cursor-test.") as tmpdir:
@@ -308,7 +400,7 @@ class AutoreviewCompatibilityTests(unittest.TestCase):
             )
             with self.assertRaises(SystemExit) as exc_info:
                 AUTOREVIEW.run_cursor(args, repo, "prompt")
-            self.assertIn("cursor engine refused project-local hooks", str(exc_info.exception))
+            self.assertIn("cursor engine is unavailable", str(exc_info.exception))
 
     def test_cursor_local_permissions_are_always_refused(self) -> None:
         with tempfile.TemporaryDirectory(prefix="autoreview-cursor-test.") as tmpdir:
@@ -326,15 +418,14 @@ class AutoreviewCompatibilityTests(unittest.TestCase):
             )
             with self.assertRaises(SystemExit) as exc_info:
                 AUTOREVIEW.run_cursor(args, repo, "prompt")
-            self.assertIn("cursor engine refused project-local permission config", str(exc_info.exception))
+            self.assertIn("cursor engine is unavailable", str(exc_info.exception))
 
-    def test_cursor_command_uses_current_print_contract(self) -> None:
+    def test_cursor_is_disabled_without_repo_only_read_sandbox(self) -> None:
         with tempfile.TemporaryDirectory(prefix="autoreview-cursor-test.") as tmpdir:
             root = Path(tmpdir)
             repo = root / "repo"
             repo.mkdir()
             cursor_bin = root / "cursor-agent"
-            record_path = root / "record.json"
             AUTOREVIEW.write_executable(cursor_bin, AUTOREVIEW.fake_cursor_script())
             args = argparse.Namespace(
                 thinking=None,
@@ -345,30 +436,11 @@ class AutoreviewCompatibilityTests(unittest.TestCase):
                 model=None,
                 stream_engine_output=False,
             )
-            old_record = os.environ.get("AUTOREVIEW_FAKE_RECORD")
-            try:
-                os.environ["AUTOREVIEW_FAKE_RECORD"] = str(record_path)
-                with mock.patch.object(AUTOREVIEW, "cursor_global_hook_paths", return_value=[]):
+            with mock.patch.object(AUTOREVIEW, "cursor_global_hook_paths", return_value=[]):
+                with self.assertRaisesRegex(SystemExit, "Cursor read permissions"):
                     AUTOREVIEW.run_cursor(args, repo, "prompt")
-            finally:
-                if old_record is None:
-                    os.environ.pop("AUTOREVIEW_FAKE_RECORD", None)
-                else:
-                    os.environ["AUTOREVIEW_FAKE_RECORD"] = old_record
-            record = json.loads(record_path.read_text())
-            self.assertEqual(Path(record["cwd"]).resolve(), repo.resolve())
-            self.assertEqual(record["stdin"], "prompt")
-            self.assertIn("--print", record["argv"])
-            self.assertIn("--output-format", record["argv"])
-            self.assertIn("json", record["argv"])
-            self.assertIn("--mode", record["argv"])
-            self.assertIn("ask", record["argv"])
-            self.assertIn("--sandbox", record["argv"])
-            self.assertIn("enabled", record["argv"])
-            for unsupported in ("--workspace", "--trust"):
-                self.assertNotIn(unsupported, record["argv"])
 
-    def test_cursor_engine_runs_end_to_end_with_sanitized_environment(self) -> None:
+    def test_cursor_engine_fails_closed_end_to_end(self) -> None:
         with tempfile.TemporaryDirectory(prefix="autoreview-cursor-e2e.") as tmpdir:
             root = Path(tmpdir)
             repo = root / "repo"
@@ -417,33 +489,9 @@ class AutoreviewCompatibilityTests(unittest.TestCase):
                 check=False,
             )
 
-            self.assertEqual(result.returncode, 0, result.stderr)
-            self.assertIn("autoreview clean: no accepted/actionable findings reported", result.stdout)
-            record = json.loads(record_path.read_text())
-            self.assertEqual(Path(record["cwd"]).resolve(), repo.resolve())
-            self.assertIn("diff --git a/example.txt b/example.txt", record["stdin"])
-            self.assertIn("-before", record["stdin"])
-            self.assertIn("+after", record["stdin"])
-            self.assertEqual(record["environment"]["GIT_CONFIG_GLOBAL"], None)
-            self.assertEqual(record["environment"]["NODE_OPTIONS"], None)
-            self.assertEqual(record["environment"]["PYTHONPATH"], None)
-            self.assertNotIn(str(repo), record["environment"]["PATH"].split(os.pathsep))
-            cursor_config_dir = Path(record["environment"]["CURSOR_CONFIG_DIR"])
-            self.assertFalse(cursor_config_dir.exists())
-            cursor_config = json.loads(record["cursor_config"])
-            self.assertEqual(cursor_config["permissions"]["allow"], ["Read(**)"])
-            self.assertEqual(
-                cursor_config["permissions"]["deny"],
-                ["Shell(*)", "Write(**)", "Write(/**)"],
-            )
-
-            invocations = [json.loads(line) for line in (root / "cursor-invocations.jsonl").read_text().splitlines()]
-            help_invocation = next(invocation for invocation in invocations if "--help" in invocation["argv"])
-            self.assertNotEqual(Path(help_invocation["cwd"]).resolve(), repo.resolve())
-            self.assertEqual(help_invocation["environment"]["GIT_CONFIG_GLOBAL"], None)
-            self.assertEqual(help_invocation["environment"]["NODE_OPTIONS"], None)
-            self.assertEqual(help_invocation["environment"]["PYTHONPATH"], None)
-            self.assertNotIn(str(repo), help_invocation["environment"]["PATH"].split(os.pathsep))
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("Cursor read permissions", result.stderr)
+            self.assertFalse(record_path.exists())
 
 
 if __name__ == "__main__":

--- a/skills/autoreview/tests/test_autoreview_hardening.py
+++ b/skills/autoreview/tests/test_autoreview_hardening.py
@@ -51,6 +51,10 @@ def init_repo(tempdir: Path) -> Path:
     return repo
 
 
+def realistic_secret_value() -> str:
+    return "A7f9K2m4Q8v6" + "N3x5R1p0T9z8"
+
+
 class AutoreviewHardeningTests(unittest.TestCase):
     def setUp(self) -> None:
         self.helper = load_helper()
@@ -76,7 +80,7 @@ class AutoreviewHardeningTests(unittest.TestCase):
             self.assertIn("## image.bin\n[binary file omitted]", bundle)
             self.assertFalse(truncated)
 
-    def test_full_file_secret_scan_blocks_truncated_tail(self) -> None:
+    def test_oversized_text_is_rejected_without_scanning_binary_tail(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:
             repo = init_repo(Path(tempdir))
             tail_secret = "\ntoken=" + "A" * 24 + "\n"
@@ -84,19 +88,21 @@ class AutoreviewHardeningTests(unittest.TestCase):
 
             untracked = repo / "untracked.txt"
             untracked.write_text(content, encoding="utf-8")
-            with self.assertRaisesRegex(SystemExit, "secret-like content"):
+            with self.assertRaisesRegex(SystemExit, "file too large to scan safely"):
                 self.helper["safe_untracked_files"](repo)
 
             untracked.unlink()
             binary = repo / "binary.bin"
             binary.write_bytes(b"\0" + content.encode())
-            with self.assertRaisesRegex(SystemExit, "secret-like content"):
-                self.helper["safe_untracked_files"](repo)
+            self.assertEqual(
+                self.helper["safe_untracked_files"](repo),
+                ["binary.bin"],
+            )
 
             binary.unlink()
             evidence = repo / "evidence.txt"
             evidence.write_text(content, encoding="utf-8")
-            with self.assertRaisesRegex(SystemExit, "secret-like content"):
+            with self.assertRaisesRegex(SystemExit, "file too large to scan safely"):
                 self.helper["validate_evidence_file"](repo, "evidence.txt", "--dataset")
 
     def test_branch_bundle_rejects_unsafe_or_unknown_base_before_diff(self) -> None:
@@ -110,6 +116,26 @@ class AutoreviewHardeningTests(unittest.TestCase):
                 self.helper["branch_bundle"](repo, "--help")
             with self.assertRaisesRegex(SystemExit, "unknown base ref"):
                 self.helper["branch_bundle"](repo, "origin/main")
+
+    def test_commit_bundle_rejects_merge_commits(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo = init_repo(Path(tempdir))
+            (repo / "base.txt").write_text("base\n", encoding="utf-8")
+            git(repo, "add", "base.txt")
+            git(repo, "commit", "-q", "-m", "base")
+            base_branch = git(repo, "branch", "--show-current").strip()
+            git(repo, "checkout", "-q", "-b", "side")
+            (repo / "side.txt").write_text("side\n", encoding="utf-8")
+            git(repo, "add", "side.txt")
+            git(repo, "commit", "-q", "-m", "side")
+            git(repo, "checkout", "-q", base_branch)
+            (repo / "main.txt").write_text("main\n", encoding="utf-8")
+            git(repo, "add", "main.txt")
+            git(repo, "commit", "-q", "-m", "main")
+            git(repo, "merge", "-q", "--no-ff", "side", "-m", "merge")
+
+            with self.assertRaisesRegex(SystemExit, "does not accept merge commits"):
+                self.helper["commit_bundle"](repo, "HEAD")
 
     def test_git_path_list_preserves_newline_filenames(self) -> None:
         if os.name == "nt":
@@ -162,6 +188,7 @@ class AutoreviewHardeningTests(unittest.TestCase):
             "password_validator.go",
             ".env.example",
             "private/parser.py",
+            ".agents/skills/openclaw-secret-scanning-maintainer/SKILL.md",
             "design-tokens/colors.json",
             "token_count/generated.py",
             ".docker/Dockerfile",
@@ -181,6 +208,16 @@ class AutoreviewHardeningTests(unittest.TestCase):
         ):
             with self.subTest(rel=rel):
                 self.assertIsNone(self.helper["sensitive_repo_path_risk"](rel))
+
+    def test_sensitive_source_directories_are_blocked_untracked(self) -> None:
+        for rel in (
+            "credentials/prod.py",
+            "secrets/runtime.ts",
+            "src/credentials/provider.py",
+            "src/secrets/scanner.ts",
+        ):
+            with self.subTest(rel=rel):
+                self.assertIsNotNone(self.helper["sensitive_repo_path_risk"](rel))
 
     def test_tracked_env_variants_remain_sensitive(self) -> None:
         for rel in (
@@ -217,6 +254,16 @@ class AutoreviewHardeningTests(unittest.TestCase):
             "tokens/device.sqlite",
             "tokens/session.jwt",
             "tokens/session",
+            "secrets/prod.md",
+            "credentials/prod.xml",
+            "credentials/prod.py",
+            "secrets/runtime.ts",
+            "src/credentials/provider.py",
+            "src/secrets/scanner.ts",
+            "backup-secrets/prod.json",
+            "dev_credentials/runtime.yaml",
+            "client-secrets-old/account.ini",
+            "client-secrets/account.properties",
             "credentials.txt",
             "client-secret.csv",
             ".docker/config.json",
@@ -228,7 +275,7 @@ class AutoreviewHardeningTests(unittest.TestCase):
                 )
 
     def test_secret_detector_handles_quoted_json_keys(self) -> None:
-        content = '{"' + 'api_key": "' + "a" * 24 + '"}'
+        content = '{"' + 'api_key": "' + realistic_secret_value() + '"}'
 
         self.assertTrue(self.helper["secret_text_risk"](content))
 
@@ -276,7 +323,56 @@ class AutoreviewHardeningTests(unittest.TestCase):
                 self.assertFalse(self.helper["secret_text_risk"](content))
 
     def test_secret_detector_handles_bare_call_keyword_values(self) -> None:
-        content = "client(api_key=" + "a" * 24 + ")"
+        content = "client(api_" + "key=" + realistic_secret_value() + ")"
+
+        self.assertTrue(self.helper["secret_text_risk"](content))
+
+    def test_secret_detector_handles_unquoted_underscore_tokens(self) -> None:
+        content = "token=prod_" + realistic_secret_value()
+
+        self.assertTrue(self.helper["secret_text_risk"](content))
+
+    def test_secret_detector_allows_dotted_calls(self) -> None:
+        for content in (
+            "token=secrets.token_urlsafe(32)",
+            "token = provider.issue_token()",
+            "token = generate_secure_token()",
+        ):
+            with self.subTest(content=content):
+                self.assertFalse(self.helper["secret_text_risk"](content))
+
+    def test_secret_detector_rejects_ambiguous_bare_values(self) -> None:
+        for content in (
+            "pass" + "word=CORRECTHORSEBATTERYSTAPLE",
+            "to" + "ken=prod.opaquecredentialvalue",
+            "to" + "ken=TOKEN_FROM_ENVIRONMENT_SECRET",
+            "to" + "ken: prod.A7f9K2m4Q8v6N3x5R1p0T9z8 (production)",
+        ):
+            with self.subTest(content=content):
+                self.assertTrue(self.helper["secret_text_risk"](content))
+
+    def test_secret_detector_handles_lowercase_passphrases(self) -> None:
+        content = 'password="' + "correcthorsebatterystaple" + '"'
+
+        self.assertTrue(self.helper["secret_text_risk"](content))
+
+    def test_secret_detector_does_not_exempt_expression_text_in_literals(self) -> None:
+        for value in (
+            "correct horse + battery staple",
+            "prefix-${credential}-suffix",
+            "secret.format(value)",
+        ):
+            with self.subTest(value=value):
+                content = "pass" + f'word="{value}"'
+                self.assertTrue(self.helper["secret_text_risk"](content))
+
+    def test_secret_detector_handles_low_diversity_passwords(self) -> None:
+        content = 'password="' + "letmeinletmein" + '"'
+
+        self.assertTrue(self.helper["secret_text_risk"](content))
+
+    def test_secret_detector_does_not_exempt_placeholder_substrings(self) -> None:
+        content = "pass" + 'word="prod-sample-' + realistic_secret_value() + '"'
 
         self.assertTrue(self.helper["secret_text_risk"](content))
 
@@ -329,7 +425,7 @@ class AutoreviewHardeningTests(unittest.TestCase):
 
     def test_secret_detector_handles_compound_json_keys(self) -> None:
         for key in ("client_secret", "refresh_token"):
-            content = '{"' + key + '": "' + "a" * 24 + '"}'
+            content = '{"' + key + '": "' + realistic_secret_value() + '"}'
             with self.subTest(key=key):
                 self.assertTrue(self.helper["secret_text_risk"](content))
 
@@ -342,7 +438,10 @@ class AutoreviewHardeningTests(unittest.TestCase):
             git(repo, "commit", "-q", "-m", "base")
             base = git(repo, "rev-parse", "HEAD").strip()
 
-            path.write_text("api" + "_key=" + "a" * 24 + "\n", encoding="utf-8")
+            path.write_text(
+                "api" + "_key=" + realistic_secret_value() + "\n",
+                encoding="utf-8",
+            )
             git(repo, "add", "settings.txt")
             with self.assertRaisesRegex(SystemExit, "secret-like content"):
                 self.helper["local_bundle"](repo)
@@ -467,7 +566,7 @@ class AutoreviewHardeningTests(unittest.TestCase):
                 os.environ,
                 {"HOME": str(root), "USERPROFILE": str(root)},
             ):
-                with self.assertRaisesRegex(SystemExit, "cursor engine refused global MCP config"):
+                with self.assertRaisesRegex(SystemExit, "cursor engine is unavailable"):
                     self.helper["run_cursor"](args, repo, "prompt")
 
     def test_cursor_refuses_user_level_hooks(self) -> None:
@@ -488,7 +587,7 @@ class AutoreviewHardeningTests(unittest.TestCase):
                 os.environ,
                 {"HOME": str(root), "USERPROFILE": str(root)},
             ):
-                with self.assertRaisesRegex(SystemExit, "cursor engine refused user-level hooks"):
+                with self.assertRaisesRegex(SystemExit, "cursor engine is unavailable"):
                     self.helper["run_cursor"](args, repo, "prompt")
 
             settings.write_text('{"permissions":{"allow":["Read(**)"]}}\n', encoding="utf-8")
@@ -546,11 +645,45 @@ class AutoreviewHardeningTests(unittest.TestCase):
                 os.environ["GIT_CONFIG_COUNT"] = "99"
                 os.environ["DYLD_INSERT_LIBRARIES"] = "/tmp/unsafe.dylib"
                 os.environ["NODE_OPTIONS"] = "--require=/tmp/unsafe.js"
+                os.environ["NODE_PATH"] = "/tmp/unsafe-node"
+                os.environ["LD_AUDIT"] = "/tmp/unsafe-audit.so"
+                os.environ["LD_LIBRARY_PATH"] = "/tmp/unsafe-lib"
+                os.environ["RUBYOPT"] = "-r/tmp/unsafe.rb"
+                os.environ["PERL5OPT"] = "-Munsafe"
+                os.environ["BUN_OPTIONS"] = "--preload=/tmp/unsafe.js"
+                os.environ["OPENCODE_CONFIG"] = "/tmp/unsafe-opencode.json"
+                os.environ["OPENCODE_PERMISSION"] = "allow"
+                os.environ["OPENCODE_AUTO_SHARE"] = "1"
                 os.environ["COPILOT_ALLOW_ALL"] = "1"
+                os.environ["CODEX_HOME"] = "/tmp/codex-auth"
+                os.environ["CLAUDE_CONFIG_DIR"] = "/tmp/claude-auth"
+                os.environ["PI_CODING_AGENT_DIR"] = "/tmp/pi-auth"
+                os.environ["CLAUDE_CODE_USE_FOUNDRY"] = "1"
+                os.environ["CLOUD_ML_REGION"] = "us-east5"
+                os.environ["ANTHROPIC_AUTH_TOKEN"] = "test-auth-token"
+                os.environ["AWS_BEARER_TOKEN_BEDROCK"] = "test-token-placeholder"
+                os.environ["ANTHROPIC_BEDROCK_BASE_URL"] = (
+                    "https://bedrock.example.invalid"
+                )
+                os.environ["ANTHROPIC_VERTEX_BASE_URL"] = (
+                    "https://vertex.example.invalid"
+                )
+                os.environ["AWS_PROFILE"] = "review-profile"
+                os.environ["AWS_CONFIG_FILE"] = "/tmp/unsafe-aws-config"
+                os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = (
+                    "/tmp/unsafe-google-credentials"
+                )
+                os.environ["GOOGLE_EXTERNAL_ACCOUNT_ALLOW_EXECUTABLES"] = "1"
+                os.environ["OPENROUTER_API_KEY"] = "test-provider-key"
                 os.environ["GITHUB_TOKEN"] = "test-token-placeholder"
                 os.environ["HTTPS_PROXY"] = "http://proxy.example.invalid:8080"
+                os.environ["DO_NOT_TRACK"] = "1"
+                os.environ["DISABLE_TELEMETRY"] = "1"
+                os.environ["CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC"] = "1"
 
-                env = self.helper["safe_engine_env"](repo)
+                env = self.helper["safe_engine_env"](repo, engine="codex")
+                claude_env = self.helper["safe_engine_env"](repo, engine="claude")
+                pi_env = self.helper["safe_engine_env"](repo, engine="pi")
 
                 self.assertNotEqual(env.get("GIT_DIR"), "/tmp/unsafe-git-dir")
                 self.assertEqual(
@@ -559,12 +692,248 @@ class AutoreviewHardeningTests(unittest.TestCase):
                 )
                 self.assertNotIn("DYLD_INSERT_LIBRARIES", env)
                 self.assertNotIn("NODE_OPTIONS", env)
+                for key in (
+                    "NODE_PATH",
+                    "LD_AUDIT",
+                    "LD_LIBRARY_PATH",
+                    "RUBYOPT",
+                    "PERL5OPT",
+                    "BUN_OPTIONS",
+                    "OPENCODE_CONFIG",
+                    "OPENCODE_PERMISSION",
+                    "OPENCODE_AUTO_SHARE",
+                ):
+                    self.assertNotIn(key, env)
                 self.assertNotIn("COPILOT_ALLOW_ALL", env)
-                self.assertEqual(env["GITHUB_TOKEN"], "test-token-placeholder")
+                self.assertNotIn("GITHUB_TOKEN", env)
                 self.assertEqual(env["HTTPS_PROXY"], "http://proxy.example.invalid:8080")
+                self.assertEqual(env["DO_NOT_TRACK"], "1")
+                self.assertEqual(env["DISABLE_TELEMETRY"], "1")
+                self.assertEqual(env["CODEX_HOME"], "/tmp/codex-auth")
+                self.assertEqual(
+                    claude_env["CLAUDE_CONFIG_DIR"],
+                    "/tmp/claude-auth",
+                )
+                self.assertEqual(pi_env["PI_CODING_AGENT_DIR"], "/tmp/pi-auth")
+                self.assertEqual(claude_env["CLAUDE_CODE_USE_FOUNDRY"], "1")
+                self.assertEqual(claude_env["CLOUD_ML_REGION"], "us-east5")
+                self.assertEqual(
+                    claude_env["ANTHROPIC_AUTH_TOKEN"],
+                    "test-auth-token",
+                )
+                self.assertEqual(
+                    claude_env["AWS_BEARER_TOKEN_BEDROCK"],
+                    "test-token-placeholder",
+                )
+                self.assertEqual(
+                    claude_env["ANTHROPIC_BEDROCK_BASE_URL"],
+                    "https://bedrock.example.invalid",
+                )
+                self.assertEqual(
+                    claude_env["ANTHROPIC_VERTEX_BASE_URL"],
+                    "https://vertex.example.invalid",
+                )
+                self.assertEqual(claude_env["AWS_PROFILE"], "review-profile")
+                self.assertNotIn("AWS_CONFIG_FILE", env)
+                self.assertNotIn("GOOGLE_APPLICATION_CREDENTIALS", env)
+                self.assertNotIn(
+                    "GOOGLE_EXTERNAL_ACCOUNT_ALLOW_EXECUTABLES",
+                    env,
+                )
+                self.assertNotIn("OPENROUTER_API_KEY", env)
+                self.assertEqual(
+                    claude_env["CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC"],
+                    "1",
+                )
             finally:
                 os.environ.clear()
                 os.environ.update(old)
+
+    def test_multi_provider_engines_preserve_provider_auth(self) -> None:
+        old = os.environ.copy()
+        with tempfile.TemporaryDirectory() as tempdir:
+            root = Path(tempdir)
+            repo = init_repo(root)
+            try:
+                os.environ["DEEPSEEK_API_KEY"] = "test-token-placeholder"
+                os.environ["CEREBRAS_API_KEY"] = "test-token-placeholder"
+                os.environ["CLOUDFLARE_ACCOUNT_ID"] = "test-account"
+                os.environ["CLOUDFLARE_API_TOKEN"] = "test-token-placeholder"
+                os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = (
+                    str(root / "provider-credentials.json")
+                )
+                os.environ["AWS_ROLE_ARN"] = (
+                    "arn:aws:iam::123456789012:role/autoreview"
+                )
+                os.environ["AWS_WEB_IDENTITY_TOKEN_FILE"] = str(
+                    root / "web-identity",
+                )
+                os.environ["AWS_CONFIG_FILE"] = str(root / "aws-config")
+                os.environ["AWS_SHARED_CREDENTIALS_FILE"] = str(
+                    root / "aws-credentials",
+                )
+                os.environ["NODE_EXTRA_CA_CERTS"] = str(root / "corporate-ca.pem")
+                os.environ["SSL_CERT_FILE"] = str(root / "tls-ca.pem")
+                os.environ["SSL_CERT_DIR"] = str(root / "tls-ca")
+                os.environ["SNOWFLAKE_ACCOUNT"] = "test-account"
+                os.environ["SNOWFLAKE_CORTEX_TOKEN"] = "test-token-placeholder"
+                os.environ["AZURE_RESOURCE_NAME"] = "test-resource"
+                os.environ["ANTHROPIC_OAUTH_TOKEN"] = "test-token-placeholder"
+                os.environ["AWS_BEDROCK_FORCE_HTTP1"] = "1"
+                os.environ["AWS_BEDROCK_SKIP_AUTH"] = "1"
+                os.environ["AZURE_CLIENT_ID"] = "test-client"
+                os.environ["AZURE_CLIENT_SECRET"] = "test-token-placeholder"
+                os.environ["AZURE_TENANT_ID"] = "test-tenant"
+                os.environ["GCLOUD_PROJECT"] = "test-project"
+                os.environ["GOOGLE_CLOUD_PROJECT"] = "test-project"
+                os.environ["CODEX_API_KEY"] = "test-token-placeholder"
+                os.environ["CODEX_CA_CERTIFICATE"] = str(root / "codex-ca.pem")
+                os.environ["NODE_OPTIONS"] = "--require=/tmp/unsafe.js"
+                os.environ["GOOGLE_EXTERNAL_ACCOUNT_ALLOW_EXECUTABLES"] = "1"
+                os.environ["XDG_DATA_HOME"] = str(root / "opencode-auth")
+
+                for engine in ("opencode", "pi"):
+                    with self.subTest(engine=engine):
+                        env = self.helper["safe_engine_env"](repo, engine=engine)
+                        for key in (
+                            "AWS_ROLE_ARN",
+                            "AWS_BEDROCK_FORCE_HTTP1",
+                            "AWS_BEDROCK_SKIP_AUTH",
+                            "AWS_CONFIG_FILE",
+                            "AWS_SHARED_CREDENTIALS_FILE",
+                            "AWS_WEB_IDENTITY_TOKEN_FILE",
+                            "CEREBRAS_API_KEY",
+                            "CLOUDFLARE_ACCOUNT_ID",
+                            "CLOUDFLARE_API_TOKEN",
+                            "DEEPSEEK_API_KEY",
+                            "GOOGLE_APPLICATION_CREDENTIALS",
+                            "NODE_EXTRA_CA_CERTS",
+                            "SSL_CERT_DIR",
+                            "SSL_CERT_FILE",
+                            "SNOWFLAKE_ACCOUNT",
+                            "SNOWFLAKE_CORTEX_TOKEN",
+                            "AZURE_RESOURCE_NAME",
+                            "ANTHROPIC_OAUTH_TOKEN",
+                        ):
+                            self.assertEqual(env[key], os.environ[key])
+                        self.assertNotIn("NODE_OPTIONS", env)
+                        self.assertNotIn(
+                            "GOOGLE_EXTERNAL_ACCOUNT_ALLOW_EXECUTABLES",
+                            env,
+                        )
+                        if engine == "opencode":
+                            self.assertEqual(
+                                env["XDG_DATA_HOME"],
+                                str(root / "opencode-auth"),
+                            )
+
+                claude_env = self.helper["safe_engine_env"](repo, engine="claude")
+                for key in (
+                    "AZURE_CLIENT_ID",
+                    "AZURE_CLIENT_SECRET",
+                    "AZURE_TENANT_ID",
+                    "GCLOUD_PROJECT",
+                    "GOOGLE_CLOUD_PROJECT",
+                    "AWS_ROLE_ARN",
+                    "AWS_CONFIG_FILE",
+                    "AWS_SHARED_CREDENTIALS_FILE",
+                    "AWS_WEB_IDENTITY_TOKEN_FILE",
+                    "GOOGLE_APPLICATION_CREDENTIALS",
+                    "NODE_EXTRA_CA_CERTS",
+                    "SSL_CERT_DIR",
+                    "SSL_CERT_FILE",
+                ):
+                    self.assertEqual(claude_env[key], os.environ[key])
+                self.assertNotIn("DEEPSEEK_API_KEY", claude_env)
+                self.assertNotIn("NODE_OPTIONS", claude_env)
+                codex_env = self.helper["safe_engine_env"](repo, engine="codex")
+                for key in (
+                    "CODEX_API_KEY",
+                    "CODEX_CA_CERTIFICATE",
+                    "SSL_CERT_DIR",
+                    "SSL_CERT_FILE",
+                ):
+                    self.assertEqual(codex_env[key], os.environ[key])
+            finally:
+                os.environ.clear()
+                os.environ.update(old)
+
+    def test_opencode_rejects_repo_local_xdg_auth_store(self) -> None:
+        old = os.environ.copy()
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo = init_repo(Path(tempdir))
+            try:
+                os.environ["XDG_DATA_HOME"] = str(repo / ".opencode-data")
+                os.environ["AWS_CONFIG_FILE"] = str(repo / ".aws-config")
+                os.environ["NODE_EXTRA_CA_CERTS"] = str(repo / "ca.pem")
+                os.environ["SSL_CERT_FILE"] = str(repo / "tls-ca.pem")
+                os.environ["SSL_CERT_DIR"] = os.pathsep.join(
+                    (str(repo.parent / "tls-ca"), str(repo / "tls-ca")),
+                )
+                env = self.helper["safe_engine_env"](repo, engine="opencode")
+                self.assertNotIn("XDG_DATA_HOME", env)
+                self.assertNotIn("AWS_CONFIG_FILE", env)
+                self.assertNotIn("NODE_EXTRA_CA_CERTS", env)
+                self.assertNotIn("SSL_CERT_FILE", env)
+                self.assertNotIn("SSL_CERT_DIR", env)
+            finally:
+                os.environ.clear()
+                os.environ.update(old)
+
+    def test_engines_reject_repo_local_config_roots(self) -> None:
+        old = os.environ.copy()
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo = init_repo(Path(tempdir))
+            try:
+                os.environ["CLAUDE_CONFIG_DIR"] = str(repo / ".claude")
+                os.environ["CODEX_HOME"] = str(repo / ".codex")
+                os.environ["PI_CODING_AGENT_DIR"] = str(repo / ".pi")
+                os.environ["CODEX_CA_CERTIFICATE"] = str(repo / "codex-ca.pem")
+                os.environ["SSL_CERT_FILE"] = str(repo / "tls-ca.pem")
+                os.environ["HOME"] = str(repo)
+                os.environ["USERPROFILE"] = str(repo)
+                claude_env = self.helper["safe_engine_env"](repo, engine="claude")
+                codex_env = self.helper["safe_engine_env"](repo, engine="codex")
+                pi_env = self.helper["safe_engine_env"](repo, engine="pi")
+                self.assertNotIn("CLAUDE_CONFIG_DIR", claude_env)
+                self.assertNotIn("CODEX_HOME", codex_env)
+                self.assertNotIn("CODEX_CA_CERTIFICATE", codex_env)
+                self.assertNotIn("SSL_CERT_FILE", codex_env)
+                self.assertNotIn("PI_CODING_AGENT_DIR", pi_env)
+                self.assertNotIn("HOME", claude_env)
+                self.assertNotIn("USERPROFILE", claude_env)
+            finally:
+                os.environ.clear()
+                os.environ.update(old)
+
+    def test_codex_auth_config_ignores_repo_local_home(self) -> None:
+        old = os.environ.copy()
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo = init_repo(Path(tempdir))
+            config_dir = repo / ".codex"
+            config_dir.mkdir()
+            (config_dir / "config.toml").write_text(
+                'forced_login_method = "api"\n',
+                encoding="utf-8",
+            )
+            try:
+                os.environ["CODEX_HOME"] = str(config_dir)
+                self.assertEqual(self.helper["codex_auth_config_flags"](repo), [])
+            finally:
+                os.environ.clear()
+                os.environ.update(old)
+
+    def test_opencode_web_search_preserves_explicit_exa_opt_in(self) -> None:
+        old = os.environ.copy()
+        try:
+            os.environ["OPENCODE_ENABLE_EXA"] = "1"
+            enabled = self.helper["opencode_review_env"](True)
+            disabled = self.helper["opencode_review_env"](False)
+            self.assertEqual(enabled["OPENCODE_ENABLE_EXA"], "1")
+            self.assertNotIn("OPENCODE_ENABLE_EXA", disabled)
+        finally:
+            os.environ.clear()
+            os.environ.update(old)
 
     def test_codex_isolation_restricts_tool_environment(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:
@@ -592,7 +961,7 @@ class AutoreviewHardeningTests(unittest.TestCase):
             repo = init_repo(Path(tempdir))
             os.environ["PATH"] = f"{repo}{os.pathsep}{old_path}"
             try:
-                env = self.helper["safe_engine_env"](repo)
+                env = self.helper["safe_engine_env"](repo, engine="codex")
             finally:
                 os.environ["PATH"] = old_path
 
@@ -648,7 +1017,7 @@ class AutoreviewHardeningTests(unittest.TestCase):
 
             try:
                 with mock.patch.object(Path, "exists", fake_exists):
-                    env = self.helper["safe_engine_env"](repo)
+                    env = self.helper["safe_engine_env"](repo, engine="codex")
             finally:
                 os.environ["PATH"] = old_path
 
@@ -670,35 +1039,20 @@ class AutoreviewHardeningTests(unittest.TestCase):
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertIn("\ufffd", result.stdout)
 
-    def test_large_repo_relative_evidence_file_is_truncated(self) -> None:
+    def test_large_repo_relative_evidence_file_is_rejected(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:
             repo = init_repo(Path(tempdir))
             evidence = repo / "evidence.txt"
             evidence.write_text("x" * 600_000, encoding="utf-8")
 
-            _, content, truncated = self.helper["validate_evidence_file"](repo, "evidence.txt", "--dataset")
+            with self.assertRaisesRegex(SystemExit, "file too large to scan safely"):
+                self.helper["validate_evidence_file"](
+                    repo,
+                    "evidence.txt",
+                    "--dataset",
+                )
 
-            self.assertIn("[truncated at 180000 characters]", content)
-            self.assertTrue(truncated)
-
-    def test_copilot_allows_web_fetch_only_when_web_search_is_enabled(self) -> None:
-        captured: list[list[str]] = []
-        prompts: list[str] = []
-
-        def fake_run_with_heartbeat(
-            cmd: list[str],
-            cwd: Path,
-            **kwargs: object,
-        ) -> subprocess.CompletedProcess[str]:
-            captured.append(cmd)
-            prompts.append((cwd / "prompt.txt").read_text())
-            self.assertTrue((cwd / "repo").is_dir())
-            return subprocess.CompletedProcess(cmd, 0, '{"findings":[]}', "")
-
-        self.helper["run_copilot"].__globals__["run_with_heartbeat"] = fake_run_with_heartbeat
-        self.helper["run_copilot"].__globals__["resolve_command"] = (
-            lambda command, repo: f"/resolved/{command}"
-        )
+    def test_copilot_fails_closed_without_repo_only_read_sandbox(self) -> None:
         args = argparse.Namespace(
             copilot_bin="copilot",
             thinking=None,
@@ -710,44 +1064,35 @@ class AutoreviewHardeningTests(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as tempdir:
             repo = init_repo(Path(tempdir))
-            self.helper["run_copilot"](args, repo, "Repository root: .\n\nprompt")
+            with self.assertRaisesRegex(SystemExit, "ignored repository secrets"):
+                self.helper["run_copilot"](
+                    args,
+                    repo,
+                    "Repository root: .\n\nprompt",
+                )
 
-        self.assertNotIn("--allow-tool=web_fetch", captured[-1])
-        self.assertFalse(any(arg == "--allow-all-urls" for arg in captured[-1]))
-        self.assertIn("--add-dir=./repo", captured[-1])
-        self.assertIn("Repository root: ./repo", prompts[-1])
-        self.assertNotIn(str(repo), prompts[-1])
-
-        args.web_search = True
-        with tempfile.TemporaryDirectory() as tempdir:
-            repo = init_repo(Path(tempdir))
-            self.helper["run_copilot"](args, repo, "Repository root: .\n\nprompt")
-
-        self.assertIn("--allow-tool=web_fetch", captured[-1])
-        self.assertIn("--allow-all-urls", captured[-1])
-
-    def test_claude_inventory_preserves_scoped_permission_rules(self) -> None:
+    def test_claude_inventory_is_bundle_and_web_only(self) -> None:
         args = argparse.Namespace(
-            claude_allowed_tools="Read,Grep,WebFetch(domain:docs.example.com),Bash(git diff *)",
+            claude_allowed_tools="WebFetch(domain:docs.example.com),WebSearch",
             web_search=True,
         )
 
         self.assertEqual(
             self.helper["claude_allowed_tools"](args),
-            "Read,Grep,WebFetch(domain:docs.example.com),Bash(git diff *)",
+            "WebFetch(domain:docs.example.com),WebSearch",
         )
         self.assertEqual(
             self.helper["claude_tool_inventory"](args),
-            "Read,Grep,WebFetch,Bash",
+            "WebFetch,WebSearch",
         )
 
         args.web_search = False
         self.assertEqual(
             self.helper["claude_allowed_tools"](args),
-            "Read,Grep,Bash(git diff *)",
+            "",
         )
 
-        args.claude_allowed_tools = "Read,Edit"
+        args.claude_allowed_tools = "Read"
         with self.assertRaisesRegex(SystemExit, "not read-only"):
             self.helper["claude_tool_inventory"](args)
 


### PR DESCRIPTION
## What Problem This Solves

Autoreview could expose broader host state than a code review needs, and its Codex fallback behavior could be triggered by model-controlled output.

## Why This Change Was Made

Constrain every reviewer engine to the minimum filesystem, tool, environment, and credential surface it needs. Keep Codex on `gpt-5.6-sol` with `high` reasoning, falling back to `gpt-5.6-terra` only when structured or stderr evidence shows the user cannot access Sol.

This also restores the canonical vendoring instructions: downstream repositories should update `openclaw/agent-skills` first and sync the complete autoreview directory from there.

## User Impact

- Codex reviews default to Sol/high.
- Users without Sol access transparently retry with Terra.
- Review engines receive narrowly allowlisted credentials and configuration paths.
- Unsupported CLI reviewers fail closed instead of running with stale assumptions.
- Downstream vendored copies have a single canonical update path.

## Evidence

- 80 autoreview Python tests pass.
- All autoreview self-tests pass.
- Cursor JSONL parser self-test passes.
- `scripts/validate-skills` passes for all 6 skills.
- Validate-skills test suite: 9 passed.
- Python compilation and `git diff --check` pass.
- Fresh branch autoreview using Sol/high: no findings, confidence 0.90.

Follow-up hardening for #54.