### PR TITLE
fix(autoreview): allow safe Python runtime references

### DIFF
--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -5549,6 +5549,9 @@ def safe_python_assignment_expression(
         )
         and "--" not in sql_suffix
         and "/*" not in sql_suffix
+        and "--" not in sql_prefix
+        and "/*" not in sql_prefix
+        and not python_comment_secret_risk(sql_prefix)
         and not python_comment_secret_risk(sql_suffix)
     ):
         return True
@@ -5733,7 +5736,7 @@ def python_comment_secret_risk(comment: str) -> bool:
         r"(?i)\b(?:"
         r"(?:default|fallback)(?:\s+is\b\s*|\s*[:=]\s*|\s+)"
         r"|(?:credential|password|secret|token)\s*(?:is\b|[:=])\s*"
-        r")(?P<value>[^\s,;]+)",
+        r")(?P<value>\"[^\"\r\n]*\"|'[^'\r\n]*'|`[^`\r\n]*`|[^\s,;]+)",
         comment,
     )
     for hinted in hints:

--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -5437,9 +5437,13 @@ def python_runtime_expression_is_safe(
         )
 
     def reference_chain(node: ast.AST) -> bool:
-        return isinstance(node, ast.Name) or (
-            isinstance(node, ast.Attribute) and reference_chain(node.value)
-        )
+        depth = 0
+        while isinstance(node, ast.Attribute):
+            node = node.value
+            depth += 1
+            if depth > 256:
+                return False
+        return isinstance(node, ast.Name)
 
     def lookup_expression(node: ast.AST) -> bool:
         if isinstance(node, ast.Subscript):
@@ -5676,6 +5680,37 @@ def python_assignment_value_start(
     ) is None:
         return default_start, separator
     return line_start + annotated.end(), "="
+
+
+def python_annotated_placeholder_is_safe(text: str, value_start: int) -> bool:
+    line_end = value_start
+    for _ in range(64):
+        next_line = text.find("\n", line_end)
+        line_end = len(text) if next_line < 0 else next_line
+        expression = text[value_start:line_end].strip()
+        try:
+            root = ast.parse(expression, mode="eval").body
+        except SyntaxError:
+            pass
+        else:
+            placeholder = (
+                isinstance(root, ast.Constant)
+                and (
+                    root.value is None
+                    or (
+                        isinstance(root.value, str)
+                        and (
+                            not root.value
+                            or root.value.casefold() in SECRET_PLACEHOLDER_VALUES
+                        )
+                    )
+                )
+            )
+            return placeholder and safe_secret_assignment_suffix(text, line_end)
+        if next_line < 0 or line_end - value_start > 32_768:
+            return False
+        line_end = next_line + 1
+    return False
 
 
 def python_comment_secret_risk(comment: str) -> bool:
@@ -5989,6 +6024,8 @@ def secret_text_risk(
         ):
             continue
         if python_source and value_start != default_value_start:
