### PR TITLE
fix(autoreview): allow TypeScript secret references

### DIFF
--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -450,7 +450,10 @@ CSHARP_METHOD_PREFIX_PATTERN = (
 )
 CSHARP_EVIDENCE_WINDOW = 8192
 SOURCE_CODE_REFERENCE_ROOT_VALUES = {
+    "accountConfig",
     "attemptAuthProfileStore",
+    "baseConfig",
+    "merged",
 }
 SOURCE_CODE_REFERENCE_ROOT_PATTERN = re.compile(
     r"(?<![A-Za-z0-9_$?.])(?:"
@@ -533,13 +536,26 @@ SOURCE_CODE_REFERENCE_PATTERN = re.compile(
         for value in sorted(SOURCE_CODE_REFERENCE_VALUES, key=len, reverse=True)
     ) + r")(?![A-Za-z0-9_$])"
 )
+SOURCE_CODE_SECRET_REFERENCE_TERM_PATTERN = (
+    r"(?:apiKey|ApiKey|key|Key|credential|Credential|credentials|Credentials"
+    r"|password|Password|secret|Secret|token|Token)"
+)
+SOURCE_CODE_SECRET_REFERENCE_SUFFIX_PATTERN = (
+    r"(?:Diagnostics?|File|Info|Reference|Ref|Resolution|Result)"
+)
 SOURCE_CODE_LIFECYCLE_REFERENCE_PATTERN = re.compile(
-    r"(?<![A-Za-z0-9_$?.])"
-    r"(?:(?:cached|current|existing|loaded|previous|resolved|saved|stored|successful)"
-    r"[A-Za-z0-9_$]*"
-    r"(?:ApiKey|Credential|Credentials|Password|Secret|Token)"
-    r"|(?:apiKey|credential|credentials|password|secret|token))(?:Info)?"
-    r"(?:(?:\?\.|\.)[A-Za-z_$][A-Za-z0-9_$]*)*"
+    r"(?<![A-Za-z0-9_$?.])(?:"
+    r"(?:account|base|cached|channel|current|existing|file|inline|loaded|merged"
+    r"|previous|resolved|saved|stored|successful)"
+    r"[A-Za-z0-9_$]{0,64}"
+    rf"{SOURCE_CODE_SECRET_REFERENCE_TERM_PATTERN}"
+    rf"(?:{SOURCE_CODE_SECRET_REFERENCE_SUFFIX_PATTERN})?"
+    r"|[A-Za-z0-9_$]{0,64}"
+    rf"{SOURCE_CODE_SECRET_REFERENCE_TERM_PATTERN}"
+    r"[A-Za-z0-9_$]{0,64}"
+    rf"{SOURCE_CODE_SECRET_REFERENCE_SUFFIX_PATTERN}"
+    rf"|{SOURCE_CODE_SECRET_REFERENCE_TERM_PATTERN}"
+    r")(?:(?:\?\.|\.)[A-Za-z_$][A-Za-z0-9_$]*)*"
     r"(?![A-Za-z0-9_$])"
 )
 DEFAULT_ENGINE_PATHS = ("/usr/local/bin", "/usr/bin", "/bin")
