### PR TITLE
fix(autoreview): skip impossible markerless key runs

### DIFF
--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -5510,6 +5510,13 @@ def require_no_known_secret_fragments(
         )
 
 
+def repeatable_private_key_fragment(fragment: str) -> bool:
+    return (
+        fragment.casefold() not in SECRET_PLACEHOLDER_VALUES
+        and re.fullmatch(r"[a-z_][a-z0-9_]*", fragment) is None
+    )
+
+
 def review_secret_fragments(
     text: str,
     *,
@@ -5518,8 +5525,7 @@ def review_secret_fragments(
     private_fragments = {
         fragment
         for fragment in private_key_body_fragments(text)
-        if fragment.casefold() not in SECRET_PLACEHOLDER_VALUES
-        and re.fullmatch(r"[a-z_][a-z0-9_]*", fragment) is None
+        if repeatable_private_key_fragment(fragment)
     }
     fragments = {
         text[start:end]
@@ -6202,6 +6208,14 @@ def markerless_private_key_run_ranges(
         matches = list(PRIVATE_KEY_BODY_PATTERN.finditer(lines[line_index]))
         assert matches
         values.append("".join(match.group(0) for match in matches))
+    run_value = "".join(value.rstrip("=") for value in values)
+    if not (
+        len(set(run_value)) >= 20
+        and any(char.islower() for char in run_value)
+        and any(char.isupper() for char in run_value)
+        and any(char.isdigit() or char in "+/" for char in run_value)
+    ):
+        return []
     ranges: list[tuple[int, int]] = []
     search_start = 0
     window_evaluations = 0
@@ -6514,11 +6528,11 @@ def review_hunk_header_secret_fragments(
             segment = header_section[begin.end() : segment_end]
             for start, end in private_key_token_spans(segment):
                 fragment = normalized_private_key_fragment(segment, start, end)
-                if fragment:
+                if fragment and repeatable_private_key_fragment(fragment):
                     fragments.add(fragment)
         for start, end in markerless_private_key_body_spans(header_section):
             fragment = normalized_private_key_fragment(header_section, start, end)
-            if fragment:
+            if fragment and repeatable_private_key_fragment(fragment):
                 fragments.add(fragment)
         for dialect in dialects:
             if not secret_text_risk(
@@ -6555,8 +6569,16 @@ def redact_secret_like_diff_section(
     )
     secret_fragments = set(known_secret_fragments or ())
     old_content, new_content = unified_diff_contents(section)
-    secret_fragments.update(private_key_body_fragments(old_content))
-    secret_fragments.update(private_key_body_fragments(new_content))
+    secret_fragments.update(
+        fragment
+        for fragment in private_key_body_fragments(old_content)
+        if repeatable_private_key_fragment(fragment)
+    )
+    secret_fragments.update(
+        fragment
+        for fragment in private_key_body_fragments(new_content)
+        if repeatable_private_key_fragment(fragment)
+    )
     old_risk = secret_text_risk(old_content, javascript_dialect=old_dialect)
     new_risk = secret_text_risk(new_content, javascript_dialect=new_dialect)
     for content, dialect, risk in (

--- a/skills/autoreview/tests/test_autoreview_hardening.py
+++ b/skills/autoreview/tests/test_autoreview_hardening.py
@@ -4242,7 +4242,10 @@ class AutoreviewHardeningTests(unittest.TestCase):
         self.assertTrue(all(chunk not in redacted_patch for chunk in chunks))
 
     def test_review_patch_bounds_ambiguous_markerless_key_scan(self) -> None:
-        values = ["AbC1"] * 512
+        values = [
+            f"A1{chr(97 + (index // 26) % 26)}{chr(97 + index % 26)}"
+            for index in range(512)
+        ]
         patch = (
             "diff --git a/fixture.txt b/fixture.txt\n"
             "--- a/fixture.txt\n"
@@ -4259,22 +4262,27 @@ class AutoreviewHardeningTests(unittest.TestCase):
             )
 
     def test_review_patch_preserves_ordinary_identifier_run(self) -> None:
-        values = ["identifier"] * 128
-        patch = (
-            "diff --git a/fixture.txt b/fixture.txt\n"
-            "--- a/fixture.txt\n"
-            "+++ b/fixture.txt\n"
-            f"@@ -0,0 +1,{len(values)} @@\n"
-            + "".join(f"+{value}\n" for value in values)
-        )
+        for values in (
+            ["identifier"] * 362,
+            ["Identifier1"] * 362,
+            ["identifier"] * 361 + ["Identifier1"],
+        ):
+            with self.subTest(value_kinds=len(set(values))):
+                patch = (
+                    "diff --git a/fixture.txt b/fixture.txt\n"
+                    "--- a/fixture.txt\n"
+                    "+++ b/fixture.txt\n"
+                    f"@@ -0,0 +1,{len(values)} @@\n"
+                    + "".join(f"+{value}\n" for value in values)
+                )
 
-        redacted_patch = self.helper["validate_review_patch"](
-            "local unstaged diff",
-            ["fixture.txt"],
-            patch,
-        )
+                redacted_patch = self.helper["validate_review_patch"](
+                    "local unstaged diff",
+                    ["fixture.txt"],
+                    patch,
+                )
 
-        self.assertEqual(redacted_patch, patch)
+                self.assertEqual(redacted_patch, patch)
 
     def test_review_patch_preserves_bare_multi_token_added_lines(self) -> None:
         values = ["AbC1 AbC1"] * 128


### PR DESCRIPTION
## Summary

- apply wrapper-token filtering consistently at every private-key fragment propagation site
- skip markerless-key scans whose character alphabet cannot meet the entropy threshold
- preserve the bounded-work failure for sufficiently diverse ambiguous runs

## Proof

- `python3 skills/autoreview/tests/test_autoreview_hardening.py -k review_patch` (73 pass)
- targeted benign, mixed-case, poison-range, and bounded-work cases (5 pass)
- `python3 -m py_compile skills/autoreview/scripts/autoreview skills/autoreview/tests/test_autoreview_hardening.py`
- fresh autoreview clean
