### PR TITLE
fix(autoreview): allow invalid recovery fixtures

### DIFF
--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -287,6 +287,7 @@ SECRET_PLACEHOLDER_VALUES = {
     "matrix_qa_e2ee_thread",
     "matrix_qa_e2ee_verify_notice",
     "not-a-real",
+    "not-a-valid-matrix-recovery-key",
     "placeholder",
     "redacted",
     "sample",

--- a/skills/autoreview/tests/test_autoreview_hardening.py
+++ b/skills/autoreview/tests/test_autoreview_hardening.py
@@ -2359,6 +2359,10 @@ class AutoreviewHardeningTests(unittest.TestCase):
             + 'decoy-'
             + 'token" };'
         )
+        invalid_recovery_fixture = (
+            'const recoveryKey = "not-'
+            + 'a-valid-matrix-recovery-key";'
+        )
         literal_value = "actual-production-" + "secret"
         fixture_shaped_literal = "PROD_TEST_ACTUAL_" + "SECRET_0123456789"
         adversarial_label = "TEST_Q7WX9M2NK4PV8R6DH3JC"
@@ -2391,7 +2395,12 @@ class AutoreviewHardeningTests(unittest.TestCase):
             + f'buildTestToken("{adversarial_label}");'
         )
 
-        for content in (generated_fixture, generated_marker, decoy_fixture):
+        for content in (
+            generated_fixture,
+            generated_marker,
+            decoy_fixture,
+            invalid_recovery_fixture,
+        ):
             with self.subTest(content=content):
                 self.assertFalse(self.helper["secret_text_risk"](content))
         for content in (


### PR DESCRIPTION
## Summary

- classify the explicit invalid Matrix recovery-key QA fixture as a placeholder
- keep a focused regression in the secret detector

## Validation

- 77 focused secret-detector tests
- skill validation
- autoreview clean
