### PR TITLE
fix(autoreview): isolate reviewer workspace

### DIFF
--- a/skills/autoreview/SKILL.md
+++ b/skills/autoreview/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: autoreview
-description: "Pre-commit/ship code review: Codex default; optional Claude, Pi, or OpenCode."
+description: "Pre-commit/ship code review: Codex default; optional Claude or Pi."
 ---
 
 # Auto Review
@@ -13,7 +13,7 @@ For user-visible behavior, pair autoreview with `behavior-validator`. Autoreview
 
 Use when:
 
-- user asks for Codex review / Claude review / Pi review / Droid review / Cursor review / OpenCode review / autoreview / second-model review
+- user asks for Codex review / Claude review / Pi review / autoreview / second-model review
 - after non-trivial code edits, before final/commit/ship
 - reviewing a local branch or PR branch after fixes
 
@@ -33,7 +33,7 @@ Use when:
 - Be patient with large bundles. Structured review can take up to 30 minutes while the model call is active, especially with Codex tools or web search.
 - Treat heartbeat lines like `review still running: ... elapsed=... pid=...` as healthy progress, not a hang. Let the helper continue while heartbeats are advancing. Pass `--stream-engine-output` when live engine text is useful; Codex, Claude, and Cursor filter tool/file chatter, other engines pass raw output through.
 - Do not kill a review just because it has been quiet for 2-5 minutes, or because it is still running under the 30-minute window. Inspect the process only after missing multiple expected heartbeats, after 30 minutes, or after an obviously failed subprocess; prefer letting the same helper command finish.
-- Tools are useful in review mode. The helper allows read-only inspection tools and web search by default so reviewers can check dependency contracts, upstream docs, and current behavior.
+- Tools are useful in review mode. Codex receives the validated bundle in an empty workspace so ignored files and linked-worktree metadata remain unreadable; web search stays available for dependency contracts and upstream docs.
 - Security perspective is always included, but it should not cripple legitimate functionality. Report security findings only when the change creates a concrete, actionable risk or removes an important safety check.
 - Reviewer subprocesses preserve authentication and proxy variables needed by headless or restricted-network environments while stripping process-injection and Git override variables.
 - Review bundles fail closed before engine invocation when tracked or untracked paths look sensitive, patch text looks secret-like, or a Git diff exceeds the bundle limit. Redact/split the change; never accept a truncated patch as complete review proof.
@@ -175,7 +175,7 @@ Tradeoff: tests may force code changes that stale the review. If tests or review
 Run multiple reviewers against one frozen bundle:
 
 ```bash
-"$AUTOREVIEW" --reviewers codex,claude,pi,opencode
+"$AUTOREVIEW" --reviewers codex,claude,pi
 ```
 
 `--panel` is shorthand for Codex plus Claude unless `--engine` changes the first reviewer:
@@ -200,12 +200,10 @@ For models with slashes or extra colons, prefer keyed form:
 
 ```bash
 "$AUTOREVIEW" --engine pi --model anthropic/claude-sonnet-4 --thinking high
-"$AUTOREVIEW" --engine opencode --model opencode/north-mini-code-free --thinking high
 "$AUTOREVIEW" --reviewers codex,pi --model codex=gpt-5.6-sol --model pi=anthropic/claude-sonnet-4
-"$AUTOREVIEW" --reviewers codex,opencode --model codex=gpt-5.6-sol --model opencode=opencode/north-mini-code-free
 ```
 
-`--reviewers all` covers Codex, Claude, Pi, and OpenCode. Droid, Copilot, and Cursor selections fail closed because their current CLI contracts cannot confine all project instructions and filesystem reads to the review bundle.
+`--reviewers all` covers Codex, Claude, and Pi. Droid, Copilot, Cursor, and OpenCode selections fail closed because their current CLI contracts cannot confine project instructions, filesystem reads, or network fetches to the review boundary.
 
 ## Models and thinking
 
@@ -218,7 +216,7 @@ Recommended model defaults:
 | **codex** (default) | `gpt-5.6-sol` -> `gpt-5.6-terra` on access failure | OpenClaw org review default                           |
 | **claude**          | `claude-fable-5`                                   | Anthropic's most capable widely released Claude model |
 
-CLI flags and environment variables override these defaults. Droid, Copilot, Pi, Cursor, and OpenCode do not get built-in model defaults here because their provider catalogs are external to the Codex/Claude closeout path and may vary by installation.
+CLI flags and environment variables override these defaults. Pi does not get a built-in model default because its provider catalog may vary by installation. Droid, Copilot, Cursor, and OpenCode are currently refused.
 
 | Engine              | Model flag                 | Example model IDs                                                            | Thinking flag                 | Accepted levels                                        |
 | ------------------- | -------------------------- | ---------------------------------------------------------------------------- | ----------------------------- | ------------------------------------------------------ |
@@ -228,7 +226,7 @@ CLI flags and environment variables override these defaults. Droid, Copilot, Pi,
 | **copilot**         | currently refused          | Copilot model aliases                                                        | not supported                 | n/a                                                    |
 | **pi**              | `pi --model X`             | `anthropic/claude-sonnet-4`, `openai/gpt-4o`                                 | `--thinking Y`                | `off`, `minimal`, `low`, `medium`, `high`, `xhigh`     |
 | **cursor**          | currently refused          | Cursor model aliases                                                         | not supported                 | n/a                                                    |
