### PR TITLE
fix(autoreview): allow SUT password references

### DIFF
--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -467,6 +467,7 @@ SOURCE_CODE_REFERENCE_VALUES = {
     "context.observerAccessToken",
     "context.observerPassword",
     "context.sutAccessToken",
+    "context.sutPassword",
     "driverAccount.accessToken",
     "driverAccount.password",
     "driverPassword",

--- a/skills/autoreview/tests/test_autoreview_hardening.py
+++ b/skills/autoreview/tests/test_autoreview_hardening.py
@@ -1884,6 +1884,11 @@ class AutoreviewHardeningTests(unittest.TestCase):
         yaml_flow_reference = (
             "{ pass" + "word: context.driverPass" + "word, enabled: true }"
         )
+        sut_reference = (
+            "const pass"
+            + "word = context.sutPass"
+            + "word;"
+        )
         literal_value = "actual-production-" + "secret"
         source_literal = (
             "function configure() { return { pass"
@@ -1955,6 +1960,13 @@ class AutoreviewHardeningTests(unittest.TestCase):
         self.assertFalse(
             self.helper["secret_text_risk"](content, source_code=True)
         )
+        self.assertFalse(
+            self.helper["secret_text_risk"](
+                sut_reference,
+                source_code=True,
+            )
+        )
+        self.assertTrue(self.helper["secret_text_risk"](sut_reference))
         self.assertFalse(
             self.helper["secret_text_risk"](
                 final_property,


### PR DESCRIPTION
## Summary

- allow the Matrix QA SUT password source reference in TypeScript and JavaScript review bundles
- retain strict rejection outside source-code mode

## Validation

- 77 focused secret-detector tests
- skill validation
- autoreview clean
