### PR TITLE
fix(autoreview): restrict truncated PEM tolerance

### DIFF
--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -6370,8 +6370,7 @@ def redact_unbalanced_private_key_hunks(section: str) -> str:
         new_content: list[str] = []
         raw_content: list[str] = []
         hunk_lines: list[tuple[int, str, str, str]] = []
-        old_only_marker_kinds: set[str] = set()
-        new_only_marker_kinds: set[str] = set()
+        has_changed_marker = False
         for line_index in range(index + 1, hunk_end):
             line = lines[line_index]
             body = line.rstrip("\r\n")
@@ -6382,18 +6381,11 @@ def redact_unbalanced_private_key_hunks(section: str) -> str:
             content = body[prefix_columns:]
             hunk_lines.append((line_index, prefix, content, ending))
             raw_content.append(content)
-            marker_kinds = {
-                kind
-                for kind, pattern in (
-                    ("begin", PRIVATE_KEY_BEGIN_PATTERN),
-                    ("end", PRIVATE_KEY_END_PATTERN),
-                )
-                if pattern.search(content) is not None
-            }
-            if "+" in prefix and "-" not in prefix:
-                new_only_marker_kinds.update(marker_kinds)
-            elif "-" in prefix and "+" not in prefix:
-                old_only_marker_kinds.update(marker_kinds)
+            if set(prefix) != {" "} and (
+                PRIVATE_KEY_BEGIN_PATTERN.search(content) is not None
+                or PRIVATE_KEY_END_PATTERN.search(content) is not None
+            ):
+                has_changed_marker = True
             if set(prefix) == {" "} or "-" in prefix:
                 old_content.append(content)
             if set(prefix) == {" "} or "+" in prefix:
@@ -6407,8 +6399,7 @@ def redact_unbalanced_private_key_hunks(section: str) -> str:
         if old_balanced and new_balanced and raw_balanced:
             index = hunk_end
             continue
-        genuinely_new_marker_kinds = new_only_marker_kinds - old_only_marker_kinds
-        if genuinely_new_marker_kinds and not new_balanced:
+        if has_changed_marker:
             index = hunk_end
             continue
         old_depth = private_key_initial_depth(old_text)

--- a/skills/autoreview/tests/test_autoreview_hardening.py
+++ b/skills/autoreview/tests/test_autoreview_hardening.py
@@ -3282,6 +3282,7 @@ class AutoreviewHardeningTests(unittest.TestCase):
             + 'PRIVATE KEY-----",\n'
             '   "MIIEvQIBADANBgkqhkiG9w0BAQEFAASC1234567890",\n'
             '   "Q5pEdChn3fuWgi7gC+pvd5VQ1eAX/7qVE72fhx14NxhaiZU3hCzXjG2S",\n'
+            "+runDangerousOperation();\n"
             "@@ -20 +21 @@\n"
             "-const timeout = 0;\n"
             "+const timeout = 30_000;\n"
@@ -3296,14 +3297,15 @@ class AutoreviewHardeningTests(unittest.TestCase):
         self.assertNotIn("BEGIN PRIVATE KEY", redacted)
         self.assertNotIn("MIIEvQIBADANBgkqhkiG9w0BAQEFAASC1234567890", redacted)
         self.assertIn("+expect(socket.closed).toBe(true);", redacted)
+        self.assertIn("+runDangerousOperation();", redacted)
         self.assertIn("+const timeout = 30_000;", redacted)
 
