### PR TITLE
fix(autoreview): avoid spaced-call false positives

### DIFF
--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -146,7 +146,7 @@ SECRET_ASSIGNMENT_PATTERN = re.compile(
     r"'(?P<single_value>[^'\r\n]{12,})'|"
     r"`(?P<backtick_value>[^`\r\n]{12,})`|"
     r"(?P<call_value>[A-Za-z_$][A-Za-z0-9_$]*"
-    r"(?:(?:\?\.|\.)[A-Za-z_$][A-Za-z0-9_$]*)*)(?=\s*\()|"
+    r"(?:(?:\?\.|\.)[A-Za-z_$][A-Za-z0-9_$]*)*)(?=\()|"
     r"(?P<reference_value>[A-Za-z_$][A-Za-z0-9_$]*"
     r"(?:(?:\?\.|\.)[A-Za-z_$][A-Za-z0-9_$]*"
     r"|\[(?:[\"'][A-Za-z_$][A-Za-z0-9_$]*[\"']|[0-9]+)\])+)"

--- a/skills/autoreview/tests/test_autoreview_hardening.py
+++ b/skills/autoreview/tests/test_autoreview_hardening.py
@@ -859,6 +859,11 @@ class AutoreviewHardeningTests(unittest.TestCase):
             with self.subTest(content=content):
                 self.assertFalse(self.helper["secret_text_risk"](content))
 
+    def test_secret_detector_allows_short_spaced_calls(self) -> None:
+        self.assertFalse(
+            self.helper["secret_text_risk"]("to" + "ken = mint_token ()")
+        )
+
     def test_secret_detector_rejects_ambiguous_bare_values(self) -> None:
         for content in (
             "pass" + "word=CORRECTHORSEBATTERYSTAPLE",


### PR DESCRIPTION
## What Problem This Solves

Autoreview could classify safe short function calls as hard-coded credentials when legal horizontal whitespace appeared before the opening parenthesis.

## Why This Change Was Made

Require the secret scanner's dedicated call-value branch to match only adjacent opening parentheses. Short whitespace-separated identifiers now retain their prior non-secret behavior, while long ambiguous values remain fail-closed under the existing bare-value rule.

## User Impact

Safe code such as `token = mint_token ()` no longer blocks review, without adding a generic whitespace-parenthetical secret bypass.

## Evidence

- `python -m unittest skills/autoreview/scripts/autoreview_test.py skills.autoreview.tests.test_autoreview_hardening` (146 passed, 1 skipped)
- `python scripts/validate-skills`
- `bash -n skills/autoreview/scripts/test-review-harness`
- `python skills/autoreview/scripts/autoreview --self-test`
- fresh `gpt-5.6-sol` / high autoreview: clean, thread `019f529a-0301-7481-a1df-3527ad6bbe26`