@@ -3885,6 +3901,13 @@ def secret_literal_risk(
                 continue
             if (
                 javascript_dialect is not None
+                and re.fullmatch(r"[A-Za-z_$][A-Za-z0-9_$]*:", value)
+            ):
+                # Object/type property names are syntax, not credential content.
+                # Any literal value after the colon is scanned independently.
+                continue
+            if (
+                javascript_dialect is not None
                 and SOURCE_CODE_REFERENCE_ROOT_PATTERN.fullmatch(value)
             ):
                 continue
@@ -4794,7 +4817,28 @@ def safe_secret_call_suffix(
     def safe_call_end(start: int, target: str) -> int | None:
         cursor = balanced_delimiter_end(text, start, "(", ")")
         if cursor is None:
-            return None
+            if javascript_dialect is None:
+                return None
+            boundary = re.search(r"(?m)^;\r?$", text[start + 1 :])
+            visible_end = (
+                start + 1 + boundary.start()
+                if boundary is not None
+                else len(text)
+            )
+            visible_arguments = text[start + 1 : visible_end]
+            return (
+                None
+                if any(
+                    pattern.search(visible_arguments)
+                    for pattern in SECRET_FALLBACK_LITERAL_PATTERNS
+                )
+                or fallback_secret_risk(
+                    visible_arguments,
+                    minimum_length=12,
+                    javascript_dialect=javascript_dialect,
+                )
+                else visible_end
+            )
         arguments = text[start + 1 : cursor - 1]
         return (
             None
@@ -5804,7 +5848,6 @@ def review_call_literal_spans(
         for literal in candidates
         if len(literal.group("value")) >= 7
         and any(char.isalpha() for char in literal.group("value"))
-        and any(char.isdigit() for char in literal.group("value"))
         and literal.group("value").casefold() not in SECRET_PLACEHOLDER_VALUES
         and not any(
             pattern.fullmatch(literal.group("value"))
@@ -5990,14 +6033,47 @@ def known_secret_fragment_spans(
     return [match.span("fragment") for match in pattern.finditer(text)]
 
 
+def javascript_regex_literal_ranges(text: str) -> list[tuple[int, int]]:
+    ranges: list[tuple[int, int]] = []
+    cursor = 0
+    while cursor < len(text):
+        end = javascript_regex_literal_end(text, cursor)
+        if end is None:
+            cursor += 1
+            continue
+        ranges.append((cursor, end))
+        cursor = end
+    return ranges
+
+
 def repeated_secret_fragment_spans(
     text: str,
     pattern: re.Pattern[str] | None,
+    *,
+    javascript_dialect: str | None = None,
 ) -> list[tuple[int, int]]:
     matches = known_secret_fragment_spans(text, pattern)
     contexts = string_contexts_at(text, {start for start, _ in matches})
+    regex_ranges = (
+        javascript_regex_literal_ranges(text)
+        if javascript_dialect is not None
+        else []
+    )
+    regex_index = 0
     spans: list[tuple[int, int]] = []
     for start, end in matches:
+        while (
+            regex_index < len(regex_ranges)
+            and regex_ranges[regex_index][1] <= start
+        ):
+            regex_index += 1
+        if (
+            regex_index < len(regex_ranges)
+            and regex_ranges[regex_index][0] <= start
+            and end <= regex_ranges[regex_index][1]
+        ):
+            spans.append((start, end))
+            continue
         token_start = start
         while token_start > 0 and re.match(r"[A-Za-z0-9_$.-]", text[token_start - 1]):
             token_start -= 1
@@ -6692,7 +6768,18 @@ def redact_secret_like_diff_section(
                         javascript_dialect=dialect,
                     )
                 )
-            spans.extend(repeated_secret_fragment_spans(content, fragment_pattern))
+            fragment_dialect = (
+                old_dialect
+                if old_line and old_dialect is not None
+                else new_dialect if new_line else None
+            )
+            spans.extend(
+                repeated_secret_fragment_spans(
+                    content,
+                    fragment_pattern,
+                    javascript_dialect=fragment_dialect,
+                )
+            )
             spans.extend(match.span() for match in PRIVATE_KEY_END_PATTERN.finditer(content))
             if old_line:
                 old_spans, old_pem = pem_line_body_spans(content, old_pem)

--- a/skills/autoreview/tests/fixtures/typescript-benign-references.ts
+++ b/skills/autoreview/tests/fixtures/typescript-benign-references.ts
@@ -1,0 +1,55 @@
+type SecretRef = { source: "env"; id: string };
+type CredentialUnavailableDiagnostic = { path: string; reason: string };
+
+declare const tokenRef: SecretRef;
+declare const keyRef: SecretRef;
+declare const inlinePassword: string;
+declare const inlineSecret: string;
+declare const accountFileToken: string;
+declare const baseFileToken: string;
+declare const passwordResolution: { password: string };
+declare const secretResolution: { secret: string };
+declare const tokenResolution: { token: string };
+declare const accountTokenFile: { token: string };
+declare const channelTokenFile: { token: string };
+declare const merged: { apiPassword: string; passwordFile: string };
+declare const tryReadSecretFileSync: (...args: unknown[]) => string;
+declare const normalizeResolvedSecretInputString: (options: unknown) => string;
+declare const resolveToken: (options: unknown) => { value: string };
+
+const filePassword = tryReadSecretFileSync(merged.passwordFile, "IRC password file", {
+  credentialDiagnostic: {
+    configPath: `channels.irc.accounts.${accountId}.passwordFile`,
+    report: (diagnostic: CredentialUnavailableDiagnostic) => diagnostic,
+  },
+});
+const configPassword = normalizeResolvedSecretInputString({
+  value: merged.apiPassword,
+  path: "channels.nextcloud-talk.apiPassword",
+});
+const token = resolveToken({ accountId });
+const priorPasswordFileError = /IRC password file.*must not be a symlink/;
+
+export type CredentialPlumbing = {
+  tokenRef?: SecretRef;
+  keyRef?: SecretRef;
+  credentialDiagnostics?: CredentialUnavailableDiagnostic[];
+};
+
+export const resolvedCredentialPlumbing = {
+  token: tokenRef,
+  apiKey: keyRef,
+  password: filePassword,
+  configPassword,
+  nextPassword: inlinePassword,
+  secret: inlineSecret,
+  accountToken: accountFileToken,
+  baseToken: baseFileToken,
+  resolvedPassword: passwordResolution.password,
+  resolvedSecret: secretResolution.secret,
+  resolvedToken: tokenResolution.token,
+  accountTokenFile: accountTokenFile.token,
+  channelTokenFile: channelTokenFile.token,
+  apiPassword: merged.apiPassword,
+  channelAccessToken: token.value,
+};

--- a/skills/autoreview/tests/fixtures/typescript-sensitive-literals.ts
+++ b/skills/autoreview/tests/fixtures/typescript-sensitive-literals.ts
@@ -1,0 +1,10 @@
+const password = "FAKE-CorrectHorseBattery-Staple-2026!";
+const credential = "FAKE_A7f9K2m4Q8v6N3x5R1p0T9z8";
+const apiKey = "sk-proj-FAKE00000000000000000000000000000000000000000000";
+const githubToken = "ghp_FAKE000000000000000000000000000000";
+const awsAccessKey = "AKIAFAKE000000000000";
+const slackToken = "xoxb-FAKE000000000-FAKE000000000-FAKE000000000000000000000000";
+const authorization = "Bearer eyJhbGciOiJIUzI1NiJ9.RkFLRS1OT1QtQS1SRUFM.TOKENFAKESIGNATURE";
+const resolvedToken = resolveToken({ value: "FAKE_B8g0L3n5R9w7P4y6S2q1U0a9" });
+const filePassword = tryReadSecretFileSync(path, "FAKE-A7f9K2m4Q8v6N3x5R1p0T9z8");
+const password = readPassword("alice", "FAKE correct horse secret battery 2026");

--- a/skills/autoreview/tests/test_autoreview_hardening.py
+++ b/skills/autoreview/tests/test_autoreview_hardening.py
@@ -21,6 +21,7 @@ from pathlib import Path
 
 
 SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "autoreview"
+FIXTURES = Path(__file__).with_name("fixtures")
 PRIVATE_KEY_BEGIN_TEXT = "BEGIN " + "PRIVATE KEY"
 RSA_PRIVATE_KEY_BEGIN_TEXT = "BEGIN RSA " + "PRIVATE KEY"
 
@@ -2311,6 +2312,116 @@ class AutoreviewHardeningTests(unittest.TestCase):
                 javascript_dialect="typescript",
             )
         )
+
+    def test_secret_detector_allows_typescript_credential_plumbing_fixture(self) -> None:
+        source = (FIXTURES / "typescript-benign-references.ts").read_text(
+            encoding="utf-8"
+        )
+
+        fragments = self.helper["review_secret_fragments"](
+            source,
+            javascript_dialect="typescript",
+        )
+        self.assertNotIn("filePassword", fragments)
+        self.assertNotIn("passwordResolution.password", fragments)
+        self.assertNotIn("tokenResolution.token", fragments)
+        self.assertNotIn("CredentialUnavailableDiagnostic", fragments)
+        patch = (
+            "diff --git a/src/credential-plumbing.ts b/src/credential-plumbing.ts\n"
+            "new file mode 100644\n"
+            "--- /dev/null\n"
+            "+++ b/src/credential-plumbing.ts\n"
+            f"@@ -0,0 +1,{len(source.splitlines())} @@\n"
+            + "".join(f"+{line}\n" for line in source.splitlines())
+        )
+        validated = self.helper["validate_review_patch"](
+            "typescript credential plumbing fixture",
+            ["src/credential-plumbing.ts"],
+            patch,
+        )
+        for reference in (
+            "filePassword",
+            "passwordResolution.password",
+            "tokenResolution.token",
+            "CredentialUnavailableDiagnostic",
+            "tokenRef",
+            "keyRef",
+        ):
+            self.assertIn(reference, validated)
+
+        token_term = "To" + "ken"
+        truncated_call_patch = (
+            "diff --git a/src/token.ts b/src/token.ts\n"
+            "--- a/src/token.ts\n"
+            "+++ b/src/token.ts\n"
+            "@@ -40,3 +40,4 @@ function resolveAccountToken() {\n"
+            f"+  const account{token_term} = resolveRuntime{token_term}Value({{\n"
+            "+    value: accountConfig.token,\n"
+            "@@ -70,3 +71,4 @@ function resolveConfigToken() {\n"
+            f"+  const config{token_term} = resolveRuntime{token_term}Value({{\n"
+            "+    value: merged.token,\n"
+        )
+        self.assertEqual(
+            self.helper["validate_review_patch"](
+                "typescript truncated credential calls fixture",
+                ["src/token.ts"],
+                truncated_call_patch,
+            ),
+            truncated_call_patch,
+        )
+
+    def test_secret_detector_rejects_sensitive_literal_fixture_corpus(self) -> None:
+        source = (FIXTURES / "typescript-sensitive-literals.ts").read_text(
+            encoding="utf-8"
+        )
+        corpus = [line for line in source.splitlines() if line.strip()]
+
+        self.assertGreaterEqual(len(corpus), 7)
+        for literal_assignment in corpus:
+            with self.subTest(literal_assignment=literal_assignment):
+                self.assertTrue(
+                    self.helper["secret_text_risk"](
+                        literal_assignment,
+                        javascript_dialect="typescript",
+                    )
+                )
+        truncated_literal = (
+            "const incompleteToken = resolveToken({ value: \""
+            + realistic_secret_value()
+            + "\";"
+        )
+        self.assertTrue(
+            self.helper["secret_text_risk"](
+                truncated_literal,
+                javascript_dialect="typescript",
+            )
+        )
+        truncated_short_literal = (
+            "const incompleteToken = resolveToken({ value: \""
+            + "short"
+            + "pwd"
+            + "\";"
+        )
+        self.assertTrue(
+            self.helper["secret_text_risk"](
+                truncated_short_literal,
+                javascript_dialect="typescript",
+            )
+        )
+
+    def test_known_secret_fragment_scan_handles_many_javascript_regexes(self) -> None:
+        fragment = "password file"
+        regex_count = 2_000
+        source = ";".join(f"/{fragment} {index}/" for index in range(regex_count))
+        pattern = self.helper["known_secret_fragment_pattern"]([fragment])
+
+        spans = self.helper["repeated_secret_fragment_spans"](
+            source,
+            pattern,
+            javascript_dialect="typescript",
+        )
+
+        self.assertEqual(len(spans), regex_count)
 
     def test_lifecycle_reference_scan_is_bounded_for_non_matching_identifier(self) -> None:
         source = "const value = resolved" + "A" * 100_000 + "X;"


### PR DESCRIPTION
## Summary

- distinguish benign TypeScript credential reference plumbing from secret-like literal content
- preserve fail-closed handling for literal assignments, known key formats, high-entropy values, and truncated calls containing literals
- redact secret-like fragments inside JavaScript and TypeScript regex literals with bounded scanning

## Validation

- `python3 -m unittest discover -s skills/autoreview/tests -p 'test_*.py'` (289 tests, 1 skipped)
- `scripts/validate-skills`
- `python3 skills/autoreview/scripts/autoreview --mode local` (clean, xhigh)
- verified the previously blocked OpenClaw staged diff now builds a review bundle

## Safety coverage

- benign fixture: identifier, type, property, and `SecretRef` plumbing patterns
- sensitive fixture: obviously fake password, token, API key, GitHub, AWS, Slack, JWT, and bearer literals; every entry must still flag
