### PR TITLE
feat(autoreview): demand exhaustive single-pass findings from reviewers

### DIFF
--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -2643,6 +2643,8 @@ def build_prompt(repo: Path, target: str, target_ref: str | None, bundle: str, e
         - Shell commands, if available, must be read-only inspection commands. Do not run tests, formatters, package installs, generators, network mutation commands, git mutation commands, or commands that write files.
         - Report only actionable defects introduced or exposed by this change.
         - Prefer high-signal findings over style feedback.
+        - Report EVERY distinct actionable defect in this single pass, ordered most severe first. Each review round costs the caller a full fix-test-review cycle; withholding a known defect until a later round wastes one.
+        - Before returning, sweep the bundle once more for independent defects in other files or failure modes that you may have stopped scanning for after an earlier find.
         - Include security findings: injection, secret leaks, authz/authn bypass, path traversal, unsafe deserialization, unsafe filesystem or shell use, privacy leaks, and credential handling.
         - Do not reject legitimate functionality merely because it touches shell, filesystem, network, auth, or sensitive data. Report a security finding only when the patch creates a concrete exploitable risk, removes an important safety check, or lacks validation at a trust boundary.
         - For each finding, use the smallest file/line location that demonstrates the issue.

--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -1544,7 +1544,9 @@ def bounded_field(text: str, limit: int) -> str:
 def read_prefix(path: Path, limit: int) -> tuple[bytes, bool]:
     descriptor: int | None = None
     try:
-        before = path.stat(follow_symlinks=False)
+        # os.stat, not Path.stat: the follow_symlinks kwarg on pathlib needs
+        # Python 3.10+, and macOS system python3 is still 3.9.
+        before = os.stat(path, follow_symlinks=False)
         if not stat.S_ISREG(before.st_mode):
             raise OSError("not a regular file")
         flags = (


### PR DESCRIPTION
## What

Adds two hard rules to the review prompt: report every distinct actionable defect in a single pass (ordered most severe first), and do a final sweep for independent defects before returning.

## Why

In practice reviewers (Codex included) tend to stop deep-scanning after the first strong finding, so multi-defect changes surface one finding per round. Each round costs the caller a full fix-test-review cycle: a recent OpenClaw UI change took 7 sequential review rounds for 5 real findings that could have been reported in 2. The schema already supports multiple findings; the prompt just never demanded exhaustiveness.

## Validation

- `scripts/validate-skills` → 6 skills validated.
- `python3 -m unittest skills.autoreview.scripts.autoreview_test` → OK.
- Prompt-only change; no helper logic touched.