### PR TITLE
fix(autoreview): restrict quoted credential keys

### DIFF
--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -423,7 +423,7 @@ SOURCE_CODE_REFERENCE_ROOT_PATTERN = re.compile(
     )
     + r")(?:(?:\?\.|\.)[A-Za-z_$][A-Za-z0-9_$]*"
     r"|(?:\?\.)?\[(?:[A-Za-z_$][A-Za-z0-9_$]*"
-    r"|[\"'][A-Za-z_$][A-Za-z0-9_$]*[\"']|[0-9]+)\])+"
+    r"|[\"']profiles[\"']|[0-9]+)\])+"
     r"(?![A-Za-z0-9_$])"
 )
 QUOTED_SECRET_REFERENCE_PATTERNS = (

--- a/skills/autoreview/tests/test_autoreview_hardening.py
+++ b/skills/autoreview/tests/test_autoreview_hardening.py
@@ -2277,6 +2277,13 @@ class AutoreviewHardeningTests(unittest.TestCase):
             + literal_value
             + '"]'
         )
+        quoted_secret_key = "N7xQ2mP9vK4r" + "T8wZ"
+        typescript_store_literal = (
+            "const pass"
+            + 'word = attemptAuthProfileStore["'
+            + quoted_secret_key
+            + '"];'
+        )
         self.assertFalse(
             self.helper["secret_text_risk"](
                 store_reference,
@@ -2296,6 +2303,12 @@ class AutoreviewHardeningTests(unittest.TestCase):
             )
         )
         self.assertTrue(self.helper["secret_text_risk"](yaml_store_literal))
+        self.assertTrue(
+            self.helper["secret_text_risk"](
+                typescript_store_literal,
+                javascript_dialect="typescript",
+            )
+        )
 
     def test_lifecycle_reference_scan_is_bounded_for_non_matching_identifier(self) -> None:
         source = "const value = resolved" + "A" * 100_000 + "X;"


### PR DESCRIPTION
## Summary

- restrict trusted credential-store computed string access to the known `profiles` field
- keep identifier and numeric computed references working for runtime lookups
- add a regression proving arbitrary quoted computed keys cannot hide hardcoded credentials

## Testing

- `python3 -m unittest skills/autoreview/scripts/autoreview_test.py skills.autoreview.tests.test_autoreview_hardening`
- `uv run --with PyYAML==6.0.3 scripts/validate-skills`
- `skills/autoreview/scripts/autoreview --mode uncommitted`
