### PR TITLE
fix(autoreview): redact wrapped key fragments

### DIFF
--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -6078,20 +6078,27 @@ def likely_private_key_token(value: str) -> bool:
     )
 
 
-def private_key_body_wrapper_only(
+def private_key_body_wrapper_text(
     text: str,
     matches: list[re.Match[str]],
-) -> bool:
+) -> str:
     wrapper_parts: list[str] = []
     cursor = 0
     for match in matches:
         wrapper_parts.append(text[cursor : match.start()])
         cursor = match.end()
     wrapper_parts.append(text[cursor:])
+    return "".join(wrapper_parts).strip()
+
+
+def private_key_body_wrapper_only(
+    text: str,
+    matches: list[re.Match[str]],
+) -> bool:
     return (
         re.fullmatch(
             r"(?:(?:#|//|/\*|\*)\s*)?[\s\"'`,;+\[\]]*(?:\*/)?",
-            "".join(wrapper_parts).strip(),
+            private_key_body_wrapper_text(text, matches),
         )
         is not None
     )
@@ -6191,9 +6198,9 @@ def markerless_private_key_run_ranges(
         )
     values = []
     for line_index in range(run_start, run_end):
-        match = PRIVATE_KEY_BODY_PATTERN.search(lines[line_index])
-        assert match is not None
-        values.append(match.group(0))
+        matches = list(PRIVATE_KEY_BODY_PATTERN.finditer(lines[line_index]))
+        assert matches
+        values.append("".join(match.group(0) for match in matches))
     ranges: list[tuple[int, int]] = []
     search_start = 0
     window_evaluations = 0
@@ -6210,7 +6217,7 @@ def markerless_private_key_run_ranges(
                 normalized_value = value.rstrip("=")
                 window_evaluations += 1
                 scanned_characters += len(normalized_value)
-                if window_evaluations > 8192 or scanned_characters > 1_000_000:
+                if window_evaluations > 65_536 or scanned_characters > 1_000_000:
                     raise SystemExit(
                         "refusing review bundle with an oversized ambiguous markerless-key run"
                     )
@@ -6254,9 +6261,21 @@ def markerless_private_key_spans_by_line(
             if index < len(lines)
             else []
         )
-        candidate = len(matches) == 1 and private_key_body_wrapper_only(
-            lines[index],
-            matches,
+        # Callers pass reconstructed file content; unified-diff prefixes are
+        # already removed, so a plus here is an actual source-level wrapper.
+        wrapper_text = (
+            private_key_body_wrapper_text(lines[index], matches)
+            if matches
+            else ""
+        )
+        explicit_multi_value_wrapper = len(matches) == 1 or any(
+            marker in wrapper_text
+            for marker in ('"', "'", "`", "+", ",", "[", "]", "#", "//", "/*", "*")
+        )
+        candidate = (
+            bool(matches)
+            and explicit_multi_value_wrapper
+            and private_key_body_wrapper_only(lines[index], matches)
         )
         if candidate:
             if run_start is None:

--- a/skills/autoreview/tests/test_autoreview_hardening.py
+++ b/skills/autoreview/tests/test_autoreview_hardening.py
@@ -4083,6 +4083,27 @@ class AutoreviewHardeningTests(unittest.TestCase):
         self.assertIn("+ * redacted */\n", redacted_patch)
         self.assertTrue(all(chunk not in redacted_patch for chunk in chunks))
 
+    def test_review_patch_redacts_multiple_key_fragments_per_line(self) -> None:
+        body = markerless_private_key_fixture()
+        chunks = [body[index : index + 4] for index in range(0, len(body), 4)]
+        pairs = list(zip(chunks[::2], chunks[1::2]))
+        patch = (
+            "diff --git a/fixture.txt b/fixture.txt\n"
+            "--- a/fixture.txt\n"
+            "+++ b/fixture.txt\n"
+            f"@@ -0,0 +1,{len(pairs)} @@\n"
+            + "".join(f'+"{left}" + "{right}"\n' for left, right in pairs)
+        )
+
+        redacted_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["fixture.txt"],
+            patch,
+        )
+
+        self.assertEqual(redacted_patch.count("redacted"), len(chunks))
+        self.assertTrue(all(chunk not in redacted_patch for chunk in chunks))
+
     def test_review_patch_finds_key_after_adjacent_token_only_line(self) -> None:
         prefix = "A" * 128
         body = markerless_private_key_fixture()
@@ -4178,7 +4199,7 @@ class AutoreviewHardeningTests(unittest.TestCase):
         self.assertTrue(all(chunk not in redacted_patch for chunk in chunks))
 
     def test_review_patch_bounds_ambiguous_markerless_key_scan(self) -> None:
-        values = ["AbCd"] * 1024
+        values = ["AbC1"] * 512
         patch = (
             "diff --git a/fixture.txt b/fixture.txt\n"
             "--- a/fixture.txt\n"
@@ -4193,6 +4214,42 @@ class AutoreviewHardeningTests(unittest.TestCase):
                 ["fixture.txt"],
                 patch,
             )
+
+    def test_review_patch_preserves_ordinary_identifier_run(self) -> None:
+        values = ["identifier"] * 128
+        patch = (
+            "diff --git a/fixture.txt b/fixture.txt\n"
+            "--- a/fixture.txt\n"
+            "+++ b/fixture.txt\n"
+            f"@@ -0,0 +1,{len(values)} @@\n"
+            + "".join(f"+{value}\n" for value in values)
+        )
+
+        redacted_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["fixture.txt"],
+            patch,
+        )
+
+        self.assertEqual(redacted_patch, patch)
+
+    def test_review_patch_preserves_bare_multi_token_added_lines(self) -> None:
+        values = ["AbC1 AbC1"] * 128
+        patch = (
+            "diff --git a/fixture.txt b/fixture.txt\n"
+            "--- a/fixture.txt\n"
+            "+++ b/fixture.txt\n"
+            f"@@ -0,0 +1,{len(values)} @@\n"
+            + "".join(f"+{value}\n" for value in values)
+        )
+
+        redacted_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["fixture.txt"],
+            patch,
+        )
+
+        self.assertEqual(redacted_patch, patch)
 
     def test_review_patch_keeps_scanning_after_transient_key_miss(self) -> None:
         chunks = [


### PR DESCRIPTION
## Problem

Markerless private-key chunks grouped as multiple quoted or comment-wrapped fragments on each physical line were excluded from cross-line detection. The earlier scan budget also rejected an ordinary 128-line identifier list.

## Solution

- aggregate every Base64 fragment on explicitly quoted, concatenated, list, or comment-wrapped lines
- keep bare multi-token prose excluded, including submodule metadata
- raise the bounded evaluation budget so routine 128-line runs remain reviewable
- retain the separate rescanned-character ceiling and fail-closed behavior for pathological ambiguous runs
- document that scanners receive reconstructed content after unified-diff prefixes are removed

## Proof

- 150 focused review-patch and secret-detector tests pass
- full hardening suite: 276 pass, 1 skip; 4 local-only failures require a Java runtime unavailable on this machine
- repository skill validator passes
- validator test suite: 9 tests pass
- fresh mandatory autoreview: clean
