### PR TITLE
fix(autoreview): allow block wrapper suffixes

### DIFF
--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -6089,7 +6089,8 @@ def orphan_private_key_body_spans(text: str) -> list[tuple[int, int]]:
         cursor = match.end()
     wrapper_parts.append(text[cursor:])
     if re.fullmatch(
-        r"(?:(?:#|//|/\*|\*)\s*)?[\s\\\"'`,;+\[\]]*(?:\*/)?",
+        r"(?:(?:#|//|/\*|\*)\s*)?[\s\\\"'`,;+\[\]]*"
+        r"(?:\*/[\s\\\"'`,;+\[\]]*)?",
         "".join(wrapper_parts).strip(),
     ) is None:
         return []

--- a/skills/autoreview/tests/test_autoreview_hardening.py
+++ b/skills/autoreview/tests/test_autoreview_hardening.py
@@ -4044,6 +4044,7 @@ class AutoreviewHardeningTests(unittest.TestCase):
         )
         cases = (
             (f"+/* {body} */\n", "+/* redacted */\n"),
+            (f"+/* {body} */;\\\n", "+/* redacted */;\\\n"),
             (f"+{body}\\\n", "+redacted\\\n"),
         )
         for addition, expected in cases:


### PR DESCRIPTION
## Summary

- permit existing safe wrapper punctuation after a closing block-comment delimiter
- cover a block-comment key followed by semicolon and continuation backslash

## Proof

- focused regression passes
- Python compile and diff checks pass
- fresh autoreview clean
