### PR TITLE
fix(autoreview): preserve chunk positions and capacity

### DIFF
--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -5919,6 +5919,17 @@ def review_chunk_context(
     lines = compact_review_chunk_context(context)
     if context and context[0] == "# Untracked File\n" and next_new_line is not None:
         lines.append(f"[Continuation begins at untracked source line {next_new_line}.]\n")
+    elif (
+        next_new_line is not None
+        and next_new_line >= 1
+        and next_old_line is not None
+        and next_old_line >= 1
+        and next_new_line != next_old_line
+    ):
+        lines.append(
+            f"[Continuation position: new-file line {next_new_line}; "
+            f"old-file line {next_old_line}.]\n"
+        )
     elif next_new_line is not None and next_new_line >= 1:
         lines.append(f"[Continuation begins at new-file line {next_new_line}.]\n")
     elif next_old_line is not None and next_old_line >= 1:
@@ -6024,7 +6035,7 @@ def split_oversized_review_unit(
                 limit,
                 first_limit=chunk_limit,
             )
-            for index, fragment in enumerate(fragments):
+            for index, fragment in enumerate(fragments[:-1]):
                 chunks.append(
                     ReviewChunk(
                         fragment,
@@ -6037,6 +6048,15 @@ def split_oversized_review_unit(
                         ),
                     )
                 )
+            current = [fragments[-1]]
+            current_bytes = utf8_size(fragments[-1])
+            current_context = review_chunk_context(
+                context,
+                untracked_source_line or next_new_line,
+                next_old_line,
+                continued_line=len(fragments) > 1,
+                diff_line_marker=diff_line_marker,
+            )
             next_new_line, next_old_line, in_hunk = update_review_chunk_context(
                 context,
                 line,

--- a/skills/autoreview/tests/test_autoreview_hardening.py
+++ b/skills/autoreview/tests/test_autoreview_hardening.py
@@ -520,6 +520,54 @@ class AutoreviewHardeningTests(unittest.TestCase):
                 )
                 self.assertEqual("".join(chunk.content for chunk in chunks), unit)
 
+    def test_modified_file_deletion_context_keeps_old_and_new_offsets(self) -> None:
+        context: list[str] = []
+        next_new_line = None
+        next_old_line = None
+        in_hunk = False
+        for line in (
+            "diff --git a/safe.txt b/safe.txt\n",
+            "--- a/safe.txt\n",
+            "+++ b/safe.txt\n",
+            "@@ -10,3 +10,2 @@\n",
+            "-first deleted line\n",
+        ):
+            next_new_line, next_old_line, in_hunk = self.helper[
+                "update_review_chunk_context"
+            ](
+                context,
+                line,
+                next_new_line,
+                next_old_line,
+                in_hunk,
+            )
+
+        rendered = self.helper["review_chunk_context"](
+            context,
+            next_new_line,
+            next_old_line,
+        )
+
+        self.assertIn("new-file line 10", rendered)
+        self.assertIn("old-file line 11", rendered)
+
+    def test_multiple_long_line_tails_pack_into_following_chunks(self) -> None:
+        limit = 200
+        unit = (
+            "diff --git a/large.txt b/large.txt\n"
+            "--- a/large.txt\n"
+            "+++ b/large.txt\n"
+            "@@ -1,5 +1,5 @@\n"
+            + ("+" + "x" * 205 + "\n") * 5
+        )
+
+        chunks = self.helper["split_oversized_review_unit"](unit, limit)
+        minimum_chunks = (len(unit.encode("utf-8")) + limit - 1) // limit
+
+        self.assertLessEqual(len(chunks), minimum_chunks + 1)
+        self.assertEqual("".join(chunk.content for chunk in chunks), unit)
+        self.assertTrue(all(len(chunk.content.encode("utf-8")) <= limit for chunk in chunks))
+
     def test_untracked_continuation_context_keeps_source_line(self) -> None:
         unit = (
             "# Untracked File\n"


### PR DESCRIPTION
## Summary

- retain both old-file and new-file continuation positions when a deletion makes them diverge
- keep the final fragment of an oversized line available for packing with following diff content
- add regression coverage for deletion offsets and repeated long-line tails

## Evidence

- `python3 -m unittest skills/autoreview/tests/test_autoreview_hardening.py` (209 tests, 1 skipped)
- `git diff --check`
- `scripts/validate-skills` (6 skills)
- fresh canonical autoreview: clean, 0 findings

