### PR TITLE
fix(autoreview): review large diffs in bounded passes

### DIFF
--- a/skills/autoreview/SKILL.md
+++ b/skills/autoreview/SKILL.md
@@ -36,10 +36,10 @@ Use when:
 - Tools are useful in review mode. Codex receives the validated bundle in an empty workspace so ignored files and linked-worktree metadata remain unreadable; web search stays available for dependency contracts and upstream docs.
 - Security perspective is always included, but it should not cripple legitimate functionality. Report security findings only when the change creates a concrete, actionable risk or removes an important safety check.
 - Reviewer subprocesses preserve engine authentication and non-credentialed proxy variables needed by headless or restricted-network environments while stripping process-injection, Git override, and credentialed proxy values.
-- Review bundles fail closed before engine invocation when tracked or untracked paths look sensitive, patch text looks secret-like, or a Git diff exceeds the bundle limit. Redact/split the change; never accept a truncated patch as complete review proof.
+- Review bundles fail closed before engine invocation when tracked or untracked paths look sensitive or patch text looks secret-like. Safe large diffs are scanned in full, sent as one pass while they fit the aggregate prompt limit, then partitioned into complete bounded passes without truncation.
 - For regression provenance, keep roles separate: blamed code author, blamed PR author, PR merger/committer, current PR author, and PR/date. If no blamed PR is traceable, use the blamed commit as the provenance: commit SHA, date, and author username. Do not guess a merger or frame missing PR metadata as a separate finding.
 - If the blamed PR was merged by `clawsweeper[bot]` or another automation, identify the human trigger when practical. Check timeline/comments first; if rate-limited, use gitcrawl/cache or public PR HTML. Look for maintainer commands such as `@clawsweeper automerge`, `/landpr`, or labels/status comments that armed automerge. Report `automerge triggered by @login`; if not found, say trigger unknown.
-- Do not invoke built-in `codex review`, nested reviewers, or reviewer panels from inside the review. The helper builds one bundle, calls one selected engine, validates one structured result, and stops.
+- Do not invoke built-in `codex review`, nested reviewers, or reviewer panels from inside the review. The helper builds one validated bundle, calls the selected engine once for normal inputs or once per complete bounded chunk for oversized inputs, validates the structured results, and stops.
 - Stop as soon as the helper exits 0 with no accepted/actionable findings. Do not run an extra review just to get a nicer "clean" line, a second opinion, or clearer closeout wording.
 - Treat the helper's successful exit plus absence of actionable findings as the clean review result, even if the underlying Codex CLI output is terse.
 - Multi-reviewer panels are opt-in only. Use them when explicitly requested or when risk justifies the extra spend; the main agent still verifies every accepted finding before fixing.
@@ -189,43 +189,27 @@ clean `main` against `origin/main` is usually an empty diff after push. For a
 small stack, review each commit explicitly or review the branch before merging
 with `--base`.
 
-## Oversized Bundle Recovery
+## Oversized Bundles
 
-When a branch diff exceeds the bundle limit, preserve the full real-code review
-surface and remove only machine-generated noise:
+The helper scans the full patch before partitioning it. A safe bundle that fits
+the aggregate prompt limit remains one integrated review pass. Larger bundles
+are split at bundle sections and file boundaries where possible; an oversized
+single-file block is split at line boundaries with repeated file/hunk context
+and an absolute new- or old-file line offset. Untracked snapshots use
+injection-safe source-line records so continuation passes retain reportable
+locations.
+Every original bundle byte appears exactly once across the pass sequence, and
+all validated reports are merged before required-finding and exit-status checks.
+The helper caps one run at eight bounded passes so an unexpectedly huge branch
+cannot create unbounded model calls; split still-larger work into coherent review
+targets.
 
-1. Set `REVIEW_BASE` to the exact ref passed to `--base` in the failed review.
-   Record the delivery head and merge base, then classify generated paths with
-   an explicit merge-base-aware range:
-
-   ```bash
-   delivery_head=$(git rev-parse HEAD)
-   review_base=${REVIEW_BASE:?set REVIEW_BASE to the exact ref passed to --base}
-   merge_base=$(git merge-base "$review_base" "$delivery_head")
-   git diff --name-status "$merge_base" "$delivery_head"
-   ```
-
-2. Neutralize only paths the repository declares non-authoritative and
-   non-shipping. Verify the candidate against the delivery-head artifact by exact
-   comparison or the repository's semantic verifier in trusted CI or a
-   credential-free sandbox. Never execute unreviewed delivery-head generator
-   code on the host. Any executable verification chain must come from the merge
-   base or another trusted toolchain, or be reviewed separately before it runs.
-3. Reproducibility alone does not make an artifact noise. Lockfiles, generated
-   clients, policies, manifests, schemas, and every independently semantic
-   artifact remain in review scope. When their raw representation is too large,
-   provide a compact semantic diff or dataset that preserves the complete change.
-4. On a throwaway branch or worktree from `delivery_head`, restore verified
-   base-existing noise to its merge-base version and use `git rm` only for
-   verified noise added by the branch. Leave every genuine or unresolved change
-   untouched, commit the neutralization, and review against `review_base`.
-5. If genuine code still exceeds the limit, subtree passes are diagnostic and
-   partial only. Keep the merge gate blocked until the actual delivery change is
-   reduced or split into integrated branches or PRs that each fit the limit and
-   receive a complete review.
-
-Keep the delivery branch intact. Neutralization changes only the review surface,
-not the change that will ship.
+Chunking makes large-diff review usable, but it cannot give one model call every
+cross-file implementation detail. For architecture-heavy changes, still prefer
+a coherent branch or PR shape whose semantic decision surface fits one pass.
+Removing verified non-authoritative generated noise remains useful, but never
+drop lockfiles, generated clients, policies, manifests, schemas, or other
+independently semantic artifacts merely to shrink the review.
 
 ## Parallel Closeout
 
