### PR TITLE
fix(autoreview): fail closed on residual hunk-header risk

### DIFF
--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -6466,23 +6466,28 @@ def redact_secret_like_hunk_headers(
             redacted.append(line)
             continue
         raw_header_section = header_match.group("section")
-        private_key_header = (
-            PRIVATE_KEY_BEGIN_PATTERN.search(raw_header_section) is not None
-            or PRIVATE_KEY_END_PATTERN.search(raw_header_section) is not None
-        )
+        marker_spans = [
+            match.span()
+            for pattern in (PRIVATE_KEY_BEGIN_PATTERN, PRIVATE_KEY_END_PATTERN)
+            for match in pattern.finditer(raw_header_section)
+        ]
         header_section = redact_review_spans(
             raw_header_section,
-            (
+            marker_spans
+            + (
                 [match.span() for match in fragment_pattern.finditer(raw_header_section)]
                 if fragment_pattern is not None
                 else []
             ),
         )
-        if private_key_header or any(
-            secret_text_risk(header_section, javascript_dialect=dialect)
-            for dialect in dialects
-        ):
-            header_section = f" {REVIEW_SECRET_REDACTION}"
+        # Never replace a still-risky header wholesale: doing so can hide an
+        # unextracted value that repeats in otherwise innocuous diff content.
+        for dialect in dialects:
+            require_no_secret_values(
+                "review diff hunk header",
+                header_section,
+                javascript_dialect=dialect,
+            )
         redacted.append(
             f"{header_match.group('marker')} {header_match.group('ranges')} "
             f"{header_match.group('marker')}{header_section}{ending}"

--- a/skills/autoreview/tests/test_autoreview_hardening.py
+++ b/skills/autoreview/tests/test_autoreview_hardening.py
@@ -4425,8 +4425,49 @@ class AutoreviewHardeningTests(unittest.TestCase):
         )
 
         self.assertNotIn(body, redacted_patch)
-        self.assertIn(self.helper["REVIEW_SECRET_REDACTION"], redacted_patch)
+        self.assertNotIn("BEGIN PRIVATE KEY", redacted_patch)
         self.assertIn('+log("redacted");', redacted_patch)
+
+    def test_review_patch_rejects_residual_hunk_header_secret_risk(self) -> None:
+        primary = "CorrectHorse7" + "Battery"
+        backup = "BackupHorse8" + "Battery"
+        patch = (
+            "diff --git a/runtime.ts b/runtime.ts\n"
+            "--- a/runtime.ts\n"
+            "+++ b/runtime.ts\n"
+            '@@ -1 +1 @@ function f(pass'
+            + 'word = getenv("PASSWORD") '
+            + f'|| choose("{primary}", "{backup}"))\n'
+            + f'+log("{primary}");\n'
+        )
+
+        with self.assertRaisesRegex(SystemExit, "review diff hunk header"):
+            self.helper["validate_review_patch"](
+                "local unstaged diff",
+                ["runtime.ts"],
+                patch,
+            )
+
+    def test_private_marker_redaction_does_not_hide_residual_header_risk(self) -> None:
+        primary = "CorrectHorse7" + "Battery"
+        backup = "BackupHorse8" + "Battery"
+        patch = (
+            "diff --git a/runtime.ts b/runtime.ts\n"
+            "--- a/runtime.ts\n"
+            "+++ b/runtime.ts\n"
+            '@@ -1 +1 @@ function f(pass'
+            + 'word = getenv("PASSWORD") '
+            + f'|| choose("{primary}", "{backup}")) {{ return "-----BEGIN '
+            + 'PRIVATE KEY-----"; }\n'
+            + f'+log("{primary}");\n'
+        )
+
+        with self.assertRaisesRegex(SystemExit, "review diff hunk header"):
+            self.helper["validate_review_patch"](
+                "local unstaged diff",
+                ["runtime.ts"],
+                patch,
+            )
 
     def test_review_patch_rejects_known_secret_in_diff_metadata(self) -> None:
         secret = realistic_secret_value()


### PR DESCRIPTION
## Summary

- redact known hunk-header fragments and PEM markers surgically
- fail closed when the remaining header still has secret-like risk
- cover ordinary and private-marker header paths

## Evidence

- 5 focused hunk-header tests pass
- full hardening suite reaches all project tests; 4 unrelated local Java-runtime checks fail because no JRE is installed
- fresh mandatory autoreview clean
