### PR TITLE
feat(agent-transcript): discover Copilot sessions automatically

### DIFF
--- a/skills/agent-transcript/AGENTS.md
+++ b/skills/agent-transcript/AGENTS.md
@@ -1,0 +1,6 @@
+# Agent Transcript Skill
+
+- Canonical source: `openclaw/agent-skills`, under `skills/agent-transcript`.
+- Before editing any copy, fast-forward a checkout of `openclaw/agent-skills` from `origin/main`.
+- Make and validate shared changes in canonical `skills/agent-transcript` first, then sync the complete directory into downstream repos.
+- Never create repo-local behavior variants; downstream differences belong in repo-level validation, not the skill.

--- a/skills/agent-transcript/CLAUDE.md
+++ b/skills/agent-transcript/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/skills/agent-transcript/SKILL.md
+++ b/skills/agent-transcript/SKILL.md
@@ -17,6 +17,7 @@ Best-effort local-only provenance for OpenClaw PR/issue bodies. Use during agent
 - Fail closed on unresolved secrets, private keys, browser/session/cookie details, or auth URLs.
 - Drop system/developer prompts, raw tool outputs, reasoning, env, cookies, tokens, and broad local paths.
 - Keep user prompts, assistant visible decisions, terse tool summaries, and test/proof outcomes.
+- For GitHub Copilot, discover `~/.copilot/session-state/*/events.jsonl`, keep only visible `user.message` and `assistant.message` content, count tool starts, and drop tool completions/outputs plus system, transformed, reasoning, encrypted, and hook content.
 - Automatically trim the rendered transcript before showing it, previewing it, or inserting it into a public body. Never paste the raw full-session render into a PR/issue body just because `render` or `append-body` produced it.
 - Remove session turns unrelated to the PR/issue work. Use the PR/issue title, branch name, changed files, and stated goal as scope; omit earlier/later unrelated tasks even when they are in the same session log.
 - Best effort only: PR/issue creation must continue if no safe transcript is found.
@@ -25,48 +26,56 @@ Best-effort local-only provenance for OpenClaw PR/issue bodies. Use during agent
 
 ## Helper
 
-```bash
-skills/agent-transcript/scripts/agent-transcript --help
+```sh
+node "{baseDir}/scripts/agent-transcript" --help
 ```
 
 Find a likely local session:
 
-```bash
-skills/agent-transcript/scripts/agent-transcript find \
-  --query "$PR_TITLE $BRANCH_OR_PR_URL" \
-  --cwd "$PWD" \
+```sh
+node "{baseDir}/scripts/agent-transcript" find \
+  --query "PR title branch-or-URL" \
+  --cwd "." \
   --since-days 14
 ```
 
-`find` scans the newest 400 matching local JSONL logs by default across Codex, Claude, Pi, and OpenClaw agent sessions. Use `--max-files N` for a wider local search.
-
-In a downstream repo that syncs shared skills under `.agents/skills`, replace
-`skills/agent-transcript` with `.agents/skills/agent-transcript`.
+`find` scans the newest 400 matching local JSONL logs by default across Codex, Claude, GitHub Copilot, Pi, and OpenClaw agent sessions. Use `--max-files N` for a wider local search.
 
 Render a PR/issue body section:
 
-```bash
-skills/agent-transcript/scripts/agent-transcript render \
-  --session "$SESSION_JSONL" \
-  --out /tmp/agent-transcript.md
+```sh
+node "{baseDir}/scripts/agent-transcript" render \
+  --session "SESSION_JSONL" \
+  --out "agent-transcript.md"
 ```
+
+For Codex sessions whose JSONL was compacted or archived, prefer local app-server rendering:
+
+```sh
+node "{baseDir}/scripts/agent-transcript" render-thread \
+  --thread-id "THREAD_ID" \
+  --out "agent-transcript.md"
+```
+
+`render --app-server --session "SESSION_JSONL"` can infer a UUID thread ID from the session filename.
 
 Preview one candidate session locally:
 
-```bash
-skills/agent-transcript/scripts/agent-transcript preview \
-  --session "$SESSION_JSONL" \
-  --out /tmp/agent-transcript-preview.html
-open /tmp/agent-transcript-preview.html
+```sh
+node "{baseDir}/scripts/agent-transcript" preview \
+  --session "SESSION_JSONL" \
+  --out "agent-transcript-preview.html"
 ```
+
+Open the generated HTML locally with the platform's normal file viewer.
 
 Append/update a body file before `gh pr create --body-file` or connector PR creation:
 
-```bash
-skills/agent-transcript/scripts/agent-transcript append-body \
-  --body /tmp/pr-body.md \
-  --session "$SESSION_JSONL" \
-  --out /tmp/pr-body.with-transcript.md
+```sh
+node "{baseDir}/scripts/agent-transcript" append-body \
+  --body "pr-body.md" \
+  --session "SESSION_JSONL" \
+  --out "pr-body.with-transcript.md"
 ```
 
 ## PR/Issue Workflow
@@ -83,16 +92,16 @@ skills/agent-transcript/scripts/agent-transcript append-body \
 
 ## Validate
 
-```bash
-node --test skills/agent-transcript/scripts/agent-transcript.test.mjs
+```sh
+node --test "{baseDir}/scripts/agent-transcript.test.mjs"
 ```
 
 ## Review Artifacts
 
 For manual audits across many PR/session candidates, create a local HTML preview from a local JSON file. This is for maintainers only and is not part of the PR/issue workflow:
 