@@ -424,6 +408,7 @@ The helper:
 - recognizes `--engine droid`, `copilot`, `cursor`, and `opencode` only to fail closed with isolation errors; runnable engines are `codex`, `claude`, and `pi`; default is `AUTOREVIEW_ENGINE` or `codex`
 - resolves bare `git`, `gh`, reviewer, and PowerShell shell commands from absolute `PATH` entries only, never from the reviewed checkout; explicit `--*-bin` paths are interpreted from the reviewed repository root when relative and accepted only when both the supplied path and resolved target stay outside the reviewed repository
 - use `--mode commit --commit <ref>` for already-committed work, especially clean `main` after landing
+- scans safe Git patches in full, reviews them in one pass up to the aggregate prompt limit, and automatically uses complete bounded passes above it
 - should be left in `--mode auto` or forced to `--mode branch` for PR/branch work; do not force `--mode local` after committing
 - writes only to stdout unless `--output`, `--json-output`, or live streamed engine stderr is set
 - supports `--dry-run`, `--parallel-tests`, `--parallel-tests-shell`, `--prompt`, repo-relative `--prompt-file`, repo-relative `--dataset`, `--no-tools`, `--no-web-search`, repeatable Codex-only safe model/response tuning with `--codex-config key=value`, Codex-only `--codex-speed fast|flex|default`, and commit refs

--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -269,6 +269,13 @@ POWERSHELL_ENV_REFERENCE_PATTERN = re.compile(
 )
 MAX_BUNDLE_TEXT_BYTES = 180_000
 MAX_REVIEW_PROMPT_BYTES = 512_000
+MAX_REVIEW_CHUNK_CONTEXT_BYTES = 64_000
+MAX_REVIEW_PASSES = 8
+
+
+class ReviewChunk(NamedTuple):
+    content: str
+    context: str = ""
 SECRET_PLACEHOLDER_VALUES = {
     "changeme",
     "dummy",
@@ -5142,7 +5149,7 @@ def validate_review_patch(
     label: str,
     paths: list[str],
     patch: str,
-    limit: int = MAX_BUNDLE_TEXT_BYTES,
+    limit: int | None = None,
 ) -> str:
     blocked = [
         f"{display_escape(rel, 500)} ({risk})"
@@ -5157,7 +5164,7 @@ def validate_review_patch(
             f"{details}{more}"
         )
     patch_bytes = len(patch.encode("utf-8"))
-    if patch_bytes > limit:
+    if limit is not None and patch_bytes > limit:
         raise SystemExit(
             f"{label} is too large to review safely "
             f"({patch_bytes} bytes; limit {limit}); split the change into smaller review targets"
@@ -5372,12 +5379,20 @@ def local_bundle(repo: Path) -> tuple[str, bool]:
         git(repo, "diff", *SAFE_DIFF_FLAGS, "--stat"),
         unstaged_patch,
     ]
-    input_truncated = len(staged_patch) > 180_000 or len(unstaged_patch) > 180_000
+    input_truncated = False
     if untracked:
         parts.append("# Untracked Files")
         for rel, content, truncated in untracked_snapshots:
             input_truncated = input_truncated or truncated
-            parts.append(f"## {rel}\n{content}")
+            records = literal_lf_lines(content) or [""]
+            parts.append(
+                "# Untracked File\n"
+                f"path: {json.dumps(rel)}\n"
+                + "\n".join(
+                    f"source-line {line_number}: {json.dumps(record)}"
+                    for line_number, record in enumerate(records, start=1)
+                )
+            )
     return "\n\n".join(parts), input_truncated
 
 
@@ -5591,7 +5606,7 @@ def branch_bundle(repo: Path, base_ref: str) -> tuple[str, bool]:
             ),
             branch_patch,
         ]
-    ), len(branch_patch) > 180_000
+    ), False
 
 
 def commit_bundle(repo: Path, commit_ref: str) -> tuple[str, bool]:
@@ -5663,7 +5678,7 @@ def commit_bundle(repo: Path, commit_ref: str) -> tuple[str, bool]:
             ),
             commit_patch,
         ]
-    ), len(commit_patch) > 180_000
+    ), False
 
 
 def review_paths(repo: Path, target: str, target_ref: str | None, commit_ref: str) -> set[str]:
@@ -5772,14 +5787,351 @@ def review_scope_policy() -> str:
     ).strip()
 
 
