### PR TITLE
fix(autoreview): close review isolation gaps

### DIFF
--- a/skills/autoreview/SKILL.md
+++ b/skills/autoreview/SKILL.md
@@ -260,7 +260,7 @@ Examples matching current `main` behavior:
 # Codex fast mode (priority service tier); needs a model whose catalog lists the tier, silently standard otherwise
 "$AUTOREVIEW" --engine codex --codex-speed fast
 
-# Arbitrary Codex config overrides (isolation flags still win; --codex-speed wins over a service_tier here)
+# Safe Codex model/response tuning overrides (--codex-speed wins over a service_tier here)
 "$AUTOREVIEW" --engine codex --codex-config 'service_tier="fast"'
 
 # Claude Code aliases or full model names, with optional availability fallback
@@ -283,16 +283,16 @@ Store persistent personal defaults in your shell startup file or launcher
 environment. For repository-local defaults, use an existing local environment
 loader such as an untracked `.envrc`; the helper does not write a config file.
 
-| Variable                           | Purpose                                                                                                                       |
-| ---------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
-| `AUTOREVIEW_MODEL`                 | Override the built-in default `--model` for all engines                                                                       |
-| `AUTOREVIEW_THINKING`              | Default `--thinking` for all engines                                                                                          |
-| `AUTOREVIEW_FALLBACK_MODEL`        | Default Claude `--fallback-model` chain                                                                                       |
-| `AUTOREVIEW_<ENGINE>_MODEL`        | Per-engine model override, for example `AUTOREVIEW_CODEX_MODEL=gpt-5.6-sol`                                                   |
-| `AUTOREVIEW_<ENGINE>_THINKING`     | Per-engine thinking override                                                                                                  |
-| `AUTOREVIEW_CODEX_CONFIG`          | Default Codex `-c key=value` overrides, semicolon-separated, e.g. `service_tier="fast"`; isolation flags still win            |
-| `AUTOREVIEW_CODEX_SPEED`           | Codex service tier override: `fast` (priority), `flex`, or `default`; silently standard when the model does not list the tier |
-| `AUTOREVIEW_CLAUDE_FALLBACK_MODEL` | Claude-only fallback chain                                                                                                    |
+| Variable                           | Purpose                                                                                                                          |
+| ---------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| `AUTOREVIEW_MODEL`                 | Override the built-in default `--model` for all engines                                                                          |
+| `AUTOREVIEW_THINKING`              | Default `--thinking` for all engines                                                                                             |
+| `AUTOREVIEW_FALLBACK_MODEL`        | Default Claude `--fallback-model` chain                                                                                          |
+| `AUTOREVIEW_<ENGINE>_MODEL`        | Per-engine model override, for example `AUTOREVIEW_CODEX_MODEL=gpt-5.6-sol`                                                      |
+| `AUTOREVIEW_<ENGINE>_THINKING`     | Per-engine thinking override                                                                                                     |
+| `AUTOREVIEW_CODEX_CONFIG`          | Safe Codex model/response tuning overrides, semicolon-separated, e.g. `service_tier="fast"`; capability-bearing keys fail closed |
+| `AUTOREVIEW_CODEX_SPEED`           | Codex service tier override: `fast` (priority), `flex`, or `default`; silently standard when the model does not list the tier    |
+| `AUTOREVIEW_CLAUDE_FALLBACK_MODEL` | Claude-only fallback chain                                                                                                       |
 
 Codex maps thinking to `model_reasoning_effort`. Claude maps thinking to `--effort`. Pi maps thinking to `--thinking`. Only Claude accepts `--fallback-model`; global CLI/env fallback requires at least one Claude reviewer, and engine-specific fallback overrides require that reviewer to be selected. Non-Claude fallback overrides, including `AUTOREVIEW_<NONCLAUDE>_FALLBACK_MODEL`, fail closed instead of being silently ignored.
 
@@ -356,7 +356,7 @@ The helper:
 - use `--mode commit --commit <ref>` for already-committed work, especially clean `main` after landing
 - should be left in `--mode auto` or forced to `--mode branch` for PR/branch work; do not force `--mode local` after committing
 - writes only to stdout unless `--output`, `--json-output`, or live streamed engine stderr is set
