### PR TITLE
fix(autoreview): harden source reference scanning

### DIFF
--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -1931,8 +1931,19 @@ def raw_repo_path_has_symlink_component(repo: Path, rel_path: Path) -> bool:
     return False
 
 
-def fallback_expression(text: str) -> str:
-    operator = re.match(r"\s*(?:\|\||&&|\?\?|\+|\?|or\b|and\b|if\b|unless\b)", text)
+def fallback_expression(text: str, *, typescript: bool = False) -> str:
+    operator_keywords = (
+        r"|as(?![\w$])|satisfies(?![\w$])" if typescript else ""
+    )
+    operator = re.match(
+        r"\s*(?:\|\||&&|\?\?|[=<>!~:+\-*/%&|^?.,]"
+        r"|and\b|else\b|if\b|in(?![\w$])|instanceof(?![\w$])"
+        r"|is\b|not\b|or\b"
+        r"|unless\b"
+        + operator_keywords
+        + r")",
+        text,
+    )
     cursor = operator.end() if operator is not None else 0
     stack: list[str] = []
     operand_started = False
@@ -1945,9 +1956,16 @@ def fallback_expression(text: str) -> str:
         char = text[cursor]
         next_char = text[cursor + 1] if cursor + 1 < len(text) else ""
         if line_comment:
-            if char == "\n":
+            if char in "\r\n\u2028\u2029":
                 line_comment = False
-                if operand_started and not stack:
+                if (
+                    operand_started
+                    and not stack
+                    and not javascript_continues_after_line_terminator(
+                        text[cursor + 1 :],
+                        typescript=typescript,
+                    )
+                ):
                     break
             cursor += 1
             continue
@@ -1999,12 +2017,52 @@ def fallback_expression(text: str) -> str:
             continue
         if not stack and char in ",;)]}":
             break
-        if char == "\n" and operand_started and not stack:
-            break
-        if not char.isspace():
+        if char in "\r\n\u2028\u2029" and operand_started and not stack:
+            if not javascript_continues_after_line_terminator(
+                text[cursor + 1 :],
+                typescript=typescript,
+            ):
+                break
+        if not stack and (char.isalpha() or char in "_$"):
+            word_end = cursor + 1
+            while word_end < len(text) and (
+                text[word_end].isalnum() or text[word_end] in "_$"
+            ):
+                word_end += 1
+            word = text[cursor:word_end]
+            word_operators = {"in", "instanceof"}
+            if typescript:
+                word_operators.update({"as", "satisfies"})
+            operand_started = word not in word_operators
+            cursor = word_end
+            continue
+        if not stack and char in "=<>!~:+-*/%&|^?.":
+            operand_started = False
+        elif not char.isspace():
             operand_started = True
         cursor += 1
     return text[:cursor]