-def build_prompt(repo: Path, target: str, target_ref: str | None, bundle: str, extra_prompt: str, datasets: str) -> str:
+def utf8_size(text: str) -> int:
+    return len(text.encode("utf-8"))
+
+
+def split_utf8_fragment(
+    text: str,
+    limit: int,
+    first_limit: int | None = None,
+) -> list[str]:
+    current_limit = first_limit or limit
+    if min(limit, current_limit) < 4:
+        raise SystemExit("review chunk byte limit is too small")
+    fragments: list[str] = []
+    current: list[str] = []
+    current_bytes = 0
+    for character in text:
+        character_bytes = utf8_size(character)
+        if current and current_bytes + character_bytes > current_limit:
+            fragments.append("".join(current))
+            current = []
+            current_bytes = 0
+            current_limit = limit
+        current.append(character)
+        current_bytes += character_bytes
+    if current:
+        fragments.append("".join(current))
+    return fragments
+
+
+def review_bundle_units(bundle: str) -> list[str]:
+    section_boundaries = {
+        "# Git Status\n",
+        "# Staged Diff\n",
+        "# Unstaged Diff\n",
+        "# Untracked Files\n",
+        "# Untracked File\n",
+        "# Branch Diff\n",
+        "# Commit Diff\n",
+    }
+    units: list[str] = []
+    current: list[str] = []
+    for line in literal_lf_lines(bundle):
+        boundary = line.startswith("diff --git ") or line in section_boundaries
+        if boundary and current:
+            units.append("".join(current))
+            current = []
+        current.append(line)
+    if current:
+        units.append("".join(current))
+    return units
+
+
+def literal_lf_lines(text: str) -> list[str]:
+    parts = text.split("\n")
+    lines = [part + "\n" for part in parts[:-1]]
+    if parts[-1]:
+        lines.append(parts[-1])
+    return lines
+
+
+def update_review_chunk_context(
+    context: list[str],
+    line: str,
+    next_new_line: int | None,
+    next_old_line: int | None,
+    in_hunk: bool,
+) -> tuple[int | None, int | None, bool]:
+    if line.startswith("diff --git "):
+        context[:] = [line]
+        return None, None, False
+    if line == "# Untracked File\n":
+        context[:] = [line]
+        return None, None, False
+    if context == ["# Untracked File\n"] and line.startswith("path: "):
+        context.append(line)
+        return None, None, False
+    if not context:
+        return next_new_line, next_old_line, in_hunk
+    if context[0] == "# Untracked File\n":
+        match = re.match(r"^source-line (\d+): ", line)
+        if match:
+            return int(match.group(1)) + 1, None, False
+        return next_new_line, None, False
+    if not in_hunk and line.startswith(("--- ", "+++ ")):
+        header_prefix = line[:4]
+        context[:] = [entry for entry in context if not entry.startswith(header_prefix)]
+        context.append(line)
+        return next_new_line, next_old_line, False
+    if line.startswith("@@ "):
+        context[:] = [entry for entry in context if not entry.startswith("@@ ")]
+        context.append(line)
+        match = re.match(r"^@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@", line)
+        if not match:
+            return None, None, True
+        return int(match.group(2)), int(match.group(1)), True
+    if in_hunk and line.startswith(" "):
+        return increment_line(next_new_line), increment_line(next_old_line), True
+    if in_hunk and line.startswith("+"):
+        return increment_line(next_new_line), next_old_line, True
+    if in_hunk and line.startswith("-"):
+        return next_new_line, increment_line(next_old_line), True
+    return next_new_line, next_old_line, in_hunk
+
+
+def increment_line(line: int | None) -> int | None:
+    return line + 1 if line is not None else None
+
+
+def compact_review_chunk_context(context: list[str]) -> list[str]:
+    if not context or context[0] == "# Untracked File\n":
+        return list(context)
+    new_header = next((entry for entry in context if entry.startswith("+++ ")), None)
+    old_header = next((entry for entry in context if entry.startswith("--- ")), None)
+    hunk_header = next((entry for entry in context if entry.startswith("@@ ")), None)
+    path_header = new_header if new_header and new_header != "+++ /dev/null\n" else old_header
+    compact = [path_header or context[0]]
+    if hunk_header:
+        compact.append(hunk_header)
+    return compact
+
+
+def review_chunk_context(
+    context: list[str],
+    next_new_line: int | None,
+    next_old_line: int | None,
+    *,
+    continued_line: bool = False,
+) -> str:
+    lines = compact_review_chunk_context(context)
+    if context and context[0] == "# Untracked File\n" and next_new_line is not None:
+        lines.append(f"[Continuation begins at untracked source line {next_new_line}.]\n")
+    elif next_new_line is not None and next_new_line >= 1:
+        lines.append(f"[Continuation begins at new-file line {next_new_line}.]\n")
+    elif next_old_line is not None and next_old_line >= 1:
+        lines.append(
+            f"[Continuation begins at old-file line {next_old_line}; "
+            "use this positive line for deleted content.]\n"
+        )
+    if continued_line:
+        lines.append("[The change content below continues the preceding long line.]\n")
+    text = "".join(lines)
+    if utf8_size(text) > MAX_REVIEW_CHUNK_CONTEXT_BYTES:
+        raise SystemExit(
+            "review continuation context exceeds the bounded prompt allowance; "
+            "shorten the changed path or split the review target"
+        )
+    return text
+
+
+def split_oversized_review_unit(
+    unit: str,
+    limit: int,
+    first_limit: int | None = None,
+) -> list[ReviewChunk]:
+    chunks: list[ReviewChunk] = []
+    current: list[str] = []
+    current_bytes = 0
+    current_context = ""
+    context: list[str] = []
+    next_new_line: int | None = None
+    next_old_line: int | None = None
+    in_hunk = False
+
+    def current_limit() -> int:
+        return first_limit if not chunks and first_limit is not None else limit
+
+    def flush() -> None:
+        nonlocal current, current_bytes, current_context
+        if current:
+            chunks.append(ReviewChunk("".join(current), current_context))
+            current = []
+            current_bytes = 0
+            current_context = ""
+
+    for line in literal_lf_lines(unit):
+        line_bytes = utf8_size(line)
+        untracked_source_line = None
+        if context and context[0] == "# Untracked File\n":
+            match = re.match(r"^source-line (\d+): ", line)
+            if match:
+                untracked_source_line = int(match.group(1))
+        chunk_limit = current_limit()
+        if current and current_bytes + line_bytes > chunk_limit:
+            if line_bytes <= limit:
+                flush()
+                chunk_limit = current_limit()
+            else:
+                remaining_line_bytes = chunk_limit - current_bytes
+                if remaining_line_bytes < 4:
+                    flush()
+                    chunk_limit = current_limit()
+                else:
+                    fragments = split_utf8_fragment(
+                        line,
+                        limit,
+                        first_limit=remaining_line_bytes,
+                    )
+                    current.append(fragments[0])
+                    flush()
+                    continued_context = review_chunk_context(
+                        context,
+                        untracked_source_line or next_new_line,
+                        next_old_line,
+                        continued_line=True,
+                    )
+                    chunks.extend(
+                        ReviewChunk(fragment, continued_context)
+                        for fragment in fragments[1:-1]
+                    )
+                    if len(fragments) > 1:
+                        current = [fragments[-1]]
+                        current_bytes = utf8_size(fragments[-1])
+                        current_context = continued_context
+                    next_new_line, next_old_line, in_hunk = update_review_chunk_context(
+                        context,
+                        line,
+                        next_new_line,
+                        next_old_line,
+                        in_hunk,
+                    )
+                    continue
+        if line_bytes > chunk_limit:
+            flush()
+            fragments = split_utf8_fragment(
+                line,
+                limit,
+                first_limit=chunk_limit,
+            )
+            for index, fragment in enumerate(fragments):
+                chunks.append(
+                    ReviewChunk(
+                        fragment,
+                        review_chunk_context(
+                            context,
+                            untracked_source_line or next_new_line,
+                            next_old_line,
+                            continued_line=index > 0,
+                        ),
+                    )
+                )
+            next_new_line, next_old_line, in_hunk = update_review_chunk_context(
+                context,
+                line,
+                next_new_line,
+                next_old_line,
+                in_hunk,
+            )
+            continue
+        if not current:
+            current_context = review_chunk_context(context, next_new_line, next_old_line)
+        current.append(line)
+        current_bytes += line_bytes
+        next_new_line, next_old_line, in_hunk = update_review_chunk_context(
+            context,
+            line,
+            next_new_line,
+            next_old_line,
+            in_hunk,
+        )
+    flush()
+    return chunks
+
+
+def split_review_bundle(bundle: str, limit: int) -> list[ReviewChunk]:
+    if utf8_size(bundle) <= limit:
+        return [ReviewChunk(bundle)]
+    chunks: list[ReviewChunk] = []
+    pending: ReviewChunk | None = None
+
+    def flush_pending() -> None:
+        nonlocal pending
+        if pending is not None:
+            chunks.append(pending)
+            pending = None
+
+    for unit in review_bundle_units(bundle):
+        unit_bytes = utf8_size(unit)
+        pending_bytes = utf8_size(pending.content) if pending else 0
+        remaining = limit - pending_bytes
+        if pending and unit_bytes <= remaining:
+            pending = ReviewChunk(pending.content + unit, pending.context)
+            continue
+        if pending and remaining >= 256:
+            first_line = literal_lf_lines(unit)[0]
+            if utf8_size(first_line) > remaining and utf8_size(first_line) <= limit:
+                flush_pending()
+                pieces = split_oversized_review_unit(unit, limit)
+                chunks.extend(pieces[:-1])
+                pending = pieces[-1]
+                continue
+            pieces = split_oversized_review_unit(
+                unit,
+                limit,
+                first_limit=remaining,
+            )
+            first, *rest = pieces
+            pending = ReviewChunk(pending.content + first.content, pending.context)
+            flush_pending()
+            if rest:
+                chunks.extend(rest[:-1])
+                pending = rest[-1]
+            continue
+        flush_pending()
+        if unit_bytes <= limit:
+            pending = ReviewChunk(unit)
+            continue
+        pieces = split_oversized_review_unit(unit, limit)
+        chunks.extend(pieces[:-1])
+        pending = pieces[-1]
+    flush_pending()
+    if "".join(chunk.content for chunk in chunks) != bundle:
+        raise SystemExit("internal error: review bundle chunking omitted or reordered input")
+    return chunks
+
+
+def render_review_prompt(
+    repo: Path,
+    target: str,
+    target_ref: str | None,
+    chunk: ReviewChunk,
+    extra_prompt: str,
+    datasets: str,
+    chunk_position: tuple[int, int] | None = None,
+) -> str:
     target_line = f"{target} {target_ref}" if target_ref else target
     branch = current_branch(repo)
     require_no_secret_values("current branch", branch)
     if target_ref:
         require_no_secret_values("review target ref", target_ref)
     scope_policy = review_scope_policy()