-- supports `--dry-run`, `--parallel-tests`, `--parallel-tests-shell`, `--prompt`, repo-relative `--prompt-file`, repo-relative `--dataset`, `--no-tools`, `--no-web-search`, repeatable Codex-only `--codex-config key=value`, Codex-only `--codex-speed fast|flex|default`, and commit refs
+- supports `--dry-run`, `--parallel-tests`, `--parallel-tests-shell`, `--prompt`, repo-relative `--prompt-file`, repo-relative `--dataset`, `--no-tools`, `--no-web-search`, repeatable Codex-only safe model/response tuning with `--codex-config key=value`, Codex-only `--codex-speed fast|flex|default`, and commit refs
 - supports `--stream-engine-output` or `AUTOREVIEW_STREAM_ENGINE_OUTPUT=1` for live engine text while preserving structured validation; Codex and Claude hide tool/file event details, emit compact activity summaries, and report usage at turn completion
 - supports opt-in review panels with `--panel` / `--reviewers`, plus per-engine `--model`, `--thinking`, and Claude `--fallback-model`
 - uses built-in defaults `codex=gpt-5.6-sol` with `high` reasoning and an access-only `gpt-5.6-terra` retry, plus `claude=claude-fable-5`; honors `AUTOREVIEW_MODEL`, `AUTOREVIEW_THINKING`, `AUTOREVIEW_FALLBACK_MODEL`, and per-engine `AUTOREVIEW_<ENGINE>_MODEL` / `AUTOREVIEW_<ENGINE>_THINKING` environment overrides when CLI flags are omitted

