### PR TITLE
fix(autoreview): redact truncated PEM marker replacements

### DIFF
--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -6370,7 +6370,8 @@ def redact_unbalanced_private_key_hunks(section: str) -> str:
         new_content: list[str] = []
         raw_content: list[str] = []
         hunk_lines: list[tuple[int, str, str, str]] = []
-        new_only_marker = False
+        old_only_marker_kinds: set[str] = set()
+        new_only_marker_kinds: set[str] = set()
         for line_index in range(index + 1, hunk_end):
             line = lines[line_index]
             body = line.rstrip("\r\n")
@@ -6381,11 +6382,18 @@ def redact_unbalanced_private_key_hunks(section: str) -> str:
             content = body[prefix_columns:]
             hunk_lines.append((line_index, prefix, content, ending))
             raw_content.append(content)
-            if "+" in prefix and "-" not in prefix and (
-                PRIVATE_KEY_BEGIN_PATTERN.search(content) is not None
-                or PRIVATE_KEY_END_PATTERN.search(content) is not None
-            ):
-                new_only_marker = True
+            marker_kinds = {
+                kind
+                for kind, pattern in (
+                    ("begin", PRIVATE_KEY_BEGIN_PATTERN),
+                    ("end", PRIVATE_KEY_END_PATTERN),
+                )
+                if pattern.search(content) is not None
+            }
+            if "+" in prefix and "-" not in prefix:
+                new_only_marker_kinds.update(marker_kinds)
+            elif "-" in prefix and "+" not in prefix:
+                old_only_marker_kinds.update(marker_kinds)
             if set(prefix) == {" "} or "-" in prefix:
                 old_content.append(content)
             if set(prefix) == {" "} or "+" in prefix:
@@ -6399,7 +6407,8 @@ def redact_unbalanced_private_key_hunks(section: str) -> str:
         if old_balanced and new_balanced and raw_balanced:
             index = hunk_end
             continue
-        if new_only_marker and not new_balanced:
+        genuinely_new_marker_kinds = new_only_marker_kinds - old_only_marker_kinds
+        if genuinely_new_marker_kinds and not new_balanced:
             index = hunk_end
             continue
         old_depth = private_key_initial_depth(old_text)

--- a/skills/autoreview/tests/test_autoreview_hardening.py
+++ b/skills/autoreview/tests/test_autoreview_hardening.py
@@ -3327,6 +3327,35 @@ class AutoreviewHardeningTests(unittest.TestCase):
         self.assertNotIn("AB12cd34EF56", redacted)
         self.assertIn("+const timeout = 30_000;", redacted)
 
+    def test_review_patch_redacts_truncated_private_key_marker_replacement(self) -> None:
+        patch = (
+            "diff --git a/fixture.test.ts b/fixture.test.ts\n"
+            "--- a/fixture.test.ts\n"
+            "+++ b/fixture.test.ts\n"
+            "@@ -1,3 +1,3 @@\n"
+            '-const key = "-----BEGIN RSA '
+            + 'PRIVATE KEY-----";\n'
+            '+const key = "-----BEGIN '
+            + 'PRIVATE KEY-----";\n'
+            ' const body = "AB12cd34EF56";\n'
+            ' expect(key).toBeDefined();\n'
+            "@@ -20 +20 @@\n"
+            "-const timeout = 0;\n"
+            "+const timeout = 30_000;\n"
+        )
+
+        redacted = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["fixture.test.ts"],
+            patch,
+        )
+
+        self.assertNotIn("BEGIN PRIVATE KEY", redacted)
+        self.assertNotIn("BEGIN RSA PRIVATE KEY", redacted)
+        self.assertNotIn("AB12cd34EF56", redacted)
+        self.assertIn("expect(key).toBeDefined();", redacted)
+        self.assertIn("+const timeout = 30_000;", redacted)
+
     def test_review_patch_redacts_before_unmatched_private_key_end(self) -> None:
         patch = (
             "diff --git a/fixture.txt b/fixture.txt\n"


### PR DESCRIPTION
## Summary

- distinguish truncated PEM marker replacements from genuinely new unmatched markers
- match BEGIN/END direction across old and new diff sides
- retain fail-closed behavior for newly introduced malformed PEM

## Evidence

- 64 focused review-patch tests pass
- fresh autoreview clean: patch correct, no actionable findings
- regression covers long PEM bodies whose END marker falls outside hunk context
