### PR TITLE
fix(autoreview): allow config token fixtures

### DIFF
--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -297,6 +297,7 @@ SECRET_PLACEHOLDER_VALUES = {
     "test-token-placeholder",
     "token-oversized",
     "clawrouter-e2e-secret",
+    "config-token",
     "very-long-browser-token-0123456789",
 }
 SYNTHETIC_SECRET_PREFIXES = frozenset(

--- a/skills/autoreview/tests/test_autoreview_hardening.py
+++ b/skills/autoreview/tests/test_autoreview_hardening.py
@@ -2956,6 +2956,7 @@ class AutoreviewHardeningTests(unittest.TestCase):
             'token: "token-oversized"',
             'API_KEY = "clawrouter-e2e-secret"',
             'token: "very-long-browser-token-0123456789"',
+            'token: "config-token"',
         ):
             with self.subTest(content=content):
                 self.assertFalse(self.helper["secret_text_risk"](content))


### PR DESCRIPTION
## Summary

- allow the exact synthetic `config-token` fixture through autoreview secret scanning
- keep generic `config-*` and real credential literals protected
- add regression coverage

## Proof

- focused hardening tests: 2 passed
- full hardening suite: 217 passed, 1 skipped; 4 unrelated Java-runtime failures on this host
- skill validation: 6 skills validated
- real OpenClaw PR #109115 bundle: scanner passed and autoreview returned no findings
- fresh autoreview of this diff: clean