-```bash
-skills/agent-transcript/scripts/agent-transcript html \
-  --prs /tmp/recent-prs.json \
-  --out /tmp/agent-transcript-preview.html
+```sh
+node "{baseDir}/scripts/agent-transcript" html \
+  --prs "recent-prs.json" \
+  --out "agent-transcript-preview.html"
 ```

--- a/skills/agent-transcript/scripts/agent-transcript
+++ b/skills/agent-transcript/scripts/agent-transcript
@@ -4,12 +4,14 @@ import os from "node:os";
 import path from "node:path";
 import process from "node:process";
 import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
 
 const MARKER_START = "<!-- agent-transcript:start -->";
 const MARKER_END = "<!-- agent-transcript:end -->";
 const DEFAULT_MAX_CHARS = 50000;
 const DEFAULT_ENTRY_MAX_CHARS = 6000;
 const MAX_JSONL_BOUNDARY_BYTES = 1024 * 1024;
+const COPILOT_PRODUCER_PROBE_BYTES = 64 * 1024;
 
 function usage() {
   console.log(`Usage:
@@ -702,6 +704,35 @@ function readFileRange(fd, start, length) {
   return buffer.subarray(0, bytesRead);
 }
 
+function readCopilotProducerProbe(file) {
+  const fd = fs.openSync(file, "r");
+  try {
+    const stat = fs.fstatSync(fd);
+    const length = Math.min(stat.size, COPILOT_PRODUCER_PROBE_BYTES);
+    const buffer = readFileRange(fd, 0, length);
+    let end = buffer.length;
+    if (length < stat.size) {
+      const boundary = buffer.lastIndexOf(0x0a);
+      end = boundary >= 0 ? boundary + 1 : 0;
+    }
+    return buffer
+      .subarray(0, end)
+      .toString("utf8")
+      .split(/\n+/)
+      .filter(Boolean)
+      .flatMap((line) => {
+        try {
+          const row = JSON.parse(line);
+          return row?.type === "session.start" ? [row] : [];
+        } catch {
+          return [];
+        }
+      });
+  } finally {
+    fs.closeSync(fd);
+  }
+}
+
 function readBoundedJsonlRows(file, maxBytes = 220000) {
   const fd = fs.openSync(file, "r");
   try {
@@ -749,11 +780,19 @@ function readBoundedJsonlRows(file, maxBytes = 220000) {
   }
 }
 
-function sessionScanRecord(file, maxBytes) {
+function sessionScanRecord(file, maxBytes, readers = {}) {
   const stat = fs.statSync(file);
   const boundedText = readBoundedText(file, maxBytes);
-  const rows = readBoundedJsonlRows(file, maxBytes);
-  const agent = detectAgent(file, rows);
+  const readProducerProbe = readers.readCopilotProducerProbe || readCopilotProducerProbe;
+  const readRows = readers.readBoundedJsonlRows || readBoundedJsonlRows;
+  let agent = detectAgent(file, []);
+  let rows = [];
+  if (agent === "copilot") {
+    rows = readRows(file, maxBytes);
+  } else if (agent === "agent") {
+    agent = detectAgent(file, readProducerProbe(file));
+    if (agent === "copilot") rows = readRows(file, maxBytes);
+  }
   const scanText =
     agent === "copilot"
       ? rows
@@ -987,9 +1026,16 @@ async function main() {
   process.exitCode = 2;
 }
 
-try {
-  await main();
-} catch (error) {
-  console.error(error instanceof Error ? error.message : String(error));
-  process.exit(1);
+const isMain =
+  process.argv[1] &&
+  fs.realpathSync(path.resolve(process.argv[1])) === fs.realpathSync(fileURLToPath(import.meta.url));
+if (isMain) {
+  try {
+    await main();
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
 }
+
+export { sessionScanRecord };

--- a/skills/agent-transcript/scripts/agent-transcript
+++ b/skills/agent-transcript/scripts/agent-transcript
@@ -9,6 +9,7 @@ const MARKER_START = "<!-- agent-transcript:start -->";
 const MARKER_END = "<!-- agent-transcript:end -->";
 const DEFAULT_MAX_CHARS = 50000;
 const DEFAULT_ENTRY_MAX_CHARS = 6000;
+const MAX_JSONL_BOUNDARY_BYTES = 1024 * 1024;
 
 function usage() {
   console.log(`Usage:
@@ -110,6 +111,7 @@ function defaultRoots() {
   return [
     homePath(".codex", "sessions"),
     ...claudeProjectRoots(),
+    homePath(".copilot", "session-state"),
     homePath(".pi", "agent", "sessions"),
     ...openClawSessionRoots(),
   ];
@@ -171,6 +173,12 @@ function stringContent(value) {
 function detectAgent(file, rows) {
   if (file.includes(`${path.sep}.codex${path.sep}`)) return "codex";
   if (claudeProjectRoots().some((root) => isPathInside(file, root))) return "claude";
+  if (
+    isPathInside(file, homePath(".copilot", "session-state")) ||
+    rows.some((row) => row?.type === "session.start" && row?.data?.producer === "copilot-agent")
+  ) {
+    return "copilot";
+  }
   if (file.includes(`${path.sep}.pi${path.sep}`)) return "pi";
   if (
     file.includes(`${path.sep}.openclaw${path.sep}`) ||
@@ -184,6 +192,9 @@ function detectAgent(file, rows) {
 }
 
 function eventText(row) {
+  if (row?.type === "user.message" || row?.type === "assistant.message") {
+    return stringContent(row.data?.content);
+  }
   if (row?.type === "compacted_replacement_item") {
     return stringContent(row.payload?.content || row.payload?.summary || row.payload?.arguments || row.payload?.output);
   }
@@ -233,6 +244,16 @@ function eventRole(row) {
   if (row?.message?.role === "user") return "user";
   if (row?.message?.role === "assistant") return "assistant";
   if (row?.type === "tool_result" || row?.type === "tool_use") return "tool";
+  return null;
+}
+
+function copilotEventRole(row) {
+  if (row?.type === "user.message") return "user";
+  if (row?.type === "assistant.message") return "assistant";
+  if (row?.type === "tool.execution_start" || row?.type === "external_tool.requested") return "tool";
+  if (row?.type === "tool.execution_complete" || row?.type === "external_tool.completed") {
+    return "tool_output";
+  }
   return null;
 }
 
@@ -359,7 +380,7 @@ function shellFamily(command) {
 }
 
 function toolCallFamily(row) {
-  const name = row.payload?.name || row.name || row.message?.name || row.type || "tool";
+  const name = row.data?.toolName || row.payload?.name || row.name || row.message?.name || row.type || "tool";
   if (name === "exec_command") {
     try {
       const args = JSON.parse(row.payload?.arguments || "{}");
@@ -427,9 +448,10 @@ function renderSession(file, options = {}) {
     const type = row?.type === "event_msg" ? row.payload?.type : null;
     return type === "user_message" || type === "agent_message";
   });
-  const renderRows = rows.flatMap((row) => [row, ...expandCompactedReplacementItems(row)]);
+  const renderRows =
+    agent === "copilot" ? rows : rows.flatMap((row) => [row, ...expandCompactedReplacementItems(row)]);
   for (const row of renderRows) {
-    const role = eventRole(row);
+    const role = agent === "copilot" ? copilotEventRole(row) : eventRole(row);
     if (!role) continue;
     if (hasEventDialogue && row.type === "response_item" && (role === "user" || role === "assistant")) {
       continue;
@@ -673,14 +695,78 @@ function readBoundedText(file, maxBytes = 220000) {
   }
 }
 
+function readFileRange(fd, start, length) {
+  if (length <= 0) return Buffer.alloc(0);
+  const buffer = Buffer.alloc(length);
+  const bytesRead = fs.readSync(fd, buffer, 0, length, start);
+  return buffer.subarray(0, bytesRead);
+}
+
+function readBoundedJsonlRows(file, maxBytes = 220000) {
+  const fd = fs.openSync(file, "r");
+  try {
+    const stat = fs.fstatSync(fd);
+    if (stat.size <= maxBytes) return readJsonl(file);
+
+    const half = Math.max(1, Math.floor(maxBytes / 2));
+    const boundaryBytes = MAX_JSONL_BOUNDARY_BYTES;
+    const headLength = Math.min(stat.size, half + boundaryBytes);
+    const headBuffer = readFileRange(fd, 0, headLength);
+    const headBoundary = headBuffer.indexOf(0x0a, half);
+    let headEnd = headBuffer.length;
+    if (headBoundary >= 0) headEnd = headBoundary + 1;
+    else if (headLength < stat.size) headEnd = headBuffer.lastIndexOf(0x0a) + 1;
+
+    const desiredTailStart = Math.max(0, stat.size - half);
+    const tailReadStart = Math.max(0, desiredTailStart - boundaryBytes);
+    const tailBuffer = readFileRange(fd, tailReadStart, stat.size - tailReadStart);
+    const desiredOffset = desiredTailStart - tailReadStart;
+    const previousBoundary = tailBuffer.lastIndexOf(0x0a, Math.max(0, desiredOffset - 1));
+    const nextBoundary = tailBuffer.indexOf(0x0a, desiredOffset);
+    let tailStart =
+      previousBoundary >= 0
+        ? previousBoundary + 1
+        : tailReadStart === 0
+          ? 0
+          : nextBoundary >= 0
+            ? nextBoundary + 1
+            : tailBuffer.length;
+    if (tailReadStart + tailStart < headEnd) {
+      tailStart = Math.min(tailBuffer.length, headEnd - tailReadStart);
+    }
+    const headText = headBuffer.subarray(0, headEnd).toString("utf8");
+    const tailText = tailBuffer.subarray(tailStart).toString("utf8");
+    const lines = [...headText.split(/\n+/), ...tailText.split(/\n+/)].filter(Boolean);
+    return lines.flatMap((line) => {
+      try {
+        return [JSON.parse(line)];
+      } catch {
+        return [];
+      }
+    });
+  } finally {
+    fs.closeSync(fd);
+  }
+}
+
 function sessionScanRecord(file, maxBytes) {
   const stat = fs.statSync(file);
-  const agent = detectAgent(file, []);
+  const boundedText = readBoundedText(file, maxBytes);
+  const rows = readBoundedJsonlRows(file, maxBytes);
+  const agent = detectAgent(file, rows);
+  const scanText =
+    agent === "copilot"
+      ? rows
+          .filter((row) => row?.type === "user.message" || row?.type === "assistant.message")
+          .map((row) => stringContent(row.data?.content))
+          .filter(Boolean)
+          .join("\n")
+      : boundedText;
   return {
     file,
     agent,
     mtime: new Date(stat.mtimeMs).toISOString(),
-    haystack: `${file}\n${readBoundedText(file, maxBytes)}`.toLowerCase(),
+    haystack: `${file}\n${scanText}`.toLowerCase(),
   };
 }
 

--- a/skills/agent-transcript/scripts/agent-transcript.test.mjs
+++ b/skills/agent-transcript/scripts/agent-transcript.test.mjs
@@ -5,23 +5,322 @@ import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 
-const script = path.resolve("skills/agent-transcript/scripts/agent-transcript");
+const script = path.join(import.meta.dirname, "agent-transcript");
 
 function tempDir() {
   return fs.mkdtempSync(path.join(os.tmpdir(), "agent-transcript-test-"));
 }
 
 function writeJsonl(file, rows) {
+  fs.mkdirSync(path.dirname(file), { recursive: true });
   fs.writeFileSync(file, `${rows.map((row) => JSON.stringify(row)).join("\n")}\n`);
 }
 
 function run(args, options = {}) {
   return execFileSync(process.execPath, [script, ...args], {
-    cwd: path.resolve("."),
+    cwd: import.meta.dirname,
     encoding: "utf8",
     ...options,
   });
 }
+
+function copilotEvents(messages) {
+  return [
+    {
+      type: "session.start",
+      data: {
+        sessionId: "copilot-session",
+        producer: "copilot-agent",
+      },
+    },
+    ...messages,
+  ];
+}
+
+test("find discovers Copilot sessions from the default local session-state root", () => {
+  const home = tempDir();
+  const session = path.join(home, ".copilot", "session-state", "copilot-session", "events.jsonl");
+  writeJsonl(
+    session,
+    copilotEvents([
+      {
+        type: "user.message",
+        data: {
+          content: "Implement portable-copilot-marker in a local checkout.",
+        },
+      },
+    ]),
+  );
+
+  const output = run(["find", "--query", "portable-copilot-marker", "--cwd", "."], {
+    env: { ...process.env, HOME: home, USERPROFILE: home },
+  });
+  const matches = JSON.parse(output);
+
+  assert.equal(matches.length, 1);
+  assert.equal(matches[0].file, session);
+  assert.equal(matches[0].agent, "copilot");
+});
+
+test("find detects Copilot producers in explicit roots and scans visible dialogue only", () => {
+  const dir = tempDir();
+  const home = tempDir();
+  const session = path.join(dir, "events.jsonl");
+  writeJsonl(
+    session,
+    copilotEvents([
+      {
+        type: "user.message",
+        data: {
+          content: "visible-copilot-marker",
+          transformedContent: "PRIVATE_TRANSFORMED_SCAN_MARKER",
+        },
+      },
+    ]),
+  );
+
+  const options = {
+    env: { ...process.env, HOME: home, USERPROFILE: home },
+  };
+  const visible = JSON.parse(
+    run(["find", "--query", "visible-copilot-marker", "--root", dir, "--since-days", "1"], options),
+  );
+  const privateField = JSON.parse(
+    run(["find", "--query", "PRIVATE_TRANSFORMED_SCAN_MARKER", "--root", dir, "--since-days", "1"], options),
+  );
+
+  assert.equal(visible.length, 1);
+  assert.equal(visible[0].file, session);
+  assert.equal(visible[0].agent, "copilot");
+  assert.deepEqual(privateField, []);
+});
+
+test("find parses Copilot visible events larger than the scan-byte budget", () => {
+  const dir = tempDir();
+  const home = tempDir();
+  const session = path.join(dir, "events.jsonl");
+  writeJsonl(
+    session,
+    copilotEvents([
+      {
+        type: "user.message",
+        data: {
+          content: `prefix-${"x".repeat(400)}-copilot-boundary-marker-${"y".repeat(400)}`,
+        },
+      },
+    ]),
+  );
+
+  const output = run(
+    [
+      "find",
+      "--query",
+      "copilot-boundary-marker",
+      "--root",
+      dir,
+      "--since-days",
+      "1",
+      "--scan-bytes",
+      "120",
+    ],
+    { env: { ...process.env, HOME: home, USERPROFILE: home } },
+  );
+  const matches = JSON.parse(output);
+
+  assert.equal(matches.length, 1);
+  assert.equal(matches[0].file, session);
+  assert.equal(matches[0].agent, "copilot");
+});
+
+test("find parses Copilot visible events up to the boundary record cap", () => {
+  const dir = tempDir();
+  const home = tempDir();
+  const session = path.join(dir, "events.jsonl");
+  writeJsonl(
+    session,
+    copilotEvents([
+      {
+        type: "user.message",
+        data: {
+          content: `prefix-${"x".repeat(330 * 1024)}-copilot-large-record-marker`,
+        },
+      },
+    ]),
+  );
+
+  const output = run(
+    [
+      "find",
+      "--query",
+      "copilot-large-record-marker",
+      "--root",
+      dir,
+      "--since-days",
+      "1",
+      "--scan-bytes",
+      "60000",
+    ],
+    { env: { ...process.env, HOME: home, USERPROFILE: home } },
+  );
+  const matches = JSON.parse(output);
+
+  assert.equal(matches.length, 1);
+  assert.equal(matches[0].file, session);
+  assert.equal(matches[0].agent, "copilot");
+});
+
+test("find keeps the first Copilot event after overlapping scan ranges", () => {
+  const dir = tempDir();
+  const home = tempDir();
+  const session = path.join(dir, "events.jsonl");
+  writeJsonl(
+    session,
+    copilotEvents([
+      {
+        type: "user.message",
+        data: {
+          content: `prefix-${"x".repeat(800)}`,
+        },
+      },
+      {
+        type: "assistant.message",
+        data: {
+          content: "first-non-overlapping-event-marker",
+        },
+      },
+    ]),
+  );
+
+  const output = run(
+    [
+      "find",
+      "--query",
+      "first-non-overlapping-event-marker",
+      "--root",
+      dir,
+      "--since-days",
+      "1",
+      "--scan-bytes",
+      "400",
+    ],
+    { env: { ...process.env, HOME: home, USERPROFILE: home } },
+  );
+  const matches = JSON.parse(output);
+
+  assert.equal(matches.length, 1);
+  assert.equal(matches[0].file, session);
+  assert.equal(matches[0].agent, "copilot");
+});
+
+test("render keeps visible Copilot dialogue and drops private event data", () => {
+  const dir = tempDir();
+  const session = path.join(dir, ".copilot", "session-state", "copilot-session", "events.jsonl");
+  writeJsonl(
+    session,
+    copilotEvents([
+      {
+        type: "system.message",
+        data: {
+          role: "system",
+          content: "PRIVATE_SYSTEM_PROMPT",
+        },
+      },
+      {
+        type: "user.message",
+        data: {
+          content: "Please update /Users/alice/repo/src/index.ts.",
+          transformedContent: "PRIVATE_TRANSFORMED_PROMPT",
+        },
+      },
+      {
+        type: "assistant.message",
+        data: {
+          content: "Updated ~/repo/src/index.ts.",
+          reasoningOpaque: "PRIVATE_REASONING",
+          encryptedContent: "PRIVATE_ENCRYPTED_CONTENT",
+        },
+      },
+      {
+        type: "hook.start",
+        data: {
+          content: "PRIVATE_HOOK_CONTENT",
+        },
+      },
+      {
+        type: "response_item",
+        payload: {
+          role: "assistant",
+          content: "PRIVATE_GENERIC_RESPONSE_ITEM",
+        },
+      },
+      {
+        type: "assistant",
+        content: "PRIVATE_GENERIC_ASSISTANT_ROW",
+      },
+      {
+        type: "compacted",
+        payload: {
+          replacement_history: [
+            {
+              role: "assistant",
+              content: "PRIVATE_COMPACTED_ROW",
+            },
+          ],
+        },
+      },
+      {
+        type: "tool.execution_start",
+        data: {
+          toolCallId: "tool-1",
+          toolName: "view",
+          arguments: {
+            path: "/Users/alice/repo/src/index.ts",
+          },
+        },
+      },
+      {
+        type: "tool.execution_complete",
+        data: {
+          toolCallId: "tool-1",
+          success: true,
+          result: "PRIVATE_TOOL_OUTPUT",
+        },
+      },
+      {
+        type: "external_tool.requested",
+        data: {
+          requestId: "tool-2",
+          toolName: "powershell",
+          arguments: {
+            command: "Get-ChildItem",
+          },
+        },
+      },
+      {
+        type: "external_tool.completed",
+        data: {
+          requestId: "tool-2",
+        },
+      },
+    ]),
+  );
+
+  const output = run(["render", "--session", session]);
+
+  assert.match(output, /<summary>Redacted copilot session transcript<\/summary>/);
+  assert.match(output, /\[user\]\nPlease update \[LOCAL_PATH\]/);
+  assert.match(output, /\[assistant\]\nUpdated \[HOME_PATH\]/);
+  assert.match(output, /1 read, 1 execute; raw tool outputs dropped: 2/);
+  assert.doesNotMatch(output, /PRIVATE_SYSTEM_PROMPT/);
+  assert.doesNotMatch(output, /PRIVATE_TRANSFORMED_PROMPT/);
+  assert.doesNotMatch(output, /PRIVATE_REASONING/);
+  assert.doesNotMatch(output, /PRIVATE_ENCRYPTED_CONTENT/);
+  assert.doesNotMatch(output, /PRIVATE_HOOK_CONTENT/);
+  assert.doesNotMatch(output, /PRIVATE_GENERIC_RESPONSE_ITEM/);
+  assert.doesNotMatch(output, /PRIVATE_GENERIC_ASSISTANT_ROW/);
+  assert.doesNotMatch(output, /PRIVATE_COMPACTED_ROW/);
+  assert.doesNotMatch(output, /PRIVATE_TOOL_OUTPUT/);
+});
 
 test("render redacts common secrets and local identifiers", () => {
   const dir = tempDir();
@@ -141,4 +440,48 @@ test("find labels explicit roots under trailing-slash CLAUDE_CONFIG_DIR as Claud
   assert.equal(matches.length, 1);
   assert.equal(matches[0].file, session);
   assert.equal(matches[0].agent, "claude");
+});
+
+test("render preserves Codex event dialogue and tool summaries", () => {
+  const dir = tempDir();
+  const session = path.join(dir, "session.jsonl");
+  writeJsonl(session, [
+    {
+      type: "event_msg",
+      payload: {
+        type: "user_message",
+        message: "Existing user message",
+      },
+    },
+    {
+      type: "event_msg",
+      payload: {
+        type: "agent_message",
+        message: "Existing assistant message",
+      },
+    },
+    {
+      type: "response_item",
+      payload: {
+        type: "function_call",
+        name: "apply_patch",
+        arguments: "{}",
+      },
+    },
+    {
+      type: "response_item",
+      payload: {
+        type: "function_call_output",
+        output: "PRIVATE_EXISTING_TOOL_OUTPUT",
+      },
+    },
+  ]);
+
+  const output = run(["render", "--session", session]);
+
+  assert.match(output, /<summary>Redacted codex session transcript<\/summary>/);
+  assert.match(output, /\[user\]\nExisting user message/);
+  assert.match(output, /\[assistant\]\nExisting assistant message/);
+  assert.match(output, /1 write; raw tool outputs dropped: 1/);
+  assert.doesNotMatch(output, /PRIVATE_EXISTING_TOOL_OUTPUT/);
 });

--- a/skills/agent-transcript/scripts/agent-transcript.test.mjs
+++ b/skills/agent-transcript/scripts/agent-transcript.test.mjs
@@ -4,8 +4,10 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
+import { pathToFileURL } from "node:url";
 
 const script = path.join(import.meta.dirname, "agent-transcript");
+const { sessionScanRecord } = await import(pathToFileURL(script).href);
 
 function tempDir() {
   return fs.mkdtempSync(path.join(os.tmpdir(), "agent-transcript-test-"));
@@ -36,6 +38,27 @@ function copilotEvents(messages) {
     ...messages,
   ];
 }
+
+test("CLI runs through a symlinked entry point", (t) => {
+  const dir = tempDir();
+  const link = path.join(dir, "agent-transcript");
+  try {
+    fs.symlinkSync(script, link, "file");
+  } catch (error) {
+    if (error?.code === "EPERM") {
+      t.skip("symlink creation is unavailable");
+      return;
+    }
+    throw error;
+  }
+
+  const output = execFileSync(process.execPath, [link, "--help"], {
+    encoding: "utf8",
+  });
+
+  assert.match(output, /Usage:/);
+  assert.match(output, /agent-transcript find/);
+});
 
 test("find discovers Copilot sessions from the default local session-state root", () => {
   const home = tempDir();
@@ -93,6 +116,83 @@ test("find detects Copilot producers in explicit roots and scans visible dialogu
   assert.equal(visible[0].file, session);
   assert.equal(visible[0].agent, "copilot");
   assert.deepEqual(privateField, []);
+});
+
+test("scan avoids complete-row parsing for known Codex and Claude paths", () => {
+  const dir = tempDir();
+  const claudeConfig = path.join(dir, "claude-config");
+  const sessions = [
+    {
+      agent: "codex",
+      file: path.join(dir, ".codex", "sessions", "codex.jsonl"),
+    },
+    {
+      agent: "claude",
+      file: path.join(claudeConfig, "projects", "-tmp-project", "claude.jsonl"),
+    },
+  ];
+  const previousClaudeConfig = process.env.CLAUDE_CONFIG_DIR;
+  process.env.CLAUDE_CONFIG_DIR = claudeConfig;
+  try {
+    for (const session of sessions) {
+      writeJsonl(session.file, [
+        {
+          type: "response_item",
+          payload: {
+            role: "user",
+            content: [{ type: "text", text: `${session.agent}-visible-marker` }],
+          },
+        },
+      ]);
+      const record = sessionScanRecord(session.file, 120, {
+        readCopilotProducerProbe() {
+          throw new Error(`producer probe should not run for known ${session.agent} paths`);
+        },
+        readBoundedJsonlRows() {
+          throw new Error(`complete-row parser should not run for known ${session.agent} paths`);
+        },
+      });
+
+      assert.equal(record.agent, session.agent);
+      assert.match(record.haystack, new RegExp(`${session.agent}-visible-marker`));
+    }
+  } finally {
+    if (previousClaudeConfig == null) delete process.env.CLAUDE_CONFIG_DIR;
+    else process.env.CLAUDE_CONFIG_DIR = previousClaudeConfig;
+  }
+});
+
+test("scan promotes an unknown path after a bounded Copilot producer probe", () => {
+  const dir = tempDir();
+  const session = path.join(dir, "events.jsonl");
+  writeJsonl(session, [{ type: "private.event", data: { content: "PRIVATE_SCAN_MARKER" } }]);
+  let probeCalls = 0;
+  let completeRowCalls = 0;
+
+  const record = sessionScanRecord(session, 120, {
+    readCopilotProducerProbe() {
+      probeCalls++;
+      return copilotEvents([]);
+    },
+    readBoundedJsonlRows() {
+      completeRowCalls++;
+      return copilotEvents([
+        {
+          type: "user.message",
+          data: {
+            content: "visible-producer-marker",
+            transformedContent: "PRIVATE_TRANSFORMED_MARKER",
+          },
+        },
+      ]);
+    },
+  });
+
+  assert.equal(record.agent, "copilot");
+  assert.equal(probeCalls, 1);
+  assert.equal(completeRowCalls, 1);
+  assert.match(record.haystack, /visible-producer-marker/);
+  assert.doesNotMatch(record.haystack, /PRIVATE_SCAN_MARKER|PRIVATE_TRANSFORMED_MARKER/);
 });
 
 test("find parses Copilot visible events larger than the scan-byte budget", () => {


### PR DESCRIPTION
## Summary

- add automatic GitHub Copilot session discovery alongside the existing Codex and Claude default-root discovery
- render Copilot sessions through a strict visible-event adapter: keep `user.message` and `assistant.message`, count tool starts by family, and never emit tool arguments, completions, results, or non-visible event types
- preserve the canonical transcript seams for Claude configuration roots, compacted-history expansion, Codex app-server/thread rendering, trimming, filtering, and `optionNumber`
- keep examples and tests portable, and document canonical ownership plus downstream whole-skill sync

## What Problem This Solves

`agent-transcript` can discover Codex and Claude sessions automatically, but GitHub Copilot sessions currently require explicit handling outside the canonical skill. This adds the same automatic discovery experience for Copilot without widening the public transcript surface.

## Implementation

- Search the default `~/.copilot/session-state/*/events.jsonl` root.
- Identify Copilot files by their known default-root path or by a bounded complete-line `session.start` producer probe for `copilot-agent`.
- Keep known Codex, Claude, Pi, and OpenClaw candidates on the existing bounded-text scan; only producer-confirmed Copilot files advance to complete bounded JSONL-row parsing.
- Adapt Copilot rows with an explicit event allowlist. Visible dialogue is retained, tool starts contribute only compact counts, and completion/result/system/transformed/reasoning/encrypted/hook events are dropped.
- Add focused discovery, boundary, rendering, symlink, copied-skill, and Codex-preservation coverage.
- Use portable `{baseDir}/scripts/agent-transcript` examples and declare `skills/agent-transcript` as the canonical source with whole-directory downstream sync.

## Preservation and Ownership

The change is intentionally confined to the canonical `skills/agent-transcript` source and its tests/documentation. Existing Claude, Codex, Pi, and OpenClaw behavior remains on the established parsing and rendering paths.

Related closed OpenClaw PR: [openclaw/openclaw#109306](https://github.com/openclaw/openclaw/pull/109306).

The broader sanitizer hardening from the previous combined branch is intentionally excluded and moved to a follow-up stacked PR.

## Validation

Exact comparison:

- Base: `06cfaef5d17cefe089e0fc3e6b793086e10bc564`
- Candidate: `d96ccaeb5e53173f6b0c9d0463cb02f2e7d65b89`
- Scope: 5 files, 634 additions, 43 deletions

Validation completed for the source-only candidate:

- `git diff --check 06cfaef5d17cefe089e0fc3e6b793086e10bc564..d96ccaeb5e53173f6b0c9d0463cb02f2e7d65b89`
- `scripts/validate-skills`
- Node syntax checks for the helper and its test file
- focused `agent-transcript` and `session-viewer` Node tests
- copied-complete-skill execution and portable README command coverage
- Windows 24H2 and WSL2 Ubuntu 24.04.4 repository workflow reproduction; all 16 workflow steps passed in each environment
- exact-head real Copilot `events.jsonl` discovery/render proof with public-output audit PASS

Final exact-head ClawSweeper + Codex review:

- patch correct, confidence `0.94`
- security cleared; no dependency or network surface added
- real behavior proof sufficient
- rating: overall `B`, proof `B`, patch `A`
- no actionable finding or identified merge blocker

## Real Terminal Proof

These are screenshots of **live output in a real Windows Terminal session** — actual command execution as rendered in the terminal, not redirected-and-reprinted text. Both ran against a real local Copilot `events.jsonl` with the exact source-only helper at commit `d96ccaeb5e53173f6b0c9d0463cb02f2e7d65b89`.

### Automatic discovery (default Copilot root)

`git rev-parse HEAD` pins the helper to the PR head, then `agent-transcript find --query "7F42"` — with **no** `--root` — discovers a real Copilot session under the default `~/.copilot/session-state` root and reports `"agent": "copilot"` with the matching reason.

![Real terminal: automatic Copilot session discovery](https://raw.githubusercontent.com/paulcam206/agent-skills/pr-assets/proof/pr111/discovery.png)

### Strict source-only render

`agent-transcript render` on the discovered session emits only visible `user` / `assistant` dialogue plus a compact tool summary. The stats line shows `"toolCalls":1,"toolOutputsDropped":1`, and the transcript ends with `[tool summary] 1 execute; raw tool outputs dropped: 1` — no tool arguments, completions, or result bodies appear.

![Real terminal: strict source-only render](https://raw.githubusercontent.com/paulcam206/agent-skills/pr-assets/proof/pr111/render.png)

Images are hosted on the fork's `pr-assets` branch and are outside this PR's 5-file source diff.


<!-- agent-transcript:start -->
## Agent Transcript

<details>
<summary>Source-only Copilot transcript and runtime proof — exact head <code>d96ccaeb5e53173f6b0c9d0463cb02f2e7d65b89</code></summary>

# PR #111 Source-Only Copilot Transcript and Runtime Proof

Generated locally from a real Copilot `events.jsonl` with the exact current source-only helper at commit `d96ccaeb5e53173f6b0c9d0463cb02f2e7d65b89`. No network calls were made, and no raw tool output is included.

## Runtime Proof

| Check | Result |
|---|---|
| Helper head | `d96ccaeb5e53173f6b0c9d0463cb02f2e7d65b89` |
| Session source | `[LOCAL_COPILOT_SESSION]/events.jsonl` |
| Default-root discovery | Selected the creator session as `copilot`; visible query reason `source-only` |
| Detection contract | Default Copilot-root path or bounded `session.start` producer probe |
| Discovery search surface | Visible `user.message` and `assistant.message` content only |
| Full private render | 17 user entries, 421 assistant entries, 1 compact tool summary |
| Tool handling | 1,721 tool starts counted; 1,716 completion/result events dropped |
| Public excerpt | 17 curated dialogue entries |
| Public-output audit | PASS |

## Controlled Event Allowlist

- Included dialogue: `user.message`, `assistant.message`.
- Counted without arguments or results: `tool.execution_start`, `external_tool.requested`.
- Dropped: tool completions/results and every other Copilot event type, including system, transformed, reasoning, encrypted, and hook content.
- Default Copilot-root files use complete bounded JSONL rows so a visible event can exceed the nominal scan-byte budget without exposing private fields.
- Known Codex, Claude, Pi, and OpenClaw paths retain the original bounded-text-only scan. Unknown paths receive only a 64 KiB complete-line producer probe; complete-row parsing runs only after the probe confirms `copilot-agent`.
- The public narrative below was selected from visible session dialogue and the original scoped request. Long turns were condensed without adding implementation claims.

## Curated Source-Only Dialogue

```text
[user — scoped request]
Add canonical GitHub Copilot session support to agent-transcript. Automatically discover the default Copilot session-state root, preserve the current canonical behavior, and keep the change suitable for a narrow upstream PR.

[assistant]
I’m starting with the canonical repository rules and current skill surface, then I’ll port the Copilot changes without regressing newer behavior.

[assistant]
The ownership boundary is confirmed. The shared implementation and tests belong in agent-skills first; downstream copies should receive the complete canonical skill only after review.

[user — discovery contract]
Match Codex and Claude automatic discovery: search ~/.copilot/session-state/*/events.jsonl and identify Copilot sessions either from their path or from a session.start event produced by copilot-agent.

[assistant — reconstruction outcome]
The default roots include the Copilot session-state directory. Known non-Copilot paths remain on the existing bounded-text scan; unknown paths get a small producer probe, and only producer-confirmed Copilot files advance to complete bounded-row parsing.

[user — event contract]
Keep only visible user.message and assistant.message content. Count tool.execution_start and external_tool.requested, drop tool completions and results, and omit all other Copilot events.

[assistant — reconstruction outcome]
Copilot rendering now uses a dedicated strict role adapter instead of the generic agent row parser. Tool names contribute only to the compact family counts; arguments, completions, and result bodies never enter the transcript.

[user — preservation contract]
Preserve canonical CLAUDE_CONFIG_DIR roots, compacted-history expansion, Codex app-server/thread rendering, automatic trimming, and optionNumber behavior.

[assistant]
The preserved implementation contains the expected Copilot parser, while canonical has since gained app-server rendering and trimming. I’ll integrate only at the discovery and adapter seams and keep the newer canonical flow intact.

[assistant — preservation proof]
The optionNumber, shared output filtering, compacted replacement expansion, and Codex thread/read rendering sections are unchanged from upstream/main.

[user — portability contract]
Make tests locate the sibling helper through import.meta.dirname. Add Copilot discovery/rendering fixtures, Codex preservation coverage, large-record and boundary discovery cases, portable node "{baseDir}/scripts/agent-transcript" examples, and canonical AGENTS.md ownership with a CLAUDE.md symlink.

[assistant — reconstruction outcome]
The five-file change adds the ownership files, portable SKILL.md commands, source helper support, and focused behavior tests. CLAUDE.md remains a Git symlink to AGENTS.md.

[assistant]
Focused tests are clean. I’m moving to repository-level Windows and WSL2 proof, including copied-skill execution and the README validation commands.

[user — validation contract]
Run the skill validator, Node syntax and transcript/session-viewer tests, a copied complete skill test, focused WSL2 validation, the repository workflow commands where feasible, and canonical Codex autoreview until there are no actionable findings.

[assistant — validation outcome]
Windows, WSL2, copied-skill, validator, workflow, and Node checks passed. The full autoreview suite passed with unrelated inherited Rust-home variables cleared. Canonical Codex local and upstream/main branch reviews were clean, and the final ClawSweeper plus Codex local-range review rated the patch correct with security cleared.

[user — scope split]
Keep this PR source-only. Move the broader shared sanitizer redesign and its detailed policy changes into PR #2 rather than carrying them in the Copilot discovery PR.

[assistant — final scope]
The source PR was rebuilt manually on current upstream/main so the existing shared filtering behavior stayed unchanged. The committed diff contains only the five intended skills/agent-transcript files, and the shared sanitizer redesign remains separated for PR #2.
```

## Source-Only Reconstruction Result

- Base: `openclaw/agent-skills` `upstream/main` at `06cfaef5d17cefe089e0fc3e6b793086e10bc564`.
- Branch: `paulcam206-rebuild-copilot-source-pr`.
- Current head: `d96ccaeb5e53173f6b0c9d0463cb02f2e7d65b89`.
- Conditional-parser fix: `d96ccaeb5e53173f6b0c9d0463cb02f2e7d65b89`.
- Diff scope:
  - `skills/agent-transcript/AGENTS.md`
  - `skills/agent-transcript/CLAUDE.md` (`AGENTS.md` symlink)
  - `skills/agent-transcript/SKILL.md`
  - `skills/agent-transcript/scripts/agent-transcript`
  - `skills/agent-transcript/scripts/agent-transcript.test.mjs`
</details>
<!-- agent-transcript:end -->