### PR TITLE
fix(autoreview): retain long diff line kind

### DIFF
--- a/skills/autoreview/SKILL.md
+++ b/skills/autoreview/SKILL.md
@@ -197,7 +197,8 @@ are split at bundle sections and file boundaries where possible; an oversized
 single-file block is split at line boundaries with repeated file/hunk context
 and an absolute new- or old-file line offset. Untracked snapshots use
 injection-safe source-line records so continuation passes retain reportable
-locations.
+locations. A single physical diff line split across passes also retains its
+original addition, deletion, or context marker.
 Every original bundle byte appears exactly once across the pass sequence, and
 all validated reports are merged before required-finding and exit-status checks.
 The helper caps one run at eight bounded passes so an unexpectedly huge branch

--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -5914,6 +5914,7 @@ def review_chunk_context(
     next_old_line: int | None,
     *,
     continued_line: bool = False,
+    diff_line_marker: str | None = None,
 ) -> str:
     lines = compact_review_chunk_context(context)
     if context and context[0] == "# Untracked File\n" and next_new_line is not None:
@@ -5926,7 +5927,13 @@ def review_chunk_context(
             "use this positive line for deleted content.]\n"
         )
     if continued_line:
-        lines.append("[The change content below continues the preceding long line.]\n")
+        if diff_line_marker:
+            lines.append(
+                "[The change content below continues a unified-diff line whose "
+                f"original marker is `{diff_line_marker}`.]\n"
+            )
+        else:
+            lines.append("[The change content below continues the preceding long line.]\n")
     text = "".join(lines)
     if utf8_size(text) > MAX_REVIEW_CHUNK_CONTEXT_BYTES:
         raise SystemExit(
@@ -5963,6 +5970,7 @@ def split_oversized_review_unit(
 
     for line in literal_lf_lines(unit):
         line_bytes = utf8_size(line)
+        diff_line_marker = line[0] if in_hunk and line.startswith(("+", "-", " ")) else None
         untracked_source_line = None
         if context and context[0] == "# Untracked File\n":
             match = re.match(r"^source-line (\d+): ", line)
@@ -5991,6 +5999,7 @@ def split_oversized_review_unit(
                         untracked_source_line or next_new_line,
                         next_old_line,
                         continued_line=True,
+                        diff_line_marker=diff_line_marker,
                     )
                     chunks.extend(
                         ReviewChunk(fragment, continued_context)
@@ -6024,6 +6033,7 @@ def split_oversized_review_unit(
                             untracked_source_line or next_new_line,
                             next_old_line,
                             continued_line=index > 0,
+                            diff_line_marker=diff_line_marker,
                         ),
                     )
                 )

--- a/skills/autoreview/tests/test_autoreview_hardening.py
+++ b/skills/autoreview/tests/test_autoreview_hardening.py
@@ -499,6 +499,27 @@ class AutoreviewHardeningTests(unittest.TestCase):
         self.assertTrue(any("@@ -1 +1 @@\n" in chunk.content for chunk in chunks))
         self.assertEqual("".join(chunk.content for chunk in chunks), unit)
 
+    def test_long_diff_line_continuations_keep_their_original_marker(self) -> None:
+        for marker in ("+", "-", " "):
+            with self.subTest(marker=marker):
+                unit = (
+                    "diff --git a/large.txt b/large.txt\n"
+                    "--- a/large.txt\n"
+                    "+++ b/large.txt\n"
+                    "@@ -1 +1 @@\n"
+                    f"{marker}{'x' * 400}\n"
+                )
+
+                chunks = self.helper["split_oversized_review_unit"](unit, 140)
+
+                self.assertTrue(
+                    any(
+                        f"original marker is `{marker}`" in chunk.context
+                        for chunk in chunks[1:]
+                    )
+                )
+                self.assertEqual("".join(chunk.content for chunk in chunks), unit)
+
     def test_untracked_continuation_context_keeps_source_line(self) -> None:
         unit = (
             "# Untracked File\n"


### PR DESCRIPTION
## Summary

- retain the original unified-diff marker when one physical line spans review passes
- distinguish long addition, deletion, and context-line fragments in continuation prompts
- add regression coverage for all three marker kinds

## Why

The downstream OpenClaw sync review found that a later fragment of a huge deleted line could be interpreted as added or neutral content because its original `-` marker lived in an earlier model call.

## Evidence

- `python3 -m unittest skills/autoreview/tests/test_autoreview_hardening.py` — 207 tests passed, 1 skipped
- `PATH=/tmp/agent-skills-validate-venv/bin:$PATH scripts/validate-skills` — 6 skills validated
- fresh autoreview — clean, no accepted/actionable findings
