### PR TITLE
fix(autoreview): scan call arguments for secrets

### DIFF
--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -1872,7 +1872,14 @@ def safe_secret_call_suffix(text: str, end: int) -> bool:
                 index += 1
         return None
 
-    cursor = balanced_end(end, "(", ")")
+    def safe_call_end(start: int) -> int | None:
+        cursor = balanced_end(start, "(", ")")
+        if cursor is None:
+            return None
+        arguments = text[start + 1 : cursor - 1]
+        return None if fallback_secret_risk(arguments) else cursor
+
+    cursor = safe_call_end(end)
     if cursor is None:
         return False
     while True:
@@ -1884,7 +1891,7 @@ def safe_secret_call_suffix(text: str, end: int) -> bool:
         assert whitespace is not None
         call_start = cursor + whitespace.end()
         if call_start < len(text) and text[call_start] == "(":
-            cursor = balanced_end(call_start, "(", ")")
+            cursor = safe_call_end(call_start)
             if cursor is None:
                 return False
             continue

--- a/skills/autoreview/tests/test_autoreview_hardening.py
+++ b/skills/autoreview/tests/test_autoreview_hardening.py
@@ -638,6 +638,19 @@ class AutoreviewHardeningTests(unittest.TestCase):
 
         self.assertTrue(self.helper["secret_text_risk"](content))
 
+    def test_secret_detector_rejects_literal_secrets_in_call_arguments(
+        self,
+    ) -> None:
+        literal_value = "actual-production-" + "secret"
+        for content in (
+            "pass"
+            + f'word = credentialProvider?.getPassword("{literal_value}")',
+            "to"
+            + f'ken = provider.issue_token("{literal_value}").strip()',
+        ):
+            with self.subTest(content=content):
+                self.assertTrue(self.helper["secret_text_risk"](content))
+
     def test_secret_detector_rejects_short_reference_fallback_literals(self) -> None:
         for expression in ("env.TOKEN", "getToken()"):
             content = (


### PR DESCRIPTION
## What Problem This Solves

Autoreview could exempt credential-producing calls without scanning their arguments, allowing a literal credential passed to an optional-chain or chained helper to enter the review bundle.

## Why This Change Was Made

Run the existing fallback secret scanner over every balanced call argument list before accepting the call as a safe credential source. Literal-free calls and chained access remain supported; calls containing secret-like literals fail closed.

## User Impact

Reviewer subprocesses no longer receive hard-coded credentials hidden inside token or password helper arguments.

## Evidence

- `python -m unittest skills/autoreview/scripts/autoreview_test.py skills.autoreview.tests.test_autoreview_hardening` (147 passed, 1 skipped)
- `python scripts/validate-skills`
- `bash -n skills/autoreview/scripts/test-review-harness`
- `python skills/autoreview/scripts/autoreview --self-test`
- fresh `gpt-5.6-sol` / high autoreview: clean, thread `019f52a0-3db5-7fb2-ba8e-e9ac2b1e8802`