-| **opencode**        | `opencode run -m X`        | `opencode/north-mini-code-free`, OpenCode provider/model IDs                 | `--variant Y`                 | `minimal`, `low`, `medium`, `high`, `max`              |
+| **opencode**        | currently refused          | OpenCode provider/model IDs                                                   | not supported                 | n/a                                                    |
 
 Claude also supports `--fallback-model a,b` for availability-based fallback chains ([model-config](https://code.claude.com/docs/en/model-config)). Current Claude docs note that auth, billing, rate-limit, request-size, and transport errors do not trigger fallback, and the changelog documents interactive-session support in `v2.1.166`.
 
@@ -251,8 +249,6 @@ Examples matching current `main` behavior:
 # Pi with explicit model and thinking level
 "$AUTOREVIEW" --engine pi --model anthropic/claude-sonnet-4 --thinking high --pi-bin pi
 
-# OpenCode with explicit provider/model and variant
-"$AUTOREVIEW" --engine opencode --model opencode/north-mini-code-free --thinking high
 ```
 
 `--cursor-agent-bin` and `CURSOR_AGENT_BIN` remain compatibility aliases for
@@ -277,7 +273,7 @@ loader such as an untracked `.envrc`; the helper does not write a config file.
 | `AUTOREVIEW_CODEX_SPEED`           | Codex service tier override: `fast` (priority), `flex`, or `default`; silently standard when the model does not list the tier |
 | `AUTOREVIEW_CLAUDE_FALLBACK_MODEL` | Claude-only fallback chain                                                                                                   |
 
-Codex maps thinking to `model_reasoning_effort`. Claude maps thinking to `--effort`. Pi maps thinking to `--thinking`. OpenCode maps thinking to `--variant`. Only Claude accepts `--fallback-model`; global CLI/env fallback requires at least one Claude reviewer, and engine-specific fallback overrides require that reviewer to be selected. Non-Claude fallback overrides, including `AUTOREVIEW_<NONCLAUDE>_FALLBACK_MODEL`, fail closed instead of being silently ignored.
+Codex maps thinking to `model_reasoning_effort`. Claude maps thinking to `--effort`. Pi maps thinking to `--thinking`. Only Claude accepts `--fallback-model`; global CLI/env fallback requires at least one Claude reviewer, and engine-specific fallback overrides require that reviewer to be selected. Non-Claude fallback overrides, including `AUTOREVIEW_<NONCLAUDE>_FALLBACK_MODEL`, fail closed instead of being silently ignored.
 
 ## Review engine isolation
 
@@ -285,17 +281,17 @@ When autoreview runs inside the repository under review, external reviewer CLIs 
 
 | Engine       | Isolation flags                                                                                                                                                        | Reference                                                                   |
 | ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
-| **codex**    | Auth-only config overrides, `-c project_doc_max_bytes=0`, repo `trust_level="untrusted"`, `exec --ignore-user-config --ignore-rules`, plus read-only sandbox           | Codex CLI `exec --help`                                                     |
+| **codex**    | Auth-only config overrides, isolated workspace, `exec --ignore-user-config --ignore-rules --skip-git-repo-check`, plus read-only sandbox                                | Codex CLI `exec --help`                                                     |
 | **claude**   | `--safe-mode --setting-sources user --strict-mcp-config --disallowedTools mcp__*`; filesystem/shell tools disabled, optional web tools only (`v2.1.169+`)              | Claude Code [CLI reference](https://code.claude.com/docs/en/cli-reference)  |
 | **droid**    | Fails closed: current CLI cannot disable both project instructions and all tools                                                                                       | Droid CLI `exec --help` and `--list-tools`                                  |
 | **copilot**  | Fails closed: repository read tools also expose ignored files outside the reviewed bundle                                                                              | GitHub Copilot CLI command reference                                        |
 | **pi**       | `--no-approve --no-session --no-context-files --no-extensions --no-skills --no-prompt-templates --no-themes --no-tools`                                                | Pi CLI `--help`; requires Pi `v0.79.0+`                                     |
-| **opencode** | `opencode run --dir <repo> --pure --format json`, prompt over stdin, neutral subprocess cwd, project config disabled, filesystem tools denied, optional web tools only | OpenCode CLI `--help`                                                       |
+| **opencode** | Fails closed: project/global config isolation and private-network fetch denial are not both proven                                                                     | OpenCode CLI contract                                                       |
 | **cursor**   | Fails closed: documented read permissions can target absolute host paths and no proven repository-only filesystem sandbox is exposed                                   | Cursor CLI [permissions](https://cursor.com/docs/cli/reference/permissions) |
 
-Codex `--ignore-user-config` skips config loading for the exec run. Autoreview reconstructs only the documented `cli_auth_credentials_store`, `forced_login_method`, and `forced_chatgpt_workspace_id` settings from `CODEX_HOME/config.toml`, keeping authentication and workspace restrictions usable without forwarding unrelated user configuration. The explicit repo trust override and zero project-doc budget keep reviewed-repo `AGENTS.md` and `.codex/` trust surfaces out of the review prompt. `--ignore-rules` skips user/project execpolicy rules. Claude `--safe-mode` disables project hooks, skills, plugins, MCP servers, and CLAUDE.md; autoreview supplies only WebSearch/WebFetch when web search is enabled and no filesystem or shell tools. Pi runs from a neutral temporary directory with project resources disabled and `--no-tools`. OpenCode runs from a neutral temporary directory with project config disabled, filesystem tools denied, and web tools gated by `--no-web-search`. Droid, Copilot, and Cursor fail closed because their current CLI contracts cannot isolate untrusted review input from host/project trust surfaces.
+Codex `--ignore-user-config` skips config loading for the exec run. Autoreview reconstructs only the documented `cli_auth_credentials_store`, `forced_login_method`, and `forced_chatgpt_workspace_id` settings from `CODEX_HOME/config.toml`, keeping authentication usable without forwarding unrelated user configuration. Codex runs in an empty temporary workspace: the validated bundle is its sole repository input, ignored files and linked-worktree metadata remain unreadable, and the zero project-doc budget keeps workspace instructions out of the prompt. `--ignore-rules` skips user/project execpolicy rules. Claude `--safe-mode` disables project hooks, skills, plugins, MCP servers, and CLAUDE.md; autoreview supplies only WebSearch/WebFetch when web search is enabled and no filesystem or shell tools. Pi runs from a neutral temporary directory with project resources disabled and `--no-tools`. Droid, Copilot, Cursor, and OpenCode fail closed because their current CLI contracts cannot isolate untrusted review input from host, project, or private-network trust surfaces.
 
-Codex uses a named permission profile that grants read access only to the active repository workspace root. This is narrower than the legacy `read-only` sandbox, which permits reads across the host filesystem.
+Codex uses a named permission profile that grants read access only to an empty temporary workspace. This is narrower than repository-root access, which would expose ignored credentials, and narrower than the legacy `read-only` sandbox, which permits reads across the host filesystem.
 
 ## Context Efficiency
 
@@ -334,7 +330,7 @@ The helper:
 - otherwise uses current PR base if `gh pr view` works
 - otherwise uses `origin/main` for non-main branches
 - does not fetch automatically during branch review; the selected base ref must already resolve locally
-- recognizes `--engine droid`, `copilot`, and `cursor` only to fail closed with isolation errors; runnable engines are `codex`, `claude`, `pi`, and `opencode`; default is `AUTOREVIEW_ENGINE` or `codex`
+- recognizes `--engine droid`, `copilot`, `cursor`, and `opencode` only to fail closed with isolation errors; runnable engines are `codex`, `claude`, and `pi`; default is `AUTOREVIEW_ENGINE` or `codex`
 - resolves bare `git`, `gh`, reviewer, and PowerShell shell commands from absolute `PATH` entries only, never from the reviewed checkout; explicit relative `--*-bin` paths are resolved from the reviewed repository root
 - use `--mode commit --commit <ref>` for already-committed work, especially clean `main` after landing
 - should be left in `--mode auto` or forced to `--mode branch` for PR/branch work; do not force `--mode local` after committing
@@ -343,11 +339,10 @@ The helper:
 - supports `--stream-engine-output` or `AUTOREVIEW_STREAM_ENGINE_OUTPUT=1` for live engine text while preserving structured validation; Codex and Claude hide tool/file event details, emit compact activity summaries, and report usage at turn completion
 - supports opt-in review panels with `--panel` / `--reviewers`, plus per-engine `--model`, `--thinking`, and Claude `--fallback-model`
 - uses built-in defaults `codex=gpt-5.6-sol` with `high` reasoning and an access-only `gpt-5.6-terra` retry, plus `claude=claude-fable-5`; honors `AUTOREVIEW_MODEL`, `AUTOREVIEW_THINKING`, `AUTOREVIEW_FALLBACK_MODEL`, and per-engine `AUTOREVIEW_<ENGINE>_MODEL` / `AUTOREVIEW_<ENGINE>_THINKING` environment overrides when CLI flags are omitted
-- allows repository-scoped read tools only for Codex; Claude and OpenCode receive the bundle plus optional web tools, and Pi receives the bundle with no tools
+- gives Codex the bundle in an empty workspace with web search available; Claude receives the bundle plus optional web tools, and Pi receives the bundle with no tools
 - runs Claude with `--safe-mode` (`v2.1.169+`), `--setting-sources user`, MCP disabled, web-only tools, and `--fallback-model` when set
-- refuses Droid, Copilot, and Cursor reviews until their CLIs expose complete project-instruction and repository-only filesystem isolation
+- refuses Droid, Copilot, Cursor, and OpenCode reviews until their CLIs expose the required project, filesystem, and network isolation
 - runs Pi `v0.79.0+` from neutral temporary directories with `--no-approve`, `--no-session`, disabled Pi context/resource loading, and `--no-tools` because its built-in read tools are not repository-confined
-- runs OpenCode with `opencode run --dir <repo> --pure --format json` from a neutral temporary directory, denies filesystem tools, forwards `--model` and `--variant`, disables project config loading, and passes the review prompt over stdin
 - prints `review still running: <engine> elapsed=<seconds>s pid=<pid>` to stderr at long-running intervals while waiting for the selected review engine, unless streamed output or compact Codex activity has been visible recently
 - prints `autoreview clean: no accepted/actionable findings reported` when the selected review command exits 0
 - exits nonzero when accepted/actionable findings are present

--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -22,7 +22,7 @@ from typing import Any, Callable
 ENGINES = ("codex", "claude", "droid", "copilot", "pi", "opencode", "cursor")
 ENGINE_ALIASES = {"cursor-agent": "cursor"}
 ENGINE_CHOICES = (*ENGINES, *ENGINE_ALIASES)
-ALL_REVIEWERS = ("codex", "claude", "pi", "opencode")
+ALL_REVIEWERS = ("codex", "claude", "pi")
 SAFE_GIT_CONFIG_ARGS = (
     "-c",
     "core.fsmonitor=false",
@@ -172,7 +172,26 @@ SECRET_PLACEHOLDER_VALUES = {
     "secret-token",
     "test-auth-token",
     "test-token-placeholder",
+    "token-oversized",
+    "clawrouter-e2e-secret",
+    "very-long-browser-token-0123456789",
 }
+QUOTED_SECRET_REFERENCE_PATTERNS = (
+    re.compile(r"^\$\{[A-Za-z_][A-Za-z0-9_]*\}$"),
+    re.compile(r"^\{\{.+\}\}$"),
+    re.compile(r"^op://"),
+)
+UNQUOTED_SECRET_REFERENCE_PATTERNS = (
+    *QUOTED_SECRET_REFERENCE_PATTERNS,
+    re.compile(
+        r"^(?:process\.env|os\.environ|env|cfg|config|params|payload|provider)"
+        r"(?:[.\[].*)$"
+    ),
+)
+SECRET_ALLOWLIST_MARKERS = (
+    "pragma: allowlist secret",
+    "gitleaks:allow",
+)
 DEFAULT_ENGINE_PATHS = ("/usr/local/bin", "/usr/bin", "/bin")
 MULTI_PROVIDER_CREDENTIAL_SUFFIXES = (
     "_ACCESS_TOKEN",
@@ -420,6 +439,17 @@ def external_env_path_value(repo: Path, key: str, value: str) -> bool:
     )
 
 
+def safe_dbus_session_address(repo: Path, value: str) -> bool:
+    match = re.fullmatch(
+        r"unix:path=(?P<path>[^,;%]+)(?:,guid=[0-9a-fA-F]+)?",
+        value,
+    )
+    if not match:
+        return False
+    path = match.group("path")
+    return Path(path).is_absolute() and external_env_path(repo, path)
+
+
 def safe_engine_env(
     repo: Path,
     extra_paths: list[Path] | None = None,
@@ -579,6 +609,12 @@ def safe_engine_env(
         if value and external_env_path(repo, value):
             env[key] = value
     if engine == "codex":
+        dbus_address = os.environ.get("DBUS_SESSION_BUS_ADDRESS")
+        if dbus_address and safe_dbus_session_address(repo, dbus_address):
+            env["DBUS_SESSION_BUS_ADDRESS"] = dbus_address
+        xdg_runtime_dir = os.environ.get("XDG_RUNTIME_DIR")
+        if xdg_runtime_dir and external_env_path(repo, xdg_runtime_dir):
+            env["XDG_RUNTIME_DIR"] = xdg_runtime_dir
         for key in CODEX_TRUST_PATH_ENV_KEYS:
             value = os.environ.get(key)
             if value and external_env_path_value(repo, key, value):
@@ -722,10 +758,10 @@ def opencode_review_config(web_search: bool = True) -> dict[str, Any]:
     }
     if web_search:
         permission["websearch"] = "allow"
-        permission["webfetch"] = "allow"
     else:
         permission["websearch"] = "deny"
-        permission["webfetch"] = "deny"
+    # Generic fetches can reach loopback, private, link-local, or metadata endpoints.
+    permission["webfetch"] = "deny"
     return {
         "$schema": "https://opencode.ai/config.json",
         "autoupdate": False,
@@ -1110,11 +1146,22 @@ def secret_text_risk(text: str) -> bool:
     if any(pattern.search(text) for pattern in SECRET_VALUE_PATTERNS):
         return True
     for match in SECRET_ASSIGNMENT_PATTERN.finditer(text):
+        line_start = text.rfind("\n", 0, match.start()) + 1
+        line_end = text.find("\n", match.end())
+        line = text[line_start : line_end if line_end >= 0 else len(text)].lower()
+        if any(marker in line for marker in SECRET_ALLOWLIST_MARKERS):
+            continue
         raw_value = match.group("value")
         quoted = raw_value.startswith(("\"", "'"))
         value = raw_value.strip("\"'")
-        lowered = value.lower()
-        if lowered in SECRET_PLACEHOLDER_VALUES:
+        if value.lower() in SECRET_PLACEHOLDER_VALUES:
+            continue
+        reference_patterns = (
+            QUOTED_SECRET_REFERENCE_PATTERNS
+            if quoted
+            else UNQUOTED_SECRET_REFERENCE_PATTERNS
+        )
+        if any(pattern.fullmatch(value) for pattern in reference_patterns):
             continue
         call_target = re.fullmatch(r"[A-Za-z_][A-Za-z0-9_.]*", value)
         if not quoted and call_target and text[match.end() :].startswith("("):
@@ -1170,7 +1217,6 @@ def sensitive_repo_path_risk(rel: str) -> str | None:
     if (
         path_has_sensitive_part(normalized)
         or credential_store_path(normalized)
-        or secret_directory_path(normalized)
         or token_credential_store_path(normalized)
     ):
         return "sensitive path"
@@ -1195,16 +1241,30 @@ def credential_store_path(normalized: str) -> bool:
         TRACKED_CREDENTIAL_DIR_PATTERN.fullmatch(part)
         for part in path.parts[:-1]
     )
-    return credential_directory and not skill_instruction_path(path)
-
-
-def secret_directory_path(normalized: str) -> bool:
-    path = Path(normalized)
-    secret_directory = any(
-        part.lower() == "secrets"
-        for part in path.parts[:-1]
-    )
-    return secret_directory and not skill_instruction_path(path)
+    credential_data_file = path.suffix.lower() not in {
+        ".c",
+        ".cc",
+        ".cpp",
+        ".cs",
+        ".go",
+        ".h",
+        ".hpp",
+        ".java",
+        ".js",
+        ".jsx",
+        ".kt",
+        ".mjs",
+        ".php",
+        ".py",
+        ".rb",
+        ".rs",
+        ".sh",
+        ".swift",
+        ".ts",
+        ".tsx",
+        ".vue",
+    }
+    return credential_directory and credential_data_file and not skill_instruction_path(path)
 
 
 def skill_instruction_path(path: Path) -> bool:
@@ -1224,7 +1284,6 @@ def tracked_sensitive_repo_path_risk(rel: str) -> str | None:
         or f"/{normalized.lower()}".endswith("/.docker/config.json")
         or parts & TRACKED_SENSITIVE_PATH_PARTS
         or credential_store_path(normalized)
-        or secret_directory_path(normalized)
         or token_credential_store_path(normalized)
     ):
         return "sensitive path"
@@ -1733,7 +1792,7 @@ def codex_auth_config_flags(repo: Path) -> list[str]:
 
 
 def codex_exec_isolation_flags() -> list[str]:
-    return ["--ignore-user-config", "--ignore-rules"]
+    return ["--ignore-user-config", "--ignore-rules", "--skip-git-repo-check"]
 
 
 def claude_review_isolation_flags() -> list[str]:
@@ -1916,12 +1975,13 @@ def codex_model_access_failure(result: subprocess.CompletedProcess[str], model: 
 
 def codex_command(
     args: argparse.Namespace,
-    repo: Path,
+    source_repo: Path,
+    review_root: Path,
     schema_path: Path,
     output_path: Path,
     model: str | None,
 ) -> list[str]:
-    cmd = [resolve_command(args.codex_bin, repo), "--ask-for-approval", "never"]
+    cmd = [resolve_command(args.codex_bin, source_repo), "--ask-for-approval", "never"]
     if args.web_search:
         cmd.append("--search")
     if model:
@@ -1936,8 +1996,8 @@ def codex_command(
     speed_override = codex_speed_override(args)
     if speed_override is not None:
         cmd.extend(["-c", speed_override])
-    cmd.extend(codex_config_isolation_flags(repo))
-    cmd.extend(codex_auth_config_flags(repo))
+    cmd.extend(codex_config_isolation_flags(review_root))
+    cmd.extend(codex_auth_config_flags(source_repo))
     cmd.append("exec")
     if args.stream_engine_output:
         cmd.append("--json")
@@ -1946,7 +2006,7 @@ def codex_command(
             *codex_exec_isolation_flags(),
             "--ephemeral",
             "-C",
-            str(repo),
+            str(review_root),
             "--output-schema",
             str(schema_path),
             "--output-last-message",
@@ -1969,45 +2029,58 @@ def run_codex(args: argparse.Namespace, repo: Path, prompt: str) -> str:
         models.append(fallback_model)
     primary_failure: subprocess.CompletedProcess[str] | None = None
     try:
-        for index, model in enumerate(models):
-            output_path.write_text("")
-            cmd = codex_command(args, repo, schema_path, output_path, model)
-            result = run_with_heartbeat(
-                cmd,
-                repo,
-                input_text=prompt,
-                label="codex",
-                stream_output=args.stream_engine_output,
-                stream_display=CodexStreamDisplay() if args.stream_engine_output else None,
-                env=safe_engine_env(
+        # The validated bundle is the sole repository input. The empty
+        # workspace keeps ignored credentials and linked-worktree metadata
+        # outside the model's readable filesystem boundary.
+        with tempfile.TemporaryDirectory(prefix="autoreview-codex-workspace.") as tempdir:
+            review_root = Path(tempdir)
+            for index, model in enumerate(models):
+                output_path.write_text("")
+                cmd = codex_command(
+                    args,
                     repo,
-                    [Path(cmd[0]).parent],
-                    engine="codex",
-                ),
-            )
-            output = output_path.read_text()
-            if result.returncode == 0:
-                return output or result.stdout
-            if (
-                index == 0
-                and len(models) > 1
-                and model
-                and codex_model_access_failure(result, model)
-            ):
-                primary_failure = result
-                print(
-                    f"codex model {model} is unavailable for this account; retrying with {models[1]}",
-                    file=sys.stderr,
+                    review_root,
+                    schema_path,
+                    output_path,
+                    model,
                 )
-                continue
-            detail = result.stderr or result.stdout
-            if primary_failure is not None:
-                primary_detail = primary_failure.stderr or primary_failure.stdout
-                raise SystemExit(
-                    f"codex engine failed with primary model ({primary_failure.returncode})\n{primary_detail}\n"
-                    f"codex fallback model failed ({result.returncode})\n{detail}"
+                result = run_with_heartbeat(
+                    cmd,
+                    review_root,
+                    input_text=prompt,
+                    label="codex",
+                    stream_output=args.stream_engine_output,
+                    stream_display=CodexStreamDisplay() if args.stream_engine_output else None,
+                    env=safe_engine_env(
+                        repo,
+                        [Path(cmd[0]).parent],
+                        engine="codex",
+                    ),
+                    resolve_root=repo,
                 )
-            raise SystemExit(f"codex engine failed ({result.returncode})\n{detail}")
+                output = output_path.read_text()
+                if result.returncode == 0:
+                    return output or result.stdout
+                if (
+                    index == 0
+                    and len(models) > 1
+                    and model
+                    and codex_model_access_failure(result, model)
+                ):
+                    primary_failure = result
+                    print(
+                        f"codex model {model} is unavailable for this account; retrying with {models[1]}",
+                        file=sys.stderr,
+                    )
+                    continue
+                detail = result.stderr or result.stdout
+                if primary_failure is not None:
+                    primary_detail = primary_failure.stderr or primary_failure.stdout
+                    raise SystemExit(
+                        f"codex engine failed with primary model ({primary_failure.returncode})\n{primary_detail}\n"
+                        f"codex fallback model failed ({result.returncode})\n{detail}"
+                    )
+                raise SystemExit(f"codex engine failed ({result.returncode})\n{detail}")
     finally:
         schema_path.unlink(missing_ok=True)
         output_path.unlink(missing_ok=True)
@@ -2089,27 +2162,11 @@ def build_opencode_cmd(args: argparse.Namespace, repo: Path) -> list[str]:
 
 
 def run_opencode(args: argparse.Namespace, repo: Path, prompt: str) -> str:
-    if not args.tools:
-        raise SystemExit("--no-tools is not supported by the opencode engine")
-    cmd = build_opencode_cmd(args, repo)
-    with tempfile.TemporaryDirectory(prefix="autoreview-opencode-run.") as tempdir:
-        result = run_with_heartbeat(
-            cmd,
-            Path(tempdir),
-            input_text=prompt,
-            label="opencode",
-            stream_output=args.stream_engine_output,
-            env=safe_engine_env(
-                repo,
-                [Path(cmd[0]).parent],
-                opencode_review_env(args.web_search),
-                engine="opencode",
-            ),
-            resolve_root=repo,
-        )
-    if result.returncode != 0:
-        raise SystemExit(f"opencode engine failed ({result.returncode})\n{result.stderr or result.stdout}")
-    return result.stdout
+    raise SystemExit(
+        "opencode engine is unavailable: the current CLI contract does not prove "
+        "project-config isolation and its generic fetch tool cannot be restricted "
+        "away from private or metadata endpoints; use codex, claude, or pi"
+    )
 
 
 def cursor_local_mcp_paths(repo: Path) -> list[Path]:
@@ -3008,27 +3065,32 @@ def self_test_engine_isolation() -> int:
             run_codex(args, repo, "review hostile patch")
             codex_record = json.loads(record_path.read_text())
             codex_argv = codex_record["argv"]
-            expected_project_override = f"projects.{toml_quoted_key_segment(str(repo.resolve()))}.trust_level=\"untrusted\""
             for required in [
                 "--ignore-user-config",
                 "--ignore-rules",
                 "project_doc_max_bytes=0",
-                expected_project_override,
                 'cli_auth_credentials_store="auto"',
                 'forced_login_method="chatgpt"',
                 'forced_chatgpt_workspace_id=["workspace-one", "workspace-two"]',
                 'default_permissions="autoreview"',
                 'permissions.autoreview.filesystem={":minimal"="read",":workspace_roots"="read"}',
                 "--ephemeral",
-                str(repo),
             ]:
                 if required not in codex_argv:
                     raise SystemExit(f"codex isolation self-test failed: missing {required}")
             for forbidden in ["hostile-user-model", "read-only"]:
                 if forbidden in codex_argv:
                     raise SystemExit(f"codex isolation self-test failed: leaked {forbidden}")
-            if Path(codex_record["cwd"]).resolve() != repo.resolve():
-                raise SystemExit("codex isolation self-test failed: wrong cwd")
+            codex_cwd = Path(codex_record["cwd"]).resolve()
+            if codex_cwd == repo.resolve() or is_within(codex_cwd, repo.resolve()):
+                raise SystemExit("codex isolation self-test failed: review ran inside hostile repo")
+            if str(repo) in codex_argv:
+                raise SystemExit("codex isolation self-test failed: hostile repo granted to tools")
+            expected_project_override = (
+                f"projects.{toml_quoted_key_segment(str(codex_cwd))}.trust_level=\"untrusted\""
+            )
+            if expected_project_override not in codex_argv:
+                raise SystemExit("codex isolation self-test failed: isolated project override missing")
 
             run_claude(args, repo, "review hostile patch")
             claude_record = json.loads(record_path.read_text())
@@ -3067,31 +3129,17 @@ def self_test_engine_isolation() -> int:
                 if Path(entry["cwd"]).resolve() == repo.resolve():
                     raise SystemExit("pi isolation self-test failed: probe ran inside hostile repo")
 
-            run_opencode(args, repo, "review hostile patch")
-            opencode_record = json.loads(record_path.read_text())
-            opencode_argv = opencode_record["argv"]
-            for required in ["run", "--dir", str(repo), "--pure", "--format", "json"]:
-                if required not in opencode_argv:
-                    raise SystemExit(f"opencode isolation self-test failed: missing {required}")
-            if "--dangerously-skip-permissions" in opencode_argv:
-                raise SystemExit("opencode isolation self-test failed: skip-permissions present")
-            if Path(opencode_record["cwd"]).resolve() == repo.resolve():
-                raise SystemExit("opencode isolation self-test failed: review ran inside hostile repo")
-            if opencode_record["stdin"] != "review hostile patch":
-                raise SystemExit("opencode isolation self-test failed: prompt not delivered over stdin")
-            if "review hostile patch" in opencode_argv:
-                raise SystemExit("opencode isolation self-test failed: prompt leaked into argv")
-            opencode_env = opencode_record["env"]
-            if opencode_env.get("OPENCODE_DISABLE_PROJECT_CONFIG") != "1":
-                raise SystemExit("opencode isolation self-test failed: project config env missing")
-            if opencode_env.get("OPENCODE_DISABLE_AUTOUPDATE") != "1":
-                raise SystemExit("opencode isolation self-test failed: autoupdate env missing")
-            config = json.loads(opencode_env["OPENCODE_CONFIG_CONTENT"])
-            if config.get("instructions") != [] or config.get("plugin") != [] or config.get("command") != {}:
-                raise SystemExit("opencode isolation self-test failed: project-controlled extensions not cleared")
-            for disabled_tool in ("bash", "edit", "skill", "task", "todowrite", "write"):
-                if config.get("tools", {}).get(disabled_tool) is not False:
-                    raise SystemExit(f"opencode isolation self-test failed: {disabled_tool} tool not disabled")
+            if record_path.exists():
+                record_path.unlink()
+            try:
+                run_opencode(args, repo, "review hostile patch")
+            except SystemExit as exc:
+                if "opencode engine is unavailable" not in str(exc):
+                    raise
+            else:
+                raise SystemExit("opencode isolation self-test failed: unsafe engine was allowed")
+            if record_path.exists():
+                raise SystemExit("opencode isolation self-test failed: disabled engine was invoked")
             if hostile_ps_path.exists():
                 raise SystemExit("heartbeat metrics isolation self-test failed: repo-local ps executed")
 
@@ -3332,8 +3380,8 @@ def _assert_opencode_permission(web_search: bool) -> None:
     expected_web = "allow" if web_search else "deny"
     if permission.get("websearch") != expected_web:
         raise SystemExit(f"opencode isolation self-test failed: websearch must be {expected_web} when web_search={web_search}")
-    if permission.get("webfetch") != expected_web:
-        raise SystemExit(f"opencode isolation self-test failed: webfetch must be {expected_web} when web_search={web_search}")
+    if permission.get("webfetch") != "deny":
+        raise SystemExit("opencode isolation self-test failed: webfetch must stay denied")
 
 
 def self_test_opencode_isolation() -> None:

--- a/skills/autoreview/scripts/autoreview_test.py
+++ b/skills/autoreview/scripts/autoreview_test.py
@@ -125,22 +125,11 @@ class AutoreviewCompatibilityTests(unittest.TestCase):
                 os.environ[key] = value
         cls.home_dir.cleanup()
 
-    def test_harness_opts_both_cursor_aliases_into_trusted_fixture(self) -> None:
+    def test_harness_rejects_disabled_cursor_engine(self) -> None:
         harness_path = SCRIPT_PATH.with_name("test-review-harness.py")
         namespace = runpy.run_path(str(harness_path))
-        commands: list[list[str]] = []
-        run_reviews = namespace["run_reviews"]
-        with mock.patch.dict(
-            run_reviews.__globals__,
-            {
-                "run": lambda command, _cwd: commands.append(command),
-                "validate_prompt_policy": lambda _repo, _autoreview: None,
-            },
-        ), tempfile.TemporaryDirectory(prefix="autoreview-harness-test.") as tmpdir:
-            run_reviews(Path(tmpdir), SCRIPT_PATH.parent, "benign", ["cursor", "cursor-agent"])
-        self.assertEqual(len(commands), 2)
-        for command in commands:
-            self.assertIn("--cursor-allow-workspace-instructions", command)
+        with self.assertRaises(SystemExit):
+            namespace["parse_args"](["--engine", "cursor"])
 
     def test_cursor_agent_bin_cli_alias(self) -> None:
         with mock.patch.object(
@@ -219,6 +208,62 @@ class AutoreviewCompatibilityTests(unittest.TestCase):
 
         self.assertEqual(json.loads(output), FINAL_REPORT)
         self.assertEqual(models, ["gpt-5.6-sol", "gpt-5.6-terra"])
+
+    def test_codex_runs_outside_repo_with_bundle_only_workspace(self) -> None:
+        args = argparse.Namespace(
+            codex_bin="codex",
+            codex_config=None,
+            codex_speed=None,
+            fallback_model=None,
+            model="gpt-5.6-sol",
+            stream_engine_output=False,
+            thinking="high",
+            tools=True,
+            web_search=False,
+        )
+        observed: dict[str, object] = {}
+
+        def fake_run(
+            command: list[str],
+            cwd: Path,
+            *_args: object,
+            **_kwargs: object,
+        ) -> subprocess.CompletedProcess[str]:
+            observed["cwd"] = cwd
+            observed["command_cwd"] = Path(command[command.index("-C") + 1])
+            observed["workspace_entries"] = list(cwd.iterdir())
+            output_path = Path(command[command.index("--output-last-message") + 1])
+            output_path.write_text(json.dumps(FINAL_REPORT))
+            return subprocess.CompletedProcess(command, 0, "", "")
+
+        with tempfile.TemporaryDirectory(prefix="autoreview-codex-workspace-test.") as tmpdir:
+            repo = Path(tmpdir)
+            (repo / ".env").write_text("OPENAI_API_KEY=ignored-secret\n")
+            with mock.patch.object(
+                AUTOREVIEW,
+                "resolve_command",
+                return_value="/usr/bin/codex",
+            ), mock.patch.object(
+                AUTOREVIEW,
+                "codex_auth_config_flags",
+                return_value=[],
+            ), mock.patch.object(
+                AUTOREVIEW,
+                "run_with_heartbeat",
+                side_effect=fake_run,
+            ):
+                output = AUTOREVIEW.run_codex(args, repo, "review")
+
+            self.assertEqual(json.loads(output), FINAL_REPORT)
+            observed_cwd = observed["cwd"]
+            command_cwd = observed["command_cwd"]
+            self.assertIsInstance(observed_cwd, Path)
+            self.assertIsInstance(command_cwd, Path)
+            assert isinstance(observed_cwd, Path)
+            assert isinstance(command_cwd, Path)
+            self.assertNotEqual(observed_cwd.resolve(), repo.resolve())
+            self.assertEqual(observed_cwd, command_cwd)
+            self.assertEqual(observed["workspace_entries"], [])
 
     def test_codex_does_not_fallback_after_unrelated_failure(self) -> None:
         args = argparse.Namespace(

--- a/skills/autoreview/scripts/test-review-harness.py
+++ b/skills/autoreview/scripts/test-review-harness.py
@@ -13,7 +13,7 @@ from collections.abc import Callable
 from pathlib import Path
 
 
-ENGINES = ("codex", "claude", "droid", "copilot", "pi", "opencode", "cursor", "cursor-agent")
+ENGINES = ("codex", "claude", "pi")
 DEFAULT_ENGINES = ("codex", "claude")
 
 MALICIOUS_INITIAL = """export function uploadPath(name) {
@@ -175,10 +175,6 @@ def run_reviews(repo: Path, script_dir: Path, fixture: str, engines: list[str]) 
             "--prompt",
             MALICIOUS_PROMPT if fixture == "malicious" else BENIGN_PROMPT,
         ]
-        if engine in {"cursor", "cursor-agent"}:
-            # The harness owns this temporary fixture, so it can make the
-            # trusted-workspace assertion required by Cursor reviews.
-            command.append("--cursor-allow-workspace-instructions")
         if fixture == "malicious":
             command.extend(["--require-finding", "command", "--expect-findings"])
         run(command, repo)

--- a/skills/autoreview/tests/test_autoreview_hardening.py
+++ b/skills/autoreview/tests/test_autoreview_hardening.py
@@ -183,6 +183,10 @@ class AutoreviewHardeningTests(unittest.TestCase):
             "packages/token/package.json",
             "scripts/tokens/session.sh",
             "src/tokens/session.mjs",
+            "credentials/prod.py",
+            "secrets/runtime.ts",
+            "src/credentials/provider.py",
+            "src/secrets/scanner.ts",
             "ui/tokens/session.vue",
             "proto/token/session.proto",
             "password_validator.go",
@@ -209,7 +213,7 @@ class AutoreviewHardeningTests(unittest.TestCase):
             with self.subTest(rel=rel):
                 self.assertIsNone(self.helper["sensitive_repo_path_risk"](rel))
 
-    def test_sensitive_source_directories_are_blocked_untracked(self) -> None:
+    def test_sensitive_named_source_directories_are_reviewable_untracked(self) -> None:
         for rel in (
             "credentials/prod.py",
             "secrets/runtime.ts",
@@ -217,7 +221,7 @@ class AutoreviewHardeningTests(unittest.TestCase):
             "src/secrets/scanner.ts",
         ):
             with self.subTest(rel=rel):
-                self.assertIsNotNone(self.helper["sensitive_repo_path_risk"](rel))
+                self.assertIsNone(self.helper["sensitive_repo_path_risk"](rel))
 
     def test_tracked_env_variants_remain_sensitive(self) -> None:
         for rel in (
@@ -254,16 +258,12 @@ class AutoreviewHardeningTests(unittest.TestCase):
             "tokens/device.sqlite",
             "tokens/session.jwt",
             "tokens/session",
-            "secrets/prod.md",
-            "credentials/prod.xml",
-            "credentials/prod.py",
-            "secrets/runtime.ts",
-            "src/credentials/provider.py",
-            "src/secrets/scanner.ts",
             "backup-secrets/prod.json",
             "dev_credentials/runtime.yaml",
             "client-secrets-old/account.ini",
             "client-secrets/account.properties",
+            "credentials/prod.xml",
+            "secrets/prod.md",
             "credentials.txt",
             "client-secret.csv",
             ".docker/config.json",
@@ -315,6 +315,8 @@ class AutoreviewHardeningTests(unittest.TestCase):
     def test_secret_detector_does_not_treat_code_expressions_as_values(self) -> None:
         for content in (
             "token = secrets.token_urlsafe(32)",
+            "token = process.env.GITHUB_TOKEN",
+            'token = os.environ["GITHUB_TOKEN"]',
             'password = payload.get("password")',
             'token_endpoint = "https://accounts.example.com/oauth2/token"',
             'password_policy = "minimum-twelve-characters"',
@@ -351,11 +353,6 @@ class AutoreviewHardeningTests(unittest.TestCase):
             with self.subTest(content=content):
                 self.assertTrue(self.helper["secret_text_risk"](content))
 
-    def test_secret_detector_handles_lowercase_passphrases(self) -> None:
-        content = 'password="' + "correcthorsebatterystaple" + '"'
-
-        self.assertTrue(self.helper["secret_text_risk"](content))
-
     def test_secret_detector_does_not_exempt_expression_text_in_literals(self) -> None:
         for value in (
             "correct horse + battery staple",
@@ -366,10 +363,38 @@ class AutoreviewHardeningTests(unittest.TestCase):
                 content = "pass" + f'word="{value}"'
                 self.assertTrue(self.helper["secret_text_risk"](content))
 
+    def test_secret_detector_handles_lowercase_passphrases(self) -> None:
+        content = 'password="' + "correcthorsebatterystaple" + '"'
+
+        self.assertTrue(self.helper["secret_text_risk"](content))
+
     def test_secret_detector_handles_low_diversity_passwords(self) -> None:
         content = 'password="' + "letmeinletmein" + '"'
 
         self.assertTrue(self.helper["secret_text_risk"](content))
+
+    def test_secret_detector_allows_common_fixture_literals_and_pragmas(self) -> None:
+        for content in (
+            'token: "token-oversized"',
+            'API_KEY = "clawrouter-e2e-secret"',
+            'token: "very-long-browser-token-0123456789"',
+            'password="CorrectHorseBatteryStaple123!"  # pragma: allowlist secret',
+        ):
+            with self.subTest(content=content):
+                self.assertFalse(self.helper["secret_text_risk"](content))
+
+    def test_secret_detector_does_not_treat_quoted_code_text_as_a_reference(self) -> None:
+        for content in (
+            "pass" + 'word="' + "CORRECT_HORSE_BATTERY_STAPLE" + '"',
+            "to" + 'ken="' + "process.env.PROD_TOKEN" + '"',
+            "api_" + 'key="' + "config.production_key" + '"',
+        ):
+            with self.subTest(content=content):
+                self.assertTrue(self.helper["secret_text_risk"](content))
+
+        self.assertFalse(
+            self.helper["secret_text_risk"]('api_key="${OPENAI_API_KEY}"')
+        )
 
     def test_secret_detector_does_not_exempt_placeholder_substrings(self) -> None:
         content = "pass" + 'word="prod-sample-' + realistic_secret_value() + '"'
@@ -656,6 +681,8 @@ class AutoreviewHardeningTests(unittest.TestCase):
                 os.environ["OPENCODE_AUTO_SHARE"] = "1"
                 os.environ["COPILOT_ALLOW_ALL"] = "1"
                 os.environ["CODEX_HOME"] = "/tmp/codex-auth"
+                os.environ["DBUS_SESSION_BUS_ADDRESS"] = "unix:path=/run/user/1000/bus"
+                os.environ["XDG_RUNTIME_DIR"] = "/run/user/1000"
                 os.environ["CLAUDE_CONFIG_DIR"] = "/tmp/claude-auth"
                 os.environ["PI_CODING_AGENT_DIR"] = "/tmp/pi-auth"
                 os.environ["CLAUDE_CODE_USE_FOUNDRY"] = "1"
@@ -710,6 +737,14 @@ class AutoreviewHardeningTests(unittest.TestCase):
                 self.assertEqual(env["DO_NOT_TRACK"], "1")
                 self.assertEqual(env["DISABLE_TELEMETRY"], "1")
                 self.assertEqual(env["CODEX_HOME"], "/tmp/codex-auth")
+                if os.name == "nt":
+                    self.assertNotIn("DBUS_SESSION_BUS_ADDRESS", env)
+                else:
+                    self.assertEqual(
+                        env["DBUS_SESSION_BUS_ADDRESS"],
+                        "unix:path=/run/user/1000/bus",
+                    )
+                self.assertEqual(env["XDG_RUNTIME_DIR"], "/run/user/1000")
                 self.assertEqual(
                     claude_env["CLAUDE_CONFIG_DIR"],
                     "/tmp/claude-auth",
@@ -745,6 +780,20 @@ class AutoreviewHardeningTests(unittest.TestCase):
                     claude_env["CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC"],
                     "1",
                 )
+            finally:
+                os.environ.clear()
+                os.environ.update(old)
+
+    def test_codex_env_rejects_executable_dbus_transport(self) -> None:
+        old = os.environ.copy()
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo = init_repo(Path(tempdir))
+            try:
+                os.environ["DBUS_SESSION_BUS_ADDRESS"] = (
+                    "unixexec:path=/tmp/hostile-helper"
+                )
+                env = self.helper["safe_engine_env"](repo, engine="codex")
+                self.assertNotIn("DBUS_SESSION_BUS_ADDRESS", env)
             finally:
                 os.environ.clear()
                 os.environ.update(old)


### PR DESCRIPTION
## What Problem This Solves

The OpenClaw smoke exposed review-boundary regressions after #55: Codex could read ignored repository files, path and assignment secret guards rejected legitimate source/fixture changes, and disabled engines still appeared runnable in the smoke harness.

## Why This Change Was Made

Run Codex in an empty read-only workspace and deliver repository content only through the validated review bundle. Preserve Sol/high with the access-only Terra retry, validate Linux keyring session-bus inputs, narrow secret exemptions to exact fixtures and syntactic references, keep credential data paths blocked while allowing source directories named `secrets` or `credentials`, and fail OpenCode closed until its project/network isolation is provable.

## User Impact

- Codex cannot inspect ignored `.env` or credential files, nor linked-worktree metadata.
- Linux file/keyring authentication keeps validated local session-bus support.
- Source trees named `secrets` remain reviewable.
- Exact common fixtures and explicit allowlist pragmas avoid false positives without weakening ambiguous-secret handling.
- The smoke harness advertises only runnable Codex, Claude, and Pi engines.

## Evidence

- 84 autoreview Python tests pass.
- Full autoreview engine isolation self-test passes.
- `scripts/validate-skills` passes for 6 skills.
- Validate-skills suite: 9 passed.
- Python compilation, shell syntax, and `git diff --check` pass.
- Fresh Sol/high local autoreview: no findings, confidence 0.86.
- OpenClaw smoke findings were reproduced and addressed before downstream publication.

Follow-up to #55.