--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -193,14 +193,10 @@ UNQUOTED_SECRET_REFERENCE_PATTERNS = (
     *QUOTED_SECRET_REFERENCE_PATTERNS,
     re.compile(
         r"^(?:process\.env|os\.environ|env|cfg|config|params|payload|provider|"
-        r"response|result|account|client|auth|auth_response|oauth_response|"
+        r"request|response|result|account|client|auth|auth_response|oauth_response|"
         r"token_response|api_response|authentication|credentials|settings)"
         r"(?:[.\[].*)$"
     ),
-)
-SECRET_ALLOWLIST_MARKERS = (
-    "pragma: allowlist secret",
-    "gitleaks:allow",
 )
 DEFAULT_ENGINE_PATHS = ("/usr/local/bin", "/usr/bin", "/bin")
 MULTI_PROVIDER_CREDENTIAL_SUFFIXES = (
@@ -1224,11 +1220,6 @@ def secret_text_risk(text: str) -> bool:
     if any(pattern.search(text) for pattern in SECRET_VALUE_PATTERNS):
         return True
     for match in SECRET_ASSIGNMENT_PATTERN.finditer(text):
-        line_start = text.rfind("\n", 0, match.start()) + 1
-        line_end = text.find("\n", match.end())
-        line = text[line_start : line_end if line_end >= 0 else len(text)].lower()
-        if any(marker in line for marker in SECRET_ALLOWLIST_MARKERS):
-            continue
         quoted = match.group("bare_value") is None
         value = (
             match.group("double_value")

--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -494,6 +494,19 @@ def safe_dbus_session_address(repo: Path, value: str) -> bool:
     return Path(path).is_absolute() and external_env_path(repo, path)
 
 
+def safe_temp_root(repo: Path) -> Path:
+    try:
+        root = Path(tempfile.gettempdir()).resolve(strict=True)
+    except OSError as exc:
+        raise SystemExit(f"unable to resolve temporary directory: {exc}") from exc
+    if is_within(root, repo.resolve()):
+        raise SystemExit(
+            "temporary directory must be outside the reviewed repository; "
+            "unset or relocate TMPDIR/TMP/TEMP"
+        )
+    return root
+
+
 def safe_proxy_url(value: str) -> bool:
     try:
         candidate = value if "://" in value else f"http://{value}"
@@ -1184,7 +1197,7 @@ def read_text_with_status(path: Path, limit: int = MAX_BUNDLE_TEXT_BYTES) -> tup
     except SystemExit as exc:
         return f"[unreadable: {exc}]", False
     if b"\0" in data:
-        return "[binary file omitted]", False
+        return "[binary file omitted]", True
     text = data.decode("utf-8", errors="replace")
     if len(text) > limit:
         text = text[:limit]
@@ -1393,10 +1406,11 @@ def validate_review_patch(
     require_no_secret_values(label, patch)
     for content in unified_diff_contents(patch):
         require_no_secret_values(label, content)
-    if len(patch) > limit:
+    patch_bytes = len(patch.encode("utf-8"))
+    if patch_bytes > limit:
         raise SystemExit(
             f"{label} is too large to review safely "
-            f"({len(patch)} characters; limit {limit}); split the change into smaller review targets"
+            f"({patch_bytes} bytes; limit {limit}); split the change into smaller review targets"
         )
     return patch
 
@@ -1755,8 +1769,13 @@ def build_prompt(repo: Path, target: str, target_ref: str | None, bundle: str, e
     return prompt
 
 
-def write_json_temp(data: dict[str, Any]) -> Path:
-    handle = tempfile.NamedTemporaryFile("w", suffix=".json", delete=False)
+def write_json_temp(data: dict[str, Any], temp_root: Path) -> Path:
+    handle = tempfile.NamedTemporaryFile(
+        "w",
+        suffix=".json",
+        delete=False,
+        dir=temp_root,
+    )
     with handle:
         json.dump(data, handle)
     return Path(handle.name)
@@ -1922,9 +1941,10 @@ def ensure_claude_isolation_supported(args: argparse.Namespace, repo: Path) -> N
         [Path(claude_bin).parent],
         engine="claude",
     )
-    result = run([claude_bin, "--version"], repo, check=False, env=engine_env)
+    temp_root = safe_temp_root(repo)
+    result = run([claude_bin, "--version"], temp_root, check=False, env=engine_env)
     selected_models = [args.model, *(getattr(args, "fallback_model", "") or "").split(",")]
-    uses_fable = "claude-fable-5" in selected_models
+    uses_fable = any(model in {"claude-fable-5", "fable"} for model in selected_models)
     minimum_version = CLAUDE_FABLE_MIN_VERSION if uses_fable else CLAUDE_SAFE_MODE_MIN_VERSION
     version_reason = "for claude-fable-5" if uses_fable else "for --safe-mode"
     if result.returncode != 0:
@@ -1937,7 +1957,7 @@ def ensure_claude_isolation_supported(args: argparse.Namespace, repo: Path) -> N
             f"claude engine requires Claude Code >= {format_version(minimum_version)} "
             f"{version_reason} (found {format_version(version)})"
         )
-    help_result = run([claude_bin, "--help"], repo, check=False, env=engine_env)
+    help_result = run([claude_bin, "--help"], temp_root, check=False, env=engine_env)
     help_text = f"{help_result.stdout}\n{help_result.stderr}"
     required_flags = ["--safe-mode", "--setting-sources", "--strict-mcp-config", "--disallowedTools", "--tools"]
     missing = [flag for flag in required_flags if flag not in help_text]
@@ -1949,7 +1969,10 @@ def ensure_claude_isolation_supported(args: argparse.Namespace, repo: Path) -> N
 def ensure_pi_isolation_supported(args: argparse.Namespace, repo: Path) -> str:
     pi_bin = resolve_command(args.pi_bin, repo)
     engine_env = safe_engine_env(repo, [Path(pi_bin).parent], engine="pi")
-    with tempfile.TemporaryDirectory(prefix="autoreview-pi-probe.") as tempdir:
+    with tempfile.TemporaryDirectory(
+        prefix="autoreview-pi-probe.",
+        dir=safe_temp_root(repo),
+    ) as tempdir:
         probe_cwd = Path(tempdir)
         result = run([pi_bin, "--version"], probe_cwd, check=False, env=engine_env)
         help_result = run([pi_bin, "--help"], probe_cwd, check=False, env=engine_env)
@@ -1981,6 +2004,22 @@ def format_version(version: tuple[int, int, int]) -> str:
     return ".".join(str(part) for part in version)
 
 
+SAFE_CODEX_CONFIG_KEYS = {
+    "hide_agent_reasoning",
+    "model_auto_compact_token_limit",
+    "model_auto_compact_token_limit_scope",
+    "model_context_window",
+    "model_reasoning_effort",
+    "model_reasoning_summary",
+    "model_verbosity",
+    "personality",
+    "plan_mode_reasoning_effort",
+    "service_tier",
+    "show_raw_agent_reasoning",
+    "tool_output_token_limit",
+}
+
+
 def codex_config_overrides(args: argparse.Namespace) -> list[str]:
     raw = list(getattr(args, "codex_config", None) or [])
     if not raw:
@@ -1991,8 +2030,14 @@ def codex_config_overrides(args: argparse.Namespace) -> list[str]:
         if not item:
             continue
         key, sep, value = item.partition("=")
-        if not sep or not value.strip() or not re.fullmatch(r"[A-Za-z0-9_][A-Za-z0-9_.-]*", key.strip()):
+        key = key.strip()
+        if not sep or not value.strip() or not re.fullmatch(r"[A-Za-z0-9_][A-Za-z0-9_.-]*", key):
             raise SystemExit(f"invalid Codex config override (expected key=value): {item}")
+        if key not in SAFE_CODEX_CONFIG_KEYS:
+            raise SystemExit(
+                f"unsafe Codex config override refused: {key}; "
+                "only model and response tuning keys are allowed"
+            )
         overrides.append(item)
     return overrides
 
@@ -2110,8 +2155,14 @@ def codex_command(
 def run_codex(args: argparse.Namespace, repo: Path, prompt: str) -> str:
     if not args.tools:
         raise SystemExit("--no-tools is not supported by the Codex engine; use --engine claude --no-tools for a no-tools run")
-    schema_path = write_json_temp(SCHEMA)
-    with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as output_file:
+    temp_root = safe_temp_root(repo)
+    schema_path = write_json_temp(SCHEMA, temp_root)
+    with tempfile.NamedTemporaryFile(
+        "w",
+        suffix=".json",
+        delete=False,
+        dir=temp_root,
+    ) as output_file:
         output_path = Path(output_file.name)
     models = [args.model]
     fallback_model = getattr(args, "fallback_model", None)
@@ -2122,7 +2173,10 @@ def run_codex(args: argparse.Namespace, repo: Path, prompt: str) -> str:
         # The validated bundle is the sole repository input. The empty
         # workspace keeps ignored credentials and linked-worktree metadata
         # outside the model's readable filesystem boundary.
-        with tempfile.TemporaryDirectory(prefix="autoreview-codex-workspace.") as tempdir:
+        with tempfile.TemporaryDirectory(
+            prefix="autoreview-codex-workspace.",
+            dir=temp_root,
+        ) as tempdir:
             review_root = Path(tempdir)
             for index, model in enumerate(models):
                 output_path.write_text("")
@@ -2442,7 +2496,10 @@ def run_pi(args: argparse.Namespace, repo: Path, prompt: str) -> str:
     # Pi's built-in read tools accept absolute paths and have no repository
     # confinement, so an untrusted review prompt must never receive them.
     cmd.append("--no-tools")
-    with tempfile.TemporaryDirectory(prefix="autoreview-pi-run.") as tempdir:
+    with tempfile.TemporaryDirectory(
+        prefix="autoreview-pi-run.",
+        dir=safe_temp_root(repo),
+    ) as tempdir:
         result = run_with_heartbeat(
             cmd,
             Path(tempdir),
@@ -3803,7 +3860,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--codex-config",
         action="append",
-        help='Extra Codex "-c key=value" config override (TOML value), codex reviewer only. Repeatable. Env default: AUTOREVIEW_CODEX_CONFIG (semicolon-separated), e.g. service_tier="fast". Reviewed-repo isolation flags still take precedence.',
+        help='Safe Codex model/response tuning "-c key=value" override (TOML value), codex reviewer only. Repeatable. Capability-, command-, and path-bearing keys are refused. Env default: AUTOREVIEW_CODEX_CONFIG (semicolon-separated), e.g. service_tier="fast".',
     )
     parser.add_argument(
         "--codex-speed",
@@ -4263,6 +4320,18 @@ def self_test_config_defaults() -> None:
             rejected = "invalid Codex config override" in str(error)
         if not rejected:
             raise SystemExit("self-test config defaults failed: malformed codex config override accepted")
+        rejected = False
+        try:
+            codex_config_overrides(
+                reviewer_test_args(
+                    engine="codex",
+                    codex_config=['mcp_servers.review.command="touch /tmp/owned"'],
+                )
+            )
+        except SystemExit as error:
+            rejected = "unsafe Codex config override refused" in str(error)
+        if not rejected:
+            raise SystemExit("self-test config defaults failed: capability-bearing codex config override accepted")
         os.environ.pop("AUTOREVIEW_CODEX_CONFIG")
         try:
             reviewer_args(reviewer_test_args(engine="claude", codex_config=['service_tier="fast"']))

--- a/skills/autoreview/scripts/autoreview_test.py
+++ b/skills/autoreview/scripts/autoreview_test.py
@@ -164,8 +164,8 @@ class AutoreviewCompatibilityTests(unittest.TestCase):
         )
 
     def test_codex_config_status_exposes_keys_only(self) -> None:
-        args = argparse.Namespace(codex_config=['model_provider="private-value"'])
-        self.assertEqual(AUTOREVIEW.codex_config_keys(args), ["model_provider"])
+        args = argparse.Namespace(codex_config=['model_verbosity="low"'])
+        self.assertEqual(AUTOREVIEW.codex_config_keys(args), ["model_verbosity"])
 
     def test_codex_retries_terra_after_sol_access_failure(self) -> None:
         args = argparse.Namespace(

--- a/skills/autoreview/tests/test_autoreview_hardening.py
+++ b/skills/autoreview/tests/test_autoreview_hardening.py
@@ -373,6 +373,7 @@ class AutoreviewHardeningTests(unittest.TestCase):
             'password = payload.get("password")',
             "token = auth_response.credentials.access_token",
             "token = response.authentication.accessToken",
+            "token = request.headers.authorization",
             "password = account.credentials.password",
             "api_key = client.settings.apiKey",
             'token = "$GITHUB_TOKEN"',
@@ -437,15 +438,24 @@ class AutoreviewHardeningTests(unittest.TestCase):
 
         self.assertTrue(self.helper["secret_text_risk"](content))
 
-    def test_secret_detector_allows_common_fixture_literals_and_pragmas(self) -> None:
+    def test_secret_detector_allows_common_fixture_literals(self) -> None:
         for content in (
             'token: "token-oversized"',
             'API_KEY = "clawrouter-e2e-secret"',
             'token: "very-long-browser-token-0123456789"',
-            'password="CorrectHorseBatteryStaple123!"  # pragma: allowlist secret',
         ):
             with self.subTest(content=content):
                 self.assertFalse(self.helper["secret_text_risk"](content))
+
+    def test_secret_detector_does_not_trust_in_band_suppressions(self) -> None:
+        for marker in ("pragma: allowlist secret", "gitleaks:allow"):
+            with self.subTest(marker=marker):
+                content = (
+                    "pass"
+                    + 'word="CorrectHorseBatteryStaple123!"  # '
+                    + marker
+                )
+                self.assertTrue(self.helper["secret_text_risk"](content))
 
     def test_secret_detector_does_not_treat_quoted_code_text_as_a_reference(self) -> None:
         for content in (

--- a/skills/autoreview/tests/test_autoreview_hardening.py
+++ b/skills/autoreview/tests/test_autoreview_hardening.py
@@ -77,7 +77,7 @@ class AutoreviewHardeningTests(unittest.TestCase):
                 with self.assertRaisesRegex(SystemExit, "untracked sensitive files"):
                     self.helper["local_bundle"](repo)
 
-    def test_local_bundle_omits_safe_untracked_binary_content(self) -> None:
+    def test_local_bundle_marks_untracked_binary_input_incomplete(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:
             repo = init_repo(Path(tempdir))
             (repo / "image.bin").write_bytes(b"\x89PNG\r\n\0binary-content")
@@ -85,7 +85,37 @@ class AutoreviewHardeningTests(unittest.TestCase):
             bundle, truncated = self.helper["local_bundle"](repo)
 
             self.assertIn("## image.bin\n[binary file omitted]", bundle)
-            self.assertFalse(truncated)
+            self.assertTrue(truncated)
+
+    def test_codex_config_rejects_capability_bearing_overrides(self) -> None:
+        for override in (
+            'mcp_servers.review.command="touch /tmp/owned"',
+            'notify=["sh", "-c", "touch /tmp/owned"]',
+            'model_instructions_file="/tmp/hostile.md"',
+            'model_provider="credential-sink"',
+            'hooks.PreToolUse.command="touch /tmp/owned"',
+        ):
+            with self.subTest(override=override), self.assertRaisesRegex(
+                SystemExit,
+                "unsafe Codex config override refused",
+            ):
+                self.helper["codex_config_overrides"](
+                    argparse.Namespace(codex_config=[override])
+                )
+
+    def test_codex_config_accepts_safe_tuning_overrides(self) -> None:
+        args = argparse.Namespace(
+            codex_config=[
+                'service_tier="fast"',
+                'model_verbosity="low"',
+                'model_reasoning_summary="concise"',
+            ]
+        )
+
+        self.assertEqual(
+            self.helper["codex_config_overrides"](args),
+            args.codex_config,
+        )
 
     def test_untracked_files_respect_trusted_global_excludes(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:
@@ -198,6 +228,10 @@ class AutoreviewHardeningTests(unittest.TestCase):
     def test_review_patch_rejects_oversized_content(self) -> None:
         with self.assertRaisesRegex(SystemExit, "too large to review safely"):
             self.helper["validate_review_patch"]("local staged diff", ["safe.txt"], "x" * 25, 10)
+
+    def test_review_patch_limit_counts_utf8_bytes(self) -> None:
+        with self.assertRaisesRegex(SystemExit, r"12 bytes; limit 10"):
+            self.helper["validate_review_patch"]("local staged diff", ["safe.txt"], "界" * 4, 10)
 
     def test_tracked_sensitive_paths_are_blocked_in_all_modes(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:
@@ -882,6 +916,51 @@ class AutoreviewHardeningTests(unittest.TestCase):
         ):
             with self.subTest(value=value):
                 self.assertFalse(self.helper["safe_proxy_url"](value))
+
+    def test_safe_temp_root_rejects_reviewed_repo_parent(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo = init_repo(Path(tempdir))
+            hostile_temp = repo / "tmp"
+            hostile_temp.mkdir()
+
+            with mock.patch.object(
+                tempfile,
+                "gettempdir",
+                return_value=str(hostile_temp),
+            ), self.assertRaisesRegex(
+                SystemExit,
+                "temporary directory must be outside",
+            ):
+                self.helper["safe_temp_root"](repo)
+
+    def test_claude_fable_alias_requires_fable_safe_mode_version(self) -> None:
+        args = argparse.Namespace(
+            claude_bin="claude",
+            fallback_model=None,
+            model="fable",
+        )
+        version_result = subprocess.CompletedProcess(
+            ["claude", "--version"],
+            0,
+            "2.1.169 (Claude Code)",
+            "",
+        )
+
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo = init_repo(Path(tempdir))
+            with mock.patch.dict(
+                self.helper["ensure_claude_isolation_supported"].__globals__,
+                {
+                    "resolve_command": lambda *_args: "/usr/bin/claude",
+                    "safe_engine_env": lambda *_args, **_kwargs: {},
+                    "safe_temp_root": lambda _repo: Path(tempdir),
+                    "run": lambda *_args, **_kwargs: version_result,
+                },
+            ), self.assertRaisesRegex(
+                SystemExit,
+                "2.1.170",
+            ):
+                self.helper["ensure_claude_isolation_supported"](args, repo)
 
     def test_codex_env_rejects_executable_dbus_transport(self) -> None:
         old = os.environ.copy()


### PR DESCRIPTION
## What Problem This Solves

The autoreview harness still had several fail-open edges after the initial orgwide isolation rollout: in-band scanner suppressions, reviewed-repo temporary directories, capability-bearing Codex config overrides, omitted binary input, and character-counted patch limits.

## Why This Change Was Made

Reviewer input and execution must stay bounded outside the repository under review. This change rejects user-controlled secret-scanner suppressions, requires external temporary roots, permits only safe Codex model/response tuning overrides, marks omitted binary input incomplete, counts patch limits in UTF-8 bytes, and applies the Claude Fable version floor to its short alias.

## User Impact

Autoreview remains Codex `gpt-5.6-sol` at `high` reasoning with an access-only retry on `gpt-5.6-terra`. Unsafe or incomplete review inputs now fail closed instead of producing a potentially clean verdict.

## Evidence

- `skills/autoreview/scripts/autoreview_test.py`: 25 tests passed
- `skills/autoreview/tests/test_autoreview_hardening.py`: 69 tests passed
- `skills/autoreview/scripts/autoreview --self-test`: passed
- `scripts/validate-skills`: 6 skills validated
- `oxfmt --check skills/autoreview/SKILL.md`: passed
- fresh Sol/high implementation review: clean, confidence 0.91
- fresh Sol/high test review: clean, confidence 0.94
