### PR TITLE
fix(autoreview): harden rollout review isolation

### DIFF
--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -197,6 +197,13 @@ UNQUOTED_SECRET_REFERENCE_PATTERNS = (
         r"token_response|api_response|authentication|credentials|settings|self|this)"
         r"(?:[.\[].*)$"
     ),
+    re.compile(
+        r"^(?:cached|current|existing|loaded|previous|resolved|saved|stored)_"
+        r"(?:api[_-]?key|aws[_-]?secret[_-]?access[_-]?key|client[_-]?secret|"
+        r"refresh[_-]?token|access[_-]?token|auth[_-]?token|id[_-]?token|"
+        r"token|secret|password)$",
+        re.IGNORECASE,
+    ),
 )
 DEFAULT_ENGINE_PATHS = ("/usr/local/bin", "/usr/bin", "/bin")
 MULTI_PROVIDER_CREDENTIAL_SUFFIXES = (
@@ -663,11 +670,16 @@ def safe_engine_env(
         "OPENAI_ORGANIZATION",
         "OPENAI_PROJECT",
     } | MULTI_PROVIDER_ENV_KEYS
+    pi_allowed_exact = multi_provider_allowed_exact | {
+        "PI_OFFLINE",
+        "PI_SKIP_VERSION_CHECK",
+        "PI_TELEMETRY",
+    }
     engine_allowed_exact = {
         "claude": claude_allowed_exact,
         "codex": codex_allowed_exact,
         "opencode": multi_provider_allowed_exact,
-        "pi": multi_provider_allowed_exact,
+        "pi": pi_allowed_exact,
     }.get(engine or "", set())
     allowed_prefixes = ("AUTOREVIEW_FAKE_",)
     allow_multi_provider_credentials = engine in {"opencode", "pi"}
@@ -748,6 +760,13 @@ def safe_engine_env(
     env.update(extra or {})
     if engine == "claude":
         env["CLAUDE_CODE_DISABLE_AUTO_MEMORY"] = "1"
+    return env
+
+
+def safe_test_env(repo: Path) -> dict[str, str]:
+    env = safe_engine_env(repo)
+    if path := os.environ.get("PATH"):
+        env["PATH"] = path
     return env
 
 
@@ -1389,6 +1408,8 @@ def unified_diff_contents(patch: str) -> tuple[str, str]:
 def sensitive_repo_path_risk(rel: str) -> str | None:
     normalized = rel.replace(os.sep, "/")
     path = Path(normalized)
+    if secret_text_risk(normalized):
+        return "secret-like path"
     credential_directory = any(
         TRACKED_CREDENTIAL_DIR_PATTERN.fullmatch(part)
         for part in path.parts[:-1]
@@ -1400,7 +1421,10 @@ def sensitive_repo_path_risk(rel: str) -> str | None:
         or token_credential_store_path(normalized)
     ):
         return "sensitive path"
-    if any(pattern.search(normalized) for pattern in SENSITIVE_NAME_PATTERNS):
+    if (
+        any(pattern.search(normalized) for pattern in SENSITIVE_NAME_PATTERNS)
+        and not design_token_artifact_path(path)
+    ):
         return "sensitive filename"
     return None
 
@@ -1412,6 +1436,14 @@ def token_credential_store_path(normalized: str) -> bool:
         bool(parts & {"token", "tokens"})
         and path.stem.lower() in TRACKED_TOKEN_CREDENTIAL_STEMS
         and path.suffix.lower() in TRACKED_TOKEN_CREDENTIAL_EXTENSIONS
+    )
+
+
+def design_token_artifact_path(path: Path) -> bool:
+    return (
+        len(path.parts) == 1
+        and re.fullmatch(r"design[-_]?tokens?\.json", path.name, re.IGNORECASE)
+        is not None
     )
 
 
@@ -1458,7 +1490,10 @@ def skill_instruction_path(path: Path) -> bool:
 
 def tracked_sensitive_repo_path_risk(rel: str) -> str | None:
     normalized = rel.replace(os.sep, "/")
-    parts = {part.lower() for part in Path(normalized).parts}
+    path = Path(normalized)
+    if secret_text_risk(normalized):
+        return "secret-like path"
+    parts = {part.lower() for part in path.parts}
     if (
         "/.config/gcloud/" in f"/{normalized.lower()}/"
         or f"/{normalized.lower()}".endswith("/.docker/config.json")
@@ -1467,7 +1502,10 @@ def tracked_sensitive_repo_path_risk(rel: str) -> str | None:
         or token_credential_store_path(normalized)
     ):
         return "sensitive path"
-    if any(pattern.search(normalized) for pattern in TRACKED_SENSITIVE_NAME_PATTERNS):
+    if (
+        any(pattern.search(normalized) for pattern in TRACKED_SENSITIVE_NAME_PATTERNS)
+        and not design_token_artifact_path(path)
+    ):
         return "sensitive filename"
     return None
 
@@ -4048,19 +4086,22 @@ def print_report(report: dict[str, Any], *, label: str = "autoreview") -> None:
 
 def start_parallel_tests(command: str, repo: Path, shell_kind: str) -> tuple[subprocess.Popen, float]:
     print(f"tests: {command}")
+    env = safe_test_env(repo)
     if shell_kind == "default" or shell_kind == "cmd":
-        return subprocess.Popen(command, cwd=repo, shell=True), time.time()
+        return subprocess.Popen(command, cwd=repo, shell=True, env=env), time.time()
     if shell_kind == "powershell":
         powershell = resolve_command("powershell", repo)
         return subprocess.Popen(
             [powershell, "-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", command],
             cwd=repo,
+            env=env,
         ), time.time()
     if shell_kind == "pwsh":
         pwsh = resolve_command("pwsh", repo)
         return subprocess.Popen(
             [pwsh, "-NoProfile", "-Command", command],
             cwd=repo,
+            env=env,
         ), time.time()
     raise SystemExit(f"invalid --parallel-tests-shell/AUTOREVIEW_PARALLEL_TESTS_SHELL: {shell_kind}")
 

--- a/skills/autoreview/tests/test_autoreview_hardening.py
+++ b/skills/autoreview/tests/test_autoreview_hardening.py
@@ -375,6 +375,8 @@ class AutoreviewHardeningTests(unittest.TestCase):
             "private/parser.py",
             ".agents/skills/openclaw-secret-scanning-maintainer/SKILL.md",
             "design-tokens/colors.json",
+            "design-tokens.json",
+            "design_tokens.json",
             "tokens/default.json",
             "token_count/generated.py",
             ".docker/Dockerfile",
@@ -395,6 +397,19 @@ class AutoreviewHardeningTests(unittest.TestCase):
             with self.subTest(rel=rel):
                 self.assertIsNone(self.helper["sensitive_repo_path_risk"](rel))
 
+    def test_untracked_design_token_artifacts_remain_reviewable(self) -> None:
+        for rel in ("design-tokens.json", "design_tokens.json"):
+            with self.subTest(rel=rel):
+                self.assertIsNone(self.helper["sensitive_repo_path_risk"](rel))
+        self.assertIsNotNone(
+            self.helper["sensitive_repo_path_risk"](".env/design-tokens.json")
+        )
+        self.assertIsNotNone(
+            self.helper["tracked_sensitive_repo_path_risk"](
+                ".env/design-tokens.json"
+            )
+        )
+
     def test_sensitive_named_source_directories_are_blocked_untracked(self) -> None:
         for rel in (
             "credentials/prod.py",
@@ -404,6 +419,18 @@ class AutoreviewHardeningTests(unittest.TestCase):
         ):
             with self.subTest(rel=rel):
                 self.assertIsNotNone(self.helper["sensitive_repo_path_risk"](rel))
+
+    def test_secret_like_path_values_are_blocked(self) -> None:
+        secret_path = "notes-" + "ghp_" + "A" * 24 + ".txt"
+
+        self.assertEqual(
+            self.helper["sensitive_repo_path_risk"](secret_path),
+            "secret-like path",
+        )
+        self.assertEqual(
+            self.helper["tracked_sensitive_repo_path_risk"](secret_path),
+            "secret-like path",
+        )
 
     def test_tracked_env_variants_remain_sensitive(self) -> None:
         for rel in (
@@ -460,6 +487,29 @@ class AutoreviewHardeningTests(unittest.TestCase):
         content = '{"' + 'api_key": "' + realistic_secret_value() + '"}'
 
         self.assertTrue(self.helper["secret_text_risk"](content))
+
+    def test_secret_detector_allows_bare_variable_secret_references(self) -> None:
+        for prefix in (
+            "cached",
+            "current",
+            "existing",
+            "loaded",
+            "previous",
+            "resolved",
+            "saved",
+            "stored",
+        ):
+            with self.subTest(prefix=prefix):
+                self.assertFalse(
+                    self.helper["secret_text_risk"](
+                        f"refresh_token = {prefix}_refresh_token"
+                    )
+                )
+        self.assertTrue(
+            self.helper["secret_text_risk"](
+                "refresh_" + "token = " + "abcdefghijklmnopqrstuvwxyz"
+            )
+        )
 
     def test_secret_detector_handles_raw_jwt(self) -> None:
         content = ".".join(
@@ -1041,6 +1091,63 @@ class AutoreviewHardeningTests(unittest.TestCase):
                 os.environ.clear()
                 os.environ.update(old)
 
+    def test_parallel_tests_use_sanitized_environment_for_every_shell(self) -> None:
+        observed: list[dict[str, object]] = []
+        sanitized_env = {"PATH": "/usr/bin", "HOME": "/safe/home"}
+
+        def fake_popen(command: object, **kwargs: object) -> mock.Mock:
+            observed.append({"command": command, **kwargs})
+            return mock.Mock()
+
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo = init_repo(Path(tempdir))
+            with mock.patch.dict(
+                self.helper["start_parallel_tests"].__globals__,
+                {
+                    "safe_test_env": lambda actual_repo: (
+                        sanitized_env
+                        if actual_repo == repo
+                        else self.fail("parallel tests sanitized the wrong repository")
+                    ),
+                    "resolve_command": lambda name, actual_repo: (
+                        f"/usr/bin/{name}"
+                        if actual_repo == repo
+                        else self.fail("parallel tests resolved a shell for the wrong repository")
+                    ),
+                },
+            ), mock.patch("subprocess.Popen", side_effect=fake_popen):
+                for shell_kind in ("default", "cmd", "powershell", "pwsh"):
+                    self.helper["start_parallel_tests"]("run tests", repo, shell_kind)
+
+        self.assertEqual(len(observed), 4)
+        for invocation in observed:
+            self.assertEqual(invocation["cwd"], repo)
+            self.assertEqual(invocation["env"], sanitized_env)
+        self.assertTrue(observed[0]["shell"])
+        self.assertTrue(observed[1]["shell"])
+        self.assertNotIn("shell", observed[2])
+        self.assertNotIn("shell", observed[3])
+
+    def test_parallel_test_environment_preserves_path_without_credentials(self) -> None:
+        old = os.environ.copy()
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo = init_repo(Path(tempdir))
+            local_bin = repo / ".venv" / "bin"
+            local_bin.mkdir(parents=True)
+            try:
+                os.environ["PATH"] = f"{local_bin}{os.pathsep}/usr/bin"
+                os.environ["GITHUB_TOKEN"] = "test-token-placeholder"
+                os.environ["NODE_OPTIONS"] = "--require=/tmp/unsafe.js"
+
+                env = self.helper["safe_test_env"](repo)
+
+                self.assertEqual(env["PATH"], os.environ["PATH"])
+                self.assertNotIn("GITHUB_TOKEN", env)
+                self.assertNotIn("NODE_OPTIONS", env)
+            finally:
+                os.environ.clear()
+                os.environ.update(old)
+
     def test_safe_proxy_url_accepts_credential_free_formats(self) -> None:
         for value in (
             "http://proxy.example.invalid:8080",
@@ -1235,6 +1342,9 @@ class AutoreviewHardeningTests(unittest.TestCase):
                 os.environ["GOOGLE_CLOUD_PROJECT"] = "test-project"
                 os.environ["CODEX_API_KEY"] = "test-token-placeholder"
                 os.environ["CODEX_CA_CERTIFICATE"] = str(root / "codex-ca.pem")
+                os.environ["PI_OFFLINE"] = "1"
+                os.environ["PI_SKIP_VERSION_CHECK"] = "1"
+                os.environ["PI_TELEMETRY"] = "0"
                 os.environ["NODE_OPTIONS"] = "--require=/tmp/unsafe.js"
                 os.environ["GOOGLE_EXTERNAL_ACCOUNT_ALLOW_EXECUTABLES"] = "1"
                 os.environ["XDG_DATA_HOME"] = str(root / "opencode-auth")
@@ -1273,6 +1383,10 @@ class AutoreviewHardeningTests(unittest.TestCase):
                                 env["XDG_DATA_HOME"],
                                 str(root / "opencode-auth"),
                             )
+                        else:
+                            self.assertEqual(env["PI_OFFLINE"], "1")
+                            self.assertEqual(env["PI_SKIP_VERSION_CHECK"], "1")
+                            self.assertEqual(env["PI_TELEMETRY"], "0")
 
                 claude_env = self.helper["safe_engine_env"](repo, engine="claude")
                 for key in (


### PR DESCRIPTION
## What Problem This Solves

The orgwide autoreview rollout exposed credential and false-positive regressions in the canonical skill before wider propagation:

- `--parallel-tests` inherited host credentials.
- Reusing reviewer-engine isolation would remove repo-local test toolchains.
- Pi privacy and offline flags were dropped.
- Secret-like filenames were not rejected.
- Stored credential variable references and root design-token artifacts were falsely rejected.

## Why This Change Was Made

This adds a separate parallel-test environment policy: preserve the caller's `PATH`, while stripping credentials and process-injection variables. It also tightens path scanning, preserves Pi privacy controls, and narrows the two confirmed false-positive cases without allowing sensitive parent directories.

## User Impact

Autoreview keeps `gpt-5.6-sol` with `high` reasoning and the account-access-only `gpt-5.6-terra` fallback, while parallel tests can use local toolchains without receiving host credentials.

## Evidence

- `python scripts/validate-skills`
- `python scripts/install-skills.test.py`
- `python scripts/validate-skills.test.py`
- `python skills/autoreview/scripts/autoreview --self-test`
- `python -m unittest skills/autoreview/scripts/autoreview_test.py skills.autoreview.tests.test_autoreview_hardening` (114 passed, 1 skipped)
- Node checks/tests (32 passed)
- Fresh Codex autoreview: `gpt-5.6-sol`, `high`, clean at 0.90 confidence