-    prompt = textwrap.dedent(
+    chunk_policy = ""
+    if chunk_position:
+        index, total = chunk_position
+        chunk_policy = textwrap.dedent(
+            f"""
+            Oversized review bundle chunk: {index}/{total}
+            - The complete validated change is distributed across all {total} chunks.
+            - Original change bytes appear exactly once across the chunk sequence.
+            - Continuation context may repeat file and hunk headers; it is not extra change content.
+            - Report every actionable defect demonstrated by this chunk. Reports from all chunks are merged after every pass finishes.
+            """
+        ).strip()
+        if chunk.context:
+            chunk_policy += "\n\n# Continuation Context\n" + chunk.context
+    instructions = textwrap.dedent(
         f"""
         You are a senior code reviewer. Review the provided git change bundle only.
 
@@ -5807,14 +6159,27 @@ def build_prompt(repo: Path, target: str, target_ref: str | None, bundle: str, e
 
         {scope_policy}
 
+        {chunk_policy}
+
         {extra_prompt}
 
         {datasets}
 
         # Change Bundle
-        {bundle}
         """
     ).strip()
+    return instructions + "\n" + chunk.content
+
+
+def build_prompt(repo: Path, target: str, target_ref: str | None, bundle: str, extra_prompt: str, datasets: str) -> str:
+    prompt = render_review_prompt(
+        repo,
+        target,
+        target_ref,
+        ReviewChunk(bundle),
+        extra_prompt,
+        datasets,
+    )
     prompt_bytes = len(prompt.encode("utf-8"))
     if prompt_bytes > MAX_REVIEW_PROMPT_BYTES:
         raise SystemExit(
@@ -5822,6 +6187,81 @@ def build_prompt(repo: Path, target: str, target_ref: str | None, bundle: str, e
             "reduce the change, prompt files, or datasets"
         )
     return prompt
+
+
+def build_review_prompts(
+    repo: Path,
+    target: str,
+    target_ref: str | None,
+    bundle: str,
+    extra_prompt: str,
+    datasets: str,
+) -> list[str]:
+    full_prompt = render_review_prompt(
+        repo,
+        target,
+        target_ref,
+        ReviewChunk(bundle),
+        extra_prompt,
+        datasets,
+    )
+    if utf8_size(full_prompt) <= MAX_REVIEW_PROMPT_BYTES:
+        return [full_prompt]
+
+    empty_chunk_prompt = render_review_prompt(
+        repo,
+        target,
+        target_ref,
+        ReviewChunk(""),
+        extra_prompt,
+        datasets,
+        (999_999, 999_999),
+    )
+    content_limit = (
+        MAX_REVIEW_PROMPT_BYTES
+        - utf8_size(empty_chunk_prompt)
+        - MAX_REVIEW_CHUNK_CONTEXT_BYTES
+        - 4_096
+    )
+    if content_limit < 16_000:
+        raise SystemExit(
+            "review prompt files and datasets leave too little room for change chunks; "
+            "reduce the extra review context"
+        )
+    if utf8_size(bundle) > content_limit * MAX_REVIEW_PASSES:
+        raise SystemExit(
+            f"review bundle requires more than {MAX_REVIEW_PASSES} bounded passes; "
+            "reduce or split the change before review"
+        )
+
+    for _attempt in range(4):
+        chunks = split_review_bundle(bundle, content_limit)
+        if len(chunks) > MAX_REVIEW_PASSES:
+            raise SystemExit(
+                f"review bundle requires {len(chunks)} bounded passes; "
+                f"limit {MAX_REVIEW_PASSES}; reduce or split the change before review"
+            )
+        prompts = [
+            render_review_prompt(
+                repo,
+                target,
+                target_ref,
+                chunk,
+                extra_prompt,
+                datasets,
+                (index, len(chunks)),
+            )
+            for index, chunk in enumerate(chunks, start=1)
+        ]
+        largest = max(utf8_size(prompt) for prompt in prompts)
+        if largest <= MAX_REVIEW_PROMPT_BYTES:
+            return prompts
+        content_limit -= largest - MAX_REVIEW_PROMPT_BYTES + 1_024
+        if content_limit < 16_000:
+            break
+    raise SystemExit(
+        "unable to partition the review bundle within the aggregate prompt limit"
+    )
 
 
 def write_json_temp(data: dict[str, Any], temp_root: Path) -> Path:
@@ -8468,6 +8908,19 @@ def merge_panel_reports(reports: list[tuple[str, dict[str, Any]]]) -> dict[str, 
     }
 
 
+def merge_chunk_reports(reports: list[tuple[str, dict[str, Any]]]) -> dict[str, Any]:
+    report = merge_panel_reports(reports)
+    summary = ", ".join(
+        f"{label}: {len(chunk_report['findings'])} finding(s)"
+        for label, chunk_report in reports
+    )
+    report["overall_explanation"] = bounded_field(
+        f"Chunked review complete. {summary}.",
+        3000,
+    )
+    return report
+
+
 def run_panel(
     args: argparse.Namespace,
     reviewers: list[argparse.Namespace],
@@ -8475,6 +8928,7 @@ def run_panel(
     prompt: str,
     changed_paths: set[str],
     input_truncated: bool,
+    required: list[str] | None = None,
 ) -> dict[str, Any]:
     reports: list[tuple[str, dict[str, Any]]] = []
     failures: list[str] = []
@@ -8508,7 +8962,12 @@ def run_panel(
         raise SystemExit("autoreview panel produced no reports")
     reports.sort(key=lambda item: item[0])
     report = merge_panel_reports(reports)
-    validate_report(report, repo, changed_paths, args.require_finding)
+    validate_report(
+        report,
+        repo,
+        changed_paths,
+        args.require_finding if required is None else required,
+    )
     return report
 
 
@@ -8894,7 +9353,7 @@ def main() -> int:
     extra_prompt, prompt_truncated = load_extra_prompt(args, repo)
     datasets, datasets_truncated = load_datasets(args, repo)
     input_truncated = bundle_truncated or prompt_truncated or datasets_truncated
-    prompt = build_prompt(
+    prompts = build_review_prompts(
         repo,
         target,
         target_ref,
@@ -8903,7 +9362,7 @@ def main() -> int:
         datasets,
     )
     changed_paths = review_paths(repo, target, target_ref, args.commit)
-    print(f"bundle: {len(prompt)} chars")
+    print(f"bundle: {utf8_size(bundle)} bytes; review passes: {len(prompts)}")
     if source_tree_snapshot(repo) != review_source_snapshot:
         raise SystemExit(
             "source changed while the review bundle was being created; "
@@ -8914,19 +9373,42 @@ def main() -> int:
     if args.parallel_tests:
         tests_proc = start_parallel_tests(args.parallel_tests, repo, args.parallel_tests_shell)
     try:
-        if len(reviewers) == 1:
-            report = run_reviewer(
-                reviewers[0],
-                repo,
-                prompt,
-                changed_paths,
-                args.require_finding,
-                input_truncated,
-            )
-            label = "autoreview"
+        chunk_reports: list[tuple[str, dict[str, Any]]] = []
+        for index, prompt in enumerate(prompts, start=1):
+            if len(prompts) > 1:
+                print(
+                    f"review pass: {index}/{len(prompts)} "
+                    f"({utf8_size(prompt)} prompt bytes)"
+                )
+            required = args.require_finding if len(prompts) == 1 else []
+            if len(reviewers) == 1:
+                chunk_report = run_reviewer(
+                    reviewers[0],
+                    repo,
+                    prompt,
+                    changed_paths,
+                    required,
+                    input_truncated,
+                )
+            else:
+                chunk_report = run_panel(
+                    args,
+                    reviewers,
+                    repo,
+                    prompt,
+                    changed_paths,
+                    input_truncated,
+                    required,
+                )
+            chunk_reports.append((f"chunk {index}/{len(prompts)}", chunk_report))
+        if len(chunk_reports) == 1:
+            report = chunk_reports[0][1]
         else:
-            report = run_panel(args, reviewers, repo, prompt, changed_paths, input_truncated)
-            label = "autoreview panel"
+            report = merge_chunk_reports(chunk_reports)
+            validate_report(report, repo, changed_paths, args.require_finding)
+        label = "autoreview panel" if len(reviewers) > 1 else "autoreview"
+        if len(chunk_reports) > 1:
+            label += " chunked"
     finally:
         tests_status = finish_parallel_tests(*tests_proc) if tests_proc else 0
 

--- a/skills/autoreview/tests/test_autoreview_hardening.py
+++ b/skills/autoreview/tests/test_autoreview_hardening.py
@@ -126,9 +126,10 @@ class AutoreviewHardeningTests(unittest.TestCase):
             ):
                 bundle, truncated = self.helper["local_bundle"](repo)
 
+            expected_record = json.dumps("review me" + os.linesep)
             self.assertIn(
                 '# Untracked File\npath: "notes.txt"\n'
-                'source-line 1: "review me\\n"',
+                f"source-line 1: {expected_record}",
                 bundle,
             )
             self.assertFalse(truncated)

--- a/skills/autoreview/tests/test_autoreview_hardening.py
+++ b/skills/autoreview/tests/test_autoreview_hardening.py
@@ -91,7 +91,11 @@ class AutoreviewHardeningTests(unittest.TestCase):
 
             bundle, truncated = self.helper["local_bundle"](repo)
 
-            self.assertIn("## image.bin\n[binary file omitted]", bundle)
+            self.assertIn(
+                '# Untracked File\npath: "image.bin"\n'
+                'source-line 1: "[binary file omitted]"',
+                bundle,
+            )
             self.assertTrue(truncated)
 
     def test_local_bundle_rejects_non_utf8_untracked_text(self) -> None:
@@ -122,7 +126,11 @@ class AutoreviewHardeningTests(unittest.TestCase):
             ):
                 bundle, truncated = self.helper["local_bundle"](repo)
 
-            self.assertIn("## notes.txt\nreview me", bundle)
+            self.assertIn(
+                '# Untracked File\npath: "notes.txt"\n'
+                'source-line 1: "review me\\n"',
+                bundle,
+            )
             self.assertFalse(truncated)
             self.assertEqual(reads, 1)
 
@@ -364,6 +372,269 @@ class AutoreviewHardeningTests(unittest.TestCase):
     def test_review_patch_limit_counts_utf8_bytes(self) -> None:
         with self.assertRaisesRegex(SystemExit, r"12 bytes; limit 10"):
             self.helper["validate_review_patch"]("local staged diff", ["safe.txt"], "界" * 4, 10)
+
+    def test_review_patch_accepts_large_content_without_explicit_limit(self) -> None:
+        patch = (
+            "diff --git a/safe.txt b/safe.txt\n"
+            "--- a/safe.txt\n"
+            "+++ b/safe.txt\n"
+            "@@ -0,0 +1,100000 @@\n"
+            + "+safe review content\n" * 100_000
+        )
+
+        self.assertEqual(
+            self.helper["validate_review_patch"](
+                "local staged diff",
+                ["safe.txt"],
+                patch,
+            ),
+            patch,
+        )
+
+    def test_review_bundle_chunking_preserves_every_byte_and_diff_context(self) -> None:
+        bundle = (
+            "# Commit Diff\n\n"
+            "diff --git a/safe.txt b/safe.txt\n"
+            "--- a/safe.txt\n"
+            "+++ b/safe.txt\n"
+            "@@ -0,0 +1,200 @@\n"
+            + "+safe review content\n" * 200
+        )
+
+        chunks = self.helper["split_review_bundle"](bundle, 300)
+
+        self.assertGreater(len(chunks), 1)
+        self.assertEqual("".join(chunk.content for chunk in chunks), bundle)
+        self.assertTrue(all(len(chunk.content.encode("utf-8")) <= 300 for chunk in chunks))
+        self.assertTrue(
+            any(
+                "+++ b/safe.txt" in chunk.context
+                and "@@ -0,0 +1,200 @@" in chunk.context
+                and "Continuation begins at new-file line" in chunk.context
+                for chunk in chunks[1:]
+            )
+        )
+
+    def test_untracked_markdown_headings_do_not_create_bundle_boundaries(self) -> None:
+        bundle = (
+            "# Untracked Files\n\n"
+            "# Untracked File\n"
+            'path: "notes.md"\n'
+            'source-line 1: "# title\\n"\n'
+            'source-line 2: "## section\\n"\n\n'
+            "# Untracked File\n"
+            'path: "todo.md"\n'
+            'source-line 1: "# next\\n"'
+        )
+
+        units = self.helper["review_bundle_units"](bundle)
+
+        self.assertEqual(len(units), 3)
+        self.assertIn(r'source-line 2: "## section\n"', units[1])
+        self.assertEqual("".join(units), bundle)
+
+    def test_unicode_line_separators_do_not_create_bundle_boundaries(self) -> None:
+        bundle = (
+            "# Untracked Files\n\n"
+            "# Untracked File\n"
+            'path: "notes.txt"\n'
+            'source-line 1: "before\u2028diff --git a/fake b/fake"\n\n'
+            "diff --git a/real.txt b/real.txt\n"
+            "--- a/real.txt\n"
+            "+++ b/real.txt\n"
+        )
+
+        units = self.helper["review_bundle_units"](bundle)
+
+        self.assertEqual(len(units), 3)
+        self.assertIn("\u2028diff --git a/fake b/fake", units[1])
+        self.assertEqual("".join(units), bundle)
+
+    def test_diff_source_prefixes_do_not_replace_file_context(self) -> None:
+        context: list[str] = []
+        next_new_line = None
+        next_old_line = None
+        in_hunk = False
+        lines = (
+            "diff --git a/safe.txt b/safe.txt\n",
+            "--- a/safe.txt\n",
+            "+++ b/safe.txt\n",
+            "@@ -10,2 +10,3 @@\n",
+            "+++ added source beginning with pluses\n",
+            "--- deleted source beginning with minuses\n",
+            " context\n",
+        )
+
+        for line in lines:
+            next_new_line, next_old_line, in_hunk = self.helper[
+                "update_review_chunk_context"
+            ](
+                context,
+                line,
+                next_new_line,
+                next_old_line,
+                in_hunk,
+            )
+
+        self.assertEqual(next_new_line, 12)
+        self.assertEqual(next_old_line, 12)
+        self.assertIn("--- a/safe.txt\n", context)
+        self.assertIn("+++ b/safe.txt\n", context)
+        self.assertNotIn("--- deleted source beginning with minuses\n", context)
+
+    def test_hunk_header_that_fits_fresh_chunk_is_not_split(self) -> None:
+        unit = (
+            "diff --git a/abcdefghijk b/abcdefghijk\n"
+            "--- a/abcdefghijk\n"
+            "+++ b/abcdefghijk\n"
+            "@@ -1 +1 @@\n"
+            "-old\n"
+            "+new\n"
+        )
+
+        chunks = self.helper["split_oversized_review_unit"](unit, 85)
+
+        self.assertGreater(len(chunks), 1)
+        self.assertTrue(any("@@ -1 +1 @@\n" in chunk.content for chunk in chunks))
+        self.assertEqual("".join(chunk.content for chunk in chunks), unit)
+
+    def test_untracked_continuation_context_keeps_source_line(self) -> None:
+        unit = (
+            "# Untracked File\n"
+            'path: "notes.txt"\n'
+            'source-line 1: "short\\n"\n'
+            f'source-line 2: "{"x" * 300}"\n'
+        )
+
+        chunks = self.helper["split_oversized_review_unit"](unit, 120)
+
+        self.assertGreater(len(chunks), 2)
+        self.assertTrue(
+            any(
+                "Continuation begins at untracked source line 2" in chunk.context
+                for chunk in chunks[1:]
+            )
+        )
+        self.assertEqual("".join(chunk.content for chunk in chunks), unit)
+
+    def test_deleted_file_continuation_uses_positive_old_line(self) -> None:
+        unit = (
+            "diff --git a/removed.txt b/removed.txt\n"
+            "--- a/removed.txt\n"
+            "+++ /dev/null\n"
+            "@@ -40,50 +0,0 @@\n"
+            + "-deleted content\n" * 50
+        )
+
+        chunks = self.helper["split_oversized_review_unit"](unit, 180)
+
+        deletion_contexts = [
+            chunk.context for chunk in chunks[1:] if "old-file line" in chunk.context
+        ]
+        self.assertTrue(deletion_contexts)
+        self.assertTrue(all("line 0" not in context for context in deletion_contexts))
+        self.assertTrue(all("--- a/removed.txt" in context for context in deletion_contexts))
+
+    def test_long_complete_context_is_retained_or_rejected(self) -> None:
+        path = "nested/" + "x" * 10_000 + ".txt"
+        context = [
+            f'diff --git "a/{path}" "b/{path}"\n',
+            f'--- "a/{path}"\n',
+            f'+++ "b/{path}"\n',
+            "@@ -1 +1 @@\n",
+        ]
+
+        rendered = self.helper["review_chunk_context"](context, 2, 2)
+
+        self.assertIn(f'+++ "b/{path}"', rendered)
+        self.assertIn("@@ -1 +1 @@", rendered)
+        self.assertIn("Continuation begins at new-file line 2", rendered)
+
+    def test_review_bundle_packs_oversized_unit_tails_globally(self) -> None:
+        limit = 1_000
+        units = []
+        for index in range(5):
+            header = (
+                f"diff --git a/file-{index}.txt b/file-{index}.txt\n"
+                f"--- a/file-{index}.txt\n"
+                f"+++ b/file-{index}.txt\n"
+                "@@ -0,0 +1 @@\n"
+            )
+            body = "+" + "x" * (1_100 - len(header.encode("utf-8")) - 2) + "\n"
+            units.append(header + body)
+        bundle = "".join(units)
+
+        chunks = self.helper["split_review_bundle"](bundle, limit)
+
+        self.assertEqual(len(chunks), 6)
+        self.assertEqual("".join(chunk.content for chunk in chunks), bundle)
+        self.assertTrue(all(len(chunk.content.encode("utf-8")) <= limit for chunk in chunks))
+
+    def test_large_bundle_stays_single_pass_until_prompt_limit(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo = init_repo(Path(tempdir))
+            prompts = self.helper["build_review_prompts"](
+                repo,
+                "commit",
+                "HEAD",
+                "# Commit Diff\n" + "safe review content\n" * 18_000,
+                "",
+                "",
+            )
+
+        self.assertEqual(len(prompts), 1)
+
+    def test_bundle_above_prompt_limit_uses_complete_bounded_passes(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo = init_repo(Path(tempdir))
+            prompts = self.helper["build_review_prompts"](
+                repo,
+                "commit",
+                "HEAD",
+                "# Commit Diff\n" + "safe review content\n" * 35_000,
+                "",
+                "",
+            )
+
+        self.assertGreater(len(prompts), 1)
+        self.assertTrue(
+            all(
+                len(prompt.encode("utf-8"))
+                <= self.helper["MAX_REVIEW_PROMPT_BYTES"]
+                for prompt in prompts
+            )
+        )
+        self.assertTrue(all("Oversized review bundle chunk:" in prompt for prompt in prompts))
+
+    def test_review_prompt_preserves_bundle_ending_whitespace(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo = init_repo(Path(tempdir))
+            bundle = "# Commit Diff\n+Markdown hard break  \n+\n"
+            prompt = self.helper["render_review_prompt"](
+                repo,
+                "commit",
+                "HEAD",
+                self.helper["ReviewChunk"](bundle),
+                "",
+                "",
+            )
+
+        self.assertTrue(prompt.endswith(bundle))
+
+    def test_review_pass_count_is_bounded(self) -> None:
+        builder = self.helper["build_review_prompts"]
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo = init_repo(Path(tempdir))
+            with mock.patch.dict(builder.__globals__, {"MAX_REVIEW_PASSES": 1}):
+                with self.assertRaisesRegex(SystemExit, "more than 1 bounded passes"):
+                    builder(
+                        repo,
+                        "commit",
+                        "HEAD",
+                        "# Commit Diff\n" + "safe review content\n" * 35_000,
+                        "",
+                        "",
+                    )
 
     def test_review_patch_escapes_controls_in_blocked_paths(self) -> None:
         path = ".env.\x1b]52;c;VEVTVA==\x07\udc9b"


### PR DESCRIPTION
## Summary

- remove the 180 KB fail-closed ceiling for fully validated Git patches
- keep one integrated review through the 512 KB aggregate prompt limit
- partition larger bundles into at most eight byte-complete review passes, then merge and validate reports once
- preserve diff paths, hunk state, old/new line locations, and injection-safe untracked source locations across continuations

## Why

Autoreview refused the 380,993-byte OpenClaw settings refactor even though the patch was safe and semantically coherent. This keeps full secret/path scanning and byte-preservation checks while making the reviewer useful on realistic large diffs.

## Evidence

- `python3 -m unittest skills/autoreview/tests/test_autoreview_hardening.py` — 206 tests passed, 1 skipped
- `PATH=/tmp/agent-skills-validate-venv/bin:$PATH scripts/validate-skills` — 6 skills validated
- `python3 -m py_compile skills/autoreview/scripts/autoreview`
- `git diff --check`
- real OpenClaw commit `9b64c861e5c6e2028b06e3945c79d3deb8ab5d3b`: 380,993-byte bundle admitted as one integrated pass
- fresh autoreview converged clean after fixing six accepted chunk-context findings