+
+
+def javascript_continues_after_line_terminator(
+    text: str,
+    *,
+    typescript: bool = False,
+) -> bool:
+    suffix = text.lstrip()
+    if suffix.startswith(("++", "--", "~")) or (
+        suffix.startswith("!") and not suffix.startswith("!=")
+    ):
+        return False
+    type_operators = (
+        r"|as(?![\w$])|satisfies(?![\w$])" if typescript else ""
+    )
+    return re.match(
+        r"(?:[=<>!:+\-*/%&|^?.,([`]|in(?![\w$])|instanceof(?![\w$])"
+        + type_operators
+        + r")",
+        suffix,
+    ) is not None
 
 
 def top_level_fallback_suffix(
@@ -3742,9 +3800,14 @@ def secret_literal_risk(expression: str, minimum_length: int = 12) -> bool:
     return False
 
 
-def fallback_secret_risk(text: str, minimum_length: int = 8) -> bool:
+def fallback_secret_risk(
+    text: str,
+    minimum_length: int = 8,
+    *,
+    typescript: bool = False,
+) -> bool:
     return secret_literal_risk(
-        fallback_expression(text),
+        fallback_expression(text, typescript=typescript),
         minimum_length=minimum_length,
     )
 
@@ -4800,11 +4863,79 @@ def mask_reference_declaration_evidence(text: str) -> str:
 
 
 @functools.lru_cache(maxsize=8)
-def source_code_reference_spans(text: str) -> frozenset[tuple[int, int]]:
+def javascript_reference_spans(text: str) -> frozenset[tuple[int, int]]:
     return frozenset(
         (match.start(), match.end())
         for match in SOURCE_CODE_REFERENCE_PATTERN.finditer(text)
     )
+
+
+def javascript_source_whitespace(char: str) -> bool:
+    return (
+        char in "\t\v\f \r\n\u2028\u2029\ufeff"
+        or unicodedata.category(char) == "Zs"
+    )
+
+
+def safe_javascript_reference_suffix(
+    text: str,
+    end: int,
+    *,
+    typescript: bool,
+) -> bool:
+    line_terminators = "\r\n\u2028\u2029"
+    cursor = end
+    saw_newline = False
+    while cursor < len(text):
+        while cursor < len(text) and javascript_source_whitespace(text[cursor]):
+            saw_newline = saw_newline or text[cursor] in line_terminators
+            cursor += 1
+        if text.startswith("//", cursor):
+            newline = re.search(r"[\r\n\u2028\u2029]", text[cursor + 2 :])
+            if newline is None:
+                return True
+            cursor += 2 + newline.start()
+            saw_newline = True
+            continue
+        if text.startswith("/*", cursor):
+            comment_end = text.find("*/", cursor + 2)
+            if comment_end < 0:
+                return True
+            comment = text[cursor : comment_end + 2]
+            saw_newline = saw_newline or any(
+                terminator in comment for terminator in line_terminators
+            )
+            cursor = comment_end + 2
+            continue
+        break
+    if cursor >= len(text):
+        return True
+    if text[cursor] in ";}])" or text[cursor] == ",":
+        return True
+    if saw_newline and (
+        text.startswith(("++", "--"), cursor)
+        or text[cursor] == "~"
+        or (text[cursor] == "!" and not text.startswith("!=", cursor))
+    ):
+        return True
+    continuation_keyword = re.match(
+        (
+            r"(?:as|in|instanceof|satisfies)(?![\w$])"
+            if typescript
+            else r"(?:in|instanceof)(?![\w$])"
+        ),
+        text[cursor:],
+    )
+    continuation = (
+        text[cursor] in "=<>!~:+-*/%&|^?.,([`"
+        or continuation_keyword is not None
+    )
+    if continuation:
+        return not fallback_secret_risk(
+            text[cursor:],
+            typescript=typescript,
+        )
+    return saw_newline
 
 
 def bare_code_reference(
@@ -4891,7 +5022,11 @@ def basic_authorization_risk(text: str) -> bool:
     return False
 
 
-def secret_text_risk(text: str, *, source_code: bool = False) -> bool:
+def secret_text_risk(
+    text: str,
+    *,
+    javascript_dialect: str | None = None,
+) -> bool:
     uri_authorities = uri_authority_ranges(text)
     if credentialed_uri_risk(text, uri_authorities) or basic_authorization_risk(text) or any(
         pattern.search(text) for pattern in SECRET_VALUE_PATTERNS
@@ -4913,7 +5048,9 @@ def secret_text_risk(text: str, *, source_code: bool = False) -> bool:
         {prefix.start() for prefix in assignment_prefixes},
     )
     source_reference_spans = (
-        source_code_reference_spans(text) if source_code else frozenset()
+        javascript_reference_spans(text)
+        if javascript_dialect is not None
+        else frozenset()
     )
     for prefix in assignment_prefixes:
         fallback = top_level_fallback_suffix(
@@ -4994,7 +5131,14 @@ def secret_text_risk(text: str, *, source_code: bool = False) -> bool:
         if not quoted:
             source_start = match.end() - len(value)
             source_end = match.end() - (1 if value.endswith("!") else 0)
-            if (source_start, source_end) in source_reference_spans:
+            if (
+                (source_start, source_end) in source_reference_spans
+                and safe_javascript_reference_suffix(
+                    text,
+                    match.end(),
+                    typescript=javascript_dialect == "typescript",
+                )
+            ):
                 continue
         reference_patterns = (
             QUOTED_SECRET_REFERENCE_PATTERNS
@@ -5046,9 +5190,9 @@ def require_no_secret_values(
     label: str,
     text: str,
     *,
-    source_code: bool = False,
+    javascript_dialect: str | None = None,
 ) -> None:
-    if secret_text_risk(text, source_code=source_code):
+    if secret_text_risk(text, javascript_dialect=javascript_dialect):
         raise SystemExit(
             "refusing to include secret-like content in review bundle; "
             f"clean or redact {label} before running autoreview"
@@ -5233,17 +5377,13 @@ def tracked_sensitive_repo_path_risk(rel: str) -> str | None:
     return None
 
 
-def source_code_review_path(rel: str) -> bool:
-    return Path(rel).suffix.lower() in {
-        ".cjs",
-        ".cts",
-        ".js",
-        ".jsx",
-        ".mjs",
-        ".mts",
-        ".ts",
-        ".tsx",
-    }
+def javascript_review_dialect(rel: str) -> str | None:
+    suffix = Path(rel).suffix.lower()
+    if suffix in {".cts", ".mts", ".ts", ".tsx"}:
+        return "typescript"
+    if suffix in {".cjs", ".js", ".jsx", ".mjs"}:
+        return "javascript"
+    return None
 
 
 def git_c_unquote(value: str) -> str | None:
@@ -5352,15 +5492,15 @@ def validate_review_patch(
                 (old_path, old_content),
                 (new_path, new_content),
             ):
-                source_code = (
-                    rel is not None
-                    and rel in expected_paths
-                    and source_code_review_path(rel)
+                javascript_dialect = (
+                    javascript_review_dialect(rel)
+                    if rel is not None and rel in expected_paths
+                    else None
                 )
                 require_no_secret_values(
                     f"{label} {rel or '<unknown>'}",
                     content,
-                    source_code=source_code,
+                    javascript_dialect=javascript_dialect,
                 )
     else:
         for content in unified_diff_contents(patch):
@@ -5473,7 +5613,10 @@ def file_bundle_snapshot(
         text = data.decode("utf-8")
     except UnicodeDecodeError:
         return "", True, "non-UTF-8 file"
-    if secret_text_risk(text, source_code=source_code_review_path(rel)):
+    if secret_text_risk(
+        text,
+        javascript_dialect=javascript_review_dialect(rel),
+    ):
         return "", True, "secret-like content"
     return text, False, None
 

--- a/skills/autoreview/tests/test_autoreview_hardening.py
+++ b/skills/autoreview/tests/test_autoreview_hardening.py
@@ -1956,33 +1956,235 @@ class AutoreviewHardeningTests(unittest.TestCase):
             + "word: context.driverPass"
             + "word as string }; }"
         )
+        union_cast_property = (
+            "function configure(context: RuntimeContext) { return { pass"
+            + "word: context.driverPass"
+            + "word as string | undefined }; }"
+        )
+        next_statement = (
+            "function configure(context: RuntimeContext) {\n"
+            + "  const pass"
+            + "word = context.driverPass"
+            + "word\n"
+            + "  return consume();\n"
+            + "}"
+        )
+        line_comment = (
+            "const pass"
+            + "word = context.driverPass"
+            + "word // supplied by CI\n"
+            + "consume();"
+        )
+        block_comment = (
+            "const pass"
+            + "word = context.driverPass"
+            + "word /* supplied by CI */;"
+        )
+        concatenated_literal = (
+            "function configure(context: RuntimeContext) { return { pass"
+            + "word: context.driverPass"
+            + 'word + "'
+            + literal_value
+            + '" }; }'
+        )
+        continued_literal = (
+            "function configure(context: RuntimeContext) { return { pass"
+            + "word: context.driverPass"
+            + "word\n"
+            + '  + "'
+            + literal_value
+            + '" }; }'
+        )
+        fallback_literal = (
+            "function configure(context: RuntimeContext) { return { pass"
+            + "word: context.driverPass"
+            + 'word ?? "'
+            + literal_value
+            + '" }; }'
+        )
+        assigned_literal = (
+            "const pass"
+            + "word = context.driverPass"
+            + "word\n"
+            + '  = "'
+            + literal_value
+            + '";'
+        )
+        newline_cast_literal = (
+            "const pass"
+            + "word = context.driverPass"
+            + "word\n"
+            + "  as string + \""
+            + literal_value
+            + '";'
+        )
+        commented_continuation = (
+            "const pass"
+            + "word = context.driverPass"
+            + "word // supplied by CI\n"
+            + '  + "'
+            + literal_value
+            + '";'
+        )
+        unicode_comment_continuation = (
+            "const pass"
+            + "word = context.driverPass"
+            + "word // supplied by CI"
+            + chr(0x2028)
+            + '  + "'
+            + literal_value
+            + '";'
+        )
+        unicode_space_continuation = (
+            "const pass"
+            + "word = context.driverPass"
+            + "word\n"
+            + chr(0x00A0)
+            + '+ "'
+            + literal_value
+            + '";'
+        )
+        multiline_cast_literal = (
+            "const pass"
+            + "word = context.driverPass"
+            + "word as string\n"
+            + '+ "'
+            + literal_value
+            + '";'
+        )
+        leading_comma_statement = (
+            "const pass"
+            + "word = context.driverPass"
+            + "word\n"
+            + ', username = "'
+            + literal_value
+            + '";'
+        )
+        unary_statement = (
+            "const pass"
+            + "word = context.driverPass"
+            + "word\n"
+            + '!audit("'
+            + literal_value
+            + '");'
+        )
+        inequality_literal = (
+            "const pass"
+            + "word = context.driverPass"
+            + "word\n"
+            + '!== "'
+            + literal_value
+            + '";'
+        )
+        member_call_literal = (
+            "const pass"
+            + "word = context.driverPass"
+            + 'word["concat"]("safe", "'
+            + literal_value
+            + '");'
+        )
+        continued_then_unary_statement = (
+            "const pass"
+            + "word = context.driverPass"
+            + "word + suffix\n"
+            + '!audit("'
+            + literal_value
+            + '");'
+        )
+        trailing_operator_literal = (
+            "const pass"
+            + "word = context.driverPass"
+            + "word + suffix +\n"
+            + '  "'
+            + literal_value
+            + '";'
+        )
+        plain_javascript_as_statement = (
+            "const pass"
+            + "word = context.driverPass"
+            + "word\n"
+            + 'as("'
+            + literal_value
+            + '");'
+        )
+        typescript_dollar_identifier = (
+            "const pass"
+            + "word = context.driverPass"
+            + "word\n"
+            + 'as$logger("'
+            + literal_value
+            + '");'
+        )
 
         self.assertFalse(
-            self.helper["secret_text_risk"](content, source_code=True)
+            self.helper["secret_text_risk"](
+                content,
+                javascript_dialect="typescript",
+            )
         )
         self.assertFalse(
             self.helper["secret_text_risk"](
                 sut_reference,
-                source_code=True,
+                javascript_dialect="typescript",
             )
         )
         self.assertTrue(self.helper["secret_text_risk"](sut_reference))
         self.assertFalse(
             self.helper["secret_text_risk"](
+                plain_javascript_as_statement,
+                javascript_dialect="javascript",
+            )
+        )
+        self.assertFalse(
+            self.helper["secret_text_risk"](
+                typescript_dollar_identifier,
+                javascript_dialect="typescript",
+            )
+        )
+        self.assertFalse(
+            self.helper["secret_text_risk"](
                 final_property,
-                source_code=True,
+                javascript_dialect="typescript",
             )
         )
         for source_reference in (
             inline_property,
             asserted_property,
             cast_property,
+            union_cast_property,
+            next_statement,
+            line_comment,
+            block_comment,
+            leading_comma_statement,
+            unary_statement,
+            continued_then_unary_statement,
         ):
             with self.subTest(source_reference=source_reference):
                 self.assertFalse(
                     self.helper["secret_text_risk"](
                         source_reference,
-                        source_code=True,
+                        javascript_dialect="typescript",
+                    )
+                )
+        for unsafe_source_reference in (
+            concatenated_literal,
+            continued_literal,
+            fallback_literal,
+            assigned_literal,
+            newline_cast_literal,
+            commented_continuation,
+            unicode_comment_continuation,
+            unicode_space_continuation,
+            multiline_cast_literal,
+            inequality_literal,
+            member_call_literal,
+            trailing_operator_literal,
+        ):
+            with self.subTest(unsafe_source_reference=unsafe_source_reference):
+                self.assertTrue(
+                    self.helper["secret_text_risk"](
+                        unsafe_source_reference,
+                        javascript_dialect="typescript",
                     )
                 )
         self.assertTrue(self.helper["secret_text_risk"](yaml_literal))
@@ -1998,13 +2200,13 @@ class AutoreviewHardeningTests(unittest.TestCase):
         self.assertTrue(
             self.helper["secret_text_risk"](
                 suffixed_reference,
-                source_code=True,
+                javascript_dialect="typescript",
             )
         )
         self.assertTrue(
             self.helper["secret_text_risk"](
                 prefixed_reference,
-                source_code=True,
+                javascript_dialect="typescript",
             )
         )
 
@@ -2131,8 +2333,14 @@ class AutoreviewHardeningTests(unittest.TestCase):
             ),
             patch,
         )
-        self.assertTrue(self.helper["source_code_review_path"]("module.mts"))
-        self.assertTrue(self.helper["source_code_review_path"]("module.cts"))
+        self.assertEqual(
+            self.helper["javascript_review_dialect"]("module.mts"),
+            "typescript",
+        )
+        self.assertEqual(
+            self.helper["javascript_review_dialect"]("module.cts"),
+            "typescript",
+        )
 
     def test_secret_detector_allows_generated_fixture_credentials(self) -> None:
         property_name = "pass" + "word"


### PR DESCRIPTION
## Summary

- harden JavaScript and TypeScript credential-reference exemptions against trailing literal expressions
- preserve safe direct references across comments, casts, Unicode whitespace, and automatic semicolon insertion
- scope contextual operators by JavaScript versus TypeScript file dialect
- add adversarial regression coverage for continuations, quoted paths, comments, renames, and expression boundaries

## Validation

- 77 focused secret-detector tests
- skill validation
- autoreview clean
