### PR TITLE
fix(autoreview): filter wrapper fragments contextually

### DIFF
--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -5511,10 +5511,7 @@ def require_no_known_secret_fragments(
 
 
 def repeatable_private_key_fragment(fragment: str) -> bool:
-    return (
-        fragment.casefold() not in SECRET_PLACEHOLDER_VALUES
-        and re.fullmatch(r"[a-z_][a-z0-9_]*", fragment) is None
-    )
+    return fragment.casefold() not in SECRET_PLACEHOLDER_VALUES
 
 
 def review_secret_fragments(
@@ -5524,7 +5521,7 @@ def review_secret_fragments(
 ) -> set[str]:
     private_fragments = {
         fragment
-        for fragment in private_key_body_fragments(text)
+        for fragment in private_key_body_fragments(text, repeatable=True)
         if repeatable_private_key_fragment(fragment)
     }
     fragments = {
@@ -6364,17 +6361,34 @@ def pem_line_body_spans(
     return spans, in_pem
 
 
-def private_key_body_fragments(text: str) -> set[str]:
+def private_key_body_fragments(
+    text: str,
+    *,
+    repeatable: bool = False,
+) -> set[str]:
     fragments: set[str] = set()
     in_private_key = False
     lines = text.split("\n")
     markerless_spans = markerless_private_key_spans_by_line(text)
     for line_index, line in enumerate(lines):
         spans, in_private_key = pem_line_body_spans(line, in_private_key)
+        line_spans = set(spans) | set(markerless_spans[line_index])
+        contexts = string_contexts_at(line, {start for start, _end in line_spans})
+        has_quoted_fragment = any(
+            contexts[start] is not None
+            for start, _end in line_spans
+        )
         fragments.update(
             fragment
-            for start, end in set(spans) | set(markerless_spans[line_index])
+            for start, end in line_spans
             if (fragment := normalized_private_key_fragment(line, start, end))
+            and not (
+                repeatable
+                and has_quoted_fragment
+                and contexts[start] is None
+                and not likely_private_key_token(fragment)
+                and re.fullmatch(r"[a-z_][a-z0-9_]*", fragment.casefold()) is not None
+            )
         )
     if in_private_key:
         raise SystemExit("refusing review bundle with an unterminated private-key block")
@@ -6575,12 +6589,12 @@ def redact_secret_like_diff_section(
     old_content, new_content = unified_diff_contents(section)
     secret_fragments.update(
         fragment
-        for fragment in private_key_body_fragments(old_content)
+        for fragment in private_key_body_fragments(old_content, repeatable=True)
         if repeatable_private_key_fragment(fragment)
     )
     secret_fragments.update(
         fragment
-        for fragment in private_key_body_fragments(new_content)
+        for fragment in private_key_body_fragments(new_content, repeatable=True)
         if repeatable_private_key_fragment(fragment)
     )
     old_risk = secret_text_risk(old_content, javascript_dialect=old_dialect)

--- a/skills/autoreview/tests/test_autoreview_hardening.py
+++ b/skills/autoreview/tests/test_autoreview_hardening.py
@@ -4129,26 +4129,28 @@ class AutoreviewHardeningTests(unittest.TestCase):
     def test_review_patch_does_not_propagate_wrapper_keyword_as_secret(self) -> None:
         body = markerless_private_key_fixture()
         chunks = [body[index : index + 4] for index in range(0, len(body), 4)]
-        patch = (
-            "diff --git a/fixture.py b/fixture.py\n"
-            "--- a/fixture.py\n"
-            "+++ b/fixture.py\n"
-            "@@ -0,0 +1,2 @@\n"
-            + '+return "'
-            + '" + "'.join(chunks)
-            + '"\n'
-            + "+return ordinary_value\n"
-        )
+        for wrapper in ("return", "RETURN", "ReturnValue"):
+            with self.subTest(wrapper=wrapper):
+                patch = (
+                    "diff --git a/fixture.py b/fixture.py\n"
+                    "--- a/fixture.py\n"
+                    "+++ b/fixture.py\n"
+                    "@@ -0,0 +1,2 @@\n"
+                    + f'+{wrapper} "'
+                    + '" + "'.join(chunks)
+                    + '"\n'
+                    + f"+{wrapper} ordinary_value\n"
+                )
 
-        redacted_patch = self.helper["validate_review_patch"](
-            "local unstaged diff",
-            ["fixture.py"],
-            patch,
-        )
+                redacted_patch = self.helper["validate_review_patch"](
+                    "local unstaged diff",
+                    ["fixture.py"],
+                    patch,
+                )
 
-        self.assertIn("+return ordinary_value\n", redacted_patch)
-        self.assertEqual(redacted_patch.count("redacted"), len(chunks) + 1)
-        self.assertTrue(all(chunk not in redacted_patch for chunk in chunks))
+                self.assertIn(f"+{wrapper} ordinary_value\n", redacted_patch)
+                self.assertEqual(redacted_patch.count("redacted"), len(chunks) + 1)
+                self.assertTrue(all(chunk not in redacted_patch for chunk in chunks))
 
     def test_review_patch_keeps_unquoted_key_beside_quoted_decoy(self) -> None:
         body = markerless_private_key_fixture()


### PR DESCRIPTION
## Summary

- distinguish unquoted source wrappers from quoted markerless-key fragments before propagation
- handle lowercase, uppercase, and camel-case wrappers consistently
- retain real grouped key fragments for redacting repeated log/string occurrences

## Proof

- `python3 skills/autoreview/tests/test_autoreview_hardening.py -k review_patch` (74 pass)
- targeted wrapper and repeated-log cases (3 pass)
- `python3 -m py_compile skills/autoreview/scripts/autoreview skills/autoreview/tests/test_autoreview_hardening.py`
- fresh autoreview clean
