### PR TITLE
fix(autoreview): handle continued markerless keys

### DIFF
--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -6104,7 +6104,7 @@ def private_key_body_wrapper_only(
 ) -> bool:
     return (
         re.fullmatch(
-            r"(?:(?:#|//|/\*|\*)\s*)?[\s\"'`,;+\[\]]*(?:\*/)?",
+            r"(?:(?:#|//|/\*|\*)\s*)?[\s\\\"'`,;+\[\]]*(?:\*/)?",
             private_key_body_wrapper_text(text, matches),
         )
         is not None
@@ -6199,16 +6199,14 @@ def markerless_private_key_run_ranges(
     run_start: int,
     run_end: int,
 ) -> list[tuple[int, int]]:
-    if run_end - run_start > 1024:
-        raise SystemExit(
-            "refusing review bundle with an oversized ambiguous markerless-key run"
-        )
     values = []
     for line_index in range(run_start, run_end):
         matches = list(PRIVATE_KEY_BODY_PATTERN.finditer(lines[line_index]))
         assert matches
         values.append("".join(match.group(0) for match in matches))
     run_value = "".join(value.rstrip("=") for value in values)
+    # Shannon entropy cannot exceed log2(alphabet size); 19 characters stay
+    # below the 4.25-bit key threshold regardless of run length.
     if not (
         len(set(run_value)) >= 20
         and any(char.islower() for char in run_value)
@@ -6216,6 +6214,10 @@ def markerless_private_key_run_ranges(
         and any(char.isdigit() or char in "+/" for char in run_value)
     ):
         return []
+    if run_end - run_start > 1024:
+        raise SystemExit(
+            "refusing review bundle with an oversized ambiguous markerless-key run"
+        )
     ranges: list[tuple[int, int]] = []
     search_start = 0
     window_evaluations = 0
@@ -6252,6 +6254,8 @@ def markerless_private_key_run_ranges(
                     encoded_length,
                     mixed_chunk_failures,
                 ):
+                    # Bare identifiers are also valid Base64 chunks. Keep the
+                    # maximal qualifying window so key tails cannot leak.
                     detected_end = candidate_end + 1
             if detected_end is not None:
                 detected = (candidate_start, detected_end)

--- a/skills/autoreview/tests/test_autoreview_hardening.py
+++ b/skills/autoreview/tests/test_autoreview_hardening.py
@@ -4039,6 +4039,28 @@ class AutoreviewHardeningTests(unittest.TestCase):
         self.assertEqual(redacted_patch.count("+redacted\n"), len(chunks))
         self.assertTrue(all(chunk not in redacted_patch for chunk in chunks))
 
+    def test_review_patch_redacts_continued_markerless_private_key_lines(self) -> None:
+        body = markerless_private_key_fixture()
+        chunks = [body[index : index + 4] for index in range(0, len(body), 4)]
+        patch = (
+            "diff --git a/fixture.py b/fixture.py\n"
+            "--- a/fixture.py\n"
+            "+++ b/fixture.py\n"
+            f"@@ -0,0 +1,{len(chunks)} @@\n"
+            + "".join(f"+{chunk}\\\n" for chunk in chunks[:-1])
+            + f"+{chunks[-1]}\n"
+        )
+
+        redacted_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["fixture.py"],
+            patch,
+        )
+
+        self.assertEqual(redacted_patch.count("+redacted\\\n"), len(chunks) - 1)
+        self.assertIn("+redacted\n", redacted_patch)
+        self.assertTrue(all(chunk not in redacted_patch for chunk in chunks))
+
     def test_review_patch_redacts_commented_markerless_private_key_lines(self) -> None:
         body = markerless_private_key_fixture()
         chunks = [body[index : index + 4] for index in range(0, len(body), 4)]
@@ -4263,9 +4285,9 @@ class AutoreviewHardeningTests(unittest.TestCase):
 
     def test_review_patch_preserves_ordinary_identifier_run(self) -> None:
         for values in (
-            ["identifier"] * 362,
-            ["Identifier1"] * 362,
-            ["identifier"] * 361 + ["Identifier1"],
+            ["identifier"] * 1025,
+            ["Identifier1"] * 1025,
+            ["identifier"] * 1024 + ["Identifier1"],
         ):
             with self.subTest(value_kinds=len(set(values))):
                 patch = (


### PR DESCRIPTION
## Summary

- recognize source line-continuation backslashes around markerless private-key chunks
- preserve continuation syntax while redacting the key fragments
- let cheap entropy/class checks reject benign long runs before the ambiguity cap

## Proof

- `python3 skills/autoreview/tests/test_autoreview_hardening.py -k review_patch` (74 pass)
- targeted continuation, 1,025-line benign-run, and ambiguous-run tests (4 pass)
- `python3 -m py_compile skills/autoreview/scripts/autoreview skills/autoreview/tests/test_autoreview_hardening.py`
- fresh autoreview clean
