### PR TITLE
fix(autoreview): prioritize deletion-first findings

### DIFF
--- a/skills/autoreview/SKILL.md
+++ b/skills/autoreview/SKILL.md
@@ -22,8 +22,11 @@ Use when:
 - Treat review output as advisory. Never blindly apply it.
 - Verify every finding by reading the real code path and adjacent files.
 - Read dependency docs/source/types when the finding depends on external behavior.
+- Prioritize review findings in this order: remove duplicated code, duplicated lanes, and parallel successors; reduce and simplify code; then remove unrequested features, speculative validation, and defensive layers.
+- Treat a finding that an unnecessary feature, validator, or defensive layer should be deleted as P1-class.
+- Reject findings that only propose adding a validator, guard, receipt, or defensive layer unless they cite a real observed failure such as a reproduced bug, failing test, log, incident, or concrete exploitable path in the diff.
 - Reject unrealistic edge cases, speculative risks, broad rewrites, and fixes that over-complicate the codebase.
-- Prefer small fixes at the right ownership boundary; no refactor unless it clearly improves the bug class.
+- Prefer small fixes at the right ownership boundary; no refactor unless it clearly improves the bug class. Prefer deletion when it is the complete fix.
 - When an accepted finding shows a bug class or repeated pattern, inspect the current PR scope for sibling instances before fixing.
 - Fix the scoped bug class at once when practical; stop at touched surfaces, owner boundaries, and clear follow-up territory.
 - Keep going until structured review returns no accepted/actionable findings only while the work remains inside the original task scope.
@@ -56,9 +59,9 @@ Before the first review, freeze a scope baseline: original request or issue, tar
 
 Before patching a finding, classify it:
 
-- **In-scope blocker**: the finding is introduced by the current diff, affects the same owner boundary, and can be fixed without changing the task's contract.
+- **In-scope blocker**: the finding is introduced by the current diff, affects the same owner boundary, and can be fixed without changing the task's contract. Deletion of duplicated lanes, parallel successors, unrequested validators, or speculative defensive layers in the current diff is in scope by default.
 - **Follow-up**: the finding is real but belongs to an adjacent bug class, sibling surface, cleanup, or broader hardening track.
-- **Stop-and-escalate**: the finding requires a new protocol/config/storage/public API contract, a different owner boundary, a release-process change, or a design choice outside the original request.
+- **Stop-and-escalate**: the finding requires a new protocol/config/storage/public API contract, a different owner boundary, a release-process change, or a design choice outside the original request. Reject an evidence-free request to add a validator, guard, receipt, or defensive layer instead of treating it as a blocker.
 
 Stop patching and report the scope break instead of continuing when:
 

--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -6245,6 +6245,10 @@ def review_scope_policy() -> str:
           redesign request.
         - Report a finding only when this diff introduces or exposes a concrete
           defect that must be fixed before this target can land.
+        - Deletion findings against this diff are in scope by default when they
+          remove duplicated lanes, parallel successor implementations, or
+          unrequested defensive machinery. The fix shrinks the diff and is not
+          scope creep.
         - If the best fix requires a new protocol, config, storage, public API,
           release process, migration, owner-boundary move, or canonical contract,
           say that directly in the finding and keep the finding tied to the
