### PR TITLE
fix(autoreview): allow safe credential templates

### DIFF
--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -228,6 +228,10 @@ BACKTICK_SECRET_REFERENCE_PATTERNS = (
         r")$"
     ),
 )
+BACKTICK_TEMPLATE_INTERPOLATION_PATTERN = re.compile(r"\$\{([^{}\r\n]+)\}")
+BACKTICK_TEMPLATE_SAFE_LITERAL_PATTERN = re.compile(
+    r"(?i)(?:(?:Bearer|Basic)[ \t]+|[ \t:./,_-]*)"
+)
 DEFAULT_ENGINE_PATHS = ("/usr/local/bin", "/usr/bin", "/bin")
 # Keep this explicit: suffix matching leaks unrelated process credentials such
 # as package-registry and telemetry tokens into reviewer subprocesses.
@@ -1892,6 +1896,29 @@ def safe_secret_call_suffix(text: str, end: int) -> bool:
         return safe_secret_assignment_suffix(text, cursor)
 
 
+def safe_backtick_secret_template(value: str) -> bool:
+    cursor = 0
+    found_interpolation = False
+    for match in BACKTICK_TEMPLATE_INTERPOLATION_PATTERN.finditer(value):
+        literal = value[cursor : match.start()]
+        if BACKTICK_TEMPLATE_SAFE_LITERAL_PATTERN.fullmatch(literal) is None:
+            return False
+        expression = match.group(1).strip()
+        quoted_reference = "${" + expression + "}"
+        if not any(
+            pattern.fullmatch(quoted_reference)
+            for pattern in QUOTED_SECRET_REFERENCE_PATTERNS
+        ):
+            return False
+        found_interpolation = True
+        cursor = match.end()
+    literal = value[cursor:]
+    return (
+        found_interpolation
+        and BACKTICK_TEMPLATE_SAFE_LITERAL_PATTERN.fullmatch(literal) is not None
+    )
+
+
 def secret_text_risk(text: str) -> bool:
     if any(pattern.search(text) for pattern in SECRET_VALUE_PATTERNS):
         return True
@@ -1912,9 +1939,12 @@ def secret_text_risk(text: str) -> bool:
             continue
         if (
             match.group("backtick_value") is not None
-            and any(
-                pattern.fullmatch(value)
-                for pattern in BACKTICK_SECRET_REFERENCE_PATTERNS
+            and (
+                any(
+                    pattern.fullmatch(value)
+                    for pattern in BACKTICK_SECRET_REFERENCE_PATTERNS
+                )
+                or safe_backtick_secret_template(value)
             )
             and safe_secret_assignment_suffix(text, match.end())
         ):

--- a/skills/autoreview/tests/test_autoreview_hardening.py
+++ b/skills/autoreview/tests/test_autoreview_hardening.py
@@ -523,6 +523,31 @@ class AutoreviewHardeningTests(unittest.TestCase):
             with self.subTest(content=content):
                 self.assertFalse(self.helper["secret_text_risk"](content))
 
+    def test_secret_detector_allows_safe_backtick_interpolation(self) -> None:
+        for content in (
+            "to" + "ken = `Bearer ${process.env.TOKEN}`",
+            "pass"
+            + "word = `${user.credentials.password}:${config.passwordSalt}`",
+            "api_" + "key = `${config.primary.apiKey}-${config.secondary.apiKey}`",
+        ):
+            with self.subTest(content=content):
+                self.assertFalse(self.helper["secret_text_risk"](content))
+
+    def test_secret_detector_rejects_backtick_interpolation_with_literal_secret(
+        self,
+    ) -> None:
+        literal_secret = "hardcoded" + "credential"
+        for content in (
+            "to" + f"ken = `{literal_secret}-${{process.env.TOKEN}}`",
+            "pass"
+            + f"word = `${{user.credentials.password}}-{literal_secret}`",
+            "to"
+            + f'ken = `Bearer ${{process.env.TOKEN || "{literal_secret}"}}`',
+            "pass" + "word = `p@ssw0rd-${process.env.PASSWORD}`",
+        ):
+            with self.subTest(content=content):
+                self.assertTrue(self.helper["secret_text_risk"](content))
+
     def test_secret_detector_rejects_op_backtick_shell_fallbacks(self) -> None:
         content = (
             "pass"


### PR DESCRIPTION
## What Problem This Solves

Autoreview rejected otherwise safe credential templates such as a `Bearer` prefix around a recognized environment reference, blocking review before the model could inspect the change.

## Why This Change Was Made

Allow backtick templates only when every interpolation is an existing approved credential reference and every literal segment is either a separator or a standard `Bearer`/`Basic` scheme. Literal credential fragments, fallback expressions, nested braces, and unknown references remain fail-closed.

## User Impact

Repositories can review safe reference-only credential templates without weakening the pre-review secret boundary.

## Evidence

- `python -m unittest skills/autoreview/scripts/autoreview_test.py skills.autoreview.tests.test_autoreview_hardening` (145 passed, 1 skipped)
- `python scripts/validate-skills`
- `bash -n skills/autoreview/scripts/test-review-harness`
- `python skills/autoreview/scripts/autoreview --self-test`
- fresh `gpt-5.6-sol` / high autoreview: clean, thread `019f5292-125f-7f32-8607-2ede7176d73c`
