### PR TITLE
fix(autoreview): allow TypeScript parameter annotations

### DIFF
--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -4767,6 +4767,7 @@ def mask_reference_declaration_evidence(text: str) -> str:
 def bare_code_reference(
     text: str,
     start: int,
+    end: int,
     separator: str,
     value: str,
 ) -> bool:
@@ -4796,6 +4797,31 @@ def bare_code_reference(
             re.DOTALL,
         ):
             return True
+        # TS/JS named-function parameter annotations use PascalCase type names.
+        function_prefix = re.search(
+            r"\bfunction\b[^()\r\n]*\((?P<parameters>[^()]*)$",
+            declaration,
+        )
+        annotation_suffix = re.match(
+            r"[ \t\r\n]*(?P<terminator>[,)=])",
+            text[end:],
+        )
+        if (
+            function_prefix is not None
+            and re.fullmatch(
+                r"\s*(?:\.\.\.\s*)?",
+                split_top_level_call_arguments(
+                    function_prefix.group("parameters")
+                )[-1],
+            )
+            and annotation_suffix is not None
+        ):
+            if annotation_suffix.group("terminator") != "=":
+                return True
+            return not fallback_secret_risk(
+                text[end + annotation_suffix.end() :],
+                minimum_length=8,
+            )
     if camel_reference is None and snake_reference is None:
         return False
     return bool(
@@ -4909,7 +4935,13 @@ def secret_text_risk(text: str) -> bool:
             return True
         if (
             match.group("bare_value") is not None
-            and bare_code_reference(text, match.start(), separator, value)
+            and bare_code_reference(
+                text,
+                match.start(),
+                match.end(),
+                separator,
+                value,
+            )
             and safe_secret_assignment_suffix(text, match.end())
         ):
             continue

--- a/skills/autoreview/tests/test_autoreview_hardening.py
+++ b/skills/autoreview/tests/test_autoreview_hardening.py
@@ -1762,6 +1762,44 @@ class AutoreviewHardeningTests(unittest.TestCase):
             )
         )
 
+    def test_secret_detector_allows_typescript_function_parameter_types(self) -> None:
+        signature = (
+            "function formatCredentialLabel("
+            + "credential"
+            + ": ClaudeCliReadableCredential"
+            + "): string {"
+        )
+        access_key = "AKIA" + "ABCDEFGHIJKLMNOP"
+        secret_assignment = "const api" + 'Key = "' + access_key + '";'
+        literal_value = "actual-production-" + "secret"
+        parameter_name = "api" + "Key"
+        type_name = "Api" + "Credential"
+        typed_default = (
+            "function connect("
+            + parameter_name
+            + ": "
+            + type_name
+            + ' = "'
+            + literal_value
+            + '") {}'
+        )
+        benign_default = (
+            "function connect("
+            + parameter_name
+            + ": "
+            + type_name
+            + " = defaultCredential) {}"
+        )
+
+        self.assertFalse(self.helper["secret_text_risk"](signature))
+        self.assertFalse(self.helper["secret_text_risk"](benign_default))
+        self.assertTrue(
+            self.helper["secret_text_risk"](
+                signature + "\n  " + secret_assignment + "\n}"
+            )
+        )
+        self.assertTrue(self.helper["secret_text_risk"](typed_default))
+
     def test_secret_detector_handles_punctuation_and_multiline_diff_values(self) -> None:
         value = "Correct-Horse!" + "@Battery$Staple"
         patch = (


### PR DESCRIPTION
## Summary

- recognize PascalCase TypeScript named-function parameter annotations as code references during secret scanning
- scan typed parameter default initializers independently so benign references pass while hardcoded literals remain blocked
- add regression coverage for the reported function signature and real-secret negative cases

## Root cause

`bare_code_reference` recognized PascalCase type references inside class, interface, record, struct, and type bodies, but not inside named function parameter lists. A parameter such as `credential: ClaudeCliReadableCredential` was therefore treated as a secret assignment.

## Evidence

- `uvx pytest skills/autoreview/tests/ -q` (209 passed, 1 skipped, 675 subtests passed)
- `python3 -m unittest skills/autoreview/scripts/autoreview_test.py skills.autoreview.tests.test_autoreview_hardening` (236 tests, 1 skipped)
- `scripts/validate-skills` (validated 6 skills)
- `git diff --check`

## Real behavior proof

Exact PR head: `2702ba87579454cfff2cb9753855f24820a29c51`.

The PR helper was run against two disposable local Git repositories. Paths and the hardcoded fixture value are redacted below.

Accepted TypeScript annotation fixture:

```text
$ <checkout>/skills/autoreview/scripts/autoreview --mode local --stream-engine-output
autoreview target: local
branch: main
bundle: 380 bytes; review passes: 1
{"findings":[],"overall_correctness":"patch is correct","overall_confidence":0.99}
autoreview clean: no accepted/actionable findings reported
overall: patch is correct (0.99)
exit code: 0
```

Rejected hardcoded typed-default fixture:

```text
$ <checkout>/skills/autoreview/scripts/autoreview --mode local
autoreview target: local
branch: main
refusing to include untracked sensitive files in review bundle; stage, ignore, remove, or redact them before running autoreview:
- proof.ts (secret-like content)
exit code: 1
```
