### PR TITLE
fix(autoreview): align markerless key prefilter

### DIFF
--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -6204,11 +6204,23 @@ def markerless_private_key_run_ranges(
     run_value = "".join(value.rstrip("=") for value in values)
     # Shannon entropy cannot exceed log2(alphabet size); 19 characters stay
     # below the 4.25-bit key threshold regardless of run length.
+    has_lower = any(char.islower() for char in run_value)
+    has_upper = any(char.isupper() for char in run_value)
+    has_digit_or_special = any(
+        char.isdigit() or char in "+/" for char in run_value
+    ) or any(value.endswith("=") for value in values)
+    mixed_chunk_classes = all(
+        any(char.isdigit() for char in value)
+        and any(char.isupper() or char in "+/" for char in value)
+        for value in values
+    )
     if not (
         len(set(run_value)) >= 20
-        and any(char.islower() for char in run_value)
-        and any(char.isupper() for char in run_value)
-        and any(char.isdigit() or char in "+/" for char in run_value)
+        and has_lower
+        and (
+            (has_upper and has_digit_or_special)
+            or mixed_chunk_classes
+        )
     ):
         return []
     if run_end - run_start > 1024:

--- a/skills/autoreview/tests/test_autoreview_hardening.py
+++ b/skills/autoreview/tests/test_autoreview_hardening.py
@@ -4039,6 +4039,59 @@ class AutoreviewHardeningTests(unittest.TestCase):
         self.assertEqual(redacted_patch.count("+redacted\n"), len(chunks))
         self.assertTrue(all(chunk not in redacted_patch for chunk in chunks))
 
+    def test_review_patch_redacts_padding_only_markerless_key_signal(self) -> None:
+        body = (
+            "ABCDEFGHIJKLMNOP"
+            + "QRSTUVWXYZabcdef"
+            + "ghijklmnopqrstuv="
+        )
+        patch = (
+            "diff --git a/fixture.txt b/fixture.txt\n"
+            "--- a/fixture.txt\n"
+            "+++ b/fixture.txt\n"
+            "@@ -0,0 +1,1 @@\n"
+            + f"+{body}\n"
+        )
+
+        redacted_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["fixture.txt"],
+            patch,
+        )
+
+        self.assertNotIn(body, redacted_patch)
+        self.assertIn("+redacted\n", redacted_patch)
+
+    def test_review_patch_redacts_lowercase_special_mixed_chunks(self) -> None:
+        chunks = [
+            "ab1+",
+            "cd2/",
+            "ef3+",
+            "gh4/",
+            "ij5+",
+            "kl6/",
+            "mn7+",
+            "op8/",
+            "qr9+",
+            "st0/",
+        ]
+        patch = (
+            "diff --git a/fixture.txt b/fixture.txt\n"
+            "--- a/fixture.txt\n"
+            "+++ b/fixture.txt\n"
+            f"@@ -0,0 +1,{len(chunks)} @@\n"
+            + "".join(f"+{chunk}\n" for chunk in chunks)
+        )
+
+        redacted_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["fixture.txt"],
+            patch,
+        )
+
+        self.assertEqual(redacted_patch.count("+redacted\n"), len(chunks))
+        self.assertTrue(all(chunk not in redacted_patch for chunk in chunks))
+
     def test_review_patch_redacts_continued_markerless_private_key_lines(self) -> None:
         body = markerless_private_key_fixture()
         chunks = [body[index : index + 4] for index in range(0, len(body), 4)]


### PR DESCRIPTION
## Summary

- align the cheap markerless-key prefilter with the authoritative detector union
- include terminal padding as a Base64 signal
- allow lowercase mixed chunks when each contains digits and `+/`

## Proof

- `python3 skills/autoreview/tests/test_autoreview_hardening.py -k review_patch` (76 pass)
- targeted prefilter, benign-run, and bounded-run cases (4 pass)
- `python3 -m py_compile skills/autoreview/scripts/autoreview skills/autoreview/tests/test_autoreview_hardening.py`
- fresh autoreview clean