-    def test_review_patch_quarantines_interleaved_private_key_marker_edit(self) -> None:
+    def test_review_patch_redacts_interleaved_balanced_private_key_marker_edit(self) -> None:
         patch = (
             "diff --git a/fixture.test.ts b/fixture.test.ts\n"
             "--- a/fixture.test.ts\n"
             "+++ b/fixture.test.ts\n"
-            "@@ -1,3 +1,3 @@\n"
+            "@@ -1,4 +1,4 @@\n"
             '-const key = "-----BEGIN RSA '
             + 'PRIVATE KEY-----";\n'
             '+const key = "-----BEGIN '
@@ -3311,6 +3313,7 @@ class AutoreviewHardeningTests(unittest.TestCase):
             ' const body = "AB12cd34EF56";\n'
             ' const end = "-----END '
             + 'PRIVATE KEY-----";\n'
+            ' const label = "visible";\n'
             "@@ -10 +10 @@\n"
             "-const timeout = 0;\n"
             "+const timeout = 30_000;\n"
@@ -3325,9 +3328,10 @@ class AutoreviewHardeningTests(unittest.TestCase):
         self.assertNotIn("BEGIN PRIVATE KEY", redacted)
         self.assertNotIn("BEGIN RSA PRIVATE KEY", redacted)
         self.assertNotIn("AB12cd34EF56", redacted)
+        self.assertIn('const label = "visible";', redacted)
         self.assertIn("+const timeout = 30_000;", redacted)
 
-    def test_review_patch_redacts_truncated_private_key_marker_replacement(self) -> None:
+    def test_review_patch_rejects_truncated_private_key_marker_replacement(self) -> None:
         patch = (
             "diff --git a/fixture.test.ts b/fixture.test.ts\n"
             "--- a/fixture.test.ts\n"
@@ -3344,17 +3348,79 @@ class AutoreviewHardeningTests(unittest.TestCase):
             "+const timeout = 30_000;\n"
         )
 
-        redacted = self.helper["validate_review_patch"](
-            "local unstaged diff",
-            ["fixture.test.ts"],
-            patch,
+        with self.assertRaisesRegex(SystemExit, "private-key"):
+            self.helper["validate_review_patch"](
+                "local unstaged diff",
+                ["fixture.test.ts"],
+                patch,
+            )
+
+    def test_review_patch_rejects_removed_private_key_end_marker(self) -> None:
+        replacement = "AB12cd34EF56gh78"
+        patch = (
+            "diff --git a/fixture.test.ts b/fixture.test.ts\n"
+            "--- a/fixture.test.ts\n"
+            "+++ b/fixture.test.ts\n"
+            "@@ -8,3 +8,3 @@\n"
+            ' const body = "ZX90yu12WV34";\n'
+            '-const end = "-----END '
+            + 'PRIVATE KEY-----";\n'
+            f'+const replacement = "{replacement}";\n'
+            "@@ -20 +20 @@\n"
+            "-const timeout = 0;\n"
+            "+const timeout = 30_000;\n"
         )
 
-        self.assertNotIn("BEGIN PRIVATE KEY", redacted)
-        self.assertNotIn("BEGIN RSA PRIVATE KEY", redacted)
-        self.assertNotIn("AB12cd34EF56", redacted)
-        self.assertIn("expect(key).toBeDefined();", redacted)
-        self.assertIn("+const timeout = 30_000;", redacted)
+        with self.assertRaisesRegex(SystemExit, "private-key"):
+            self.helper["validate_review_patch"](
+                "local unstaged diff",
+                ["fixture.test.ts"],
+                patch,
+            )
+
+    def test_review_patch_rejects_removed_private_key_begin_marker(self) -> None:
+        replacement = "AB12cd34EF56gh78"
+        patch = (
+            "diff --git a/fixture.test.ts b/fixture.test.ts\n"
+            "--- a/fixture.test.ts\n"
+            "+++ b/fixture.test.ts\n"
+            "@@ -1,2 +1,2 @@\n"
+            '-const begin = "-----BEGIN '
+            + 'PRIVATE KEY-----";\n'
+            f'+const replacement = "{replacement}";\n'
+            ' const body = "ZX90yu12WV34";\n'
+            "@@ -20 +20 @@\n"
+            "-const timeout = 0;\n"
+            "+const timeout = 30_000;\n"
+        )
+
+        with self.assertRaisesRegex(SystemExit, "private-key"):
+            self.helper["validate_review_patch"](
+                "local unstaged diff",
+                ["fixture.test.ts"],
+                patch,
+            )
+
+    def test_review_patch_rejects_net_new_unmatched_private_key_marker(self) -> None:
+        patch = (
+            "diff --git a/fixture.test.ts b/fixture.test.ts\n"
+            "--- a/fixture.test.ts\n"
+            "+++ b/fixture.test.ts\n"
+            "@@ -1 +1,2 @@\n"
+            '-const first = "-----BEGIN RSA '
+            + 'PRIVATE KEY-----";\n'
+            '+const first = "-----BEGIN '
+            + 'PRIVATE KEY-----";\n'
+            '+const second = "-----BEGIN EC '
+            + 'PRIVATE KEY-----";\n'
+        )
+
+        with self.assertRaisesRegex(SystemExit, "private-key"):
+            self.helper["validate_review_patch"](
+                "local unstaged diff",
+                ["fixture.test.ts"],
+                patch,
+            )
 
     def test_review_patch_redacts_before_unmatched_private_key_end(self) -> None:
         patch = (


### PR DESCRIPTION
## Summary

- narrow truncated PEM tolerance to unchanged inherited diff context
- keep every added or deleted malformed PEM delimiter fail-closed
- preserve unrelated changed code around inherited fake-key fixtures
- retain balanced marker replacement redaction

## Evidence

- 67 focused review-patch tests pass
- fresh autoreview clean: patch correct, no actionable findings
- regressions cover removed begin/end markers, duplicate additions, balanced replacements, and visible neighboring code
