### PR TITLE
fix(autoreview): sanitize secret-like review fixtures

### DIFF
--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -12,6 +12,7 @@ import functools
 import hashlib
 import io
 import json
+import math
 import os
 import queue
 import re
@@ -210,12 +211,43 @@ SECRET_ASSIGNMENT_PREFIX_PATTERN = re.compile(
     rf"(?i){SECRET_ASSIGNMENT_KEY_PATTERN}"
     r"\s*(?:=(?!=|>)|:(?![:=]))\s*"
 )
+PRIVATE_KEY_BOUNDARY_PREFIX = r"-----"
+PRIVATE_KEY_BEGIN_PATTERN = re.compile(
+    PRIVATE_KEY_BOUNDARY_PREFIX
+    + r"BEGIN (?:RSA |DSA |EC |OPENSSH |PGP |ENCRYPTED )?"
+    r"PRIVATE KEY(?: BLOCK)?-----"
+)
+PRIVATE_KEY_END_PATTERN = re.compile(
+    PRIVATE_KEY_BOUNDARY_PREFIX
+    + r"END (?:RSA |DSA |EC |OPENSSH |PGP |ENCRYPTED )?"
+    r"PRIVATE KEY(?: BLOCK)?-----"
+)
+PRIVATE_KEY_BODY_PATTERN = re.compile(
+    r"(?<![A-Za-z0-9+/])"
+    r"(?:[A-Za-z0-9+/]{4,}={0,2}|[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)"
+    r"(?![A-Za-z0-9+/=])"
+)
+ESCAPED_PRIVATE_KEY_BODY_PATTERN = re.compile(
+    r"\\[nr](?P<body>"
+    r"(?:[A-Za-z0-9+/]{4,}={0,2}|[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)"
+    r")(?![A-Za-z0-9+/=])"
+)
+BEARER_CREDENTIAL_PATTERN = re.compile(
+    r"(?i)bearer\s+(?P<credential>[A-Za-z0-9._~+/-]{20,}=*)"
+)
+SECRET_FALLBACK_LITERAL_PATTERNS = (
+    re.compile(r'"(?P<value>[^"\r\n]+)"'),
+    re.compile(r"'(?P<value>[^'\r\n]+)'"),
+    re.compile(r"`(?P<value>[^`\r\n]+)`"),
+)
+SECRET_FALLBACK_UNQUOTED_PATTERN = re.compile(
+    r"(?<![A-Za-z0-9_./+=:@#$%&*!?-])"
+    r"(?P<value>[A-Za-z0-9_./+=:@#$%&*!?-]{4,})"
+    r"(?![A-Za-z0-9_./+=:@#$%&*!?-])"
+)
 SECRET_VALUE_PATTERNS = [
-    re.compile(
-        r"-----BEGIN (?:RSA |DSA |EC |OPENSSH |PGP |ENCRYPTED )?"
-        r"PRIVATE KEY(?: BLOCK)?-----"
-    ),
-    re.compile(r"(?i)bearer\s+[A-Za-z0-9._-]{20,}"),
+    PRIVATE_KEY_BEGIN_PATTERN,
+    BEARER_CREDENTIAL_PATTERN,
     re.compile(r"\b(?:sk|rk|pk|org|proj)-[A-Za-z0-9_-]{20,}\b"),
     re.compile(r"\bgithub_pat_[A-Za-z0-9_]{20,}\b"),
     re.compile(r"\bgh[pousr]_[A-Za-z0-9_]{20,}\b"),
@@ -272,6 +304,7 @@ MAX_BUNDLE_TEXT_BYTES = 180_000
 MAX_REVIEW_PROMPT_BYTES = 512_000
 MAX_REVIEW_CHUNK_CONTEXT_BYTES = 64_000
 MAX_REVIEW_PASSES = 8
+MAX_REVIEW_SECRET_FRAGMENTS = 256
 
 
 class ReviewChunk(NamedTuple):
@@ -4682,6 +4715,72 @@ def call_arguments_risk(
     return False
 
 
+def balanced_delimiter_end(
+    text: str,
+    start: int,
+    opener: str,
+    closer: str,
+) -> int | None:
+    depth = 0
+    quote: str | None = None
+    escaped = False
+    line_comment = False
+    block_comment = False
+    index = start
+    while index < len(text):
+        char = text[index]
+        next_char = text[index + 1] if index + 1 < len(text) else ""
+        if line_comment:
+            if char == "\n":
+                line_comment = False
+            index += 1
+            continue
+        if block_comment:
+            if char == "*" and next_char == "/":
+                block_comment = False
+                index += 2
+            else:
+                index += 1
+            continue
+        if quote is not None:
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == quote:
+                quote = None
+            index += 1
+            continue
+        regex_end = javascript_regex_literal_end(text, index)
+        if regex_end is not None:
+            index = regex_end
+        elif char == "/" and next_char == "/":
+            line_comment = True
+            index += 2
+        elif char == "/" and next_char == "*":
+            block_comment = True
+            index += 2
+        elif char == "#" and not javascript_private_member_marker(text, index):
+            line_comment = True
+            index += 1
+        elif char in {'"', "'", "`"}:
+            quote = char
+            index += 1
+        elif char == opener:
+            depth += 1
+            index += 1
+        elif char == closer:
+            depth -= 1
+            if depth == 0:
+                return index + 1
+            index += 1
+        elif depth == 0:
+            return None
+        else:
+            index += 1
+    return None
+
+
 def safe_secret_call_suffix(
     text: str,
     end: int,
@@ -4692,71 +4791,8 @@ def safe_secret_call_suffix(
     if end >= len(text) or text[end] != "(":
         return False
 
-    def balanced_end(start: int, opener: str, closer: str) -> int | None:
-        depth = 0
-        quote: str | None = None
-        escaped = False
-        line_comment = False
-        block_comment = False
-        index = start
-        while index < len(text):
-            char = text[index]
-            next_char = text[index + 1] if index + 1 < len(text) else ""
-            if line_comment:
-                if char == "\n":
-                    line_comment = False
-                index += 1
-                continue
-            if block_comment:
-                if char == "*" and next_char == "/":
-                    block_comment = False
-                    index += 2
-                else:
-                    index += 1
-                continue
-            if quote is not None:
-                if escaped:
-                    escaped = False
-                elif char == "\\":
-                    escaped = True
-                elif char == quote:
-                    quote = None
-                index += 1
-                continue
-            regex_end = javascript_regex_literal_end(text, index)
-            if regex_end is not None:
-                index = regex_end
-            elif char == "/" and next_char == "/":
-                line_comment = True
-                index += 2
-            elif char == "/" and next_char == "*":
-                block_comment = True
-                index += 2
-            elif char == "#" and not javascript_private_member_marker(
-                text,
-                index,
-            ):
-                line_comment = True
-                index += 1
-            elif char in {'"', "'", "`"}:
-                quote = char
-                index += 1
-            elif char == opener:
-                depth += 1
-                index += 1
-            elif char == closer:
-                depth -= 1
-                if depth == 0:
-                    return index + 1
-                index += 1
-            elif depth == 0:
-                return None
-            else:
-                index += 1
-        return None
-
     def safe_call_end(start: int, target: str) -> int | None:
-        cursor = balanced_end(start, "(", ")")
+        cursor = balanced_delimiter_end(text, start, "(", ")")
         if cursor is None:
             return None
         arguments = text[start + 1 : cursor - 1]
@@ -4812,7 +4848,7 @@ def safe_secret_call_suffix(
             chained_target = "<call-result>"
             continue
         if call_start < len(text) and text[call_start] == "[":
-            cursor = balanced_end(call_start, "[", "]")
+            cursor = balanced_delimiter_end(text, call_start, "[", "]")
             if cursor is None:
                 return False
             chained_target = "<call-result>"
@@ -5149,6 +5185,84 @@ def basic_authorization_risk(text: str) -> bool:
     return False
 
 
+def safe_self_reference_assignment(
+    text: str,
+    match: re.Match[str],
+    *,
+    javascript_dialect: str | None = None,
+) -> bool:
+    if javascript_dialect is None:
+        return False
+    value = (
+        match.group("reference_value")
+        or match.group("call_value")
+        or match.group("bare_value")
+    )
+    if value is None:
+        return False
+    key = re.split(r"\s*[:=]\s*", match.group(0), maxsplit=1)[0].strip("\"'")
+    if value != key:
+        return False
+    separator = re.search(r"[:=]", match.group(0))
+    if separator is None or separator.group(0) != "=":
+        return False
+    line_end_candidates = [
+        position
+        for position in (
+            text.find("\n", match.end()),
+            text.find("\r", match.end()),
+        )
+        if position >= 0
+    ]
+    line_end = min(line_end_candidates, default=len(text))
+    if not safe_secret_assignment_suffix(
+        text[:line_end],
+        match.end(),
+        javascript_dialect=javascript_dialect,
+    ):
+        return False
+    return safe_javascript_reference_suffix(
+        text,
+        line_end,
+        typescript=javascript_dialect == "typescript",
+    )
+
+
+def unsafe_multiline_self_reference_assignment(
+    text: str,
+    match: re.Match[str],
+    *,
+    javascript_dialect: str | None = None,
+) -> bool:
+    if javascript_dialect is None:
+        return False
+    value = (
+        match.group("reference_value")
+        or match.group("call_value")
+        or match.group("bare_value")
+    )
+    if value is None:
+        return False
+    key = re.split(r"\s*[:=]\s*", match.group(0), maxsplit=1)[0].strip("\"'")
+    separator = re.search(r"[:=]", match.group(0))
+    if value != key or separator is None or separator.group(0) != "=":
+        return False
+    line_end_candidates = [
+        position
+        for position in (
+            text.find("\n", match.end()),
+            text.find("\r", match.end()),
+        )
+        if position >= 0
+    ]
+    line_end = min(line_end_candidates, default=len(text))
+    return line_end < len(text) and not safe_javascript_reference_suffix(
+        text,
+        line_end,
+        typescript=javascript_dialect == "typescript",
+    )
+
+
 def secret_text_risk(
     text: str,
     *,
@@ -5180,6 +5294,19 @@ def secret_text_risk(
         else frozenset()
     )
     for prefix in assignment_prefixes:
+        assignment = SECRET_ASSIGNMENT_PATTERN.match(text, prefix.start())
+        if assignment is not None and safe_self_reference_assignment(
+            text,
+            assignment,
+            javascript_dialect=javascript_dialect,
+        ):
+            continue
+        if assignment is not None and unsafe_multiline_self_reference_assignment(
+            text,
+            assignment,
+            javascript_dialect=javascript_dialect,
+        ):
+            return True
         fallback = top_level_fallback_suffix(
             text[prefix.end() :],
             allow_chained_assignment=(
@@ -5216,6 +5343,12 @@ def secret_text_risk(
         separator_match = re.search(r"[:=]", match.group(0))
         assert separator_match is not None
         separator = separator_match.group(0)
+        if safe_self_reference_assignment(
+            text,
+            match,
+            javascript_dialect=javascript_dialect,
+        ):
+            continue
         if (
             key.strip("\"'").lower() == "credentials"
             and value.lower() in FETCH_CREDENTIAL_MODE_VALUES
@@ -5365,12 +5498,705 @@ def require_no_secret_values(
         )
 
 
+def require_no_known_secret_fragments(
+    label: str,
+    text: str,
+    fragments: set[str],
+) -> None:
+    if any(fragment and fragment in text for fragment in fragments):
+        raise SystemExit(
+            f"refusing to include a known secret-like value in {label}; "
+            "move or remove the ambiguous occurrence before running autoreview"
+        )
+
+
+def review_secret_fragments(
+    text: str,
+    *,
+    javascript_dialect: str | None = None,
+) -> set[str]:
+    private_fragments = {
+        fragment
+        for fragment in private_key_body_fragments(text)
+        if fragment.casefold() not in SECRET_PLACEHOLDER_VALUES
+    }
+    fragments = {
+        text[start:end]
+        for start, end in review_repeatable_secret_spans(
+            text,
+            javascript_dialect=javascript_dialect,
+        )
+        if text[start:end]
+        and text[start:end].casefold() not in SECRET_PLACEHOLDER_VALUES
+    }
+    fragments.update(private_fragments)
+    return fragments
+
+
+def assignment_fallback_literal_spans(
+    text: str,
+    match: re.Match[str],
+    *,
+    javascript_dialect: str | None = None,
+) -> list[tuple[int, int]]:
+    line_end_candidates = [
+        position
+        for position in (
+            text.find("\n", match.end()),
+            text.find("\r", match.end()),
+        )
+        if position >= 0
+    ]
+    line_end = min(line_end_candidates, default=len(text))
+    expression_end = line_end
+    if (
+        javascript_dialect is not None
+        and line_end < len(text)
+        and not safe_javascript_reference_suffix(
+            text,
+            line_end,
+            typescript=javascript_dialect == "typescript",
+        )
+    ):
+        continued = fallback_expression(
+            text[line_end:],
+            typescript=javascript_dialect == "typescript",
+        )
+        expression_end = line_end + len(continued)
+    fallback_start = match.end()
+    if match.group("call_value") is not None:
+        whitespace = re.match(r"[ \t]*", text[fallback_start:expression_end])
+        assert whitespace is not None
+        call_start = fallback_start + whitespace.end()
+        if call_start < line_end and text[call_start] == "(":
+            depth = 0
+            quote: str | None = None
+            escaped = False
+            cursor = call_start
+            while cursor < expression_end:
+                char = text[cursor]
+                if quote is not None:
+                    if escaped:
+                        escaped = False
+                    elif char == "\\":
+                        escaped = True
+                    elif char == quote:
+                        quote = None
+                elif char in {'"', "'", "`"}:
+                    quote = char
+                elif char == "(":
+                    depth += 1
+                elif char == ")":
+                    depth -= 1
+                    if depth == 0:
+                        fallback_start = cursor + 1
+                        break
+                cursor += 1
+    operator_span = top_level_fallback_operator_span(
+        text,
+        fallback_start,
+        expression_end,
+    )
+    if operator_span is None:
+        return []
+    expression_start = operator_span[1]
+    depth = 0
+    quote: str | None = None
+    escaped = False
+    cursor = expression_start
+    while cursor < line_end:
+        char = text[cursor]
+        if quote is not None:
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == quote:
+                quote = None
+        elif char in {'"', "'", "`"}:
+            quote = char
+        elif char in "([{":
+            depth += 1
+        elif char in ")]}":
+            if depth == 0:
+                expression_end = cursor
+                break
+            depth -= 1
+        elif depth == 0 and char in ";,":
+            expression_end = cursor
+            break
+        cursor += 1
+    return top_level_fallback_value_spans(
+        text,
+        expression_start,
+        expression_end,
+    )
+
+
+def top_level_fallback_operator_span(
+    text: str,
+    start: int,
+    end: int,
+) -> tuple[int, int] | None:
+    stack: list[str] = []
+    pairs = {"(": ")", "[": "]", "{": "}"}
+    quote: str | None = None
+    escaped = False
+    line_comment = False
+    block_comment = False
+    cursor = start
+    while cursor < end:
+        char = text[cursor]
+        next_char = text[cursor + 1] if cursor + 1 < end else ""
+        if line_comment:
+            if char in "\r\n":
+                line_comment = False
+            cursor += 1
+            continue
+        if block_comment:
+            if char == "*" and next_char == "/":
+                block_comment = False
+                cursor += 2
+            else:
+                cursor += 1
+            continue
+        if quote is not None:
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == quote:
+                quote = None
+            cursor += 1
+            continue
+        if char == "/" and next_char == "/":
+            line_comment = True
+            cursor += 2
+            continue
+        if char == "/" and next_char == "*":
+            block_comment = True
+            cursor += 2
+            continue
+        if char == "#":
+            line_comment = True
+            cursor += 1
+            continue
+        if char in {'"', "'", "`"}:
+            quote = char
+            cursor += 1
+            continue
+        if char in pairs:
+            stack.append(pairs[char])
+            cursor += 1
+            continue
+        if stack and char == stack[-1]:
+            stack.pop()
+            cursor += 1
+            continue
+        if not stack and text.startswith(("||", "??"), cursor):
+            return cursor, cursor + 2
+        if not stack and text.startswith("or", cursor):
+            before = text[cursor - 1] if cursor > start else ""
+            after = text[cursor + 2] if cursor + 2 < end else ""
+            if not (before.isalnum() or before == "_") and not (
+                after.isalnum() or after == "_"
+            ):
+                return cursor, cursor + 2
+        cursor += 1
+    return None
+
+
+def top_level_fallback_value_spans(
+    text: str,
+    start: int,
+    end: int,
+) -> list[tuple[int, int]]:
+    spans: list[tuple[int, int]] = []
+    stack: list[str] = []
+    pairs = {"(": ")", "[": "]", "{": "}"}
+    cursor = start
+    while cursor < end:
+        char = text[cursor]
+        next_char = text[cursor + 1] if cursor + 1 < end else ""
+        if char == "/" and next_char == "/":
+            newline = re.search(r"[\r\n]", text[cursor + 2 : end])
+            if newline is None:
+                break
+            cursor += 2 + newline.end()
+            continue
+        if char == "/" and next_char == "*":
+            comment_end = text.find("*/", cursor + 2, end)
+            if comment_end < 0:
+                break
+            cursor = comment_end + 2
+            continue
+        if char == "#":
+            newline = re.search(r"[\r\n]", text[cursor + 1 : end])
+            if newline is None:
+                break
+            cursor += 1 + newline.end()
+            continue
+        if char in {'"', "'", "`"}:
+            quote = char
+            value_start = cursor + 1
+            cursor = value_start
+            escaped = False
+            while cursor < end:
+                current = text[cursor]
+                if escaped:
+                    escaped = False
+                elif current == "\\":
+                    escaped = True
+                elif current == quote:
+                    if not stack and cursor > value_start:
+                        spans.append((value_start, cursor))
+                    cursor += 1
+                    break
+                cursor += 1
+            continue
+        if char in pairs:
+            stack.append(pairs[char])
+            cursor += 1
+            continue
+        if stack and char == stack[-1]:
+            stack.pop()
+            cursor += 1
+            continue
+        if not stack:
+            bare = SECRET_FALLBACK_UNQUOTED_PATTERN.match(text, cursor, end)
+            if bare is not None:
+                value = bare.group("value")
+                if len(value) >= 7 and (
+                    any(candidate.isdigit() for candidate in value)
+                    or re.fullmatch(r"[A-Za-z_$][A-Za-z0-9_$]*", value) is None
+                ):
+                    spans.append(bare.span("value"))
+                cursor = bare.end()
+                continue
+        cursor += 1
+    return sorted(set(spans))
+
+
+def review_call_literal_spans(
+    text: str,
+    match: re.Match[str],
+    *,
+    javascript_dialect: str | None = None,
+) -> list[tuple[int, int]]:
+    whitespace = re.match(r"[ \t]*", text[match.end() :])
+    assert whitespace is not None
+    call_start = match.end() + whitespace.end()
+    if call_start >= len(text) or text[call_start] != "(":
+        return []
+    call_end = balanced_delimiter_end(text, call_start, "(", ")")
+    if call_end is None or not secret_text_risk(
+        text[match.start() : call_end],
+        javascript_dialect=javascript_dialect,
+    ):
+        return []
+    candidates = [
+        literal
+        for pattern in SECRET_FALLBACK_LITERAL_PATTERNS
+        for literal in pattern.finditer(text, call_start + 1, call_end - 1)
+    ]
+    return [
+        literal.span("value")
+        for literal in candidates
+        if len(literal.group("value")) >= 7
+        and any(char.isalpha() for char in literal.group("value"))
+        and any(char.isdigit() for char in literal.group("value"))
+        and literal.group("value").casefold() not in SECRET_PLACEHOLDER_VALUES
+        and not any(
+            pattern.fullmatch(literal.group("value"))
+            for pattern in QUOTED_SECRET_REFERENCE_PATTERNS
+        )
+    ]
+
+
+def review_repeatable_secret_spans(
+    text: str,
+    *,
+    javascript_dialect: str | None = None,
+) -> list[tuple[int, int]]:
+    spans: list[tuple[int, int]] = []
+    for match in SECRET_ASSIGNMENT_PATTERN.finditer(text):
+        selected_name = next(
+            (
+                name
+                for name in (
+                    "double_value",
+                    "single_value",
+                    "backtick_value",
+                    "reference_value",
+                    "call_value",
+                    "bare_value",
+                )
+                if match.group(name) is not None
+            ),
+            None,
+        )
+        if selected_name is None:
+            continue
+        if safe_self_reference_assignment(
+            text,
+            match,
+            javascript_dialect=javascript_dialect,
+        ):
+            continue
+        fallback_spans = (
+            assignment_fallback_literal_spans(
+                text,
+                match,
+                javascript_dialect=javascript_dialect,
+            )
+            if selected_name in {"reference_value", "call_value", "bare_value"}
+            else []
+        )
+        if fallback_spans:
+            spans.extend(fallback_spans)
+            continue
+        if selected_name == "call_value":
+            spans.extend(
+                review_call_literal_spans(
+                    text,
+                    match,
+                    javascript_dialect=javascript_dialect,
+                )
+            )
+            continue
+        if secret_text_risk(
+            match.group(0),
+            javascript_dialect=javascript_dialect,
+        ):
+            spans.append(match.span(selected_name))
+    for pattern in SECRET_VALUE_PATTERNS:
+        spans.extend(
+            match.span("credential")
+            if pattern is BEARER_CREDENTIAL_PATTERN
+            else match.span()
+            for match in pattern.finditer(text)
+        )
+    spans.extend(
+        match.span("credential")
+        for match in BASIC_AUTHORIZATION_PATTERN.finditer(text)
+    )
+    for authority_range in uri_authority_ranges(text):
+        credential = uri_authority_credential(text, authority_range)
+        if credential is not None and credential.value:
+            spans.append((credential.value_start, credential.value_end))
+    return spans
+
+
+def review_secret_value_spans(
+    text: str,
+    *,
+    javascript_dialect: str | None = None,
+) -> list[tuple[int, int]]:
+    spans: list[tuple[int, int]] = []
+    for match in SECRET_ASSIGNMENT_PATTERN.finditer(text):
+        for name in (
+            "double_value",
+            "single_value",
+            "backtick_value",
+            "reference_value",
+            "call_value",
+            "bare_value",
+        ):
+            if match.group(name) is not None:
+                if safe_self_reference_assignment(
+                    text,
+                    match,
+                    javascript_dialect=javascript_dialect,
+                ):
+                    break
+                fallback_spans = (
+                    assignment_fallback_literal_spans(
+                        text,
+                        match,
+                        javascript_dialect=javascript_dialect,
+                    )
+                    if name in {"reference_value", "call_value", "bare_value"}
+                    else []
+                )
+                if fallback_spans:
+                    spans.extend(fallback_spans)
+                    break
+                if name == "call_value":
+                    spans.extend(
+                        review_call_literal_spans(
+                            text,
+                            match,
+                            javascript_dialect=javascript_dialect,
+                        )
+                    )
+                    break
+                if secret_text_risk(
+                    match.group(0),
+                    javascript_dialect=javascript_dialect,
+                ):
+                    spans.append(match.span(name))
+                break
+    for pattern in SECRET_VALUE_PATTERNS:
+        spans.extend(
+            match.span("credential")
+            if pattern is BEARER_CREDENTIAL_PATTERN
+            else match.span()
+            for match in pattern.finditer(text)
+        )
+    spans.extend(
+        match.span("credential")
+        for match in BASIC_AUTHORIZATION_PATTERN.finditer(text)
+    )
+    for authority_range in uri_authority_ranges(text):
+        credential = uri_authority_credential(text, authority_range)
+        if credential is not None and credential.value:
+            spans.append((credential.value_start, credential.value_end))
+    return spans
+
+
+def redact_review_spans(text: str, spans: list[tuple[int, int]]) -> str:
+    merged: list[tuple[int, int]] = []
+    for start, end in sorted(spans):
+        if start >= end:
+            continue
+        if merged and start <= merged[-1][1]:
+            merged[-1] = (merged[-1][0], max(end, merged[-1][1]))
+        else:
+            merged.append((start, end))
+    if not merged:
+        return text
+    parts: list[str] = []
+    cursor = 0
+    for start, end in merged:
+        parts.extend((text[cursor:start], "redacted"))
+        cursor = end
+    parts.append(text[cursor:])
+    return "".join(parts)
+
+
+def repeated_secret_fragment_spans(
+    text: str,
+    pattern: re.Pattern[str] | None,
+) -> list[tuple[int, int]]:
+    if pattern is None:
+        return []
+    matches = list(pattern.finditer(text))
+    contexts = string_contexts_at(text, {match.start() for match in matches})
+    spans: list[tuple[int, int]] = []
+    for match in matches:
+        token_start = match.start()
+        while token_start > 0 and re.match(r"[A-Za-z0-9_$.-]", text[token_start - 1]):
+            token_start -= 1
+        token_end = match.end()
+        while token_end < len(text) and re.match(r"[A-Za-z0-9_$.-]", text[token_end]):
+            token_end += 1
+        key_position = re.match(
+            r"\s*(?:=(?!=|>)|:(?![:=]))",
+            text[token_end:],
+        ) is not None
+        unquoted_token_substring = (
+            contexts[match.start()] is None
+            and (token_start < match.start() or match.end() < token_end)
+        )
+        unquoted_identifier = (
+            contexts[match.start()] is None
+            and token_start == match.start()
+            and token_end == match.end()
+            and re.fullmatch(r"[A-Za-z_$][A-Za-z0-9_$.-]*", match.group(0))
+            is not None
+        )
+        if contexts[match.start()] is None and (
+            key_position or unquoted_token_substring or unquoted_identifier
+        ):
+            continue
+        spans.append(match.span())
+    return spans
+
+
+def private_key_body_spans(text: str) -> list[tuple[int, int]]:
+    matches = list(PRIVATE_KEY_BODY_PATTERN.finditer(text))
+    contexts = string_contexts_at(text, {match.start() for match in matches})
+    wrapper_parts: list[str] = []
+    cursor = 0
+    for match in matches:
+        wrapper_parts.append(text[cursor : match.start()])
+        cursor = match.end()
+    wrapper_parts.append(text[cursor:])
+    body_only_line = re.fullmatch(
+        r"(?:(?:#|//|/\*|\*)\s*)?[\s\"'`,;+\[\]]*",
+        "".join(wrapper_parts).strip(),
+    ) is not None
+    return [
+        match.span()
+        for match in matches
+        if body_only_line or contexts[match.start()] is not None
+    ]
+
+
+def private_key_token_spans(text: str) -> list[tuple[int, int]]:
+    escaped_spans = [
+        match.span("body")
+        for match in ESCAPED_PRIVATE_KEY_BODY_PATTERN.finditer(text)
+    ]
+    ordinary_spans = [
+        match.span()
+        for match in PRIVATE_KEY_BODY_PATTERN.finditer(text)
+        if not (
+            match.start() > 0
+            and text[match.start() - 1] == "\\"
+            and match.group(0)[:1] in {"n", "r"}
+        )
+        and not any(
+            start < match.end() and match.start() < end
+            for start, end in escaped_spans
+        )
+    ]
+    return sorted(escaped_spans + ordinary_spans)
+
+
+def normalized_private_key_fragment(text: str, start: int, end: int) -> str:
+    fragment = text[start:end]
+    if start > 0 and text[start - 1] == "\\" and fragment[:1] in {"n", "r"}:
+        return fragment[1:]
+    return fragment
+
+
+def likely_private_key_token(value: str) -> bool:
+    encoded = value.rstrip("=")
+    if not encoded:
+        return False
+    entropy = -sum(
+        (frequency := encoded.count(char) / len(encoded)) * math.log2(frequency)
+        for char in set(encoded)
+    )
+    return (
+        (len(encoded) >= 48 or encoded.startswith("MII"))
+        and any(char.islower() for char in encoded)
+        and any(char.isupper() for char in encoded)
+        and any(char.isdigit() or char in "+/=" for char in value)
+        and entropy >= 4.25
+    )
+
+
+def orphan_private_key_body_spans(text: str) -> list[tuple[int, int]]:
+    matches = list(PRIVATE_KEY_BODY_PATTERN.finditer(text))
+    if not matches:
+        return []
+    wrapper_parts: list[str] = []
+    cursor = 0
+    for match in matches:
+        wrapper_parts.append(text[cursor : match.start()])
+        cursor = match.end()
+    wrapper_parts.append(text[cursor:])
+    if re.fullmatch(
+        r"(?:(?:#|//|/\*|\*)\s*)?[\s\"'`,;+\[\]]*",
+        "".join(wrapper_parts).strip(),
+    ) is None:
+        return []
+    values = [match.group(0) for match in matches]
+    raw_encoded = "".join(values)
+    encoded = raw_encoded.rstrip("=")
+    if not encoded:
+        return []
+    entropy = -sum(
+        (frequency := encoded.count(char) / len(encoded)) * math.log2(frequency)
+        for char in set(encoded)
+    )
+    mixed_short_chunks = (
+        len(encoded) >= 20
+        and len(matches) >= 2
+        and all(
+            any(char.isdigit() for char in value)
+            and any(char.isupper() or char in "+/" for char in value)
+            for value in values
+        )
+        and any(char.islower() for char in encoded)
+        and entropy >= 4.25
+    )
+    long_base64_line = len(matches) == 1 and likely_private_key_token(raw_encoded)
+    if not long_base64_line and not mixed_short_chunks:
+        return []
+    return [match.span() for match in matches]
+
+
+def markerless_private_key_body_spans(text: str) -> list[tuple[int, int]]:
+    spans = orphan_private_key_body_spans(text)
+    matches = list(PRIVATE_KEY_BODY_PATTERN.finditer(text))
+    contexts = string_contexts_at(text, {match.start() for match in matches})
+    spans.extend(
+        match.span()
+        for match in matches
+        if contexts[match.start()] is not None
+        and likely_private_key_token(match.group(0))
+    )
+    return sorted(set(spans))
+
+
+def pem_line_body_spans(
+    text: str,
+    in_pem: bool,
+) -> tuple[list[tuple[int, int]], bool]:
+    markers = sorted(
+        [
+            (match.start(), match.end(), True)
+            for match in PRIVATE_KEY_BEGIN_PATTERN.finditer(text)
+        ]
+        + [
+            (match.start(), match.end(), False)
+            for match in PRIVATE_KEY_END_PATTERN.finditer(text)
+        ]
+    )
+    if not markers and not in_pem:
+        return markerless_private_key_body_spans(text), False
+    spans: list[tuple[int, int]] = []
+    cursor = 0
+    for start, end, begins_pem in markers:
+        if in_pem:
+            spans.extend(
+                (cursor + body_start, cursor + body_end)
+                for body_start, body_end in private_key_token_spans(text[cursor:start])
+            )
+        if begins_pem:
+            if in_pem:
+                raise SystemExit("refusing review bundle with nested private-key BEGIN markers")
+            in_pem = True
+        else:
+            if not in_pem:
+                raise SystemExit(
+                    "refusing review bundle with a private-key END marker but no visible BEGIN"
+                )
+            in_pem = False
+        cursor = end
+    if in_pem:
+        spans.extend(
+            (cursor + body_start, cursor + body_end)
+            for body_start, body_end in private_key_token_spans(text[cursor:])
+        )
+    return spans, in_pem
+
+
+def private_key_body_fragments(text: str) -> set[str]:
+    fragments: set[str] = set()
+    in_private_key = False
+    for line in text.split("\n"):
+        spans, in_private_key = pem_line_body_spans(line, in_private_key)
+        fragments.update(
+            fragment
+            for start, end in spans
+            if (fragment := normalized_private_key_fragment(line, start, end))
+        )
+    if in_private_key:
+        raise SystemExit("refusing review bundle with an unterminated private-key block")
+    return fragments
+
+
 def unified_diff_contents(patch: str) -> tuple[str, str]:
     old_content: list[str] = []
     new_content: list[str] = []
     in_hunk = False
     prefix_columns = 1
-    for line in patch.splitlines():
+    for line in patch.split("\n"):
+        line = line.removesuffix("\r")
         hunk_header = re.match(r"^(@{2,})", line)
         if hunk_header:
             old_content.append(";")
@@ -5403,7 +6229,8 @@ def unified_diff_metadata(patch: str) -> str:
     metadata: list[str] = []
     in_hunk = False
     prefix_columns = 1
-    for line in patch.splitlines():
+    for line in patch.split("\n"):
+        line = line.removesuffix("\r")
         hunk_header = re.match(r"^(@{2,})", line)
         if hunk_header:
             metadata.append(line)
@@ -5423,6 +6250,225 @@ def unified_diff_metadata(patch: str) -> str:
         if not hunk_content:
             metadata.append(line)
     return "\n".join(metadata)
+
+
+REVIEW_SECRET_REDACTION = "[secret-like diff hunk redacted]"
+
+
+def redact_secret_like_hunk_headers(
+    section: str,
+    expected_paths: set[str],
+    known_secret_fragments: set[str] | None = None,
+) -> str:
+    old_path, new_path = diff_section_paths(section)
+    dialects = {
+        javascript_review_dialect(rel)
+        for rel in (old_path, new_path)
+        if rel is not None and rel in expected_paths
+    }
+    if not dialects:
+        dialects = {None}
+    ordered_secret_fragments = sorted(
+        known_secret_fragments or (),
+        key=lambda fragment: (-len(fragment), fragment),
+    )
+    fragment_pattern = (
+        re.compile("|".join(re.escape(fragment) for fragment in ordered_secret_fragments))
+        if ordered_secret_fragments
+        else None
+    )
+    redacted: list[str] = []
+    for line in literal_lf_lines(section):
+        body = line.rstrip("\r\n")
+        ending = line[len(body) :]
+        header_match = re.match(
+            r"^(?P<marker>@{2,}) (?P<ranges>.+?) (?P=marker)(?P<section> .+)$",
+            body,
+        )
+        if header_match is None:
+            redacted.append(line)
+            continue
+        raw_header_section = header_match.group("section")
+        private_key_header = (
+            PRIVATE_KEY_BEGIN_PATTERN.search(raw_header_section) is not None
+            or PRIVATE_KEY_END_PATTERN.search(raw_header_section) is not None
+        )
+        header_section = redact_review_spans(
+            raw_header_section,
+            (
+                [match.span() for match in fragment_pattern.finditer(raw_header_section)]
+                if fragment_pattern is not None
+                else []
+            ),
+        )
+        if private_key_header or any(
+            secret_text_risk(header_section, javascript_dialect=dialect)
+            for dialect in dialects
+        ):
+            header_section = f" {REVIEW_SECRET_REDACTION}"
+        redacted.append(
+            f"{header_match.group('marker')} {header_match.group('ranges')} "
+            f"{header_match.group('marker')}{header_section}{ending}"
+        )
+    return "".join(redacted)
+
+
+def review_hunk_header_secret_fragments(
+    section: str,
+    expected_paths: set[str],
+) -> set[str]:
+    old_path, new_path = diff_section_paths(section)
+    dialects = {
+        javascript_review_dialect(rel)
+        for rel in (old_path, new_path)
+        if rel is not None and rel in expected_paths
+    }
+    if not dialects:
+        dialects = {None}
+    fragments: set[str] = set()
+    for line in literal_lf_lines(section):
+        body = line.rstrip("\r\n")
+        header_match = re.match(
+            r"^(?P<marker>@{2,}) (?P<ranges>.+?) (?P=marker)(?P<section> .+)$",
+            body,
+        )
+        if header_match is None:
+            continue
+        header_section = header_match.group("section")
+        for begin in PRIVATE_KEY_BEGIN_PATTERN.finditer(header_section):
+            end = PRIVATE_KEY_END_PATTERN.search(header_section, begin.end())
+            segment_end = end.start() if end is not None else len(header_section)
+            segment = header_section[begin.end() : segment_end]
+            for start, end in private_key_token_spans(segment):
+                fragment = normalized_private_key_fragment(segment, start, end)
+                if fragment:
+                    fragments.add(fragment)
+        for start, end in markerless_private_key_body_spans(header_section):
+            fragment = normalized_private_key_fragment(header_section, start, end)
+            if fragment:
+                fragments.add(fragment)
+        for dialect in dialects:
+            if not secret_text_risk(
+                header_section,
+                javascript_dialect=dialect,
+            ):
+                continue
+            fragments.update(
+                header_section[start:end]
+                for start, end in review_repeatable_secret_spans(
+                    header_section,
+                    javascript_dialect=dialect,
+                )
+                if header_section[start:end]
+            )
+    return fragments
+
+
+def redact_secret_like_diff_section(
+    section: str,
+    expected_paths: set[str],
+    known_secret_fragments: set[str] | None = None,
+) -> str:
+    old_path, new_path = diff_section_paths(section)
+    old_dialect = (
+        javascript_review_dialect(old_path)
+        if old_path is not None and old_path in expected_paths
+        else None
+    )
+    new_dialect = (
+        javascript_review_dialect(new_path)
+        if new_path is not None and new_path in expected_paths
+        else None
+    )
+    secret_fragments = set(known_secret_fragments or ())
+    old_content, new_content = unified_diff_contents(section)
+    old_risk = secret_text_risk(old_content, javascript_dialect=old_dialect)
+    new_risk = secret_text_risk(new_content, javascript_dialect=new_dialect)
+    for content, dialect, risk in (
+        (old_content, old_dialect, old_risk),
+        (new_content, new_dialect, new_risk),
+    ):
+        if not risk:
+            continue
+        secret_fragments.update(
+            review_secret_fragments(
+                content,
+                javascript_dialect=dialect,
+            )
+        )
+    if len(secret_fragments) > MAX_REVIEW_SECRET_FRAGMENTS:
+        raise SystemExit(
+            "refusing review bundle with too many distinct secret-like values "
+            f"({len(secret_fragments)}; limit {MAX_REVIEW_SECRET_FRAGMENTS})"
+        )
+    ordered_secret_fragments = sorted(
+        secret_fragments,
+        key=lambda fragment: (-len(fragment), fragment),
+    )
+    fragment_pattern = (
+        re.compile("|".join(re.escape(fragment) for fragment in ordered_secret_fragments))
+        if ordered_secret_fragments
+        else None
+    )
+    redacted: list[str] = []
+    lines = literal_lf_lines(section)
+    index = 0
+    old_pem = False
+    new_pem = False
+    while index < len(lines):
+        line = lines[index]
+        if not line.startswith("@@"):
+            redacted.append(line)
+            index += 1
+            continue
+        hunk_end = index + 1
+        while hunk_end < len(lines) and not lines[hunk_end].startswith("@@"):
+            hunk_end += 1
+        header = line.rstrip("\r\n")
+        prefix_match = re.match(r"^(@{2,})", header)
+        assert prefix_match is not None
+        prefix_columns = len(prefix_match.group(1)) - 1
+        redacted.append(line)
+        for content_line in lines[index + 1 : hunk_end]:
+            body = content_line.rstrip("\r\n")
+            ending = content_line[len(body) :]
+            prefix = body[:prefix_columns]
+            if len(prefix) != prefix_columns or not set(prefix) <= {"+", "-", " "}:
+                redacted.append(content_line)
+                continue
+            content = body[prefix_columns:]
+            old_line = set(prefix) == {" "} or "-" in prefix
+            new_line = set(prefix) == {" "} or "+" in prefix
+            spans: list[tuple[int, int]] = []
+            line_secret_risk = (
+                old_line
+                and old_risk
+                and secret_text_risk(content, javascript_dialect=old_dialect)
+            ) or (
+                new_line
+                and new_risk
+                and secret_text_risk(content, javascript_dialect=new_dialect)
+            )
+            if line_secret_risk:
+                dialect = old_dialect if old_line and old_risk else new_dialect
+                spans.extend(
+                    review_secret_value_spans(
+                        content,
+                        javascript_dialect=dialect,
+                    )
+                )
+            spans.extend(repeated_secret_fragment_spans(content, fragment_pattern))
+            spans.extend(match.span() for match in PRIVATE_KEY_END_PATTERN.finditer(content))
+            if old_line:
+                old_spans, old_pem = pem_line_body_spans(content, old_pem)
+                spans.extend(old_spans)
+            if new_line:
+                new_spans, new_pem = pem_line_body_spans(content, new_pem)
+                spans.extend(new_spans)
+            redacted_content = redact_review_spans(content, spans)
+            redacted.append(f"{prefix}{redacted_content}{ending}")
+        index = hunk_end
+    return "".join(redacted)
 
 
 def sensitive_repo_path_risk(rel: str) -> str | None:
@@ -5643,14 +6689,67 @@ def validate_review_patch(
             f"{label} is too large to review safely "
             f"({patch_bytes} bytes; limit {limit}); split the change into smaller review targets"
         )
-    require_no_secret_values(label, unified_diff_metadata(patch))
-    sections = [
-        unit
-        for unit in review_bundle_units(patch)
+    expected_paths = set(paths)
+    units = review_bundle_units(patch)
+    known_secret_fragments: set[str] = set()
+    for unit in units:
+        if not unit.startswith("diff --git "):
+            continue
+        old_path, new_path = diff_section_paths(unit)
+        old_content, new_content = unified_diff_contents(unit)
+        for rel, content in (
+            (old_path, old_content),
+            (new_path, new_content),
+        ):
+            javascript_dialect = (
+                javascript_review_dialect(rel)
+                if rel is not None and rel in expected_paths
+                else None
+            )
+            all_fragments = review_secret_fragments(
+                content,
+                javascript_dialect=javascript_dialect,
+            )
+            known_secret_fragments.update(all_fragments)
+        known_secret_fragments.update(
+            review_hunk_header_secret_fragments(unit, expected_paths)
+        )
+    if len(known_secret_fragments) > MAX_REVIEW_SECRET_FRAGMENTS:
+        raise SystemExit(
+            "refusing review bundle with too many distinct secret-like values "
+            f"({len(known_secret_fragments)}; limit {MAX_REVIEW_SECRET_FRAGMENTS})"
+        )
+    patch = "".join(
+        redact_secret_like_hunk_headers(
+            unit,
+            expected_paths,
+            known_secret_fragments,
+        )
         if unit.startswith("diff --git ")
-    ]
+        else unit
+        for unit in units
+    )
+    require_no_secret_values(label, unified_diff_metadata(patch))
+    units = review_bundle_units(patch)
+    patch = "".join(
+        redact_secret_like_diff_section(
+            unit,
+            expected_paths,
+            known_secret_fragments,
+        )
+        if unit.startswith("diff --git ")
+        else unit
+        for unit in units
+    )
+    require_no_known_secret_fragments(label, patch, known_secret_fragments)
+    patch_bytes = len(patch.encode("utf-8"))
+    if limit is not None and patch_bytes > limit:
+        raise SystemExit(
+            f"{label} is too large to review safely after redaction "
+            f"({patch_bytes} bytes; limit {limit}); split the change into smaller review targets"
+        )
+    sections = [unit for unit in review_bundle_units(patch) if unit.startswith("diff --git ")]
     if sections:
-        expected_paths = set(paths)
         for section in sections:
             old_path, new_path = diff_section_paths(section)
             old_content, new_content = unified_diff_contents(section)

--- a/skills/autoreview/tests/test_autoreview_hardening.py
+++ b/skills/autoreview/tests/test_autoreview_hardening.py
@@ -2374,18 +2374,16 @@ class AutoreviewHardeningTests(unittest.TestCase):
             ),
             narrow_source_patch,
         )
-        with self.assertRaisesRegex(SystemExit, "secret-like content"):
-            self.helper["validate_review_patch"](
-                "local staged diff",
-                ["src/runtime.ts", "config.yml"],
-                source_patch + config_patch,
-            )
-        with self.assertRaisesRegex(SystemExit, "secret-like content"):
-            self.helper["validate_review_patch"](
-                "local staged diff",
-                ["config.yml", "src/runtime.ts"],
-                source_patch + config_patch,
-            )
+        for paths in (
+            ["src/runtime.ts", "config.yml"],
+            ["config.yml", "src/runtime.ts"],
+        ):
+            with self.assertRaisesRegex(SystemExit, "known secret-like value"):
+                self.helper["validate_review_patch"](
+                    "local staged diff",
+                    paths,
+                    source_patch + config_patch,
+                )
 
     def test_review_patch_scans_rename_sides_with_their_own_file_types(self) -> None:
         property_name = "pass" + "word"
@@ -2410,7 +2408,27 @@ class AutoreviewHardeningTests(unittest.TestCase):
             + "\n"
         )
 
-        with self.assertRaisesRegex(SystemExit, "secret-like content"):
+        old_content, new_content = self.helper["unified_diff_contents"](patch)
+        fragments = self.helper["review_secret_fragments"](old_content)
+        fragments.update(self.helper["review_secret_fragments"](new_content))
+        redacted = self.helper["redact_secret_like_diff_section"](
+            patch,
+            {"src/runtime.ts", "config.yml"},
+            fragments,
+        )
+
+        self.assertIn("-function configure", redacted)
+        self.assertIn(
+            "-function configure(context: RuntimeContext) { return { "
+            + property_name
+            + ": "
+            + reference
+            + " }; }",
+            redacted,
+        )
+        self.assertIn("+" + property_name + ": redacted", redacted)
+        self.assertNotIn("+" + property_name + ": " + reference, redacted)
+        with self.assertRaisesRegex(SystemExit, "known secret-like value"):
             self.helper["validate_review_patch"](
                 "branch diff",
                 ["src/runtime.ts", "config.yml"],
@@ -3059,7 +3077,77 @@ class AutoreviewHardeningTests(unittest.TestCase):
             with self.subTest(key=key):
                 self.assertTrue(self.helper["secret_text_risk"](content))
 
-    def test_secret_like_patch_content_is_blocked_in_all_modes(self) -> None:
+    def test_secret_detector_allows_safe_self_references(self) -> None:
+        self.assertFalse(
+            self.helper["secret_text_risk"](
+                "private" + "_key = private_key or fallback_private_key",
+                javascript_dialect="javascript",
+            )
+        )
+        self.assertFalse(
+            self.helper["secret_text_risk"](
+                "old_private"
+                + "_key = old_private_key or old_line\nnew_private"
+                + "_key = new_private_key or new_line",
+                javascript_dialect="javascript",
+            )
+        )
+        colon_assignment = self.helper["SECRET_ASSIGNMENT_PATTERN"].search(
+            "pass" + "word: password"
+        )
+        self.assertIsNotNone(colon_assignment)
+        self.assertFalse(
+            self.helper["safe_self_reference_assignment"](
+                "pass" + "word: password",
+                colon_assignment,
+                javascript_dialect="javascript",
+            )
+        )
+        self.assertTrue(
+            self.helper["secret_text_risk"](
+                "client" + "secret" + "=" + "clientsecret"
+            )
+        )
+        self.assertTrue(
+            self.helper["secret_text_risk"](
+                "if (ready) send({pass"
+                + 'word: "'
+                + realistic_secret_value()
+                + '"})'
+            )
+        )
+        self.assertTrue(
+            self.helper["secret_text_risk"](
+                "private"
+                + '_key = private_key or "'
+                + realistic_secret_value()
+                + '"'
+            )
+        )
+        self.assertTrue(
+            self.helper["secret_text_risk"](
+                "pass"
+                + 'word = password\n  || "'
+                + realistic_secret_value()
+                + '"',
+                javascript_dialect="javascript",
+            )
+        )
+        for trivia in ("\n\n  ", "\n  /* comment */\n  ", " // comment\n  "):
+            with self.subTest(trivia=trivia):
+                self.assertTrue(
+                    self.helper["secret_text_risk"](
+                        "pass"
+                        + "word = password"
+                        + trivia
+                        + '|| "'
+                        + realistic_secret_value()
+                        + '"',
+                        javascript_dialect="javascript",
+                    )
+                )
+
+    def test_secret_like_patch_content_is_redacted_in_all_modes(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:
             repo = init_repo(Path(tempdir))
             path = repo / "settings.txt"
@@ -3068,19 +3156,1067 @@ class AutoreviewHardeningTests(unittest.TestCase):
             git(repo, "commit", "-q", "-m", "base")
             base = git(repo, "rev-parse", "HEAD").strip()
 
-            path.write_text(
-                "api" + "_key=" + realistic_secret_value() + "\n",
-                encoding="utf-8",
-            )
+            secret = realistic_secret_value()
+            path.write_text("api" + "_key=" + secret + "\n", encoding="utf-8")
             git(repo, "add", "settings.txt")
-            with self.assertRaisesRegex(SystemExit, "secret-like content"):
-                self.helper["local_bundle"](repo)
+            local_bundle, local_truncated = self.helper["local_bundle"](repo)
 
             git(repo, "commit", "-q", "-m", "secret content")
-            with self.assertRaisesRegex(SystemExit, "secret-like content"):
-                self.helper["branch_bundle"](repo, base)
-            with self.assertRaisesRegex(SystemExit, "secret-like content"):
-                self.helper["commit_bundle"](repo, "HEAD")
+            branch_bundle, branch_truncated = self.helper["branch_bundle"](repo, base)
+            commit_bundle, commit_truncated = self.helper["commit_bundle"](repo, "HEAD")
+
+            for bundle, truncated in (
+                (local_bundle, local_truncated),
+                (branch_bundle, branch_truncated),
+                (commit_bundle, commit_truncated),
+            ):
+                self.assertIn("api_key=redacted", bundle)
+                self.assertNotIn(secret, bundle)
+                self.assertFalse(truncated)
+
+    def test_review_patch_redacts_private_key_fixture_hunk_and_continues(self) -> None:
+        patch = (
+            "diff --git a/fixture.test.ts b/fixture.test.ts\n"
+            "--- a/fixture.test.ts\n"
+            "+++ b/fixture.test.ts\n"
+            "@@ -1,4 +1,5 @@\n"
+            ' const key = ["-----BEGIN '
+            + 'PRIVATE KEY-----",\n'
+            '   "MIIEvQIBADANBgkqhkiG9w0BAQEFAASC1234567890",\n'
+            '   "-----END '
+            + 'PRIVATE KEY-----",\n'
+            " ];\n"
+            "+expect(key).toBeDefined();\n"
+            "@@ -20 +21 @@\n"
+            "-const timeout = 0;\n"
+            "+const timeout = 30_000;\n"
+        )
+
+        redacted = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["fixture.test.ts"],
+            patch,
+        )
+
+        self.assertIn('const key = ["redacted",', redacted)
+        self.assertNotIn("BEGIN PRIVATE KEY", redacted)
+        self.assertNotIn("MIIEvQIBADANBgkqhkiG9w0BAQEFAASC1234567890", redacted)
+        self.assertIn("+const timeout = 30_000;", redacted)
+
+    def test_review_patch_tracks_private_key_redaction_per_diff_side(self) -> None:
+        patch = (
+            "diff --git a/fixture.test.ts b/fixture.test.ts\n"
+            "--- a/fixture.test.ts\n"
+            "+++ b/fixture.test.ts\n"
+            "@@ -1,3 +1,3 @@\n"
+            ' const key = ["-----BEGIN '
+            + 'PRIVATE KEY-----",\n'
+            '-  "MIIEowIBAAKCAQEArEmoved0123456789ABCDEF", "-----END '
+            + 'PRIVATE KEY-----",\n'
+            '+  "MIIEowIBAAKCAQEAdDed0123456789ABCDEF", "-----END '
+            + 'PRIVATE KEY-----",\n'
+            " ];\n"
+        )
+
+        redacted = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["fixture.test.ts"],
+            patch,
+        )
+
+        self.assertNotIn("BEGIN PRIVATE KEY", redacted)
+        self.assertNotIn("MIIEowIBAAKCAQEArEmoved0123456789ABCDEF", redacted)
+        self.assertNotIn("MIIEowIBAAKCAQEAdDed0123456789ABCDEF", redacted)
+
+    def test_review_patch_fails_closed_after_unmatched_private_key_begin(self) -> None:
+        patch = (
+            "diff --git a/fixture.txt b/fixture.txt\n"
+            "--- a/fixture.txt\n"
+            "+++ b/fixture.txt\n"
+            "@@ -0,0 +1,3 @@\n"
+            "+-----BEGIN "
+            + "PRIVATE KEY-----\n"
+            "+MIIEowIBAAKCAQEAunmatched0123456789ABCDEF\n"
+            "+runDangerousOperation();\n"
+        )
+
+        with self.assertRaisesRegex(SystemExit, "unterminated private-key block"):
+            self.helper["validate_review_patch"](
+                "local unstaged diff",
+                ["fixture.txt"],
+                patch,
+            )
+
+    def test_review_patch_fails_closed_before_unmatched_private_key_end(self) -> None:
+        patch = (
+            "diff --git a/fixture.txt b/fixture.txt\n"
+            "--- a/fixture.txt\n"
+            "+++ b/fixture.txt\n"
+            "@@ -1,2 +1,2 @@\n"
+            " MIIEowIBAAKCAQEAtrailing0123456789ABCDEF\n"
+            " -----END "
+            + "PRIVATE KEY-----\n"
+        )
+
+        with self.assertRaisesRegex(SystemExit, "END marker but no visible BEGIN"):
+            self.helper["validate_review_patch"](
+                "local unstaged diff",
+                ["fixture.txt"],
+                patch,
+            )
+
+    def test_review_patch_tracks_same_line_private_key_markers_in_order(self) -> None:
+        patch = (
+            "diff --git a/fixture.txt b/fixture.txt\n"
+            "--- a/fixture.txt\n"
+            "+++ b/fixture.txt\n"
+            "@@ -0,0 +1,2 @@\n"
+            "+-----BEGIN "
+            + "PRIVATE KEY----- AB12 -----END "
+            + "PRIVATE KEY----- -----BEGIN "
+            + "PRIVATE KEY-----\n"
+            "+CDef3456GHij7890\n"
+        )
+
+        with self.assertRaisesRegex(SystemExit, "unterminated private-key block"):
+            self.helper["validate_review_patch"](
+                "local unstaged diff",
+                ["fixture.txt"],
+                patch,
+            )
+
+    def test_review_patch_redacts_secret_like_hunk_header_section(self) -> None:
+        fixture_value = realistic_secret_value()
+        patch = (
+            "diff --git a/runtime.ts b/runtime.ts\n"
+            "--- a/runtime.ts\n"
+            "+++ b/runtime.ts\n"
+            f'@@ -1 +1 @@ function connect(api{"Key"} = "{fixture_value}")\n'
+            "-return oldValue;\n"
+            "+return newValue;\n"
+        )
+
+        redacted_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["runtime.ts"],
+            patch,
+        )
+
+        self.assertIn('function connect(api' + 'Key = "redacted")', redacted_patch)
+        self.assertNotIn(fixture_value, redacted_patch)
+        self.assertIn("+return newValue;", redacted_patch)
+
+    def test_review_patch_redaction_treats_only_lf_as_a_diff_record_boundary(self) -> None:
+        fixture_value = realistic_secret_value()
+        patch = (
+            "diff --git a/settings.txt b/settings.txt\n"
+            "--- a/settings.txt\n"
+            "+++ b/settings.txt\n"
+            "@@ -1 +1 @@\n"
+            "-pass"
+            + "word=placeholder\n"
+            + f'+pass{"word"}="{fixture_value}\fremaining-secret"\n'
+        )
+
+        redacted_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["settings.txt"],
+            patch,
+        )
+
+        self.assertIn('+pass' + 'word="redacted"', redacted_patch)
+        self.assertNotIn(fixture_value, redacted_patch)
+        self.assertNotIn("remaining-secret", redacted_patch)
+
+    def test_review_patch_redaction_preserves_unrelated_lines_in_the_same_hunk(self) -> None:
+        fixture_value = realistic_secret_value()
+        patch = (
+            "diff --git a/runtime.ts b/runtime.ts\n"
+            "--- a/runtime.ts\n"
+            "+++ b/runtime.ts\n"
+            "@@ -1 +1,4 @@\n"
+            " export const enabled = true;\n"
+            f'+const api{"Key"} = "{fixture_value}";\n'
+            f'+useCredential("{fixture_value}");\n'
+            "+runDangerousOperation();\n"
+        )
+
+        redacted_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["runtime.ts"],
+            patch,
+        )
+
+        self.assertIn('+const api' + 'Key = "redacted";', redacted_patch)
+        self.assertNotIn(fixture_value, redacted_patch)
+        self.assertIn('+useCredential("redacted");', redacted_patch)
+        self.assertIn("+runDangerousOperation();", redacted_patch)
+
+    def test_review_patch_rejects_too_many_secret_fragments(self) -> None:
+        secrets = [f"{realistic_secret_value()}{index:03d}" for index in range(257)]
+        additions = "".join(
+            f'+const api{"Key"} = "{secret}";\n' for secret in secrets
+        )
+        patch = (
+            "diff --git a/runtime.ts b/runtime.ts\n"
+            "--- a/runtime.ts\n"
+            "+++ b/runtime.ts\n"
+            "@@ -0,0 +1,258 @@\n"
+            + additions
+            + "+runDangerousOperation();\n"
+        )
+
+        with self.assertRaisesRegex(SystemExit, "too many distinct secret-like values"):
+            self.helper["validate_review_patch"](
+                "local unstaged diff",
+                ["runtime.ts"],
+                patch,
+            )
+
+    def test_review_patch_never_replaces_a_secret_like_key_name(self) -> None:
+        long_values = [
+            f"{realistic_secret_value()}LongLiteral{index:03d}" for index in range(62)
+        ]
+        additions = '+const api' + 'Key = "veryLongClientSecret";\n'
+        additions += "".join(
+            f'+const api{"Key"} = "{value}";\n' for value in long_values
+        )
+        target_secret = "ShortS3cret"
+        additions += f'+const veryLongClient{"Secret"} = "{target_secret}";\n'
+        patch = (
+            "diff --git a/runtime.ts b/runtime.ts\n"
+            "--- a/runtime.ts\n"
+            "+++ b/runtime.ts\n"
+            "@@ -0,0 +1,64 @@\n"
+            + additions
+        )
+
+        with self.assertRaisesRegex(SystemExit, "known secret-like value"):
+            self.helper["validate_review_patch"](
+                "local unstaged diff",
+                ["runtime.ts"],
+                patch,
+            )
+
+    def test_review_patch_never_rewrites_secret_fragment_inside_key(self) -> None:
+        fragment = "client" + "Secret"
+        patch = (
+            "diff --git a/runtime.ts b/runtime.ts\n"
+            "--- a/runtime.ts\n"
+            "+++ b/runtime.ts\n"
+            "@@ -0,0 +1,2 @@\n"
+            + "+pass"
+            + f'word = "{fragment}"\n'
+            + f"+{fragment}Timeout: 30\n"
+        )
+
+        _old_content, new_content = self.helper["unified_diff_contents"](patch)
+        fragments = self.helper["review_secret_fragments"](new_content)
+        redacted_patch = self.helper["redact_secret_like_diff_section"](
+            patch,
+            {"runtime.ts"},
+            fragments,
+        )
+
+        self.assertIn("+" + fragment + "Timeout: 30", redacted_patch)
+        with self.assertRaisesRegex(SystemExit, "known secret-like value"):
+            self.helper["validate_review_patch"](
+                "local unstaged diff",
+                ["runtime.ts"],
+                patch,
+            )
+
+    def test_review_patch_never_rewrites_secret_fragment_inside_identifier(
+        self,
+    ) -> None:
+        fragment = "authorize"
+        patch = (
+            "diff --git a/runtime.ts b/runtime.ts\n"
+            "--- a/runtime.ts\n"
+            "+++ b/runtime.ts\n"
+            "@@ -0,0 +1,2 @@\n"
+            + "+pass"
+            + f'word = "{fragment}"\n'
+            + f"+{fragment}User();\n"
+        )
+
+        _old_content, new_content = self.helper["unified_diff_contents"](patch)
+        fragments = self.helper["review_secret_fragments"](new_content)
+        redacted_patch = self.helper["redact_secret_like_diff_section"](
+            patch,
+            {"runtime.ts"},
+            fragments,
+        )
+
+        self.assertIn("+" + fragment + "User();", redacted_patch)
+        with self.assertRaisesRegex(SystemExit, "known secret-like value"):
+            self.helper["validate_review_patch"](
+                "local unstaged diff",
+                ["runtime.ts"],
+                patch,
+            )
+
+    def test_review_patch_redacts_repeated_secret_across_diff_sides(self) -> None:
+        fixture_value = realistic_secret_value()
+        patch = (
+            "diff --git a/runtime.ts b/runtime.ts\n"
+            "--- a/runtime.ts\n"
+            "+++ b/runtime.ts\n"
+            "@@ -1 +1 @@\n"
+            f'-pass{"word"} = "{fixture_value}"\n'
+            f'+log("{fixture_value}")\n'
+        )
+
+        redacted_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["runtime.ts"],
+            patch,
+        )
+
+        self.assertNotIn(fixture_value, redacted_patch)
+        self.assertIn('+log("redacted")', redacted_patch)
+
+    def test_review_patch_redacts_repeated_secret_across_files(self) -> None:
+        fixture_value = realistic_secret_value()
+        patch = (
+            "diff --git a/settings.txt b/settings.txt\n"
+            "--- a/settings.txt\n"
+            "+++ b/settings.txt\n"
+            "@@ -1 +0,0 @@\n"
+            f'-pass{"word"} = "{fixture_value}"\n'
+            "diff --git a/runtime.ts b/runtime.ts\n"
+            "--- a/runtime.ts\n"
+            "+++ b/runtime.ts\n"
+            "@@ -0,0 +1 @@\n"
+            f'+log("{fixture_value}")\n'
+        )
+
+        redacted_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["settings.txt", "runtime.ts"],
+            patch,
+        )
+
+        self.assertNotIn(fixture_value, redacted_patch)
+        self.assertIn('+log("redacted")', redacted_patch)
+
+    def test_review_patch_learns_bare_secret_values(self) -> None:
+        fixture_value = "correct-" + "horse-battery-staple"
+        patch = (
+            "diff --git a/settings.txt b/settings.txt\n"
+            "--- a/settings.txt\n"
+            "+++ b/settings.txt\n"
+            "@@ -1 +1 @@\n"
+            f"-PASS{'WORD'}={fixture_value}\n"
+            f'+log("{fixture_value}")\n'
+        )
+
+        redacted = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["settings.txt"],
+            patch,
+        )
+
+        self.assertNotIn(fixture_value, redacted)
+        self.assertIn('+log("redacted")', redacted)
+
+    def test_review_patch_learns_reference_shaped_config_secrets(self) -> None:
+        fixture_value = "customer.actualPass" + "word"
+        for path, separator in (
+            ("settings.yml", ": "),
+            ("settings.txt", "="),
+            (".env.example", "="),
+        ):
+            with self.subTest(path=path):
+                patch = (
+                    f"diff --git a/{path} b/{path}\n"
+                    f"--- a/{path}\n"
+                    f"+++ b/{path}\n"
+                    "@@ -0,0 +1,2 @@\n"
+                    + "+PASS"
+                    + f"WORD{separator}{fixture_value}\n"
+                    + f'+NOTE{separator}"{fixture_value}"\n'
+                )
+
+                redacted = self.helper["validate_review_patch"](
+                    "local unstaged diff",
+                    [path],
+                    patch,
+                )
+
+                self.assertNotIn(fixture_value, redacted)
+                self.assertIn(f'+NOTE{separator}"redacted"', redacted)
+
+        for path in (".env", ".env.production"):
+            with self.subTest(blocked_path=path):
+                with self.assertRaisesRegex(SystemExit, "sensitive filename"):
+                    self.helper["validate_review_patch"](
+                        "local unstaged diff",
+                        [path],
+                        f"diff --git a/{path} b/{path}\n",
+                    )
+
+    def test_review_patch_redacts_known_secret_used_as_quoted_key(self) -> None:
+        fixture_value = realistic_secret_value()
+        patch = (
+            "diff --git a/runtime.ts b/runtime.ts\n"
+            "--- a/runtime.ts\n"
+            "+++ b/runtime.ts\n"
+            "@@ -1 +1 @@\n"
+            f'-pass{"word"} = "{fixture_value}"\n'
+            f'+const result = {{ "{fixture_value}": value }};\n'
+        )
+
+        redacted_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["runtime.ts"],
+            patch,
+        )
+
+        self.assertNotIn(fixture_value, redacted_patch)
+        self.assertIn('{ "redacted": value }', redacted_patch)
+
+    def test_review_patch_redacts_unsafe_self_reference_fallback(self) -> None:
+        fixture_value = realistic_secret_value()
+        patch = (
+            "diff --git a/runtime.py b/runtime.py\n"
+            "--- a/runtime.py\n"
+            "+++ b/runtime.py\n"
+            "@@ -0,0 +1 @@\n"
+            f'+private{"_key"} = private_key or "{fixture_value}"\n'
+        )
+
+        redacted_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["runtime.py"],
+            patch,
+        )
+
+        self.assertNotIn(fixture_value, redacted_patch)
+        self.assertIn('private' + '_key = private_key or "redacted"', redacted_patch)
+
+    def test_review_patch_preserves_and_rejects_nested_fallback_calls(self) -> None:
+        primary = realistic_secret_value() + "Primary"
+        backup = realistic_secret_value() + "Backup"
+        patch = (
+            "diff --git a/runtime.ts b/runtime.ts\n"
+            "--- a/runtime.ts\n"
+            "+++ b/runtime.ts\n"
+            "@@ -0,0 +1 @@\n"
+            + "+pass"
+            + f'word = getenv("PASSWORD") || choose("{primary}", "{backup}");\n'
+        )
+
+        _old_content, new_content = self.helper["unified_diff_contents"](patch)
+        fragments = self.helper["review_secret_fragments"](new_content)
+        redacted_patch = self.helper["redact_secret_like_diff_section"](
+            patch,
+            {"runtime.ts"},
+            fragments,
+        )
+
+        self.assertIn(f'choose("{primary}", "{backup}")', redacted_patch)
+        with self.assertRaisesRegex(SystemExit, "secret-like content"):
+            self.helper["validate_review_patch"](
+                "local unstaged diff",
+                ["runtime.ts"],
+                patch,
+            )
+
+    def test_review_patch_never_exempts_literal_secret_as_source_reference(self) -> None:
+        literal = "currentPass" + "word"
+        patch = (
+            "diff --git a/runtime.ts b/runtime.ts\n"
+            "--- a/runtime.ts\n"
+            "+++ b/runtime.ts\n"
+            "@@ -1 +1 @@\n"
+            + "-pass"
+            + f'word = "{literal}";\n'
+            + f"+consume({literal});\n"
+        )
+
+        _old_content, new_content = self.helper["unified_diff_contents"](patch)
+        fragments = self.helper["review_secret_fragments"](new_content)
+        redacted_patch = self.helper["redact_secret_like_diff_section"](
+            patch,
+            {"runtime.ts"},
+            fragments,
+        )
+
+        self.assertIn("+consume(" + literal + ");", redacted_patch)
+        with self.assertRaisesRegex(SystemExit, "known secret-like value"):
+            self.helper["validate_review_patch"](
+                "local unstaged diff",
+                ["runtime.ts"],
+                patch,
+            )
+
+    def test_review_patch_redacts_multiline_fallback_literal(self) -> None:
+        fixture_value = realistic_secret_value()
+        patch = (
+            "diff --git a/runtime.ts b/runtime.ts\n"
+            "--- a/runtime.ts\n"
+            "+++ b/runtime.ts\n"
+            "@@ -0,0 +1,2 @@\n"
+            + "+pass"
+            + "word = password\n"
+            + f'+  || "{fixture_value}";\n'
+        )
+
+        redacted_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["runtime.ts"],
+            patch,
+        )
+
+        self.assertNotIn(fixture_value, redacted_patch)
+        self.assertIn('+  || "redacted";', redacted_patch)
+
+    def test_review_patch_preserves_and_rejects_ambiguous_multiline_call_value(
+        self,
+    ) -> None:
+        fixture_value = realistic_secret_value()
+        patch = (
+            "diff --git a/runtime.py b/runtime.py\n"
+            "--- a/runtime.py\n"
+            "+++ b/runtime.py\n"
+            "@@ -0,0 +1,3 @@\n"
+            + "+pass"
+            + "word = decode(\n"
+            + f'+    "{fixture_value}",\n'
+            + "+)\n"
+        )
+
+        _old_content, new_content = self.helper["unified_diff_contents"](patch)
+        fragments = self.helper["review_secret_fragments"](new_content)
+        redacted_patch = self.helper["redact_secret_like_diff_section"](
+            patch,
+            {"runtime.py"},
+            fragments,
+        )
+
+        self.assertNotIn(fixture_value, redacted_patch)
+        self.assertIn("+pass" + "word = decode(", redacted_patch)
+        self.assertIn('+    "redacted",', redacted_patch)
+        validated_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["runtime.py"],
+            patch,
+        )
+        self.assertIn("+pass" + "word = decode(", validated_patch)
+        self.assertIn('+    "redacted",', validated_patch)
+
+    def test_review_patch_redacts_short_and_unquoted_fallbacks(self) -> None:
+        for fallback in ('"hunter2"', "12345678"):
+            with self.subTest(fallback=fallback):
+                patch = (
+                    "diff --git a/runtime.py b/runtime.py\n"
+                    "--- a/runtime.py\n"
+                    "+++ b/runtime.py\n"
+                    "@@ -0,0 +1 @@\n"
+                    + "+pass"
+                    + f'word = getenv("PASSWORD") or {fallback}\n'
+                )
+
+                redacted_patch = self.helper["validate_review_patch"](
+                    "local unstaged diff",
+                    ["runtime.py"],
+                    patch,
+                )
+
+                self.assertNotIn(fallback.strip('"'), redacted_patch)
+                expected = '"redacted"' if fallback.startswith('"') else "redacted"
+                self.assertIn(
+                    f'getenv("PASSWORD") or {expected}',
+                    redacted_patch,
+                )
+
+    def test_review_patch_preserves_redaction_placeholder_fallback(self) -> None:
+        patch = (
+            "diff --git a/runtime.py b/runtime.py\n"
+            "--- a/runtime.py\n"
+            "+++ b/runtime.py\n"
+            "@@ -0,0 +1 @@\n"
+            + "+pass"
+            + 'word = getenv("PASSWORD") or "redacted"\n'
+        )
+
+        self.assertEqual(
+            self.helper["validate_review_patch"](
+                "local unstaged diff",
+                ["runtime.py"],
+                patch,
+            ),
+            patch,
+        )
+
+    def test_review_patch_ignores_nested_fallback_operator_text(self) -> None:
+        fixture_value = realistic_secret_value()
+        patch = (
+            "diff --git a/runtime.ts b/runtime.ts\n"
+            "--- a/runtime.ts\n"
+            "+++ b/runtime.ts\n"
+            "@@ -0,0 +1 @@\n"
+            + "+pass"
+            + f'word = defaults["x || y"] || "{fixture_value}"\n'
+        )
+
+        redacted_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["runtime.ts"],
+            patch,
+        )
+
+        self.assertNotIn(fixture_value, redacted_patch)
+        self.assertIn('defaults["x || y"] || "redacted"', redacted_patch)
+
+    def test_review_patch_ignores_fallback_literals_inside_comments(self) -> None:
+        patch = (
+            "diff --git a/runtime.ts b/runtime.ts\n"
+            "--- a/runtime.ts\n"
+            "+++ b/runtime.ts\n"
+            "@@ -0,0 +1,2 @@\n"
+            + "+pass"
+            + 'word = primary || secondary // "evil-package"\n'
+            + '+import("evil-package");\n'
+        )
+
+        _old_content, new_content = self.helper["unified_diff_contents"](patch)
+        fragments = self.helper["review_secret_fragments"](new_content)
+        redacted_patch = self.helper["redact_secret_like_diff_section"](
+            patch,
+            {"runtime.ts"},
+            fragments,
+        )
+        self.assertIn('+import("evil-package");', redacted_patch)
+        with self.assertRaisesRegex(SystemExit, "secret-like content"):
+            self.helper["validate_review_patch"](
+                "local unstaged diff",
+                ["runtime.ts"],
+                patch,
+            )
+
+    def test_review_patch_learns_bearer_credential_without_prefix(self) -> None:
+        bearer_value = "AbcdEFGHijklMNOPqrstUVWX+SensitiveTail123=="
+        patch = (
+            "diff --git a/runtime.ts b/runtime.ts\n"
+            "--- a/runtime.ts\n"
+            "+++ b/runtime.ts\n"
+            "@@ -0,0 +1,2 @@\n"
+            + f'+const authorization = "Bearer {bearer_value}";\n'
+            + f'+log("{bearer_value}");\n'
+        )
+
+        redacted = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["runtime.ts"],
+            patch,
+        )
+
+        self.assertNotIn(bearer_value, redacted)
+        self.assertIn('"Bearer redacted"', redacted)
+        self.assertIn('+log("redacted");', redacted)
+
+    def test_review_patch_preserves_safe_assignment_on_mixed_risk_line(self) -> None:
+        fixture_value = realistic_secret_value()
+        patch = (
+            "diff --git a/runtime.ts b/runtime.ts\n"
+            "--- a/runtime.ts\n"
+            "+++ b/runtime.ts\n"
+            "@@ -0,0 +1 @@\n"
+            f'+const options = {{ creden{"tials"}: "include", api{"Key"}: "{fixture_value}" }};\n'
+        )
+
+        redacted_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["runtime.ts"],
+            patch,
+        )
+
+        self.assertIn('creden' + 'tials: "include"', redacted_patch)
+        self.assertIn('api' + 'Key: "redacted"', redacted_patch)
+
+    def test_review_patch_redacts_commented_private_key_body(self) -> None:
+        body = "MIIEowIBAAKCAQEAcommented0123456789ABCDEF"
+        patch = (
+            "diff --git a/fixture.txt b/fixture.txt\n"
+            "--- a/fixture.txt\n"
+            "+++ b/fixture.txt\n"
+            "@@ -0,0 +1,4 @@\n"
+            "+# -----BEGIN "
+            + "PRIVATE KEY-----\n"
+            f"+# {body}\n"
+            "+# -----END "
+            + "PRIVATE KEY-----\n"
+            "+runDangerousOperation();\n"
+        )
+
+        redacted = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["fixture.txt"],
+            patch,
+        )
+
+        self.assertNotIn(body, redacted)
+        self.assertIn("+# redacted", redacted)
+        self.assertIn("+runDangerousOperation();", redacted)
+
+    def test_review_patch_redacts_block_commented_private_key_body(self) -> None:
+        body = "MIIEvQIBADANBgkqhkiG9w0BAQEFAASC1234567890"
+        patch = (
+            "diff --git a/fixture.txt b/fixture.txt\n"
+            "--- a/fixture.txt\n"
+            "+++ b/fixture.txt\n"
+            "@@ -0,0 +1,3 @@\n"
+            "+/* -----BEGIN "
+            + "PRIVATE KEY----- */\n"
+            + f"+/* {body} */\n"
+            + "+/* -----END "
+            + "PRIVATE KEY----- */\n"
+        )
+
+        redacted = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["fixture.txt"],
+            patch,
+        )
+
+        self.assertNotIn(body, redacted)
+        self.assertIn("+/* redacted */", redacted)
+
+    def test_review_patch_normalizes_escaped_private_key_body_fragment(self) -> None:
+        body = "MIIEvQIBADANBgkqhkiG9w0BAQEFAASC1234567890"
+        patch = (
+            "diff --git a/fixture.ts b/fixture.ts\n"
+            "--- a/fixture.ts\n"
+            "+++ b/fixture.ts\n"
+            "@@ -0,0 +1,2 @@\n"
+            "+const pem = \"-----BEGIN "
+            + f"PRIVATE KEY-----\\n{body}\\n-----END "
+            + "PRIVATE KEY-----\";\n"
+            + f'+log("{body}");\n'
+        )
+
+        redacted_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["fixture.ts"],
+            patch,
+        )
+
+        self.assertNotIn(body, redacted_patch)
+        self.assertIn('+log("redacted");', redacted_patch)
+
+    def test_review_patch_redacts_escaped_private_key_tail_quanta(self) -> None:
+        for tail in ("AQ==", "AQI="):
+            with self.subTest(tail=tail):
+                patch = (
+                    "diff --git a/fixture.ts b/fixture.ts\n"
+                    "--- a/fixture.ts\n"
+                    "+++ b/fixture.ts\n"
+                    "@@ -0,0 +1 @@\n"
+                    "+const pem = \"-----BEGIN "
+                    + f"PRIVATE KEY-----\\n{tail}\\n-----END "
+                    + "PRIVATE KEY-----\";\n"
+                )
+
+                redacted_patch = self.helper["validate_review_patch"](
+                    "local unstaged diff",
+                    ["fixture.ts"],
+                    patch,
+                )
+
+                self.assertNotIn(tail, redacted_patch)
+                self.assertIn("\\nredacted\\n", redacted_patch)
+
+    def test_review_patch_redacts_short_private_key_chunks(self) -> None:
+        patch = (
+            "diff --git a/fixture.txt b/fixture.txt\n"
+            "--- a/fixture.txt\n"
+            "+++ b/fixture.txt\n"
+            "@@ -0,0 +1,3 @@\n"
+            "+-----BEGIN "
+            + "PRIVATE KEY-----\n"
+            "+AB12 CDef3456GHij7890\n"
+            "+-----END "
+            + "PRIVATE KEY-----\n"
+        )
+
+        redacted = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["fixture.txt"],
+            patch,
+        )
+
+        self.assertNotIn("AB12", redacted)
+        self.assertNotIn("CDef3456GHij7890", redacted)
+
+    def test_review_patch_redacts_padded_private_key_tail_quanta(self) -> None:
+        for tail in ("AQ==", "AQI="):
+            with self.subTest(tail=tail):
+                patch = (
+                    "diff --git a/fixture.txt b/fixture.txt\n"
+                    "--- a/fixture.txt\n"
+                    "+++ b/fixture.txt\n"
+                    "@@ -0,0 +1,3 @@\n"
+                    "+-----BEGIN "
+                    + "PRIVATE KEY-----\n"
+                    + f"+{tail}\n"
+                    + "+-----END "
+                    + "PRIVATE KEY-----\n"
+                )
+
+                redacted = self.helper["validate_review_patch"](
+                    "local unstaged diff",
+                    ["fixture.txt"],
+                    patch,
+                )
+
+                self.assertNotIn(tail, redacted)
+
+    def test_review_patch_redacts_private_key_body_without_visible_markers(self) -> None:
+        chunks = "AB12 CDef3456GHij7890 KLmn1234OPqr5678"
+        patch = (
+            "diff --git a/fixture.txt b/fixture.txt\n"
+            "--- a/fixture.txt\n"
+            "+++ b/fixture.txt\n"
+            "@@ -8 +8,2 @@\n"
+            + f"+{chunks}\n"
+            + f'+log("{chunks}")\n'
+        )
+
+        redacted = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["fixture.txt"],
+            patch,
+        )
+
+        self.assertNotIn(chunks, redacted)
+        self.assertIn("+redacted redacted redacted", redacted)
+        self.assertIn('+log("redacted redacted redacted")', redacted)
+
+    def test_review_patch_redacts_markerless_private_key_body_in_string(self) -> None:
+        body = "MIIEvQIBADANBgkqhkiG9w0BAQEFAASC1234567890abcdef"
+        patch = (
+            "diff --git a/fixture.ts b/fixture.ts\n"
+            "--- a/fixture.ts\n"
+            "+++ b/fixture.ts\n"
+            "@@ -0,0 +1,2 @@\n"
+            + f'+const fixture = "{body}";\n'
+            + f'+log("{body}");\n'
+        )
+
+        redacted_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["fixture.ts"],
+            patch,
+        )
+
+        self.assertNotIn(body, redacted_patch)
+        self.assertIn('+const fixture = "redacted";', redacted_patch)
+        self.assertIn('+log("redacted");', redacted_patch)
+
+    def test_review_patch_preserves_long_non_pem_identifier_lines(self) -> None:
+        identifier = "runDangerousOperationWithLongIdentifier"
+        patch = (
+            "diff --git a/runtime.ts b/runtime.ts\n"
+            "--- a/runtime.ts\n"
+            "+++ b/runtime.ts\n"
+            "@@ -0,0 +1 @@\n"
+            + f"+{identifier}\n"
+        )
+
+        redacted = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["runtime.ts"],
+            patch,
+        )
+
+        self.assertIn("+" + identifier, redacted)
+
+    def test_review_patch_preserves_hash_and_submodule_lines(self) -> None:
+        digest = "abcdef0123456789abcdef0123456789abcdef01"
+        patch = (
+            "diff --git a/vendor b/vendor\n"
+            "--- a/vendor\n"
+            "+++ b/vendor\n"
+            "@@ -1 +1,2 @@\n"
+            + f"+{digest}\n"
+            + f"+Subproject commit {digest}\n"
+        )
+
+        redacted = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["vendor"],
+            patch,
+        )
+
+        self.assertIn("+" + digest, redacted)
+        self.assertIn("+Subproject commit " + digest, redacted)
+
+    def test_review_patch_learns_private_key_body_chunks(self) -> None:
+        body = "MIIEowIBAAKCAQEAshared0123456789ABCDEF"
+        patch = (
+            "diff --git a/fixture.txt b/fixture.txt\n"
+            "--- a/fixture.txt\n"
+            "+++ b/fixture.txt\n"
+            "@@ -0,0 +1,4 @@\n"
+            "+-----BEGIN "
+            + "PRIVATE KEY-----\n"
+            f"+{body}\n"
+            "+-----END "
+            + "PRIVATE KEY-----\n"
+            f'+log("{body}")\n'
+        )
+
+        redacted = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["fixture.txt"],
+            patch,
+        )
+
+        self.assertNotIn(body, redacted)
+        self.assertIn('+log("redacted")', redacted)
+
+    def test_review_patch_redacts_known_secret_in_bare_comment(self) -> None:
+        fixture_value = "qjvmtzplskdwoeirutyghbnx"
+        patch = (
+            "diff --git a/runtime.ts b/runtime.ts\n"
+            "--- a/runtime.ts\n"
+            "+++ b/runtime.ts\n"
+            "@@ -1 +1 @@\n"
+            f'-pass{"word"} = "{fixture_value}"\n'
+            f"+# rotated value {fixture_value}\n"
+        )
+
+        with self.assertRaisesRegex(SystemExit, "known secret-like value"):
+            self.helper["validate_review_patch"](
+                "local unstaged diff",
+                ["runtime.ts"],
+                patch,
+            )
+
+    def test_review_patch_redacts_known_secret_in_hunk_header(self) -> None:
+        fixture_value = realistic_secret_value()
+        patch = (
+            "diff --git a/runtime.ts b/runtime.ts\n"
+            "--- a/runtime.ts\n"
+            "+++ b/runtime.ts\n"
+            f"@@ -1 +1 @@ function rotate_{fixture_value}()\n"
+            f'-pass{"word"} = "{fixture_value}"\n'
+            "+return true;\n"
+        )
+
+        redacted_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["runtime.ts"],
+            patch,
+        )
+
+        self.assertNotIn(fixture_value, redacted_patch)
+        self.assertIn("function rotate_redacted()", redacted_patch)
+
+    def test_review_patch_learns_secret_from_hunk_header(self) -> None:
+        fixture_value = realistic_secret_value()
+        patch = (
+            "diff --git a/runtime.ts b/runtime.ts\n"
+            "--- a/runtime.ts\n"
+            "+++ b/runtime.ts\n"
+            + f'@@ -1 +1 @@ function f(pass{"word"} = "{fixture_value}")\n'
+            + f'+log("{fixture_value}");\n'
+        )
+
+        redacted_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["runtime.ts"],
+            patch,
+        )
+
+        self.assertNotIn(fixture_value, redacted_patch)
+        self.assertIn('function f(pass' + 'word = "redacted")', redacted_patch)
+        self.assertIn('+log("redacted");', redacted_patch)
+
+    def test_review_patch_redacts_markerless_private_key_hunk_header(self) -> None:
+        body = "MIIEvQIBADANBgkqhkiG9w0BAQEFAASC1234567890abcdef"
+        patch = (
+            "diff --git a/fixture.txt b/fixture.txt\n"
+            "--- a/fixture.txt\n"
+            "+++ b/fixture.txt\n"
+            f"@@ -1 +1 @@ {body}\n"
+            "+return true\n"
+        )
+
+        redacted_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["fixture.txt"],
+            patch,
+        )
+
+        self.assertNotIn(body, redacted_patch)
+        self.assertIn("@@ -1 +1 @@ redacted", redacted_patch)
+
+    def test_review_patch_redacts_private_key_hunk_header_and_repeats(self) -> None:
+        body = "MIIEvQIBADANBgkqhkiG9w0BAQEFAASC1234567890"
+        patch = (
+            "diff --git a/runtime.ts b/runtime.ts\n"
+            "--- a/runtime.ts\n"
+            "+++ b/runtime.ts\n"
+            "@@ -1 +1 @@ function f() { return \"-----BEGIN "
+            + f"PRIVATE KEY-----\\n{body}\"; }}\n"
+            + f'+log("{body}");\n'
+        )
+
+        redacted_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["runtime.ts"],
+            patch,
+        )
+
+        self.assertNotIn(body, redacted_patch)
+        self.assertIn(self.helper["REVIEW_SECRET_REDACTION"], redacted_patch)
+        self.assertIn('+log("redacted");', redacted_patch)
+
+    def test_review_patch_rejects_known_secret_in_diff_metadata(self) -> None:
+        secret = realistic_secret_value()
+        patch = (
+            "diff --git a/settings.txt b/settings.txt\n"
+            "--- a/settings.txt\n"
+            "+++ b/settings.txt\n"
+            "@@ -1 +0,0 @@\n"
+            f'-pass{"word"} = "{secret}"\n'
+            f"diff --git a/{secret}.txt b/{secret}.txt\n"
+            f"--- a/{secret}.txt\n"
+            f"+++ b/{secret}.txt\n"
+            "@@ -0,0 +1 @@\n"
+            "+safe\n"
+        )
+
+        with self.assertRaisesRegex(SystemExit, "known secret-like value"):
+            self.helper["validate_review_patch"](
+                "local unstaged diff",
+                ["settings.txt", f"{secret}.txt"],
+                patch,
+            )
+
+    def test_review_patch_redacts_non_self_reference_fallback(self) -> None:
+        fixture_value = realistic_secret_value()
+        patch = (
+            "diff --git a/runtime.py b/runtime.py\n"
+            "--- a/runtime.py\n"
+            "+++ b/runtime.py\n"
+            "@@ -0,0 +1 @@\n"
+            f'+pass{"word"} = getenv("PASSWORD") or "{fixture_value}"; '
+            + 'execute("DROP DATABASE production")\n'
+        )
+
+        redacted_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["runtime.py"],
+            patch,
+        )
+
+        self.assertNotIn(fixture_value, redacted_patch)
+        self.assertIn('getenv("PASSWORD") or "redacted"', redacted_patch)
+        self.assertIn('execute("DROP DATABASE production")', redacted_patch)
 
     def test_local_bundle_allows_deleted_test_token_fixture(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:


### PR DESCRIPTION
## Problem

Autoreview rejects otherwise safe review bundles when diffs contain credential-shaped test fixtures or fake PEM material. That blocked review instead of reviewing the actual change.

## Solution

- detect and redact secret-like values from review-only diff content
- propagate exact known values across files and diff sides
- sanitize PEM markers, markerless private-key bodies, hunk headers, fallback literals, and credential-bearing calls
- fail closed when redaction would hide executable identifiers or change unsafe structure
- preserve original repository content; only the reviewer bundle is rewritten

## Proof

- 137 focused review-patch and secret-detector tests pass
- 263 full hardening tests pass; 1 skipped; 4 local-only failures require a Java runtime unavailable on this machine
- repository skill validator passes
- validator test suite: 9 tests pass
- fresh mandatory autoreview: clean