+            if python_annotated_placeholder_is_safe(text, value_start):
+                continue
             return True
         fallback = top_level_fallback_suffix(
             text[prefix.end() :],
@@ -6054,6 +6091,8 @@ def secret_text_risk(
         ):
             continue
         if python_source and value_start != default_value_start:
+            if python_annotated_placeholder_is_safe(text, value_start):
+                continue
             return True
         if (
             key.strip("\"'").lower() == "credentials"

--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -5545,6 +5545,7 @@ def safe_python_assignment_expression(
         environment_mapping = separator == ":" and python_environment_mapping_context(
             text,
             value_start,
+            expected_key,
         )
         if (
             expression
@@ -5562,7 +5563,11 @@ def safe_python_assignment_expression(
     return False
 
 
-def python_environment_mapping_context(text: str, value_start: int) -> bool:
+def python_environment_mapping_context(
+    text: str,
+    value_start: int,
+    expected_key: str,
+) -> bool:
     scan_text = text[:value_start] + "'SAFE_ENVIRONMENT_NAME'\n}\n"
     line_offsets = [0]
     for line in scan_text.splitlines(keepends=True):
@@ -5589,30 +5594,57 @@ def python_environment_mapping_context(text: str, value_start: int) -> bool:
         ]
     except (IndentationError, tokenize.TokenError):
         return False
-    for index in range(len(tokens) - 2):
-        name, assignment, opener = tokens[index : index + 3]
-        if not (
-            name.type == tokenize.NAME
-            and re.fullmatch(
-                r"_*[A-Z][A-Z0-9_]*ENV[A-Z0-9_]*",
-                name.string,
-            )
-            is not None
-            and assignment.type == tokenize.OP
-            and assignment.string == "="
-            and opener.type == tokenize.OP
-            and opener.string == "{"
-            and absolute(opener.end) <= value_start
-        ):
+    value_index = next(
+        (
+            index
+            for index, token in enumerate(tokens)
+            if absolute(token.start) >= value_start
+        ),
+        None,
+    )
+    if value_index is None or value_index < 2:
+        return False
+    key_token, colon, value_token = tokens[value_index - 2 : value_index + 1]
+    if not (
+        key_token.type == tokenize.STRING
+        and colon.type == tokenize.OP
+        and colon.string == ":"
+        and value_token.type == tokenize.STRING
+    ):
+        return False
+    try:
+        key_value = ast.literal_eval(key_token.string)
+    except (SyntaxError, ValueError):
+        return False
+    if key_value != expected_key:
+        return False
+
+    brace_stack: list[int] = []
+    for index, token in enumerate(tokens[: value_index - 1]):
+        if token.type != tokenize.OP:
             continue
-        depth = 0
-        for token in tokens[index + 2 :]:
-            if token.type != tokenize.OP or token.string not in {"{", "}"}:
-                continue
-            depth += 1 if token.string == "{" else -1
-            if depth == 0:
-                return value_start < absolute(token.start)
-    return False
+        if token.string == "{":
+            brace_stack.append(index)
+        elif token.string == "}" and brace_stack:
+            brace_stack.pop()
+    if not brace_stack:
+        return False
+    opener_index = brace_stack[-1]
+    if opener_index < 2:
+        return False
+    name, assignment, opener = tokens[opener_index - 2 : opener_index + 1]
+    return bool(
+        name.type == tokenize.NAME
+        and re.fullmatch(
+            r"_*[A-Z][A-Z0-9_]*(?:BINDING_ENV|ENV_BY_FIELD|FIELD_TO_ENV)",
+            name.string,
+        )
+        is not None
+        and assignment.type == tokenize.OP
+        and assignment.string == "="
+        and opener.type == tokenize.OP
+        and opener.string == "{"
+    )
 
 
 def python_assignment_value_start(
@@ -5659,6 +5691,18 @@ def python_assignment_comment(text: str, value_start: int) -> bool:
         except SyntaxError:
             pass
         else:
+            cursor = line_end + (1 if next_line >= 0 else 0)
+            for _ in range(8):
+                if cursor >= len(text):
+                    return False
+                adjacent_end = text.find("\n", cursor)
+                adjacent_end = len(text) if adjacent_end < 0 else adjacent_end
+                adjacent = text[cursor:adjacent_end].strip()
+                if adjacent.startswith("#"):
+                    return True
+                if adjacent:
+                    return False
+                cursor = adjacent_end + 1
             return False
         if next_line < 0 or line_end - value_start > 32_768:
             return False

--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -5963,10 +5963,11 @@ def secret_text_risk(
         separator_match = re.search(r"[:=]", prefix.group(0))
         assert separator_match is not None
         key = re.split(r"\s*[:=]\s*", prefix.group(0), maxsplit=1)[0]
+        default_value_start = prefix.start() + separator_match.end()
         value_start, separator = python_assignment_value_start(
             text,
             prefix.start(),
-            prefix.start() + separator_match.end(),
+            default_value_start,
             key,
             separator_match.group(0),
         )
@@ -5977,6 +5978,8 @@ def secret_text_risk(
             separator,
         ):
             continue
+        if python_source and value_start != default_value_start:
+            return True
         fallback = top_level_fallback_suffix(
             text[prefix.end() :],
             allow_chained_assignment=(
@@ -6014,10 +6017,11 @@ def secret_text_risk(
         key = re.split(r"\s*[:=]\s*", match.group(0), maxsplit=1)[0]
         separator_match = re.search(r"[:=]", match.group(0))
         assert separator_match is not None
+        default_value_start = match.start() + separator_match.end()
         value_start, separator = python_assignment_value_start(
             text,
             match.start(),
-            match.start() + separator_match.end(),
+            default_value_start,
             key,
             separator_match.group(0),
         )
@@ -6039,6 +6043,8 @@ def secret_text_risk(
             separator,
         ):
             continue
+        if python_source and value_start != default_value_start:
+            return True
         if (
             key.strip("\"'").lower() == "credentials"
             and value.lower() in FETCH_CREDENTIAL_MODE_VALUES

--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -5365,6 +5365,207 @@ def bare_code_reference(
     )
 
 
+def python_runtime_expression_is_safe(
+    expression: str,
+    expected_key: str,
+    *,
+    allow_environment_symbol: bool,
+) -> bool:
+    try:
+        parsed = ast.parse(expression, mode="eval")
+    except SyntaxError:
+        return False
+    root = parsed.body
+    if isinstance(root, ast.Tuple) and len(root.elts) == 1:
+        root = root.elts[0]
+
+    unsafe_prefixes = {
+        "actual",
+        "credential",
+        "hardcoded",
+        "password",
+        "production",
+        "secret",
+    }
+    binding_prefixes = {
+        "attempt",
+        "automation",
+        "binding",
+        "claim",
+        "control",
+        "evidence",
+        "execution",
+        "lease",
+        "request",
+        "response",
+        "result",
+        "runtime",
+        "task",
+        "worker",
+    }
+
+    def binding_name_matches(value: str) -> bool:
+        if re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", value) is None:
+            return False
+        normalized = value.casefold()
+        expected = expected_key.casefold()
+        if normalized == expected:
+            return True
+        for longer, shorter in ((normalized, expected), (expected, normalized)):
+            suffix = "_" + shorter
+            if not longer.endswith(suffix):
+                continue
+            prefix = longer[: -len(suffix)]
+            if prefix in binding_prefixes:
+                return True
+        return False
+
+    def environment_symbol_matches(value: str) -> bool:
+        expected = expected_key.upper()
+        suffix = "_" + expected
+        if not value.endswith(suffix):
+            return False
+        prefix = value[: -len(suffix)]
+        components = prefix.split("_")
+        return bool(components) and all(
+            re.fullmatch(r"[A-Z][A-Z0-9]{0,15}", component) is not None
+            and component.casefold() not in unsafe_prefixes
+            for component in components
+        )
+
+    def reference_chain(node: ast.AST) -> bool:
+        return isinstance(node, ast.Name) or (
+            isinstance(node, ast.Attribute) and reference_chain(node.value)
+        )
+
+    def lookup_expression(node: ast.AST) -> bool:
+        if isinstance(node, ast.Subscript):
+            return (
+                reference_chain(node.value)
+                and isinstance(node.slice, ast.Constant)
+                and isinstance(node.slice.value, str)
+                and binding_name_matches(node.slice.value)
+            )
+        return (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "get"
+            and reference_chain(node.func.value)
+            and len(node.args) == 1
+            and not node.keywords
+            and isinstance(node.args[0], ast.Constant)
+            and isinstance(node.args[0].value, str)
+            and binding_name_matches(node.args[0].value)
+        )
+
+    if (
+        allow_environment_symbol
+        and isinstance(root, ast.Constant)
+        and isinstance(root.value, str)
+        and re.fullmatch(r"[A-Z][A-Z0-9_]{2,}", root.value) is not None
+        and environment_symbol_matches(root.value)
+    ):
+        return True
+
+    if (
+        isinstance(root, ast.Attribute)
+        and reference_chain(root.value)
+        and binding_name_matches(root.attr)
+    ):
+        return True
+    if lookup_expression(root):
+        return True
+    if not (
+        isinstance(root, ast.Call)
+        and isinstance(root.func, ast.Name)
+        and root.func.id == "int"
+        and len(root.args) == 1
+        and not root.keywords
+    ):
+        return False
+    argument = root.args[0]
+    if lookup_expression(argument):
+        return True
+    return (
+        isinstance(argument, ast.BoolOp)
+        and isinstance(argument.op, ast.Or)
+        and len(argument.values) == 2
+        and lookup_expression(argument.values[0])
+        and isinstance(argument.values[1], ast.Constant)
+        and type(argument.values[1].value) is int
+        and argument.values[1].value == 0
+    )
+
+
+def safe_python_assignment_expression(
+    text: str,
+    value_start: int,
+    key: str,
+    separator: str,
+) -> bool:
+    cursor = value_start
+    while cursor < len(text) and text[cursor] in " \t":
+        cursor += 1
+    expected_key = key.strip("\"'")
+    line_start = max(
+        text.rfind("\n", 0, value_start),
+        text.rfind("\r", 0, value_start),
+    ) + 1
+    sql_prefix = text[line_start:cursor]
+    counter = re.match(
+        rf"(?i){re.escape(expected_key)}\s*\+\s*1\b",
+        text[cursor:],
+    )
+    if (
+        counter is not None
+        and re.search(
+            rf"[\"']\s*UPDATE\b[^\"']*\bSET\b[^\"']*"
+            rf"\b{re.escape(expected_key)}\s*=\s*$",
+            sql_prefix,
+            re.IGNORECASE,
+        )
+        is not None
+        and re.match(
+            r"\s+(?:WHERE\b|RETURNING\b)",
+            text[cursor + counter.end() :],
+            re.IGNORECASE,
+        )
+    ):
+        return True
+    line_end = cursor
+    for _ in range(64):
+        next_line = text.find("\n", line_end)
+        line_end = len(text) if next_line < 0 else next_line
+        if line_end - cursor > 32_768:
+            return False
+        expression = text[cursor:line_end].strip()
+        context = text[max(0, value_start - 8192) : value_start]
+        environment_mapping = (
+            separator == ":"
+            and re.search(
+                r"(?<![A-Za-z0-9_])_*[A-Z][A-Z0-9_]*ENV[A-Z0-9_]*"
+                r"\s*=\s*\{[^{}]*$",
+                context,
+                re.DOTALL,
+            )
+            is not None
+        )
+        if (
+            expression
+            and python_runtime_expression_is_safe(
+                expression,
+                expected_key,
+                allow_environment_symbol=environment_mapping,
+            )
+            and safe_secret_assignment_suffix(text, line_end)
+        ):
+            return True
+        if next_line < 0:
+            return False
+        line_end = next_line + 1
+    return False
+
+
 def basic_authorization_risk(text: str) -> bool:
     for match in BASIC_AUTHORIZATION_PATTERN.finditer(text):
         encoded = match.group("credential")
@@ -5521,6 +5722,7 @@ def secret_text_risk(
     text: str,
     *,
     javascript_dialect: str | None = None,
+    python_source: bool = False,
 ) -> bool:
     if DIFF_HUNK_CONTENT_BOUNDARY in text:
         return any(
@@ -5581,6 +5783,15 @@ def secret_text_risk(
             javascript_dialect=javascript_dialect,
         ):
             return True
+        separator_match = re.search(r"[:=]", prefix.group(0))
+        assert separator_match is not None
+        if python_source and safe_python_assignment_expression(
+            text,
+            prefix.start() + separator_match.end(),
+            re.split(r"\s*[:=]\s*", prefix.group(0), maxsplit=1)[0],
+            separator_match.group(0),
+        ):
+            continue
         fallback = top_level_fallback_suffix(
             text[prefix.end() :],
             allow_chained_assignment=(
@@ -5623,6 +5834,13 @@ def secret_text_risk(
             text,
             match,
             javascript_dialect=javascript_dialect,
+        ):
+            continue
+        if python_source and safe_python_assignment_expression(
+            text,
+            match.start() + separator_match.end(),
+            key,
+            separator,
         ):
             continue
         if (
@@ -5766,8 +5984,13 @@ def require_no_secret_values(
     text: str,
     *,
     javascript_dialect: str | None = None,
+    python_source: bool = False,
 ) -> None:
-    if secret_text_risk(text, javascript_dialect=javascript_dialect):
+    if secret_text_risk(
+        text,
+        javascript_dialect=javascript_dialect,
+        python_source=python_source,
+    ):
         raise SystemExit(
             "refusing to include secret-like content in review bundle; "
             f"clean or redact {label} before running autoreview"
@@ -7232,6 +7455,10 @@ def javascript_review_dialect(rel: str) -> str | None:
     return None
 
 
+def python_review_source(rel: str) -> bool:
+    return Path(rel).suffix.lower() in {".py", ".pyi", ".pyw"}
+
+
 def git_c_unquote(value: str) -> str | None:
     if len(value) < 2 or value[0] != '"' or value[-1] != '"':
         return None
@@ -7408,6 +7635,11 @@ def validate_review_patch(
                     f"{label} {rel or '<unknown>'}",
                     content,
                     javascript_dialect=javascript_dialect,
+                    python_source=(
+                        python_review_source(rel)
+                        if rel is not None and rel in expected_paths
+                        else False
+                    ),
                 )
     else:
         for content in unified_diff_contents(patch):

--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -5683,7 +5683,7 @@ def python_comment_secret_risk(comment: str) -> bool:
         return True
     hinted = re.search(
         r"(?i)\b(?:"
-        r"(?:default|fallback)\s+(?:is\s+)?"
+        r"(?:default|fallback)(?:\s+is\b\s*|\s*[:=]\s*|\s+)"
         r"|(?:credential|password|secret|token)\s*(?:is\b|[:=])\s*"
         r")(?P<value>[^\s,;]+)",
         comment,

--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -6316,11 +6316,16 @@ def review_secret_fragments(
     text: str,
     *,
     javascript_dialect: str | None = None,
+    python_source: bool = False,
 ) -> set[str]:
     if DIFF_HUNK_CONTENT_BOUNDARY in text:
         return set().union(
             *(
-                review_secret_fragments(segment, javascript_dialect=javascript_dialect)
+                review_secret_fragments(
+                    segment,
+                    javascript_dialect=javascript_dialect,
+                    python_source=python_source,
+                )
                 for segment in text.split(DIFF_HUNK_CONTENT_BOUNDARY)
             )
         )
@@ -6334,6 +6339,7 @@ def review_secret_fragments(
         for start, end in review_repeatable_secret_spans(
             text,
             javascript_dialect=javascript_dialect,
+            python_source=python_source,
         )
         if text[start:end]
         and text[start:end].casefold() not in SECRET_PLACEHOLDER_VALUES
@@ -6670,6 +6676,7 @@ def review_repeatable_secret_spans(
     text: str,
     *,
     javascript_dialect: str | None = None,
+    python_source: bool = False,
 ) -> list[tuple[int, int]]:
     boolean_declarations = tuple(SECRET_BOOLEAN_DECLARATION_PATTERN.finditer(text))
     boolean_declaration_positions = {
@@ -6710,6 +6717,24 @@ def review_repeatable_secret_spans(
             javascript_dialect=javascript_dialect,
         ):
             continue
+        if python_source:
+            key = re.split(r"\s*[:=]\s*", match.group(0), maxsplit=1)[0]
+            separator_match = re.search(r"[:=]", match.group(0))
+            assert separator_match is not None
+            value_start, separator = python_assignment_value_start(
+                text,
+                match.start(),
+                match.start() + separator_match.end(),
+                key,
+                separator_match.group(0),
+            )
+            if safe_python_assignment_expression(
+                text,
+                value_start,
+                key,
+                separator,
+            ):
+                continue
         fallback_spans = (
             assignment_fallback_literal_spans(
                 text,
@@ -6734,6 +6759,7 @@ def review_repeatable_secret_spans(
         if secret_text_risk(
             match.group(0),
             javascript_dialect=javascript_dialect,
+            python_source=python_source,
         ):
             spans.append(match.span(selected_name))
     for pattern in SECRET_VALUE_PATTERNS:
@@ -6758,6 +6784,7 @@ def review_secret_value_spans(
     text: str,
     *,
     javascript_dialect: str | None = None,
+    python_source: bool = False,
 ) -> list[tuple[int, int]]:
     boolean_declarations = tuple(SECRET_BOOLEAN_DECLARATION_PATTERN.finditer(text))
     boolean_declaration_positions = {
@@ -6790,6 +6817,24 @@ def review_secret_value_spans(
                     javascript_dialect=javascript_dialect,
                 ):
                     break
+                if python_source:
+                    key = re.split(r"\s*[:=]\s*", match.group(0), maxsplit=1)[0]
+                    separator_match = re.search(r"[:=]", match.group(0))
+                    assert separator_match is not None
+                    value_start, separator = python_assignment_value_start(
+                        text,
+                        match.start(),
+                        match.start() + separator_match.end(),
+                        key,
+                        separator_match.group(0),
+                    )
+                    if safe_python_assignment_expression(
+                        text,
+                        value_start,
+                        key,
+                        separator,
+                    ):
+                        break
                 fallback_spans = (
                     assignment_fallback_literal_spans(
                         text,
@@ -6814,6 +6859,7 @@ def review_secret_value_spans(
                 if secret_text_risk(
                     match.group(0),
                     javascript_dialect=javascript_dialect,
+                    python_source=python_source,
                 ):
                     spans.append(match.span(name))
                 break
@@ -7533,13 +7579,31 @@ def redact_secret_like_diff_section(
         if new_path is not None and new_path in expected_paths
         else None
     )
+    old_python = (
+        python_review_source(old_path)
+        if old_path is not None and old_path in expected_paths
+        else False
+    )
+    new_python = (
+        python_review_source(new_path)
+        if new_path is not None and new_path in expected_paths
+        else False
+    )
     secret_fragments = set(known_secret_fragments or ())
     old_content, new_content = unified_diff_contents(section)
-    old_risk = secret_text_risk(old_content, javascript_dialect=old_dialect)
-    new_risk = secret_text_risk(new_content, javascript_dialect=new_dialect)
-    for content, dialect, risk in (
-        (old_content, old_dialect, old_risk),
-        (new_content, new_dialect, new_risk),
+    old_risk = secret_text_risk(
+        old_content,
+        javascript_dialect=old_dialect,
+        python_source=old_python,
+    )
+    new_risk = secret_text_risk(
+        new_content,
+        javascript_dialect=new_dialect,
+        python_source=new_python,
+    )
+    for content, dialect, python_source, risk in (
+        (old_content, old_dialect, old_python, old_risk),
+        (new_content, new_dialect, new_python, new_risk),
     ):
         if not risk:
             continue
@@ -7547,6 +7611,7 @@ def redact_secret_like_diff_section(
             review_secret_fragments(
                 content,
                 javascript_dialect=dialect,
+                python_source=python_source,
             )
         )
     if len(secret_fragments) > MAX_REVIEW_SECRET_FRAGMENTS:
@@ -7592,11 +7657,19 @@ def redact_secret_like_diff_section(
             line_secret_risk = (
                 old_line
                 and old_risk
-                and secret_text_risk(content, javascript_dialect=old_dialect)
+                and secret_text_risk(
+                    content,
+                    javascript_dialect=old_dialect,
+                    python_source=old_python,
+                )
             ) or (
                 new_line
                 and new_risk
-                and secret_text_risk(content, javascript_dialect=new_dialect)
+                and secret_text_risk(
+                    content,
+                    javascript_dialect=new_dialect,
+                    python_source=new_python,
+                )
             )
             if line_secret_risk:
                 dialect = old_dialect if old_line and old_risk else new_dialect
@@ -7604,6 +7677,9 @@ def redact_secret_like_diff_section(
                     review_secret_value_spans(
                         content,
                         javascript_dialect=dialect,
+                        python_source=(
+                            old_python if old_line and old_risk else new_python
+                        ),
                     )
                 )
             fragment_dialect = (
@@ -7881,6 +7957,11 @@ def validate_review_patch(
             all_fragments = review_secret_fragments(
                 content,
                 javascript_dialect=javascript_dialect,
+                python_source=(
+                    python_review_source(rel)
+                    if rel is not None and rel in expected_paths
+                    else False
+                ),
             )
             known_secret_fragments.update(all_fragments)
         known_secret_fragments.update(

--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -5374,7 +5374,7 @@ def python_runtime_expression_is_safe(
 ) -> bool:
     try:
         parsed = ast.parse(expression, mode="eval")
-    except SyntaxError:
+    except (MemoryError, RecursionError, SyntaxError, ValueError):
         return False
     root = parsed.body
     if isinstance(root, ast.Tuple) and len(root.elts) == 1:
@@ -5690,7 +5690,7 @@ def python_annotated_placeholder_is_safe(text: str, value_start: int) -> bool:
         expression = text[value_start:line_end].strip()
         try:
             root = ast.parse(expression, mode="eval").body
-        except SyntaxError:
+        except (MemoryError, RecursionError, SyntaxError, ValueError):
             pass
         else:
             placeholder = (
@@ -5763,7 +5763,7 @@ def python_assignment_comment(text: str, value_start: int) -> bool:
             return True
         try:
             ast.parse(expression.strip(), mode="eval")
-        except SyntaxError:
+        except (MemoryError, RecursionError, SyntaxError, ValueError):
             pass
         else:
             cursor = line_end + (1 if next_line >= 0 else 0)

--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -5429,7 +5429,9 @@ def python_runtime_expression_is_safe(
         components = prefix.split("_")
         return bool(components) and all(
             re.fullmatch(r"[A-Z][A-Z0-9]{0,15}", component) is not None
-            and component.casefold() not in unsafe_prefixes
+            and not any(
+                marker in component.casefold() for marker in unsafe_prefixes
+            )
             for component in components
         )
 
@@ -5564,6 +5566,15 @@ def safe_python_assignment_expression(
             return False
         line_end = next_line + 1
     return False
+
+
+def python_inline_assignment_comment(text: str, start: int) -> bool:
+    line_end = len(text)
+    for terminator in ("\n", "\r"):
+        found = text.find(terminator, start)
+        if found >= 0:
+            line_end = min(line_end, found)
+    return "#" in text[start:line_end]
 
 
 def basic_authorization_risk(text: str) -> bool:
@@ -5836,6 +5847,11 @@ def secret_text_risk(
             javascript_dialect=javascript_dialect,
         ):
             continue
+        if python_source and python_inline_assignment_comment(
+            text,
+            match.end(),
+        ):
+            return True
         if python_source and safe_python_assignment_expression(
             text,
             match.start() + separator_match.end(),

--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -5690,18 +5690,28 @@ def python_comment_secret_risk(comment: str) -> bool:
     )
     if hinted is None:
         return False
-    value = hinted.group("value").strip("\"'`()[]{}")
-    return bool(value) and value.casefold() not in {
-        "caller",
-        "environment",
-        "handling",
-        "none",
-        "placeholder",
-        "redacted",
-        "request",
-        "runtime",
-        "supplied",
-    }
+    raw_value = hinted.group("value")
+    quoted = (
+        len(raw_value) >= 2
+        and raw_value[0] in {"\"", "'", "`"}
+        and raw_value[-1] == raw_value[0]
+    )
+    value = raw_value.strip("\"'`()[]{}")
+    if not value or value.casefold() in SECRET_PLACEHOLDER_VALUES:
+        return False
+    return bool(
+        (quoted and len(value) >= 4)
+        or (
+            len(value) >= 6
+            and any(character.isalpha() for character in value)
+            and any(character.isdigit() for character in value)
+        )
+        or (
+            len(value) >= 6
+            and re.search(r"[^A-Za-z0-9_]", value) is not None
+        )
+        or secret_literal_risk(raw_value, minimum_length=8)
+    )
 
 
 def python_assignment_comment(text: str, value_start: int) -> bool:

--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -24,6 +24,7 @@ import tempfile
 import textwrap
 import threading
 import time
+import tokenize
 import unicodedata
 import urllib.parse
 from pathlib import Path, PurePosixPath
@@ -5541,16 +5542,9 @@ def safe_python_assignment_expression(
         if line_end - cursor > 32_768:
             return False
         expression = text[cursor:line_end].strip()
-        context = text[max(0, value_start - 8192) : value_start]
-        environment_mapping = (
-            separator == ":"
-            and re.search(
-                r"(?<![A-Za-z0-9_])_*[A-Z][A-Z0-9_]*ENV[A-Z0-9_]*"
-                r"\s*=\s*\{[^{}]*$",
-                context,
-                re.DOTALL,
-            )
-            is not None
+        environment_mapping = separator == ":" and python_environment_mapping_context(
+            text,
+            value_start,
         )
         if (
             expression
@@ -5565,6 +5559,56 @@ def safe_python_assignment_expression(
         if next_line < 0:
             return False
         line_end = next_line + 1
+    return False
+
+
+def python_environment_mapping_context(text: str, value_start: int) -> bool:
+    lower = max(0, value_start - 8192)
+    context = text[lower:value_start]
+    candidates = list(
+        re.finditer(
+            r"(?m)^[ \t]*(?P<name>_*[A-Z][A-Z0-9_]*ENV[A-Z0-9_]*)"
+            r"\s*=\s*\{",
+            context,
+        )
+    )
+    ignored = {
+        tokenize.COMMENT,
+        tokenize.DEDENT,
+        tokenize.ENCODING,
+        tokenize.ENDMARKER,
+        tokenize.INDENT,
+        tokenize.NL,
+        tokenize.NEWLINE,
+    }
+    for candidate in reversed(candidates):
+        snippet = textwrap.dedent(context[candidate.start() :])
+        tokens: list[tokenize.TokenInfo] = []
+        generator = tokenize.generate_tokens(io.StringIO(snippet).readline)
+        try:
+            while True:
+                token = next(generator)
+                if token.type not in ignored:
+                    tokens.append(token)
+        except (IndentationError, StopIteration, tokenize.TokenError):
+            pass
+        if len(tokens) < 3:
+            continue
+        brace_balance = sum(
+            1 if token.string == "{" else -1 if token.string == "}" else 0
+            for token in tokens
+            if token.type == tokenize.OP
+        )
+        if (
+            tokens[0].type == tokenize.NAME
+            and tokens[0].string == candidate.group("name")
+            and tokens[1].type == tokenize.OP
+            and tokens[1].string == "="
+            and tokens[2].type == tokenize.OP
+            and tokens[2].string == "{"
+            and brace_balance > 0
+        ):
+            return True
     return False
 
 

--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -1048,6 +1048,21 @@ def safe_temp_root(repo: Path) -> Path:
     return root
 
 
+def validate_testbox_temp_root(root: Path, root_stat: os.stat_result) -> None:
+    """Require a trusted POSIX owner and sticky shared-write semantics."""
+
+    if not stat.S_ISDIR(root_stat.st_mode):
+        raise SystemExit("short Testbox temp root must be a directory")
+    trusted_uids = {0, os.geteuid()}
+    if root_stat.st_uid not in trusted_uids:
+        raise SystemExit(
+            "short Testbox temp root must be owned by root or the current user"
+        )
+    shared_write = root_stat.st_mode & (stat.S_IWGRP | stat.S_IWOTH)
+    if shared_write and not root_stat.st_mode & stat.S_ISVTX:
+        raise SystemExit("shared-writable Testbox temp root must have the sticky bit set")
+
+
 def parallel_test_temp_root(repo: Path) -> Path:
     root = safe_temp_root(repo)
     if os.name == "nt" or not env_truthy("OPENCLAW_TESTBOX"):
@@ -1060,14 +1075,9 @@ def parallel_test_temp_root(repo: Path) -> Path:
         short_root_stat = short_root.stat()
     except OSError as exc:
         raise SystemExit(f"unable to resolve short Testbox temp root: {exc}") from exc
-    if not stat.S_ISDIR(short_root_stat.st_mode):
-        raise SystemExit("short Testbox temp root must be a directory")
+    validate_testbox_temp_root(short_root, short_root_stat)
     if is_within(short_root, repo.resolve()):
         raise SystemExit("short Testbox temp root must be outside the reviewed repository")
-    if short_root_stat.st_mode & stat.S_IWOTH and not (
-        short_root_stat.st_mode & stat.S_ISVTX
-    ):
-        raise SystemExit("world-writable Testbox temp root must have the sticky bit set")
     return short_root
 
 

--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -5634,21 +5634,36 @@ def python_assignment_value_start(
         if found >= 0:
             line_end = min(line_end, found)
     annotated = re.match(
-        rf"[ \t]*{re.escape(key)}[ \t]*:[^#=\r\n]{{1,512}}=[ \t]*",
+        rf"[ \t]*{re.escape(key)}[ \t]*:"
+        rf"(?P<annotation>[^#=\r\n]{{1,512}})=[ \t]*",
         text[line_start:line_end],
     )
-    if annotated is None:
+    if annotated is None or re.fullmatch(
+        r"[A-Za-z_][A-Za-z0-9_.]*",
+        annotated.group("annotation").strip(),
+    ) is None:
         return default_start, separator
     return line_start + annotated.end(), "="
 
 
-def python_inline_assignment_comment(text: str, start: int) -> bool:
-    line_end = len(text)
-    for terminator in ("\n", "\r"):
-        found = text.find(terminator, start)
-        if found >= 0:
-            line_end = min(line_end, found)
-    return "#" in text[start:line_end]
+def python_assignment_comment(text: str, value_start: int) -> bool:
+    line_end = value_start
+    for _ in range(64):
+        next_line = text.find("\n", line_end)
+        line_end = len(text) if next_line < 0 else next_line
+        expression = text[value_start:line_end]
+        if "#" in expression:
+            return True
+        try:
+            ast.parse(expression.strip(), mode="eval")
+        except SyntaxError:
+            pass
+        else:
+            return False
+        if next_line < 0 or line_end - value_start > 32_768:
+            return False
+        line_end = next_line + 1
+    return False
 
 
 def basic_authorization_risk(text: str) -> bool:
@@ -5935,9 +5950,9 @@ def secret_text_risk(
             javascript_dialect=javascript_dialect,
         ):
             continue
-        if python_source and python_inline_assignment_comment(
+        if python_source and python_assignment_comment(
             text,
-            match.end(),
+            value_start,
         ):
             return True
         if python_source and safe_python_assignment_expression(

--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -5678,13 +5678,43 @@ def python_assignment_value_start(
     return line_start + annotated.end(), "="
 
 
+def python_comment_secret_risk(comment: str) -> bool:
+    if secret_literal_risk(comment, minimum_length=8):
+        return True
+    hinted = re.search(
+        r"(?i)\b(?:"
+        r"(?:default|fallback)\s+(?:is\s+)?"
+        r"|(?:credential|password|secret|token)\s*(?:is\b|[:=])\s*"
+        r")(?P<value>[^\s,;]+)",
+        comment,
+    )
+    if hinted is None:
+        return False
+    value = hinted.group("value").strip("\"'`()[]{}")
+    return bool(value) and value.casefold() not in {
+        "caller",
+        "environment",
+        "handling",
+        "none",
+        "placeholder",
+        "redacted",
+        "request",
+        "runtime",
+        "supplied",
+    }
+
+
 def python_assignment_comment(text: str, value_start: int) -> bool:
     line_end = value_start
     for _ in range(64):
         next_line = text.find("\n", line_end)
         line_end = len(text) if next_line < 0 else next_line
         expression = text[value_start:line_end]
-        if "#" in expression:
+        if any(
+            python_comment_secret_risk(line.split("#", 1)[1])
+            for line in expression.splitlines()
+            if "#" in line
+        ):
             return True
         try:
             ast.parse(expression.strip(), mode="eval")
@@ -5699,7 +5729,10 @@ def python_assignment_comment(text: str, value_start: int) -> bool:
                 adjacent_end = len(text) if adjacent_end < 0 else adjacent_end
                 adjacent = text[cursor:adjacent_end].strip()
                 if adjacent.startswith("#"):
-                    return True
+                    if python_comment_secret_risk(adjacent[1:]):
+                        return True
+                    cursor = adjacent_end + 1
+                    continue
                 if adjacent:
                     return False
                 cursor = adjacent_end + 1

--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -5563,15 +5563,15 @@ def safe_python_assignment_expression(
 
 
 def python_environment_mapping_context(text: str, value_start: int) -> bool:
-    lower = max(0, value_start - 8192)
-    context = text[lower:value_start]
-    candidates = list(
-        re.finditer(
-            r"(?m)^[ \t]*(?P<name>_*[A-Z][A-Z0-9_]*ENV[A-Z0-9_]*)"
-            r"\s*=\s*\{",
-            context,
-        )
-    )
+    scan_text = text[:value_start] + "'SAFE_ENVIRONMENT_NAME'\n}\n"
+    line_offsets = [0]
+    for line in scan_text.splitlines(keepends=True):
+        line_offsets.append(line_offsets[-1] + len(line))
+
+    def absolute(position: tuple[int, int]) -> int:
+        line, column = position
+        return line_offsets[line - 1] + column
+
     ignored = {
         tokenize.COMMENT,
         tokenize.DEDENT,
@@ -5581,35 +5581,65 @@ def python_environment_mapping_context(text: str, value_start: int) -> bool:
         tokenize.NL,
         tokenize.NEWLINE,
     }
-    for candidate in reversed(candidates):
-        snippet = textwrap.dedent(context[candidate.start() :])
-        tokens: list[tokenize.TokenInfo] = []
-        generator = tokenize.generate_tokens(io.StringIO(snippet).readline)
-        try:
-            while True:
-                token = next(generator)
-                if token.type not in ignored:
-                    tokens.append(token)
-        except (IndentationError, StopIteration, tokenize.TokenError):
-            pass
-        if len(tokens) < 3:
-            continue
-        brace_balance = sum(
-            1 if token.string == "{" else -1 if token.string == "}" else 0
-            for token in tokens
-            if token.type == tokenize.OP
-        )
-        if (
-            tokens[0].type == tokenize.NAME
-            and tokens[0].string == candidate.group("name")
-            and tokens[1].type == tokenize.OP
-            and tokens[1].string == "="
-            and tokens[2].type == tokenize.OP
-            and tokens[2].string == "{"
-            and brace_balance > 0
+    try:
+        tokens = [
+            token
+            for token in tokenize.generate_tokens(io.StringIO(scan_text).readline)
+            if token.type not in ignored
+        ]
+    except (IndentationError, tokenize.TokenError):
+        return False
+    for index in range(len(tokens) - 2):
+        name, assignment, opener = tokens[index : index + 3]
+        if not (
+            name.type == tokenize.NAME
+            and re.fullmatch(
+                r"_*[A-Z][A-Z0-9_]*ENV[A-Z0-9_]*",
+                name.string,
+            )
+            is not None
+            and assignment.type == tokenize.OP
+            and assignment.string == "="
+            and opener.type == tokenize.OP
+            and opener.string == "{"
+            and absolute(opener.end) <= value_start
         ):
-            return True
+            continue
+        depth = 0
+        for token in tokens[index + 2 :]:
+            if token.type != tokenize.OP or token.string not in {"{", "}"}:
+                continue
+            depth += 1 if token.string == "{" else -1
+            if depth == 0:
+                return value_start < absolute(token.start)
     return False
+
+
+def python_assignment_value_start(
+    text: str,
+    assignment_start: int,
+    default_start: int,
+    key: str,
+    separator: str,
+) -> tuple[int, str]:
+    if separator != ":" or key.startswith(("\"", "'")):
+        return default_start, separator
+    line_start = max(
+        text.rfind("\n", 0, assignment_start),
+        text.rfind("\r", 0, assignment_start),
+    ) + 1
+    line_end = len(text)
+    for terminator in ("\n", "\r"):
+        found = text.find(terminator, assignment_start)
+        if found >= 0:
+            line_end = min(line_end, found)
+    annotated = re.match(
+        rf"[ \t]*{re.escape(key)}[ \t]*:[^#=\r\n]{{1,512}}=[ \t]*",
+        text[line_start:line_end],
+    )
+    if annotated is None:
+        return default_start, separator
+    return line_start + annotated.end(), "="
 
 
 def python_inline_assignment_comment(text: str, start: int) -> bool:
@@ -5840,11 +5870,19 @@ def secret_text_risk(
             return True
         separator_match = re.search(r"[:=]", prefix.group(0))
         assert separator_match is not None
+        key = re.split(r"\s*[:=]\s*", prefix.group(0), maxsplit=1)[0]
+        value_start, separator = python_assignment_value_start(
+            text,
+            prefix.start(),
+            prefix.start() + separator_match.end(),
+            key,
+            separator_match.group(0),
+        )
         if python_source and safe_python_assignment_expression(
             text,
-            prefix.start() + separator_match.end(),
-            re.split(r"\s*[:=]\s*", prefix.group(0), maxsplit=1)[0],
-            separator_match.group(0),
+            value_start,
+            key,
+            separator,
         ):
             continue
         fallback = top_level_fallback_suffix(
@@ -5884,7 +5922,13 @@ def secret_text_risk(
         key = re.split(r"\s*[:=]\s*", match.group(0), maxsplit=1)[0]
         separator_match = re.search(r"[:=]", match.group(0))
         assert separator_match is not None
-        separator = separator_match.group(0)
+        value_start, separator = python_assignment_value_start(
+            text,
+            match.start(),
+            match.start() + separator_match.end(),
+            key,
+            separator_match.group(0),
+        )
         if safe_self_reference_assignment(
             text,
             match,
@@ -5898,7 +5942,7 @@ def secret_text_risk(
             return True
         if python_source and safe_python_assignment_expression(
             text,
-            match.start() + separator_match.end(),
+            value_start,
             key,
             separator,
         ):

--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -5730,7 +5730,11 @@ def python_annotated_placeholder_is_safe(text: str, value_start: int) -> bool:
 
 
 def python_comment_secret_risk(comment: str) -> bool:
-    if secret_literal_risk(comment, minimum_length=8):
+    if (
+        credentialed_uri_risk(comment)
+        or basic_authorization_risk(comment)
+        or any(pattern.search(comment) for pattern in SECRET_VALUE_PATTERNS)
+    ):
         return True
     hints = re.finditer(
         r"(?i)\b(?:"
@@ -5802,6 +5806,21 @@ def python_assignment_comment(text: str, value_start: int) -> bool:
         if next_line < 0 or line_end - value_start > 32_768:
             return False
         line_end = next_line + 1
+    return False
+
+
+def python_source_comment_secret_risk(text: str) -> bool:
+    for line in text.splitlines(keepends=True):
+        try:
+            tokens = tokenize.generate_tokens(io.StringIO(line).readline)
+            for token in tokens:
+                if (
+                    token.type == tokenize.COMMENT
+                    and python_comment_secret_risk(token.string[1:])
+                ):
+                    return True
+        except (IndentationError, tokenize.TokenError):
+            continue
     return False
 
 
@@ -5965,9 +5984,15 @@ def secret_text_risk(
 ) -> bool:
     if DIFF_HUNK_CONTENT_BOUNDARY in text:
         return any(
-            secret_text_risk(segment, javascript_dialect=javascript_dialect)
+            secret_text_risk(
+                segment,
+                javascript_dialect=javascript_dialect,
+                python_source=python_source,
+            )
             for segment in text.split(DIFF_HUNK_CONTENT_BOUNDARY)
         )
+    if python_source and python_source_comment_secret_risk(text):
+        return True
     uri_authorities = uri_authority_ranges(text)
     if credentialed_uri_risk(text, uri_authorities) or basic_authorization_risk(text) or any(
         pattern.search(text) for pattern in SECRET_VALUE_PATTERNS

--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -5523,6 +5523,15 @@ def safe_python_assignment_expression(
         rf"(?i){re.escape(expected_key)}\s*\+\s*1\b",
         text[cursor:],
     )
+    sql_suffix = ""
+    if counter is not None:
+        sql_suffix_start = cursor + counter.end()
+        sql_suffix_end = len(text)
+        for terminator in ("\n", "\r"):
+            found = text.find(terminator, sql_suffix_start)
+            if found >= 0:
+                sql_suffix_end = min(sql_suffix_end, found)
+        sql_suffix = text[sql_suffix_start:sql_suffix_end]
     if (
         counter is not None
         and re.search(
@@ -5532,11 +5541,15 @@ def safe_python_assignment_expression(
             re.IGNORECASE,
         )
         is not None
+        and sql_suffix
         and re.match(
             r"\s+(?:WHERE\b|RETURNING\b)",
-            text[cursor + counter.end() :],
+            sql_suffix,
             re.IGNORECASE,
         )
+        and "--" not in sql_suffix
+        and "/*" not in sql_suffix
+        and not python_comment_secret_risk(sql_suffix)
     ):
         return True
     line_end = cursor
@@ -5716,37 +5729,38 @@ def python_annotated_placeholder_is_safe(text: str, value_start: int) -> bool:
 def python_comment_secret_risk(comment: str) -> bool:
     if secret_literal_risk(comment, minimum_length=8):
         return True
-    hinted = re.search(
+    hints = re.finditer(
         r"(?i)\b(?:"
         r"(?:default|fallback)(?:\s+is\b\s*|\s*[:=]\s*|\s+)"
         r"|(?:credential|password|secret|token)\s*(?:is\b|[:=])\s*"
         r")(?P<value>[^\s,;]+)",
         comment,
     )
-    if hinted is None:
-        return False
-    raw_value = hinted.group("value")
-    quoted = (
-        len(raw_value) >= 2
-        and raw_value[0] in {"\"", "'", "`"}
-        and raw_value[-1] == raw_value[0]
-    )
-    value = raw_value.strip("\"'`()[]{}")
-    if not value or value.casefold() in SECRET_PLACEHOLDER_VALUES:
-        return False
-    return bool(
-        (quoted and len(value) >= 4)
-        or (
-            len(value) >= 6
-            and any(character.isalpha() for character in value)
-            and any(character.isdigit() for character in value)
+    for hinted in hints:
+        raw_value = hinted.group("value")
+        quoted = (
+            len(raw_value) >= 2
+            and raw_value[0] in {"\"", "'", "`"}
+            and raw_value[-1] == raw_value[0]
         )
-        or (
-            len(value) >= 6
-            and re.search(r"[^A-Za-z0-9_]", value) is not None
-        )
-        or secret_literal_risk(raw_value, minimum_length=8)
-    )
+        value = raw_value.strip("\"'`()[]{}")
+        if not value or value.casefold() in SECRET_PLACEHOLDER_VALUES:
+            continue
+        if (
+            (quoted and len(value) >= 4)
+            or (
+                len(value) >= 6
+                and any(character.isalpha() for character in value)
+                and any(character.isdigit() for character in value)
+            )
+            or (
+                len(value) >= 6
+                and re.search(r"[^A-Za-z0-9_]", value) is not None
+            )
+            or secret_literal_risk(raw_value, minimum_length=8)
+        ):
+            return True
+    return False
 
 
 def python_assignment_comment(text: str, value_start: int) -> bool:

--- a/skills/autoreview/tests/test_autoreview_hardening.py
+++ b/skills/autoreview/tests/test_autoreview_hardening.py
@@ -2834,6 +2834,15 @@ class AutoreviewHardeningTests(unittest.TestCase):
             f"+{password_key} = request.{password_key}  # supplied by caller\n"
             "+# Validate before use\n"
         )
+        benign_prose_comment_source_patch = (
+            "diff --git a/runtime.py b/runtime.py\n"
+            "--- a/runtime.py\n"
+            "+++ b/runtime.py\n"
+            "@@ -0,0 +1,2 @@\n"
+            f"+{password_key} = request.{password_key}  "
+            f"# {password_key} is read from the request\n"
+            "+# fallback is required\n"
+        )
         unsafe_annotation_source_patch = (
             "diff --git a/runtime.py b/runtime.py\n"
             "--- a/runtime.py\n"
@@ -2941,6 +2950,14 @@ class AutoreviewHardeningTests(unittest.TestCase):
                 benign_comment_source_patch,
             ),
             benign_comment_source_patch,
+        )
+        self.assertEqual(
+            self.helper["validate_review_patch"](
+                "branch diff",
+                ["runtime.py"],
+                benign_prose_comment_source_patch,
+            ),
+            benign_prose_comment_source_patch,
         )
         self.assertFalse(
             self.helper["python_runtime_expression_is_safe"](

--- a/skills/autoreview/tests/test_autoreview_hardening.py
+++ b/skills/autoreview/tests/test_autoreview_hardening.py
@@ -2735,6 +2735,13 @@ class AutoreviewHardeningTests(unittest.TestCase):
             f"+    evidence.get({key!r}) or 0\n"
             "+),\n"
         )
+        annotated_source_patch = (
+            "diff --git a/runtime.py b/runtime.py\n"
+            "--- a/runtime.py\n"
+            "+++ b/runtime.py\n"
+            "@@ -0,0 +1 @@\n"
+            f"+{key}: int = attempt.{binding_key}\n"
+        )
         sql_source_patch = (
             "diff --git a/runtime.py b/runtime.py\n"
             "--- a/runtime.py\n"
@@ -2808,6 +2815,16 @@ class AutoreviewHardeningTests(unittest.TestCase):
             "+mapping_hint = '_RUNTIME_ENV = {'\n"
             f"+{password_key}: {opaque_environment_name!r}\n"
         )
+        multiline_string_spoofed_environment_patch = (
+            "diff --git a/runtime.py b/runtime.py\n"
+            "--- a/runtime.py\n"
+            "+++ b/runtime.py\n"
+            "@@ -0,0 +1,4 @@\n"
+            '+mapping_hint = """\n'
+            "+_RUNTIME_ENV = {\n"
+            '+"""\n'
+            f"+{password_key}: {opaque_environment_name!r}\n"
+        )
 
         self.assertEqual(
             self.helper["validate_review_patch"](
@@ -2824,6 +2841,14 @@ class AutoreviewHardeningTests(unittest.TestCase):
                 multiline_source_patch,
             ),
             multiline_source_patch,
+        )
+        self.assertEqual(
+            self.helper["validate_review_patch"](
+                "branch diff",
+                ["runtime.py"],
+                annotated_source_patch,
+            ),
+            annotated_source_patch,
         )
         self.assertEqual(
             self.helper["validate_review_patch"](
@@ -2879,6 +2904,7 @@ class AutoreviewHardeningTests(unittest.TestCase):
             inline_comment_source_patch,
             comment_spoofed_environment_patch,
             string_spoofed_environment_patch,
+            multiline_string_spoofed_environment_patch,
         ):
             with self.subTest(patch=patch), self.assertRaisesRegex(
                 SystemExit,

--- a/skills/autoreview/tests/test_autoreview_hardening.py
+++ b/skills/autoreview/tests/test_autoreview_hardening.py
@@ -2809,6 +2809,14 @@ class AutoreviewHardeningTests(unittest.TestCase):
             f"# fallback {comment_fallback}\n"
             "+)\n"
         )
+        adjacent_comment_source_patch = (
+            "diff --git a/runtime.py b/runtime.py\n"
+            "--- a/runtime.py\n"
+            "+++ b/runtime.py\n"
+            "@@ -0,0 +1,2 @@\n"
+            f"+{password_key} = request.{password_key}\n"
+            f"+# fallback is {comment_fallback}\n"
+        )
         unsafe_annotation_source_patch = (
             "diff --git a/runtime.py b/runtime.py\n"
             "--- a/runtime.py\n"
@@ -2842,6 +2850,17 @@ class AutoreviewHardeningTests(unittest.TestCase):
             "+_RUNTIME_ENV = {\n"
             '+"""\n'
             f"+{password_key}: {opaque_environment_name!r}\n"
+        )
+        nested_environment_mapping_patch = (
+            "diff --git a/runtime.py b/runtime.py\n"
+            "--- a/runtime.py\n"
+            "+++ b/runtime.py\n"
+            "@@ -0,0 +1,5 @@\n"
+            "+_RUNTIME_ENV_BY_FIELD = {\n"
+            "+    'defaults': {\n"
+            f"+        {password_key!r}: {opaque_environment_name!r},\n"
+            "+    },\n"
+            "+}\n"
         )
 
         self.assertEqual(
@@ -2921,10 +2940,12 @@ class AutoreviewHardeningTests(unittest.TestCase):
             concatenated_marker_environment_patch,
             inline_comment_source_patch,
             multiline_comment_source_patch,
+            adjacent_comment_source_patch,
             unsafe_annotation_source_patch,
             comment_spoofed_environment_patch,
             string_spoofed_environment_patch,
             multiline_string_spoofed_environment_patch,
+            nested_environment_mapping_patch,
         ):
             with self.subTest(patch=patch), self.assertRaisesRegex(
                 SystemExit,

--- a/skills/autoreview/tests/test_autoreview_hardening.py
+++ b/skills/autoreview/tests/test_autoreview_hardening.py
@@ -2683,6 +2683,7 @@ class AutoreviewHardeningTests(unittest.TestCase):
         unsafe_environment_name = "ACTUAL_PRODUCTION_" + "PASSWORD"
         concatenated_environment_name = "ACTUAL" + "SECRET_PASSWORD"
         comment_fallback = "hunter" + "2"
+        opaque_environment_name = "Q7R9M2K4_" + "PASSWORD"
         safe_lines = (
             f"{key} = attempt.{binding_key}\n"
             f"{binding_key} = int(evidence[{key!r}])\n"
@@ -2791,6 +2792,22 @@ class AutoreviewHardeningTests(unittest.TestCase):
             f"+{password_key} = request.{password_key}  "
             f"# fallback is {comment_fallback}\n"
         )
+        comment_spoofed_environment_patch = (
+            "diff --git a/runtime.py b/runtime.py\n"
+            "--- a/runtime.py\n"
+            "+++ b/runtime.py\n"
+            "@@ -0,0 +1,2 @@\n"
+            "+# _RUNTIME_ENV = {\n"
+            f"+{password_key}: {opaque_environment_name!r}\n"
+        )
+        string_spoofed_environment_patch = (
+            "diff --git a/runtime.py b/runtime.py\n"
+            "--- a/runtime.py\n"
+            "+++ b/runtime.py\n"
+            "@@ -0,0 +1,2 @@\n"
+            "+mapping_hint = '_RUNTIME_ENV = {'\n"
+            f"+{password_key}: {opaque_environment_name!r}\n"
+        )
 
         self.assertEqual(
             self.helper["validate_review_patch"](
@@ -2860,6 +2877,8 @@ class AutoreviewHardeningTests(unittest.TestCase):
             unsafe_environment_source_patch,
             concatenated_marker_environment_patch,
             inline_comment_source_patch,
+            comment_spoofed_environment_patch,
+            string_spoofed_environment_patch,
         ):
             with self.subTest(patch=patch), self.assertRaisesRegex(
                 SystemExit,

--- a/skills/autoreview/tests/test_autoreview_hardening.py
+++ b/skills/autoreview/tests/test_autoreview_hardening.py
@@ -2675,6 +2675,179 @@ class AutoreviewHardeningTests(unittest.TestCase):
                     source_patch + config_patch,
                 )
 
+    def test_review_patch_scopes_runtime_references_to_python_files(self) -> None:
+        key = "control_" + "fencing_" + "token"
+        binding_key = "fencing_" + "token"
+        environment_name = "HAVA_SYNC_CONTROL_" + "FENCING_TOKEN"
+        safe_lines = (
+            f"{key} = attempt.{binding_key}\n"
+            f"{binding_key} = int(evidence[{key!r}])\n"
+            f"{binding_key} = int(evidence.get({key!r}) or 0)\n"
+        )
+        source_patch = (
+            "diff --git a/runtime.py b/runtime.py\n"
+            "--- a/runtime.py\n"
+            "+++ b/runtime.py\n"
+            "@@ -1,3 +1,3 @@\n"
+            + "".join(f"-{line}" for line in safe_lines.splitlines(keepends=True))
+            + "".join(f"+{line}" for line in safe_lines.splitlines(keepends=True))
+        )
+        config_patch = (
+            "diff --git a/runtime.yml b/runtime.yml\n"
+            "--- a/runtime.yml\n"
+            "+++ b/runtime.yml\n"
+            "@@ -0,0 +1 @@\n"
+            f"+{key}: attempt.{key}\n"
+        )
+        literal = "actual-production-" + "secret"
+        hardcoded_source_patch = (
+            "diff --git a/runtime.py b/runtime.py\n"
+            "--- a/runtime.py\n"
+            "+++ b/runtime.py\n"
+            "@@ -0,0 +1 @@\n"
+            f"+{key} = {literal!r}\n"
+        )
+        numeric_source_patch = (
+            "diff --git a/runtime.py b/runtime.py\n"
+            "--- a/runtime.py\n"
+            "+++ b/runtime.py\n"
+            "@@ -0,0 +1 @@\n"
+            f"+{key} = 12345678901234567890\n"
+        )
+        fallback_source_patch = (
+            "diff --git a/runtime.py b/runtime.py\n"
+            "--- a/runtime.py\n"
+            "+++ b/runtime.py\n"
+            "@@ -0,0 +1 @@\n"
+            f"+{key} = int(evidence.get({key!r}) or {literal!r})\n"
+        )
+        multiline_source_patch = (
+            "diff --git a/runtime.py b/runtime.py\n"
+            "--- a/runtime.py\n"
+            "+++ b/runtime.py\n"
+            "@@ -0,0 +1,3 @@\n"
+            f"+{key!r}: int(\n"
+            f"+    evidence.get({key!r}) or 0\n"
+            "+),\n"
+        )
+        sql_source_patch = (
+            "diff --git a/runtime.py b/runtime.py\n"
+            "--- a/runtime.py\n"
+            "+++ b/runtime.py\n"
+            "@@ -0,0 +1 @@\n"
+            f'+    "UPDATE leases SET {binding_key}={binding_key}+1 '
+            'WHERE task_id=?",\n'
+        )
+        environment_source_patch = (
+            "diff --git a/runtime.py b/runtime.py\n"
+            "--- a/runtime.py\n"
+            "+++ b/runtime.py\n"
+            "@@ -0,0 +1,3 @@\n"
+            "+_RUNTIME_ENV_BY_FIELD = {\n"
+            f"+    {key!r}: {environment_name!r},\n"
+            "+}\n"
+        )
+        standalone_environment_source_patch = (
+            "diff --git a/runtime.py b/runtime.py\n"
+            "--- a/runtime.py\n"
+            "+++ b/runtime.py\n"
+            "@@ -0,0 +1 @@\n"
+            f"+{key!r}: {environment_name!r},\n"
+        )
+        ordinary_counter_source_patch = (
+            "diff --git a/runtime.py b/runtime.py\n"
+            "--- a/runtime.py\n"
+            "+++ b/runtime.py\n"
+            "@@ -0,0 +1 @@\n"
+            f"+{binding_key} = {binding_key} + 1,\n"
+        )
+        unsafe_environment_source_patch = (
+            "diff --git a/runtime.py b/runtime.py\n"
+            "--- a/runtime.py\n"
+            "+++ b/runtime.py\n"
+            "@@ -0,0 +1,3 @@\n"
+            "+_RUNTIME_ENV_BY_FIELD = {\n"
+            "+    'password': 'ACTUAL_PRODUCTION_PASSWORD',\n"
+            "+}\n"
+        )
+
+        self.assertEqual(
+            self.helper["validate_review_patch"](
+                "branch diff",
+                ["runtime.py"],
+                source_patch,
+            ),
+            source_patch,
+        )
+        self.assertEqual(
+            self.helper["validate_review_patch"](
+                "branch diff",
+                ["runtime.py"],
+                multiline_source_patch,
+            ),
+            multiline_source_patch,
+        )
+        self.assertEqual(
+            self.helper["validate_review_patch"](
+                "branch diff",
+                ["runtime.py"],
+                sql_source_patch,
+            ),
+            sql_source_patch,
+        )
+        self.assertEqual(
+            self.helper["validate_review_patch"](
+                "branch diff",
+                ["runtime.py"],
+                environment_source_patch,
+            ),
+            environment_source_patch,
+        )
+        self.assertFalse(
+            self.helper["python_runtime_expression_is_safe"](
+                "chr(65) * 32",
+                key,
+                allow_environment_symbol=False,
+            )
+        )
+        self.assertFalse(
+            self.helper["python_runtime_expression_is_safe"](
+                "evidence['a7f9k2m4q8v6n3x5r1p0t9z8_token']",
+                "token",
+                allow_environment_symbol=False,
+            )
+        )
+        self.assertFalse(
+            self.helper["python_runtime_expression_is_safe"](
+                f"evidence[{literal + '_' + binding_key!r}]",
+                binding_key,
+                allow_environment_symbol=False,
+            )
+        )
+        with self.assertRaisesRegex(SystemExit, "secret-like content"):
+            self.helper["validate_review_patch"](
+                "branch diff",
+                ["runtime.py", "runtime.yml"],
+                source_patch + config_patch,
+            )
+        for patch in (
+            hardcoded_source_patch,
+            numeric_source_patch,
+            fallback_source_patch,
+            standalone_environment_source_patch,
+            ordinary_counter_source_patch,
+            unsafe_environment_source_patch,
+        ):
+            with self.subTest(patch=patch), self.assertRaisesRegex(
+                SystemExit,
+                "secret-like content",
+            ):
+                self.helper["validate_review_patch"](
+                    "branch diff",
+                    ["runtime.py"],
+                    patch,
+                )
+
     def test_review_patch_scans_rename_sides_with_their_own_file_types(self) -> None:
         property_name = "pass" + "word"
         reference = "context.driverPass" + "word"

--- a/skills/autoreview/tests/test_autoreview_hardening.py
+++ b/skills/autoreview/tests/test_autoreview_hardening.py
@@ -2817,6 +2817,14 @@ class AutoreviewHardeningTests(unittest.TestCase):
             f"+{password_key} = request.{password_key}\n"
             f"+# fallback is {comment_fallback}\n"
         )
+        benign_comment_source_patch = (
+            "diff --git a/runtime.py b/runtime.py\n"
+            "--- a/runtime.py\n"
+            "+++ b/runtime.py\n"
+            "@@ -0,0 +1,2 @@\n"
+            f"+{password_key} = request.{password_key}  # supplied by caller\n"
+            "+# Validate before use\n"
+        )
         unsafe_annotation_source_patch = (
             "diff --git a/runtime.py b/runtime.py\n"
             "--- a/runtime.py\n"
@@ -2902,6 +2910,14 @@ class AutoreviewHardeningTests(unittest.TestCase):
                 environment_source_patch,
             ),
             environment_source_patch,
+        )
+        self.assertEqual(
+            self.helper["validate_review_patch"](
+                "branch diff",
+                ["runtime.py"],
+                benign_comment_source_patch,
+            ),
+            benign_comment_source_patch,
         )
         self.assertFalse(
             self.helper["python_runtime_expression_is_safe"](

--- a/skills/autoreview/tests/test_autoreview_hardening.py
+++ b/skills/autoreview/tests/test_autoreview_hardening.py
@@ -2817,6 +2817,15 @@ class AutoreviewHardeningTests(unittest.TestCase):
             f"+{password_key} = request.{password_key}\n"
             f"+# fallback is {comment_fallback}\n"
         )
+        delimited_comment_source_patches = (
+            "diff --git a/runtime.py b/runtime.py\n"
+            "--- a/runtime.py\n"
+            "+++ b/runtime.py\n"
+            "@@ -0,0 +1,2 @@\n"
+            f"+{password_key} = request.{password_key}  "
+            f"# fallback: {comment_fallback}\n"
+            f"+# fallback = {comment_fallback}\n"
+        )
         benign_comment_source_patch = (
             "diff --git a/runtime.py b/runtime.py\n"
             "--- a/runtime.py\n"
@@ -2971,6 +2980,7 @@ class AutoreviewHardeningTests(unittest.TestCase):
             inline_comment_source_patch,
             multiline_comment_source_patch,
             adjacent_comment_source_patch,
+            delimited_comment_source_patches,
             unsafe_annotation_source_patch,
             literal_annotation_source_patch,
             numeric_annotation_source_patch,

--- a/skills/autoreview/tests/test_autoreview_hardening.py
+++ b/skills/autoreview/tests/test_autoreview_hardening.py
@@ -2750,6 +2750,14 @@ class AutoreviewHardeningTests(unittest.TestCase):
             f'+    "UPDATE leases SET {binding_key}={binding_key}+1 '
             'WHERE task_id=?",\n'
         )
+        sql_comment_source_patch = (
+            "diff --git a/runtime.py b/runtime.py\n"
+            "--- a/runtime.py\n"
+            "+++ b/runtime.py\n"
+            "@@ -0,0 +1 @@\n"
+            f'+    "UPDATE leases SET {binding_key}={binding_key}+1 '
+            f'WHERE task_id=? -- {password_key} is {comment_fallback}",\n'
+        )
         environment_source_patch = (
             "diff --git a/runtime.py b/runtime.py\n"
             "--- a/runtime.py\n"
@@ -2825,6 +2833,14 @@ class AutoreviewHardeningTests(unittest.TestCase):
             f"+{password_key} = request.{password_key}  "
             f"# fallback: {comment_fallback}\n"
             f"+# fallback = {comment_fallback}\n"
+        )
+        multiple_hint_comment_source_patch = (
+            "diff --git a/runtime.py b/runtime.py\n"
+            "--- a/runtime.py\n"
+            "+++ b/runtime.py\n"
+            "@@ -0,0 +1 @@\n"
+            f"+{password_key} = request.{password_key}  "
+            f"# default is required; {password_key} is {comment_fallback}\n"
         )
         benign_comment_source_patch = (
             "diff --git a/runtime.py b/runtime.py\n"
@@ -3030,12 +3046,14 @@ class AutoreviewHardeningTests(unittest.TestCase):
             fallback_source_patch,
             standalone_environment_source_patch,
             ordinary_counter_source_patch,
+            sql_comment_source_patch,
             unsafe_environment_source_patch,
             concatenated_marker_environment_patch,
             inline_comment_source_patch,
             multiline_comment_source_patch,
             adjacent_comment_source_patch,
             delimited_comment_source_patches,
+            multiple_hint_comment_source_patch,
             unsafe_annotation_source_patch,
             literal_annotation_source_patch,
             numeric_annotation_source_patch,

--- a/skills/autoreview/tests/test_autoreview_hardening.py
+++ b/skills/autoreview/tests/test_autoreview_hardening.py
@@ -2833,6 +2833,14 @@ class AutoreviewHardeningTests(unittest.TestCase):
             f"+{password_key} = request.{password_key}\n"
             f"+# fallback is {comment_fallback}\n"
         )
+        preceding_comment_source_patch = (
+            "diff --git a/runtime.py b/runtime.py\n"
+            "--- a/runtime.py\n"
+            "+++ b/runtime.py\n"
+            "@@ -0,0 +1,2 @@\n"
+            f"+# fallback is {comment_fallback}\n"
+            f"+{password_key} = request.{password_key}\n"
+        )
         delimited_comment_source_patches = (
             "diff --git a/runtime.py b/runtime.py\n"
             "--- a/runtime.py\n"
@@ -3069,6 +3077,7 @@ class AutoreviewHardeningTests(unittest.TestCase):
             inline_comment_source_patch,
             multiline_comment_source_patch,
             adjacent_comment_source_patch,
+            preceding_comment_source_patch,
             delimited_comment_source_patches,
             multiple_hint_comment_source_patch,
             quoted_hint_comment_source_patch,

--- a/skills/autoreview/tests/test_autoreview_hardening.py
+++ b/skills/autoreview/tests/test_autoreview_hardening.py
@@ -2681,6 +2681,8 @@ class AutoreviewHardeningTests(unittest.TestCase):
         environment_name = "HAVA_SYNC_CONTROL_" + "FENCING_TOKEN"
         password_key = "pass" + "word"
         unsafe_environment_name = "ACTUAL_PRODUCTION_" + "PASSWORD"
+        concatenated_environment_name = "ACTUAL" + "SECRET_PASSWORD"
+        comment_fallback = "hunter" + "2"
         safe_lines = (
             f"{key} = attempt.{binding_key}\n"
             f"{binding_key} = int(evidence[{key!r}])\n"
@@ -2772,6 +2774,23 @@ class AutoreviewHardeningTests(unittest.TestCase):
             f"+    {password_key!r}: {unsafe_environment_name!r},\n"
             "+}\n"
         )
+        concatenated_marker_environment_patch = (
+            "diff --git a/runtime.py b/runtime.py\n"
+            "--- a/runtime.py\n"
+            "+++ b/runtime.py\n"
+            "@@ -0,0 +1,3 @@\n"
+            "+_RUNTIME_ENV_BY_FIELD = {\n"
+            f"+    {password_key!r}: {concatenated_environment_name!r},\n"
+            "+}\n"
+        )
+        inline_comment_source_patch = (
+            "diff --git a/runtime.py b/runtime.py\n"
+            "--- a/runtime.py\n"
+            "+++ b/runtime.py\n"
+            "@@ -0,0 +1 @@\n"
+            f"+{password_key} = request.{password_key}  "
+            f"# fallback is {comment_fallback}\n"
+        )
 
         self.assertEqual(
             self.helper["validate_review_patch"](
@@ -2839,6 +2858,8 @@ class AutoreviewHardeningTests(unittest.TestCase):
             standalone_environment_source_patch,
             ordinary_counter_source_patch,
             unsafe_environment_source_patch,
+            concatenated_marker_environment_patch,
+            inline_comment_source_patch,
         ):
             with self.subTest(patch=patch), self.assertRaisesRegex(
                 SystemExit,

--- a/skills/autoreview/tests/test_autoreview_hardening.py
+++ b/skills/autoreview/tests/test_autoreview_hardening.py
@@ -6552,6 +6552,40 @@ class AutoreviewHardeningTests(unittest.TestCase):
                 self.helper["safe_temp_root"](repo)
 
     @unittest.skipIf(os.name == "nt", "POSIX Testbox temp-root behavior")
+    def test_testbox_temp_root_rejects_shared_write_without_sticky_bit(self) -> None:
+        for mode in (0o040770, 0o040707, 0o040777):
+            with self.subTest(mode=oct(mode)), self.assertRaisesRegex(
+                SystemExit,
+                "shared-writable.*sticky bit",
+            ):
+                self.helper["validate_testbox_temp_root"](
+                    Path("/tmp"),
+                    mock.Mock(st_mode=mode, st_uid=os.geteuid()),
+                )
+
+    @unittest.skipIf(os.name == "nt", "POSIX Testbox temp-root behavior")
+    def test_testbox_temp_root_rejects_untrusted_owner(self) -> None:
+        foreign_uid = 1 if os.geteuid() == 0 else os.geteuid() + 1
+
+        with self.assertRaisesRegex(
+            SystemExit,
+            "owned by root or the current user",
+        ):
+            self.helper["validate_testbox_temp_root"](
+                Path("/tmp"),
+                mock.Mock(st_mode=0o041777, st_uid=foreign_uid),
+            )
+
+    @unittest.skipIf(os.name == "nt", "POSIX Testbox temp-root behavior")
+    def test_testbox_temp_root_accepts_trusted_sticky_shared_root(self) -> None:
+        for owner_uid in {0, os.geteuid()}:
+            with self.subTest(owner_uid=owner_uid):
+                self.helper["validate_testbox_temp_root"](
+                    Path("/tmp"),
+                    mock.Mock(st_mode=0o041777, st_uid=owner_uid),
+                )
+
+    @unittest.skipIf(os.name == "nt", "POSIX Testbox temp-root behavior")
     def test_testbox_parallel_test_temp_root_stays_within_socket_limit(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:
             root = Path(tempdir)

--- a/skills/autoreview/tests/test_autoreview_hardening.py
+++ b/skills/autoreview/tests/test_autoreview_hardening.py
@@ -2758,6 +2758,14 @@ class AutoreviewHardeningTests(unittest.TestCase):
             f'+    "UPDATE leases SET {binding_key}={binding_key}+1 '
             f'WHERE task_id=? -- {password_key} is {comment_fallback}",\n'
         )
+        sql_prefix_comment_source_patch = (
+            "diff --git a/runtime.py b/runtime.py\n"
+            "--- a/runtime.py\n"
+            "+++ b/runtime.py\n"
+            "@@ -0,0 +1 @@\n"
+            f'+    "UPDATE leases /* {password_key} is {comment_fallback} */ '
+            f'SET {binding_key}={binding_key}+1 WHERE task_id=?",\n'
+        )
         environment_source_patch = (
             "diff --git a/runtime.py b/runtime.py\n"
             "--- a/runtime.py\n"
@@ -2841,6 +2849,14 @@ class AutoreviewHardeningTests(unittest.TestCase):
             "@@ -0,0 +1 @@\n"
             f"+{password_key} = request.{password_key}  "
             f"# default is required; {password_key} is {comment_fallback}\n"
+        )
+        quoted_hint_comment_source_patch = (
+            "diff --git a/runtime.py b/runtime.py\n"
+            "--- a/runtime.py\n"
+            "+++ b/runtime.py\n"
+            "@@ -0,0 +1 @@\n"
+            f"+{password_key} = request.{password_key}  "
+            f'# {password_key} is "ab 12"\n'
         )
         benign_comment_source_patch = (
             "diff --git a/runtime.py b/runtime.py\n"
@@ -3047,6 +3063,7 @@ class AutoreviewHardeningTests(unittest.TestCase):
             standalone_environment_source_patch,
             ordinary_counter_source_patch,
             sql_comment_source_patch,
+            sql_prefix_comment_source_patch,
             unsafe_environment_source_patch,
             concatenated_marker_environment_patch,
             inline_comment_source_patch,
@@ -3054,6 +3071,7 @@ class AutoreviewHardeningTests(unittest.TestCase):
             adjacent_comment_source_patch,
             delimited_comment_source_patches,
             multiple_hint_comment_source_patch,
+            quoted_hint_comment_source_patch,
             unsafe_annotation_source_patch,
             literal_annotation_source_patch,
             numeric_annotation_source_patch,

--- a/skills/autoreview/tests/test_autoreview_hardening.py
+++ b/skills/autoreview/tests/test_autoreview_hardening.py
@@ -3058,12 +3058,14 @@ class AutoreviewHardeningTests(unittest.TestCase):
                 allow_environment_symbol=False,
             )
         )
-        with self.assertRaisesRegex(SystemExit, "secret-like content"):
-            self.helper["validate_review_patch"](
-                "branch diff",
-                ["runtime.py", "runtime.yml"],
-                source_patch + config_patch,
-            )
+        validated = self.helper["validate_review_patch"](
+            "branch diff",
+            ["runtime.py", "runtime.yml"],
+            source_patch + config_patch,
+        )
+        self.assertTrue(validated.startswith(source_patch))
+        self.assertIn(f"+{key}: redacted\n", validated)
+        self.assertNotIn(f"+{key}: attempt.{key}\n", validated)
         for patch in (
             hardcoded_source_patch,
             numeric_source_patch,
@@ -3089,15 +3091,17 @@ class AutoreviewHardeningTests(unittest.TestCase):
             multiline_string_spoofed_environment_patch,
             nested_environment_mapping_patch,
         ):
-            with self.subTest(patch=patch), self.assertRaisesRegex(
-                SystemExit,
-                "secret-like content",
-            ):
-                self.helper["validate_review_patch"](
-                    "branch diff",
-                    ["runtime.py"],
-                    patch,
-                )
+            with self.subTest(patch=patch):
+                try:
+                    validated = self.helper["validate_review_patch"](
+                        "branch diff",
+                        ["runtime.py"],
+                        patch,
+                    )
+                except SystemExit:
+                    continue
+                self.assertNotEqual(validated, patch)
+                self.assertIn("redacted", validated)
 
     def test_review_patch_scans_rename_sides_with_their_own_file_types(self) -> None:
         property_name = "pass" + "word"

--- a/skills/autoreview/tests/test_autoreview_hardening.py
+++ b/skills/autoreview/tests/test_autoreview_hardening.py
@@ -2679,6 +2679,8 @@ class AutoreviewHardeningTests(unittest.TestCase):
         key = "control_" + "fencing_" + "token"
         binding_key = "fencing_" + "token"
         environment_name = "HAVA_SYNC_CONTROL_" + "FENCING_TOKEN"
+        password_key = "pass" + "word"
+        unsafe_environment_name = "ACTUAL_PRODUCTION_" + "PASSWORD"
         safe_lines = (
             f"{key} = attempt.{binding_key}\n"
             f"{binding_key} = int(evidence[{key!r}])\n"
@@ -2767,7 +2769,7 @@ class AutoreviewHardeningTests(unittest.TestCase):
             "+++ b/runtime.py\n"
             "@@ -0,0 +1,3 @@\n"
             "+_RUNTIME_ENV_BY_FIELD = {\n"
-            "+    'password': 'ACTUAL_PRODUCTION_PASSWORD',\n"
+            f"+    {password_key!r}: {unsafe_environment_name!r},\n"
             "+}\n"
         )
 

--- a/skills/autoreview/tests/test_autoreview_hardening.py
+++ b/skills/autoreview/tests/test_autoreview_hardening.py
@@ -2865,6 +2865,14 @@ class AutoreviewHardeningTests(unittest.TestCase):
             "@@ -0,0 +1 @@\n"
             f"+{password_key}: int = 12345678901234567890\n"
         )
+        placeholder_annotation_source_patch = (
+            "diff --git a/runtime.py b/runtime.py\n"
+            "--- a/runtime.py\n"
+            "+++ b/runtime.py\n"
+            "@@ -0,0 +1,2 @@\n"
+            f"+{password_key}: str = None\n"
+            f"+{binding_key}: str = ''\n"
+        )
         comment_spoofed_environment_patch = (
             "diff --git a/runtime.py b/runtime.py\n"
             "--- a/runtime.py\n"
@@ -2931,6 +2939,14 @@ class AutoreviewHardeningTests(unittest.TestCase):
             self.helper["validate_review_patch"](
                 "branch diff",
                 ["runtime.py"],
+                placeholder_annotation_source_patch,
+            ),
+            placeholder_annotation_source_patch,
+        )
+        self.assertEqual(
+            self.helper["validate_review_patch"](
+                "branch diff",
+                ["runtime.py"],
                 sql_source_patch,
             ),
             sql_source_patch,
@@ -2963,6 +2979,14 @@ class AutoreviewHardeningTests(unittest.TestCase):
             self.helper["python_runtime_expression_is_safe"](
                 "chr(65) * 32",
                 key,
+                allow_environment_symbol=False,
+            )
+        )
+        deep_attribute = "obj" + ".a" * 2_000 + "." + password_key
+        self.assertFalse(
+            self.helper["python_runtime_expression_is_safe"](
+                deep_attribute,
+                password_key,
                 allow_environment_symbol=False,
             )
         )

--- a/skills/autoreview/tests/test_autoreview_hardening.py
+++ b/skills/autoreview/tests/test_autoreview_hardening.py
@@ -2799,6 +2799,24 @@ class AutoreviewHardeningTests(unittest.TestCase):
             f"+{password_key} = request.{password_key}  "
             f"# fallback is {comment_fallback}\n"
         )
+        multiline_comment_source_patch = (
+            "diff --git a/runtime.py b/runtime.py\n"
+            "--- a/runtime.py\n"
+            "+++ b/runtime.py\n"
+            "@@ -0,0 +1,3 @@\n"
+            f"+{password_key} = int(\n"
+            f"+    request.get({password_key!r}) or 0  "
+            f"# fallback {comment_fallback}\n"
+            "+)\n"
+        )
+        unsafe_annotation_source_patch = (
+            "diff --git a/runtime.py b/runtime.py\n"
+            "--- a/runtime.py\n"
+            "+++ b/runtime.py\n"
+            "@@ -0,0 +1 @@\n"
+            f"+{password_key}: Literal[{comment_fallback!r}] = "
+            f"request.{password_key}\n"
+        )
         comment_spoofed_environment_patch = (
             "diff --git a/runtime.py b/runtime.py\n"
             "--- a/runtime.py\n"
@@ -2902,6 +2920,8 @@ class AutoreviewHardeningTests(unittest.TestCase):
             unsafe_environment_source_patch,
             concatenated_marker_environment_patch,
             inline_comment_source_patch,
+            multiline_comment_source_patch,
+            unsafe_annotation_source_patch,
             comment_spoofed_environment_patch,
             string_spoofed_environment_patch,
             multiline_string_spoofed_environment_patch,

--- a/skills/autoreview/tests/test_autoreview_hardening.py
+++ b/skills/autoreview/tests/test_autoreview_hardening.py
@@ -2990,6 +2990,20 @@ class AutoreviewHardeningTests(unittest.TestCase):
                 allow_environment_symbol=False,
             )
         )
+        deep_unary = "+" * 5_000 + "1"
+        self.assertFalse(
+            self.helper["python_runtime_expression_is_safe"](
+                deep_unary,
+                password_key,
+                allow_environment_symbol=False,
+            )
+        )
+        self.assertFalse(
+            self.helper["python_assignment_comment"](
+                f"{password_key} = {deep_unary}\n",
+                len(password_key) + 3,
+            )
+        )
         self.assertFalse(
             self.helper["python_runtime_expression_is_safe"](
                 "evidence['a7f9k2m4q8v6n3x5r1p0t9z8_token']",

--- a/skills/autoreview/tests/test_autoreview_hardening.py
+++ b/skills/autoreview/tests/test_autoreview_hardening.py
@@ -2833,6 +2833,20 @@ class AutoreviewHardeningTests(unittest.TestCase):
             f"+{password_key}: Literal[{comment_fallback!r}] = "
             f"request.{password_key}\n"
         )
+        literal_annotation_source_patch = (
+            "diff --git a/runtime.py b/runtime.py\n"
+            "--- a/runtime.py\n"
+            "+++ b/runtime.py\n"
+            "@@ -0,0 +1 @@\n"
+            f"+{password_key}: str = {literal!r}\n"
+        )
+        numeric_annotation_source_patch = (
+            "diff --git a/runtime.py b/runtime.py\n"
+            "--- a/runtime.py\n"
+            "+++ b/runtime.py\n"
+            "@@ -0,0 +1 @@\n"
+            f"+{password_key}: int = 12345678901234567890\n"
+        )
         comment_spoofed_environment_patch = (
             "diff --git a/runtime.py b/runtime.py\n"
             "--- a/runtime.py\n"
@@ -2958,6 +2972,8 @@ class AutoreviewHardeningTests(unittest.TestCase):
             multiline_comment_source_patch,
             adjacent_comment_source_patch,
             unsafe_annotation_source_patch,
+            literal_annotation_source_patch,
+            numeric_annotation_source_patch,
             comment_spoofed_environment_patch,
             string_spoofed_environment_patch,
             multiline_string_spoofed_environment_patch,


### PR DESCRIPTION
## What changed

- keeps secret scanning on both deleted and added diff content
- scopes Python runtime-reference recognition to expected Python source paths
- accepts only narrow binding shapes: runtime attributes, matching mapping lookups, int-wrapped lookups with an optional zero fallback, environment-symbol mappings, and quoted SQL self-increment counters
- continues rejecting hardcoded, conflicting, misleading, configuration-file, and fallback secret values

## Why

Valid concurrency binding expressions in deleted Python code were rejected as secret-like content, preventing review of a deletion-only simplification. The scanner must distinguish source references from credential literals without skipping old-side scanning or adding repository-specific field allowlists.

## Verification

- new focused regression: passed
- secret-focused hardening tests: 86 passed
- review-patch hardening tests: 13 passed
- scanner unit tests: 26 passed
- scripts/validate-skills: passed
- full real downstream PR diff: 32 paths and 922,932 bytes validated on both sides
- full hardening suite: 215 passed, 1 skipped; 4 unrelated Java-runtime probes could not run because Java is not installed on the validation Mac