@@ -6654,6 +6658,12 @@ def render_review_prompt(
         - Shell commands, if available, must be read-only inspection commands. Do not run tests, formatters, package installs, generators, network mutation commands, git mutation commands, or commands that write files.
         - Report only actionable defects introduced or exposed by this change.
         - Prefer high-signal findings over style feedback.
+        - Review priorities, first and foremost, in this exact order:
+        - Priority 1: removal of duplicated code, duplicated lanes, and parallel successor implementations. A second implementation of something that already exists in the bundle or evidence (a copy, a near-copy, a wrapper, or a v2/successor kept alongside the original) is a defect; the fix is to DELETE the duplicate, not to polish or reconcile it.
+        - Priority 2: reduction and simplification of code. Prefer findings that make the change smaller: fewer layers, fewer branches, less machinery, direct reuse of existing infrastructure instead of new scaffolding.
+        - Priority 3: removal of unasked-for features, defensive programming, speculative validation, and paranoia layers that were never requested. A validator, guard, receipt, or defensive wrapper that no stated requirement and no real observed failure demands is a defect to report for deletion.
+        - a finding that a feature, validator, or defensive layer is unnecessary and should be DELETED is a P1-class finding.
+        - Demote any finding that proposes ADDING a validator, guard, receipt, or defensive layer: it must cite a real observed failure (a reproduced bug, failing test, log, incident, or a concrete exploitable path demonstrated in this diff), not a hypothetical. Without such a citation, do not report it; with one, it still ranks below deletion and simplification findings of equal confidence.
         - Report EVERY distinct actionable defect in this single pass, ordered most severe first. Each review round costs the caller a full fix-test-review cycle; withholding a known defect until a later round wastes one.
         - Before returning, sweep the bundle once more for independent defects in other files or failure modes that you may have stopped scanning for after an earlier find.
         - Include security findings: injection, secret leaks, authz/authn bypass, path traversal, unsafe deserialization, unsafe filesystem or shell use, privacy leaks, and credential handling.

--- a/skills/autoreview/tests/test_autoreview_hardening.py
+++ b/skills/autoreview/tests/test_autoreview_hardening.py
@@ -691,6 +691,41 @@ class AutoreviewHardeningTests(unittest.TestCase):
 
         self.assertTrue(prompt.endswith(bundle))
 
+    def test_review_prompt_prioritizes_deletion_before_defensive_additions(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo = init_repo(Path(tempdir))
+            prompt = self.helper["render_review_prompt"](
+                repo,
+                "commit",
+                "HEAD",
+                self.helper["ReviewChunk"]("# Commit Diff\n+duplicate = True\n"),
+                "",
+                "",
+            )
+
+        priorities = (
+            "Priority 1: removal of duplicated code, duplicated lanes, and parallel successor implementations.",
+            "Priority 2: reduction and simplification of code.",
+            "Priority 3: removal of unasked-for features, defensive programming, speculative validation, and paranoia layers that were never requested.",
+        )
+        for priority in priorities:
+            self.assertIn(priority, prompt)
+        self.assertLess(prompt.index(priorities[0]), prompt.index(priorities[1]))
+        self.assertLess(prompt.index(priorities[1]), prompt.index(priorities[2]))
+        deletion_rule = (
+            "a finding that a feature, validator, or defensive layer is unnecessary and should be DELETED is a P1-class finding."
+        )
+        defensive_addition_rule = (
+            "Demote any finding that proposes ADDING a validator, guard, receipt, or defensive layer"
+        )
+        self.assertEqual(prompt.count(deletion_rule), 1)
+        self.assertEqual(prompt.count(defensive_addition_rule), 1)
+
+        scope_policy = " ".join(self.helper["review_scope_policy"]().split())
+        self.assertIn("Deletion findings against this diff are in scope by default", scope_policy)
+        self.assertNotIn("P1-class", scope_policy)
+        self.assertNotIn("Asking to ADD", scope_policy)
+
     def test_review_pass_count_is_bounded(self) -> None:
         builder = self.helper["build_review_prompts"]
         with tempfile.TemporaryDirectory() as tempdir:


### PR DESCRIPTION
## Summary

- make autoreview rank duplicate-lane deletion first, simplification second,
  and deletion of unrequested defensive machinery third
- classify unnecessary features, validators, and defensive layers as P1
  deletions while requiring observed-failure evidence for findings that add
  guards
- keep deletion in scope without duplicating the ranking rules in the generated
  prompt
- add a regression test for priority order, rule uniqueness, and scope
  classification

## Validation

- `scripts/validate-skills`
- `python3 skills/autoreview/scripts/autoreview --self-test`
- `python3 -m unittest skills/autoreview/scripts/autoreview_test.py skills.autoreview.tests.test_autoreview_hardening` (246 tests)
- source-blind synthetic review returned P1 duplicate deletion, P1
  unrequested-validator deletion, then P2 simplification
- autoreview rerun: no accepted/actionable findings
