### PR TITLE
fix(autoreview): redact secrets without blocking review

### DIFF
--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -199,9 +199,9 @@ SECRET_ASSIGNMENT_PATTERN = re.compile(
     r"'(?P<single_value>[^'\r\n]{8,})'|"
     r"`(?P<backtick_value>[^`\r\n]{8,})`|"
     r"(?P<call_value>[A-Za-z_$][A-Za-z0-9_$]*"
-    r"(?:(?:\?\.|\.)[A-Za-z_$][A-Za-z0-9_$]*)*)(?=[ \t]*\()|"
+    r"(?:(?:\?\.|\.|::|->)[A-Za-z_$][A-Za-z0-9_$]*)*)(?=[ \t]*\()|"
     r"(?P<reference_value>[A-Za-z_$][A-Za-z0-9_$]*"
-    r"(?:(?:\?\.|\.)[A-Za-z_$][A-Za-z0-9_$]*"
+    r"(?:(?:\?\.|\.|::|->)[A-Za-z_$][A-Za-z0-9_$]*"
     r"|(?:\?\.)?\[(?:[A-Za-z_$][A-Za-z0-9_$]*"
     r"|[\"'][A-Za-z_$][A-Za-z0-9_$]*[\"']|[0-9]+)\])+)"
     r"(?![A-Za-z0-9_./+=:@#$%&*!?-])|"
@@ -245,6 +245,184 @@ SECRET_FALLBACK_UNQUOTED_PATTERN = re.compile(
     r"(?P<value>[A-Za-z0-9_./+=:@#$%&*!?-]{4,})"
     r"(?![A-Za-z0-9_./+=:@#$%&*!?-])"
 )
+JAVASCRIPT_NUMERIC_LITERAL_PATTERN = re.compile(
+    r"(?<![A-Za-z0-9_$])(?:"
+    r"0[xX][0-9A-Fa-f](?:_?[0-9A-Fa-f])*n?"
+    r"|0[bB][01](?:_?[01])*n?"
+    r"|0[oO][0-7](?:_?[0-7])*n?"
+    r"|(?:[0-9](?:_?[0-9])*(?:\.(?:[0-9](?:_?[0-9])*)?(?!\.))?"
+    r"|\.[0-9](?:_?[0-9])*)(?:[eE][+-]?[0-9](?:_?[0-9])*)?n?"
+    r")(?![A-Za-z0-9_$])"
+)
+PYTHON_INTEGER_LITERAL_PATTERN = re.compile(
+    r"(?<![A-Za-z0-9_])(?:"
+    r"0[xX]_?[0-9A-Fa-f](?:_?[0-9A-Fa-f])*"
+    r"|0[bB]_?[01](?:_?[01])*"
+    r"|0[oO]_?[0-7](?:_?[0-7])*"
+    r"|[0-9](?:_?[0-9])*"
+    r")(?![A-Za-z0-9_])"
+)
+PYTHON_NUMERIC_LITERAL_PATTERN = re.compile(
+    r"(?<![A-Za-z0-9_])(?:"
+    r"0[xX]_?[0-9A-Fa-f](?:_?[0-9A-Fa-f])*"
+    r"|0[bB]_?[01](?:_?[01])*"
+    r"|0[oO]_?[0-7](?:_?[0-7])*"
+    r"|(?:[0-9](?:_?[0-9])*(?:\.(?:[0-9](?:_?[0-9])*)?)?"
+    r"|\.[0-9](?:_?[0-9])*)(?:[eE][+-]?[0-9](?:_?[0-9])*)?"
+    r")[jJ]?(?![A-Za-z0-9_])"
+)
+CSHARP_INTEGER_LITERAL_PATTERN = re.compile(
+    r"(?<![A-Za-z0-9_])(?:"
+    r"0[xX](?:_*[0-9A-Fa-f])+"
+    r"|0[bB](?:_*[01])+"
+    r"|[0-9](?:_*[0-9])*"
+    r")(?:[uU][lL]|[lL][uU]|[uUlL])?(?![A-Za-z0-9_])"
+)
+CSHARP_NUMERIC_LITERAL_PATTERN = re.compile(
+    r"(?<![A-Za-z0-9_])(?:"
+    r"0[xX](?:_*[0-9A-Fa-f])+(?:[uU][lL]|[lL][uU]|[uUlL])?"
+    r"|0[bB](?:_*[01])+(?:[uU][lL]|[lL][uU]|[uUlL])?"
+    r"|(?:[0-9](?:_*[0-9])*(?:\.(?:[0-9](?:_*[0-9])*)?)?"
+    r"|\.[0-9](?:_*[0-9])*)(?:[eE][+-]?[0-9](?:_*[0-9])*)?"
+    r"(?:[fFdDmM]|[uU][lL]|[lL][uU]|[uUlL])?"
+    r")(?![A-Za-z0-9_])"
+)
+DOLLAR_INTEGER_LITERAL_PATTERN = re.compile(
+    r"(?<![A-Za-z0-9_])(?:"
+    r"0[xX](?:_*[0-9A-Fa-f])+"
+    r"|0[bB](?:_*[01])+"
+    r"|0[oO](?:_*[0-7])+"
+    r"|[0-9](?:_*[0-9])*"
+    r")(?:[uU][lL]?|[lLgGiI])?(?![A-Za-z0-9_])"
+)
+SCALA_INTEGER_LITERAL_PATTERN = re.compile(
+    r"(?<![A-Za-z0-9_$])(?:"
+    r"0[xX](?:_*[0-9A-Fa-f])+"
+    r"|0[bB](?:_*[01])+"
+    r"|[0-9](?:_*[0-9])*"
+    r")[lL]?(?![A-Za-z0-9_$])"
+)
+JAVASCRIPT_REVIEW_DIALECTS = frozenset({"javascript", "typescript"})
+REGEX_LITERAL_REVIEW_DIALECTS = JAVASCRIPT_REVIEW_DIALECTS | {"groovy", "swift"}
+JAVASCRIPT_REGEX_EXPRESSION_KEYWORDS = frozenset(
+    {
+        "await",
+        "case",
+        "default",
+        "delete",
+        "do",
+        "else",
+        "extends",
+        "in",
+        "instanceof",
+        "new",
+        "return",
+        "throw",
+        "typeof",
+        "void",
+        "yield",
+    }
+)
+JAVASCRIPT_LINE_TERMINATORS = frozenset("\r\n\u2028\u2029")
+C_SHARP_LINE_TERMINATORS = frozenset("\r\n\u0085\u2028\u2029")
+SOURCE_LINE_TERMINATORS = frozenset("\r\n")
+JAVASCRIPT_LINE_TERMINATOR_PATTERN = re.compile(r"[\r\n\u2028\u2029]")
+C_SHARP_LINE_TERMINATOR_PATTERN = re.compile(r"[\r\n\u0085\u2028\u2029]")
+SOURCE_LINE_TERMINATOR_PATTERN = re.compile(r"[\r\n]")
+
+
+def is_javascript_review_dialect(dialect: str | None) -> bool:
+    return dialect in JAVASCRIPT_REVIEW_DIALECTS
+
+
+def review_dialect_has_regex_literals(dialect: str | None) -> bool:
+    # Preserve conservative parsing for unclassified source languages.
+    return dialect is None or dialect in REGEX_LITERAL_REVIEW_DIALECTS
+
+
+def review_dialect_has_slash_comments(dialect: str | None) -> bool:
+    # Preserve the historical safe default for unclassified source languages.
+    # Python uses `//` for floor division.
+    return dialect != "python"
+
+
+def review_dialect_has_hash_comments(dialect: str | None) -> bool:
+    return dialect in {None, "python"}
+
+
+def javascript_line_terminator_index(
+    text: str,
+    start: int,
+    limit: int | None = None,
+) -> int | None:
+    match = JAVASCRIPT_LINE_TERMINATOR_PATTERN.search(
+        text,
+        start,
+        len(text) if limit is None else limit,
+    )
+    return None if match is None else match.start()
+
+
+def review_line_comment_terminators(dialect: str | None) -> frozenset[str]:
+    if dialect == "csharp":
+        return C_SHARP_LINE_TERMINATORS
+    return (
+        JAVASCRIPT_LINE_TERMINATORS
+        if is_javascript_review_dialect(dialect)
+        else SOURCE_LINE_TERMINATORS
+    )
+
+
+def review_line_terminator_index(
+    text: str,
+    start: int,
+    limit: int | None,
+    dialect: str | None,
+) -> int | None:
+    search_end = len(text) if limit is None else limit
+    pattern = (
+        C_SHARP_LINE_TERMINATOR_PATTERN
+        if dialect == "csharp"
+        else JAVASCRIPT_LINE_TERMINATOR_PATTERN
+        if is_javascript_review_dialect(dialect)
+        else SOURCE_LINE_TERMINATOR_PATTERN
+    )
+    match = pattern.search(text, start, search_end)
+    return None if match is None else match.start()
+
+
+def java_unicode_escape_translation(text: str) -> str:
+    parts: list[str] = []
+    cursor = 0
+    trailing_backslashes = 0
+    previous_was_translated = False
+    while cursor < len(text):
+        char = text[cursor]
+        eligible = previous_was_translated or trailing_backslashes % 2 == 0
+        if char == "\\" and eligible and text[cursor + 1 : cursor + 2] == "u":
+            marker_end = cursor + 2
+            while text[marker_end : marker_end + 1] == "u":
+                marker_end += 1
+            digits = text[marker_end : marker_end + 4]
+            if len(digits) == 4 and all(
+                digit in "0123456789abcdefABCDEF" for digit in digits
+            ):
+                translated = chr(int(digits, 16))
+                parts.append(translated)
+                trailing_backslashes = (
+                    trailing_backslashes + 1 if translated == "\\" else 0
+                )
+                previous_was_translated = True
+                cursor = marker_end + 4
+                continue
+        parts.append(char)
+        trailing_backslashes = trailing_backslashes + 1 if char == "\\" else 0
+        # JLS eligibility depends on the translated output, not only raw-source slashes.
+        previous_was_translated = False
+        cursor += 1
+    return "".join(parts)
+
+
 SECRET_VALUE_PATTERNS = [
     PRIVATE_KEY_BEGIN_PATTERN,
     BEARER_CREDENTIAL_PATTERN,
@@ -333,6 +511,50 @@ SECRET_PLACEHOLDER_VALUES = {
     "config-token",
     "very-long-browser-token-0123456789",
 }
+def review_fragment_label(index: int) -> str:
+    label = ""
+    value = index + 1
+    while value:
+        value, remainder = divmod(value - 1, 26)
+        label = chr(ord("a") + remainder) + label
+    return label
+
+
+REVIEW_FRAGMENT_LABELS = frozenset(
+    review_fragment_label(index)
+    for index in range(MAX_REVIEW_SECRET_FRAGMENTS)
+)
+REDACTED_PLACEHOLDER_CANDIDATE_PATTERN = re.compile(
+    r"(?<![A-Za-z0-9-])redacted(?:-[a-z]+)*(?![A-Za-z0-9-])",
+    re.IGNORECASE,
+)
+
+
+def redacted_placeholder_value(value: str) -> bool:
+    components = value.casefold().split("-")
+    labels = components[1:]
+    return (
+        components[0] == "redacted"
+        and labels == sorted(set(labels))
+        and all(label in REVIEW_FRAGMENT_LABELS for label in labels)
+    )
+
+
+def secret_placeholder_value(value: str) -> bool:
+    return (
+        value.casefold() in SECRET_PLACEHOLDER_VALUES
+        or redacted_placeholder_value(value)
+    )
+
+
+def secret_placeholder_sequence(value: str) -> bool:
+    parts = re.split(r"\r\n|[\r\n]", value)
+    return bool(parts) and all(
+        not part.strip() or secret_placeholder_value(part.strip())
+        for part in parts
+    )
+
+
 SYNTHETIC_SECRET_PREFIXES = frozenset(
     {"dummy", "example", "fake", "fixture", "mock", "sample", "test"}
 )
@@ -391,7 +613,7 @@ NON_SHELL_COMMAND_WORDS = {
     "with",
     "yield",
 }
-PUBLIC_PROMPT_TARGETS = {"getpass.getpass", "input", "prompt"}
+PUBLIC_PROMPT_TARGETS = {"getpass.getpass", "input", "prompt", "ui.prompt"}
 GENERIC_CREDENTIAL_PROMPT_PATTERN = re.compile(
     r"(?i)\s*(?:(?:enter|type|provide)\s+(?:(?:your|the)\s+)?)?"
     r"(?:password|passphrase|api[\s_-]*(?:key|token))"
@@ -500,6 +722,10 @@ UNQUOTED_SECRET_REFERENCE_PATTERNS = (
         re.IGNORECASE,
     ),
 )
+SOURCE_SECRET_MEMBER_REFERENCE_PATTERN = re.compile(
+    rf"(?i)^(?:[A-Za-z_$][A-Za-z0-9_$]*(?:\?\.|\.|::|->))+"
+    rf"[A-Za-z_$][A-Za-z0-9_$]*$"
+)
 BACKTICK_SECRET_REFERENCE_PATTERNS = (
     re.compile(
         r"^op\s+read(?:\s+--no-newline)?\s+(?:"
@@ -509,6 +735,21 @@ BACKTICK_SECRET_REFERENCE_PATTERNS = (
     ),
 )
 BACKTICK_TEMPLATE_INTERPOLATION_PATTERN = re.compile(r"\$\{([^{}\r\n]+)\}")
+SUSPICIOUS_TRIPLE_INTERPOLATION_PATTERN = re.compile(
+    r"\$\{|#\{|\\\(|\$(?=[^\W\d])"
+)
+SOURCE_REFERENCE_REVIEW_DIALECTS = {
+    "javascript",
+    "typescript",
+    "python",
+    "csharp",
+    "c-family",
+    "groovy",
+    "java",
+    "kotlin",
+    "scala",
+    "swift",
+}
 BACKTICK_TEMPLATE_SAFE_LITERAL_PATTERN = re.compile(
     r"(?i)(?:(?:Bearer|Basic)[ \t]+|[ \t:./,_-]*)"
 )
@@ -2016,7 +2257,13 @@ def raw_repo_path_has_symlink_component(repo: Path, rel_path: Path) -> bool:
     return False
 
 
-def fallback_expression(text: str, *, typescript: bool = False) -> str:
+def fallback_expression(
+    text: str,
+    *,
+    typescript: bool = False,
+    dialect: str | None = None,
+    allow_incomplete_raw: bool = False,
+) -> str:
     operator_keywords = (
         r"|as(?![\w$])|satisfies(?![\w$])" if typescript else ""
     )
@@ -2041,7 +2288,7 @@ def fallback_expression(text: str, *, typescript: bool = False) -> str:
         char = text[cursor]
         next_char = text[cursor + 1] if cursor + 1 < len(text) else ""
         if line_comment:
-            if char in "\r\n\u2028\u2029":
+            if char in review_line_comment_terminators(dialect):
                 line_comment = False
                 if (
                     operand_started
@@ -2070,11 +2317,19 @@ def fallback_expression(text: str, *, typescript: bool = False) -> str:
                 quote = None
             cursor += 1
             continue
-        regex_end = javascript_regex_literal_end(text, cursor)
+        regex_end = review_regex_or_slashy_literal_end(
+            text,
+            cursor,
+            dialect=dialect,
+        )
         if regex_end is not None:
             cursor = regex_end
             continue
-        if char == "/" and next_char == "/":
+        if (
+            char == "/"
+            and next_char == "/"
+            and review_dialect_has_slash_comments(dialect)
+        ):
             line_comment = True
             cursor += 2
             continue
@@ -2082,9 +2337,52 @@ def fallback_expression(text: str, *, typescript: bool = False) -> str:
             block_comment = True
             cursor += 2
             continue
-        if char == "#":
+        if char == "#" and review_dialect_has_hash_comments(dialect):
             line_comment = True
             cursor += 1
+            continue
+        structured_literal = (
+            structured_literal_parts(
+                text,
+                cursor,
+                len(text),
+                dialect=dialect,
+                allow_incomplete_raw=allow_incomplete_raw,
+            )
+            if dialect in {"csharp", "python"} and char in {'"', "'"}
+            else None
+        )
+        if structured_literal is not None:
+            cursor = structured_literal[2]
+            operand_started = True
+            continue
+        raw_literal = (
+            c_family_raw_literal_span(
+                text,
+                cursor,
+                len(text),
+                allow_incomplete=allow_incomplete_raw,
+            )
+            if dialect == "c-family" and char == '"'
+            else None
+        )
+        if raw_literal is not None:
+            cursor = raw_literal[2]
+            operand_started = True
+            continue
+        swift_scala_literal = (
+            swift_scala_literal_span(
+                text,
+                cursor,
+                len(text),
+                dialect=dialect,
+            )
+            if dialect in {"scala", "swift"} and char == '"'
+            else None
+        )
+        if swift_scala_literal is not None:
+            cursor = swift_scala_literal[2]
+            operand_started = True
             continue
         if char in {'"', "'", "`"}:
             quote = char
@@ -2154,6 +2452,7 @@ def top_level_fallback_suffix(
     text: str,
     *,
     allow_chained_assignment: bool = False,
+    dialect: str | None = None,
 ) -> str | None:
     stack: list[tuple[str, bool]] = []
     pairs = {"(": ")", "[": "]", "{": "}"}
@@ -2175,7 +2474,7 @@ def top_level_fallback_suffix(
         char = text[cursor]
         next_char = text[cursor + 1] if cursor + 1 < len(text) else ""
         if line_comment:
-            if char == "\n":
+            if char in review_line_comment_terminators(dialect):
                 line_comment = False
                 object_member_context = any(
                     closer == "}"
@@ -2217,17 +2516,38 @@ def top_level_fallback_suffix(
         if char == "\\" and next_char:
             cursor += 2
             continue
-        regex_end = javascript_regex_literal_end(text, cursor)
+        regex_end = review_regex_or_slashy_literal_end(
+            text,
+            cursor,
+            dialect=dialect,
+        )
         if regex_end is not None:
             cursor = regex_end
             continue
-        if char == "/" and next_char == "/":
+        if (
+            char == "/"
+            and next_char == "/"
+            and review_dialect_has_slash_comments(dialect)
+        ):
             line_comment = True
             cursor += 2
             continue
         if char == "/" and next_char == "*":
             block_comment = True
             cursor += 2
+            continue
+        swift_scala_literal = (
+            swift_scala_literal_span(
+                text,
+                cursor,
+                len(text),
+                dialect=dialect,
+            )
+            if dialect in {"scala", "swift"} and char == '"'
+            else None
+        )
+        if swift_scala_literal is not None:
+            cursor = swift_scala_literal[2]
             continue
         if char in {'"', "'", "`"}:
             quote = char
@@ -2249,22 +2569,42 @@ def top_level_fallback_suffix(
                     if not allow_chained_assignment:
                         return None
                     value_start = cursor + 1 + sibling.end()
-                    value = fallback_expression(text[value_start:])
-                    if fallback_secret_risk(value):
+                    value = fallback_expression(
+                        text[value_start:],
+                        dialect=dialect,
+                    )
+                    if fallback_secret_risk(
+                        value,
+                        javascript_dialect=dialect,
+                    ):
                         return value
                     cursor = value_start + len(value)
                     continue
                 if allow_chained_assignment:
                     value_start = cursor + 1
-                    value = fallback_expression(text[value_start:])
-                    if fallback_secret_risk(value):
+                    value = fallback_expression(
+                        text[value_start:],
+                        dialect=dialect,
+                    )
+                    if fallback_secret_risk(
+                        value,
+                        javascript_dialect=dialect,
+                    ):
                         return value
                     cursor = value_start + len(value)
                     continue
             if text.startswith(("||", "&&", "??"), cursor):
-                return text[cursor:]
+                return fallback_expression(
+                    text[cursor:],
+                    typescript=dialect == "typescript",
+                    dialect=dialect,
+                )
             if char in {"+", "?"} and not text.startswith("?.", cursor):
-                return text[cursor:]
+                return fallback_expression(
+                    text[cursor:],
+                    typescript=dialect == "typescript",
+                    dialect=dialect,
+                )
             left_boundary = cursor == 0 or not (
                 text[cursor - 1].isalnum() or text[cursor - 1] == "_"
             )
@@ -2274,7 +2614,11 @@ def top_level_fallback_suffix(
                 else None
             )
             if word is not None:
-                return text[cursor:]
+                return fallback_expression(
+                    text[cursor:],
+                    typescript=dialect == "typescript",
+                    dialect=dialect,
+                )
             if char in "\n;" and not stack:
                 return None
         cursor += 1
@@ -2302,6 +2646,8 @@ def sibling_assignment_match(text: str) -> re.Match[str] | None:
 def top_level_line_assignment_positions(
     text: str,
     positions: set[int],
+    *,
+    dialect: str | None = None,
 ) -> set[int]:
     top_level: set[int] = set()
     stack: list[str] = []
@@ -2321,7 +2667,7 @@ def top_level_line_assignment_positions(
         char = text[cursor]
         next_char = text[cursor + 1] if cursor + 1 < len(text) else ""
         if line_comment:
-            if char == "\n":
+            if char in review_line_comment_terminators(dialect):
                 line_comment = False
                 line_start = cursor + 1
             cursor += 1
@@ -2358,7 +2704,11 @@ def top_level_line_assignment_positions(
             block_comment = True
             cursor += 2
             continue
-        if char == "#" and not javascript_private_member_marker(text, cursor):
+        if (
+            char == "#"
+            and review_dialect_has_hash_comments(dialect)
+            and not javascript_private_member_marker(text, cursor)
+        ):
             line_comment = True
             cursor += 1
             continue
@@ -2376,6 +2726,18 @@ def top_level_line_assignment_positions(
     return top_level
 
 
+def repeated_character_end(
+    text: str,
+    start: int,
+    limit: int,
+    character: str,
+) -> int:
+    cursor = start
+    while cursor < limit and text[cursor] == character:
+        cursor += 1
+    return cursor
+
+
 def raw_double_quote_start(
     text: str,
     start: int,
@@ -2385,10 +2747,8 @@ def raw_double_quote_start(
         or "@" in text[max(0, start - 2) : start]
     ):
         return None
-    width = 3
-    while start + width < len(text) and text[start + width] == '"':
-        width += 1
-    after = start + width
+    after = repeated_character_end(text, start, len(text), '"')
+    width = after - start
     delimiter = '"' * width
     return delimiter, after
 
@@ -2403,9 +2763,7 @@ def raw_double_quote_end(
         run_start = text.find('"', cursor)
         if run_start < 0:
             return None
-        run_end = run_start + 1
-        while run_end < len(text) and text[run_end] == '"':
-            run_end += 1
+        run_end = repeated_character_end(text, run_start, len(text), '"')
         if run_end - run_start >= width:
             return run_end
         cursor = run_end
@@ -2421,7 +2779,7 @@ def csharp_quoted_literal_end(
     nesting: int = 0,
 ) -> int | None:
     if nesting > 64:
-        return None
+        raise SystemExit("refusing review bundle with excessive interpolation nesting")
     quote = text[quote_start]
     cursor = quote_start + 1
     interpolation_depth = 0
@@ -2430,8 +2788,13 @@ def csharp_quoted_literal_end(
         next_char = text[cursor + 1] if cursor + 1 < len(text) else ""
         if interpolation_depth:
             if char == "/" and next_char == "/":
-                line_end = text.find("\n", cursor + 2)
-                cursor = len(text) if line_end < 0 else line_end
+                line_end = review_line_terminator_index(
+                    text,
+                    cursor + 2,
+                    None,
+                    "csharp",
+                )
+                cursor = len(text) if line_end is None else line_end
                 continue
             if char == "/" and next_char == "*":
                 comment_end = text.find("*/", cursor + 2)
@@ -3252,10 +3615,246 @@ def secret_assignment_matches(
     return tuple(matches)
 
 
+def scala_interpolated_string_prefix(text: str, quote_start: int) -> bool:
+    cursor = quote_start
+    while cursor > 0 and (
+        text[cursor - 1].isalnum() or text[cursor - 1] in "_$"
+    ):
+        cursor -= 1
+    return cursor < quote_start and (
+        text[cursor].isalpha() or text[cursor] in "_$"
+    )
+
+
+def swift_interpolation_expression_spans(
+    text: str,
+    start: int,
+    end: int,
+    *,
+    nesting: int = 0,
+    hash_width: int = 0,
+) -> list[tuple[int, int]]:
+    spans: list[tuple[int, int]] = []
+    cursor = start
+    marker = "\\" + "#" * hash_width + "("
+    while cursor < end:
+        slash = text.find("\\", cursor, end)
+        if slash < 0:
+            break
+        if hash_width:
+            if not text.startswith(marker, slash):
+                cursor = slash + 1
+                continue
+            run_end = slash + len(marker) - 1
+        else:
+            run_end = slash + 1
+            while run_end < end and text[run_end] == "\\":
+                run_end += 1
+            if (run_end - slash) % 2 == 0 or text[run_end : run_end + 1] != "(":
+                cursor = run_end
+                continue
+        expression_start = slash
+        expression_end = balanced_delimiter_end(
+            text,
+            run_end,
+            "(",
+            ")",
+            javascript_dialect="swift",
+            nesting=nesting + 1,
+        )
+        if expression_end is None or expression_end > end:
+            spans.append((expression_start, end))
+            break
+        spans.append((expression_start, expression_end))
+        cursor = expression_end
+    return spans
+
+
+def swift_string_hash_width(text: str, quote_start: int) -> int:
+    cursor = quote_start
+    while cursor > 0 and text[cursor - 1] == "#":
+        cursor -= 1
+    return quote_start - cursor
+
+
+def swift_quoted_literal_span(
+    text: str,
+    quote_start: int,
+    limit: int,
+    *,
+    nesting: int = 0,
+) -> tuple[int, int, int] | None:
+    if nesting > 64:
+        raise SystemExit("refusing review bundle with excessive interpolation nesting")
+    if text[quote_start : quote_start + 1] != '"':
+        return None
+    hash_width = swift_string_hash_width(text, quote_start)
+    triple = text.startswith('"""', quote_start)
+    quote_width = 3 if triple else 1
+    value_start = quote_start + quote_width
+    closing = '"' * quote_width + "#" * hash_width
+    interpolation_marker = "\\" + "#" * hash_width + "("
+    cursor = value_start
+    while cursor < limit:
+        if text.startswith(interpolation_marker, cursor):
+            expression_end = balanced_delimiter_end(
+                text,
+                cursor + len(interpolation_marker) - 1,
+                "(",
+                ")",
+                javascript_dialect="swift",
+                nesting=nesting + 1,
+            )
+            if expression_end is None or expression_end > limit:
+                return None
+            cursor = expression_end
+            continue
+        if text.startswith(closing, cursor):
+            return value_start, cursor, cursor + len(closing)
+        if not hash_width and text[cursor] == "\\":
+            cursor += 2
+            continue
+        if not triple and text[cursor] in SOURCE_LINE_TERMINATORS:
+            return None
+        cursor += 1
+    return None
+
+
+def swift_scala_literal_span(
+    text: str,
+    quote_start: int,
+    limit: int,
+    *,
+    dialect: str,
+    nesting: int = 0,
+) -> tuple[int, int, int] | None:
+    if text[quote_start : quote_start + 1] != '"':
+        return None
+    if dialect == "swift":
+        return swift_quoted_literal_span(
+            text,
+            quote_start,
+            limit,
+            nesting=nesting + 1,
+        )
+    if text.startswith('"""', quote_start):
+        return triple_quoted_literal_span(
+            text,
+            quote_start,
+            limit,
+            interpolation_dialect=dialect,
+            nesting=nesting + 1,
+        )
+    literal_end = (
+        dollar_interpolated_quoted_literal_end(
+            text,
+            quote_start,
+            limit,
+            dialect="scala",
+            nesting=nesting + 1,
+        )
+        if scala_interpolated_string_prefix(text, quote_start)
+        else csharp_quoted_literal_end(
+            text,
+            quote_start,
+            verbatim=False,
+            interpolated=False,
+            nesting=nesting + 1,
+        )
+    )
+    if literal_end is None or literal_end > limit:
+        return None
+    return quote_start + 1, literal_end - 1, literal_end
+
+
+def swift_scala_interpolation_expression_spans(
+    text: str,
+    value_start: int,
+    value_end: int,
+    *,
+    dialect: str,
+    quote_start: int,
+    nesting: int = 0,
+) -> list[tuple[int, int]]:
+    if dialect == "swift":
+        return swift_interpolation_expression_spans(
+            text,
+            value_start,
+            value_end,
+            nesting=nesting + 1,
+            hash_width=swift_string_hash_width(text, quote_start),
+        )
+    if not scala_interpolated_string_prefix(text, quote_start):
+        return []
+    return scala_interpolation_expression_spans(
+        text,
+        value_start,
+        value_end,
+        nesting=nesting + 1,
+    )
+
+
+def scala_interpolation_expression_spans(
+    text: str,
+    start: int,
+    end: int,
+    *,
+    nesting: int = 0,
+) -> list[tuple[int, int]]:
+    return dollar_interpolation_expression_spans(
+        text,
+        start,
+        end,
+        dialect="scala",
+        nesting=nesting + 1,
+        raw=True,
+        doubled_dollars_escape=True,
+    )
+
+
+def interpolation_expression_inner_bounds(
+    text: str,
+    expression_start: int,
+    expression_end: int,
+    *,
+    dialect: str,
+) -> tuple[int, int] | None:
+    if dialect == "swift" and text.startswith("\\", expression_start):
+        opening = text.find("(", expression_start + 1, expression_end)
+        if opening >= 0:
+            return opening + 1, expression_end - 1
+    if dialect == "scala" and text.startswith("${", expression_start):
+        return expression_start + 2, expression_end - 1
+    return None
+
+
+def source_backtick_identifier_end(
+    text: str,
+    start: int,
+    limit: int,
+    *,
+    dialect: str | None,
+) -> int | None:
+    if dialect not in {"kotlin", "scala"} or text[start : start + 1] != "`":
+        return None
+    end = text.find("`", start + 1, limit)
+    if end <= start + 1 or any(
+        char in SOURCE_LINE_TERMINATORS for char in text[start + 1 : end]
+    ):
+        return None
+    return end + 1
+
+
 def string_contexts_at(
     text: str,
     positions: set[int],
+    *,
+    javascript_dialect: str | None = None,
+    nesting: int = 0,
 ) -> dict[int, tuple[str, int] | None]:
+    if nesting > 64:
+        raise SystemExit("refusing review bundle with excessive interpolation nesting")
+    ordered_positions = sorted(positions)
     contexts: dict[int, tuple[str, int] | None] = {}
     quote: str | None = None
     quote_start = -1
@@ -3278,7 +3877,7 @@ def string_contexts_at(
         char = text[cursor]
         next_char = text[cursor + 1] if cursor + 1 < len(text) else ""
         if line_comment:
-            if char == "\n":
+            if char in review_line_comment_terminators(javascript_dialect):
                 line_comment = False
             cursor += 1
             continue
@@ -3309,9 +3908,290 @@ def string_contexts_at(
                 cursor += quote_length
                 continue
         elif (
-            regex_end := javascript_regex_literal_end(text, cursor)
+            javascript_dialect == "groovy"
+            and (
+                slashy := groovy_slashy_literal_span(
+                    text,
+                    cursor,
+                    len(text),
+                    nesting=nesting,
+                )
+            )
+            is not None
+        ):
+            value_start, value_end, literal_end = slashy
+            expressions = tuple(
+                dollar_interpolation_expression_spans(
+                    text,
+                    value_start,
+                    value_end,
+                    dialect="groovy",
+                    nesting=nesting + 1,
+                    raw=text.startswith("$/", cursor),
+                    doubled_dollars_escape=text.startswith("$/", cursor),
+                )
+            )
+            slashy_context = (text[cursor:value_start], cursor)
+            literal_positions = ordered_positions[
+                bisect.bisect_left(ordered_positions, value_start) :
+                bisect.bisect_left(ordered_positions, value_end)
+            ]
+            nested_positions: list[set[int]] = [set() for _ in expressions]
+            expression_index = 0
+            for position in literal_positions:
+                while (
+                    expression_index < len(expressions)
+                    and expressions[expression_index][1] <= position
+                ):
+                    expression_index += 1
+                if expression_index >= len(expressions) or not (
+                    expressions[expression_index][0]
+                    <= position
+                    < expressions[expression_index][1]
+                ):
+                    contexts[position] = slashy_context
+                    continue
+                expression_start, expression_end = expressions[expression_index]
+                if text.startswith("${", expression_start):
+                    inner_start = expression_start + 2
+                    inner_end = expression_end - 1
+                    if inner_start <= position < inner_end:
+                        nested_positions[expression_index].add(
+                            position - inner_start
+                        )
+            for (expression_start, expression_end), positions_in_expression in zip(
+                expressions,
+                nested_positions,
+            ):
+                if not positions_in_expression or not text.startswith(
+                    "${",
+                    expression_start,
+                ):
+                    continue
+                inner_start = expression_start + 2
+                inner_end = expression_end - 1
+                nested_contexts = string_contexts_at(
+                    text[inner_start:inner_end],
+                    positions_in_expression,
+                    javascript_dialect="groovy",
+                    nesting=nesting + 1,
+                )
+                for position, context in nested_contexts.items():
+                    if context is not None:
+                        contexts[position + inner_start] = (
+                            context[0],
+                            context[1] + inner_start,
+                        )
+            cursor = literal_end
+            continue
+        elif (
+            regex_end := review_regex_or_slashy_literal_end(
+                text,
+                cursor,
+                dialect=javascript_dialect,
+                nesting=nesting,
+            )
         ) is not None:
             cursor = regex_end
+            continue
+        elif (
+            javascript_dialect == "csharp"
+            and (csharp_raw := csharp_raw_literal_span(text, cursor, len(text)))
+            is not None
+        ):
+            value_start, value_end, literal_end = csharp_raw
+            brace_width = csharp_raw_interpolation_width(text, cursor)
+            expressions = (
+                tuple(
+                    interpolation_expression_spans(
+                        text,
+                        value_start,
+                        value_end,
+                        dialect="csharp",
+                        brace_width=brace_width,
+                    )
+                )
+                if brace_width
+                else ()
+            )
+            raw_context = (text[cursor:value_start], cursor)
+            literal_positions = ordered_positions[
+                bisect.bisect_left(ordered_positions, value_start) :
+                bisect.bisect_left(ordered_positions, value_end)
+            ]
+            expression_positions: list[set[int]] = [set() for _ in expressions]
+            expression_index = 0
+            for position in literal_positions:
+                while (
+                    expression_index < len(expressions)
+                    and expressions[expression_index][1] <= position
+                ):
+                    expression_index += 1
+                if expression_index >= len(expressions) or not (
+                    expressions[expression_index][0]
+                    <= position
+                    < expressions[expression_index][1]
+                ):
+                    contexts[position] = raw_context
+                    continue
+                expression_start, expression_end = expressions[expression_index]
+                inner_start = expression_start + brace_width
+                inner_end = expression_end - brace_width
+                if inner_start <= position < inner_end:
+                    expression_positions[expression_index].add(
+                        position - inner_start
+                    )
+            for (expression_start, expression_end), nested_positions in zip(
+                expressions,
+                expression_positions,
+            ):
+                if not nested_positions:
+                    continue
+                inner_start = expression_start + brace_width
+                inner_end = expression_end - brace_width
+                nested_contexts = string_contexts_at(
+                    text[inner_start:inner_end],
+                    nested_positions,
+                    javascript_dialect="csharp",
+                    nesting=nesting + 1,
+                )
+                for position, context in nested_contexts.items():
+                    if context is not None:
+                        contexts[position + inner_start] = (
+                            context[0],
+                            context[1] + inner_start,
+                        )
+            cursor = literal_end
+            continue
+        elif (
+            javascript_dialect == "csharp"
+            and text.startswith('"""', cursor)
+        ):
+            cursor = repeated_character_end(text, cursor, len(text), '"')
+            continue
+        elif (
+            identifier_end := source_backtick_identifier_end(
+                text,
+                cursor,
+                len(text),
+                dialect=javascript_dialect,
+            )
+        ) is not None:
+            for position in ordered_positions[
+                bisect.bisect_left(ordered_positions, cursor) :
+                bisect.bisect_left(ordered_positions, identifier_end)
+            ]:
+                contexts[position] = None
+            cursor = identifier_end
+            continue
+        elif (
+            javascript_dialect in {"scala", "swift"}
+            and char == '"'
+            and (
+                literal := swift_scala_literal_span(
+                    text,
+                    cursor,
+                    len(text),
+                    dialect=javascript_dialect,
+                    nesting=nesting + 1,
+                )
+            )
+            is not None
+        ):
+            value_start, value_end, literal_end = literal
+            expressions = tuple(
+                swift_scala_interpolation_expression_spans(
+                    text,
+                    value_start,
+                    value_end,
+                    dialect=javascript_dialect,
+                    quote_start=cursor,
+                    nesting=nesting + 1,
+                )
+            )
+            opening_start = (
+                cursor - swift_string_hash_width(text, cursor)
+                if javascript_dialect == "swift"
+                else cursor
+            )
+            literal_context = (text[opening_start:value_start], opening_start)
+            literal_positions = ordered_positions[
+                bisect.bisect_left(ordered_positions, value_start) :
+                bisect.bisect_left(ordered_positions, value_end)
+            ]
+            nested_positions: list[set[int]] = [set() for _ in expressions]
+            expression_index = 0
+            for position in literal_positions:
+                while (
+                    expression_index < len(expressions)
+                    and expressions[expression_index][1] <= position
+                ):
+                    expression_index += 1
+                if expression_index >= len(expressions) or not (
+                    expressions[expression_index][0]
+                    <= position
+                    < expressions[expression_index][1]
+                ):
+                    contexts[position] = literal_context
+                    continue
+                expression_start, expression_end = expressions[expression_index]
+                inner = interpolation_expression_inner_bounds(
+                    text,
+                    expression_start,
+                    expression_end,
+                    dialect=javascript_dialect,
+                )
+                if inner is not None and inner[0] <= position < inner[1]:
+                    nested_positions[expression_index].add(position - inner[0])
+            for expression, positions_in_expression in zip(
+                expressions,
+                nested_positions,
+            ):
+                if not positions_in_expression:
+                    continue
+                inner = interpolation_expression_inner_bounds(
+                    text,
+                    expression[0],
+                    expression[1],
+                    dialect=javascript_dialect,
+                )
+                if inner is None:
+                    continue
+                nested_contexts = string_contexts_at(
+                    text[inner[0] : inner[1]],
+                    positions_in_expression,
+                    javascript_dialect=javascript_dialect,
+                    nesting=nesting + 1,
+                )
+                for position, context in nested_contexts.items():
+                    if context is not None:
+                        contexts[position + inner[0]] = (
+                            context[0],
+                            context[1] + inner[0],
+                        )
+            cursor = literal_end
+            continue
+        elif (
+            javascript_dialect == "c-family"
+            and char == '"'
+            and (
+                raw_literal := c_family_raw_literal_span(
+                    text,
+                    cursor,
+                    len(text),
+                    allow_incomplete=True,
+                )
+            )
+            is not None
+        ):
+            value_start, value_end, literal_end = raw_literal
+            raw_context = (text[cursor:value_start], cursor)
+            for position in ordered_positions[
+                bisect.bisect_left(ordered_positions, value_start) :
+                bisect.bisect_left(ordered_positions, value_end)
+            ]:
+                contexts[position] = raw_context
+            cursor = literal_end
             continue
         elif text.startswith('"""', cursor):
             quote = '"""'
@@ -3323,18 +4203,30 @@ def string_contexts_at(
             quote_start = cursor
             cursor += 3
             continue
-        elif char == "/" and next_char == "/":
+        elif (
+            review_dialect_has_slash_comments(javascript_dialect)
+            and char == "/"
+            and next_char == "/"
+        ):
             line_comment = True
             cursor += 2
             continue
-        elif char == "/" and next_char == "*":
+        elif (
+            review_dialect_has_slash_comments(javascript_dialect)
+            and char == "/"
+            and next_char == "*"
+        ):
             block_comment = True
             cursor += 2
             continue
-        elif char == "#" and not javascript_private_member_marker(
+        elif (
+            char == "#"
+            and review_dialect_has_hash_comments(javascript_dialect)
+            and not javascript_private_member_marker(
             text,
             cursor,
             allow_bare=bool(class_depths),
+            )
         ):
             line_comment = True
         elif char in {'"', "'", "`"}:
@@ -3369,6 +4261,35 @@ def string_contexts_at(
     for position in positions - contexts.keys():
         contexts[position] = None if quote is None else (quote, quote_start)
     return contexts
+
+
+def source_backtick_identifier_spans(
+    text: str,
+    *,
+    dialect: str | None,
+) -> tuple[tuple[int, int], ...]:
+    if dialect not in {"kotlin", "scala"}:
+        return ()
+    matches = list(re.finditer(r"`[^`\r\n]+`", text))
+    contexts = string_contexts_at(
+        text,
+        {match.start() for match in matches},
+        javascript_dialect=dialect,
+    )
+    return tuple(
+        match.span()
+        for match in matches
+        if contexts[match.start()] is None
+    )
+
+
+def assignment_uses_source_backtick_identifier(
+    match: re.Match[str],
+    ranges: tuple[tuple[int, int], ...],
+) -> bool:
+    if "backtick_value" not in match.groupdict() or match.group("backtick_value") is None:
+        return False
+    return position_in_ranges(match.start("backtick_value"), ranges)
 
 
 def uri_password_is_interpolated(
@@ -3481,7 +4402,10 @@ def uri_password_is_interpolated(
 
 def uri_placeholder_password_is_safe(password: str, host: str) -> bool:
     normalized_password = password.lower()
-    if normalized_password in URI_PASSWORD_PLACEHOLDER_VALUES:
+    if (
+        normalized_password in URI_PASSWORD_PLACEHOLDER_VALUES
+        or redacted_placeholder_value(normalized_password)
+    ):
         return True
     normalized_host = host.lower()
     if normalized_host.startswith("[") and "]" in normalized_host:
@@ -3848,25 +4772,1176 @@ def shell_command_prefix(text: str, position: int) -> bool:
     )
 
 
+def javascript_template_literal_ranges(
+    text: str,
+    *,
+    allow_incomplete: bool = False,
+) -> list[tuple[int, int]] | None:
+    ranges: list[tuple[int, int]] = []
+    cursor = 0
+    while cursor < len(text):
+        char = text[cursor]
+        next_char = text[cursor + 1] if cursor + 1 < len(text) else ""
+        if char == "/" and next_char == "/":
+            line_end = javascript_line_terminator_index(text, cursor + 2)
+            cursor = len(text) if line_end is None else line_end
+            continue
+        if char == "/" and next_char == "*":
+            comment_end = text.find("*/", cursor + 2)
+            if comment_end < 0:
+                return ranges if allow_incomplete else None
+            cursor = comment_end + 2
+            continue
+        regex_end = javascript_regex_literal_end(text, cursor)
+        if regex_end is not None:
+            cursor = regex_end
+            continue
+        if char in {'"', "'"}:
+            string_end = csharp_quoted_literal_end(
+                text,
+                cursor,
+                verbatim=False,
+                interpolated=False,
+            )
+            if string_end is None:
+                return ranges if allow_incomplete else None
+            cursor = string_end
+            continue
+        if char == "`":
+            template_end = javascript_template_literal_end(text, cursor)
+            if template_end is None:
+                if allow_incomplete:
+                    ranges.append((cursor, len(text)))
+                    return ranges
+                return None
+            ranges.append((cursor, template_end))
+            cursor = template_end
+            continue
+        cursor += 1
+    return ranges
+
+
+def javascript_regex_literal_mask_safe_start(
+    text: str,
+    start: int,
+) -> bool:
+    previous = start - 1
+    while previous >= 0 and text[previous].isspace():
+        previous -= 1
+    if previous < 0:
+        return True
+    prefix = text[: previous + 1]
+    if prefix.endswith(("...", "=>")):
+        return True
+    if text[previous] == ")":
+        return previous in javascript_control_condition_closes(text)
+    if text[previous] in "([{:;,=!?&|+-*%^~":
+        return True
+    word_start = previous
+    while word_start >= 0 and (
+        text[word_start].isalnum() or text[word_start] in "_$"
+    ):
+        word_start -= 1
+    keyword = text[word_start + 1 : previous + 1]
+    if keyword not in JAVASCRIPT_REGEX_EXPRESSION_KEYWORDS:
+        return False
+    if word_start >= 0 and text[word_start] == ".":
+        return False
+    if keyword in {"await", "yield"}:
+        # Argument-level scanning cannot prove these contextual words are
+        # keywords rather than identifiers, so ambiguous slash ranges stay
+        # visible to the conservative literal scan.
+        return False
+    return True
+
+
+def javascript_regex_literal_ranges(text: str) -> list[tuple[int, int]]:
+    ranges: list[tuple[int, int]] = []
+    cursor = 0
+    while cursor < len(text):
+        char = text[cursor]
+        next_char = text[cursor + 1] if cursor + 1 < len(text) else ""
+        if char == "/" and next_char == "/":
+            line_end = javascript_line_terminator_index(text, cursor + 2)
+            cursor = len(text) if line_end is None else line_end
+            continue
+        if char == "/" and next_char == "*":
+            comment_end = text.find("*/", cursor + 2)
+            cursor = len(text) if comment_end < 0 else comment_end + 2
+            continue
+        regex_end = javascript_regex_literal_end(text, cursor)
+        if regex_end is not None:
+            if javascript_regex_literal_mask_safe_start(text, cursor):
+                ranges.append((cursor, regex_end))
+                cursor = regex_end
+            else:
+                cursor += 1
+            continue
+        if char in {'"', "'"}:
+            string_end = csharp_quoted_literal_end(
+                text,
+                cursor,
+                verbatim=False,
+                interpolated=False,
+            )
+            cursor = len(text) if string_end is None else string_end
+            continue
+        if char == "`":
+            template_end = javascript_template_literal_end(text, cursor)
+            cursor = len(text) if template_end is None else template_end
+            continue
+        cursor += 1
+    return ranges
+
+
+def javascript_regex_string_value_risk(
+    text: str,
+    start: int,
+    end: int,
+    *,
+    minimum_length: int,
+    dialect: str | None,
+) -> bool:
+    suffix = text[end:]
+    if re.match(
+        r'''\s*(?:(?:\?\.|\.)source\b|(?:\?\.|\.)toString\s*\(\s*\)|\[\s*["']source["']\s*\])''',
+        suffix,
+    ) is None:
+        return False
+    closing = end
+    while closing > start and text[closing - 1].isalpha():
+        closing -= 1
+    if closing <= start + 1 or text[closing - 1] != "/":
+        return True
+    return quoted_template_segment_is_risky(
+        text[start + 1 : closing - 1],
+        minimum_length,
+        dialect=dialect,
+        references_are_source=False,
+    )
+
+
+def quoted_template_segment_is_risky(
+    value: str,
+    minimum_length: int,
+    *,
+    dialect: str | None,
+    references_are_source: bool = True,
+) -> bool:
+    if (
+        credentialed_uri_risk(value)
+        or basic_authorization_risk(value)
+        or any(pattern.search(value) for pattern in SECRET_VALUE_PATTERNS)
+    ):
+        return True
+    return (
+        (
+            len(value) >= minimum_length
+            or numeric_literal_secret(value, dialect=dialect)
+        )
+        and not secret_placeholder_sequence(value)
+        and (
+            not references_are_source
+            or not any(
+                pattern.fullmatch(value)
+                for pattern in QUOTED_SECRET_REFERENCE_PATTERNS
+            )
+        )
+    )
+
+
+def integer_literal_secret(value: str) -> bool:
+    normalized = re.sub(
+        r"(?i)(?:n|ul|lu|u|l|g|i)$",
+        "",
+        value,
+    ).replace("_", "")
+    if re.fullmatch(r"0[xX][0-9A-Fa-f]+", normalized):
+        return int(normalized[2:], 16) >= 10_000_000
+    if re.fullmatch(r"0[bB][01]+", normalized):
+        return int(normalized[2:], 2) >= 10_000_000
+    if re.fullmatch(r"0[oO][0-7]+", normalized):
+        return int(normalized[2:], 8) >= 10_000_000
+    if normalized.isdigit():
+        return len(normalized) >= 8
+    return False
+
+
+def numeric_literal_secret(value: str, *, dialect: str | None) -> bool:
+    if integer_literal_secret(value):
+        return True
+    if is_javascript_review_dialect(dialect):
+        normalized = value.removesuffix("n").replace("_", "")
+        try:
+            number = float(normalized)
+        except ValueError:
+            return False
+        return (
+            math.isfinite(number)
+            and number.is_integer()
+            and abs(number) >= 10_000_000
+        )
+    if dialect not in {"csharp", "python"}:
+        return False
+    normalized = re.sub(r"(?i)[fFdDmMjJ]$", "", value).replace("_", "")
+    if re.fullmatch(
+        r"(?:[0-9]+(?:\.[0-9]*)?|\.[0-9]+)(?:[eE][+-]?[0-9]+)?",
+        normalized,
+    ):
+        return sum(char.isdigit() for char in normalized) >= 8
+    return False
+
+
+def integer_literal_syntax(
+    value: str,
+    *,
+    dialect: str | None,
+) -> bool:
+    pattern = (
+        JAVASCRIPT_NUMERIC_LITERAL_PATTERN
+        if is_javascript_review_dialect(dialect)
+        else CSHARP_NUMERIC_LITERAL_PATTERN
+        if dialect == "csharp"
+        else PYTHON_NUMERIC_LITERAL_PATTERN
+        if dialect == "python"
+        else DOLLAR_INTEGER_LITERAL_PATTERN
+        if dialect in {"groovy", "kotlin"}
+        else SCALA_INTEGER_LITERAL_PATTERN
+        if dialect == "scala"
+        else None
+    )
+    return pattern is not None and pattern.fullmatch(value) is not None
+
+
+def review_literal_candidate(
+    value: str,
+    *,
+    dialect: str | None,
+    references_are_source: bool = True,
+) -> bool:
+    if integer_literal_syntax(value, dialect=dialect):
+        return numeric_literal_secret(value, dialect=dialect)
+    return (
+        len(value) >= 7
+        and any(char.isdigit() for char in value)
+        and any(char.isalpha() for char in value)
+        and not secret_placeholder_value(value)
+        and (
+            not references_are_source
+            or not any(
+                pattern.fullmatch(value)
+                for pattern in QUOTED_SECRET_REFERENCE_PATTERNS
+            )
+        )
+    )
+
+
+def rendered_literal_span_groups(
+    text: str,
+    spans: list[tuple[int, int]],
+    comment_spans: list[tuple[int, int]] | None = None,
+    *,
+    dialect: str | None = None,
+) -> list[list[tuple[int, int]]]:
+    ordered = sorted(set(spans))
+    if not ordered:
+        return []
+    comments = tuple(comment_spans or ())
+    groups = [[ordered[0]]]
+    for span in ordered[1:]:
+        previous = groups[-1][-1]
+        previous_comment = position_in_ranges(previous[0], comments)
+        current_comment = position_in_ranges(span[0], comments)
+        gap = text[previous[1] : span[0]]
+        comment_patterns = (
+            ([] if dialect == "python" else [r"/\*.*?\*/"])
+            + (
+                [r"//[^\r\n\u0085\u2028\u2029]*"]
+                if review_dialect_has_slash_comments(dialect)
+                else []
+            )
+            + ([r"#[^\r\n]*"] if dialect in {None, "python"} else [])
+        )
+        gap_without_comments = re.sub(
+            "|".join(comment_patterns),
+            "",
+            gap,
+            flags=re.DOTALL,
+        ) if comment_patterns else gap
+        c_family_literal_gap = (
+            dialect == "c-family"
+            and re.fullmatch(
+                r'''(?:"|\)[^\s()\\]{0,16}")\s*'''
+                r'''(?:(?:u8|u|U|L)?"|(?:u8R|uR|UR|LR|R)"[^\s()\\]{0,16}\()''',
+                gap_without_comments,
+            )
+            is not None
+        )
+        swift_interpolation_gap = (
+            dialect == "swift"
+            and re.fullmatch(
+                r'''(?:[\s"'`$}{()+@\\#])*''',
+                gap_without_comments,
+            )
+            is not None
+        )
+        javascript_concat_gap = (
+            is_javascript_review_dialect(dialect)
+            and re.fullmatch(
+                r'''["']\s*\)*\s*\.concat\(\s*["']''',
+                gap_without_comments,
+            )
+            is not None
+        )
+        if (
+            previous_comment == current_comment
+            and (
+                c_family_literal_gap
+                or javascript_concat_gap
+                or swift_interpolation_gap
+                or re.fullmatch(
+                    r'''(?:[\s"'`$}{()+@]|(?:br|rb|fr|rf|tr|rt|[rubft])(?=["']))*''',
+                    gap_without_comments,
+                    re.IGNORECASE,
+                )
+                is not None
+            )
+        ):
+            groups[-1].append(span)
+        else:
+            groups.append([span])
+    return groups
+
+
+def rendered_literal_group_is_numeric_arithmetic(
+    text: str,
+    group: list[tuple[int, int]],
+    numeric_source_spans: set[tuple[int, int]],
+) -> bool:
+    gaps = [
+        text[previous[1] : current[0]]
+        for previous, current in zip(group, group[1:])
+    ]
+    return (
+        all(span in numeric_source_spans for span in group)
+        and bool(gaps)
+        and all(re.fullmatch(r"\s*\+\s*", gap) is not None for gap in gaps)
+        and re.search(
+            r"(?:\$+\{|\{+)\s*(?:\(\s*)*$",
+            text[: group[0][0]],
+        )
+        is not None
+        and re.match(
+            r"\s*(?:\)\s*)*(?:=\s*)?(?:![sra]\s*)?"
+            r"(?:,\s*-?\d+\s*)?(?::[^{}\r\n]*)?\}+",
+            text[group[-1][1] :],
+        )
+        is not None
+    )
+
+
+def rendered_literal_candidate_spans(
+    text: str,
+    spans: list[tuple[int, int]],
+    *,
+    dialect: str | None,
+    comment_spans: list[tuple[int, int]] | None = None,
+    numeric_source_spans: list[tuple[int, int]] | None = None,
+    references_are_source: bool = True,
+) -> list[tuple[int, int]]:
+    numeric_sources = set(numeric_source_spans or ())
+    selected = {
+        (start, end)
+        for start, end in spans
+        if (
+            (start, end) not in numeric_sources
+            or numeric_literal_secret(text[start:end], dialect=dialect)
+        )
+        and (
+            review_literal_candidate(
+                text[start:end],
+                dialect=dialect,
+                references_are_source=references_are_source,
+            )
+            or quoted_template_segment_is_risky(
+                text[start:end],
+                12,
+                dialect=dialect,
+                references_are_source=references_are_source,
+            )
+        )
+    }
+    for group in rendered_literal_span_groups(
+        text,
+        spans,
+        comment_spans,
+        dialect=dialect,
+    ):
+        combined = "".join(text[start:end] for start, end in group)
+        if (
+            len(group) > 1
+            and not rendered_literal_group_is_numeric_arithmetic(
+                text,
+                group,
+                numeric_sources,
+            )
+            and (
+                review_literal_candidate(
+                    combined,
+                    dialect=dialect,
+                    references_are_source=references_are_source,
+                )
+                or quoted_template_segment_is_risky(
+                    combined,
+                    12,
+                    dialect=dialect,
+                    references_are_source=references_are_source,
+                )
+            )
+        ):
+            selected.update(group)
+    return sorted(selected)
+
+
+def combined_review_literal_value(
+    text: str,
+    group: list[tuple[int, int]],
+) -> str:
+    values = [text[start:end] for start, end in group]
+    if values and all(secret_placeholder_sequence(value) for value in values):
+        return "redacted"
+    return "".join(values)
+
+
+def integer_literal_spans(
+    text: str,
+    start: int,
+    end: int,
+    *,
+    dialect: str,
+) -> list[tuple[int, int]]:
+    pattern = (
+        CSHARP_INTEGER_LITERAL_PATTERN
+        if dialect == "csharp"
+        else DOLLAR_INTEGER_LITERAL_PATTERN
+        if dialect in {"groovy", "kotlin"}
+        else SCALA_INTEGER_LITERAL_PATTERN
+        if dialect == "scala"
+        else PYTHON_INTEGER_LITERAL_PATTERN
+    )
+    return [
+        match.span()
+        for match in pattern.finditer(text, start, end)
+        if integer_literal_token_boundary(
+            text,
+            match.start(),
+            match.end(),
+            dialect=dialect,
+        )
+    ]
+
+
+def numeric_literal_spans(
+    text: str,
+    start: int,
+    end: int,
+    *,
+    dialect: str,
+) -> list[tuple[int, int]]:
+    pattern = (
+        JAVASCRIPT_NUMERIC_LITERAL_PATTERN
+        if is_javascript_review_dialect(dialect)
+        else CSHARP_NUMERIC_LITERAL_PATTERN
+        if dialect == "csharp"
+        else PYTHON_NUMERIC_LITERAL_PATTERN
+        if dialect == "python"
+        else None
+    )
+    if pattern is None:
+        return integer_literal_spans(text, start, end, dialect=dialect)
+    spans: list[tuple[int, int]] = []
+    for match in pattern.finditer(text, start, end):
+        span_start, span_end = match.span()
+        if dialect == "csharp":
+            if (
+                text[span_start : span_start + 1] == "."
+                and text[span_start - 1 : span_start] == "."
+            ):
+                span_start += 1
+            if (
+                text[span_end - 1 : span_end] == "."
+                and text[span_end : span_end + 1] == "."
+            ):
+                span_end -= 1
+        if span_start >= span_end:
+            continue
+        if identifier_continuation_character(
+            text[span_start - 1 : span_start],
+            dialect=dialect,
+        ) or identifier_continuation_character(
+            text[span_end : span_end + 1],
+            dialect=dialect,
+        ):
+            continue
+        spans.append((span_start, span_end))
+    return spans
+
+
+def identifier_continuation_character(char: str, *, dialect: str) -> bool:
+    return bool(char) and (
+        (dialect in {"javascript", "scala", "typescript"} and char == "$")
+        or ("A" + char).isidentifier()
+        or unicodedata.category(char) in {"Mn", "Mc", "Pc", "Cf"}
+    )
+
+
+def identifier_start_character(char: str, *, dialect: str) -> bool:
+    return bool(char) and (
+        (
+            dialect in {"groovy", "javascript", "kotlin", "scala", "typescript"}
+            and char == "$"
+        )
+        or char.isidentifier()
+    )
+
+
+def integer_literal_member_access(
+    text: str,
+    end: int,
+    *,
+    dialect: str,
+) -> bool:
+    if dialect == "python":
+        return False
+    cursor = end + 1
+    if dialect in {"javascript", "typescript"} and text[end : end + 2] == "..":
+        cursor += 1
+    if dialect == "csharp" and text[cursor : cursor + 1] == "@":
+        cursor += 1
+    if dialect == "kotlin" and text[cursor : cursor + 1] == "`":
+        closing = text.find("`", cursor + 1)
+        return closing > cursor + 1 and not any(
+            char in SOURCE_LINE_TERMINATORS
+            for char in text[cursor + 1 : closing]
+        )
+    if dialect == "groovy" and text[cursor : cursor + 1] in {'"', "'"}:
+        quote_end = csharp_quoted_literal_end(
+            text,
+            cursor,
+            verbatim=False,
+            interpolated=False,
+        )
+        return quote_end is not None and quote_end > cursor + 2
+    if dialect in {"javascript", "typescript"} and text.startswith(
+        "\\u",
+        cursor,
+    ):
+        return re.match(
+            r"\\u(?:[0-9A-Fa-f]{4}|\{[0-9A-Fa-f]+\})",
+            text[cursor:],
+        ) is not None
+    return identifier_start_character(text[cursor : cursor + 1], dialect=dialect)
+
+
+def integer_literal_token_boundary(
+    text: str,
+    start: int,
+    end: int,
+    *,
+    dialect: str,
+) -> bool:
+    literal = text[start:end]
+    before = text[start - 1 : start]
+    after = text[end : end + 1]
+    if identifier_continuation_character(before, dialect=dialect) or (
+        identifier_continuation_character(after, dialect=dialect)
+    ):
+        return False
+    if dialect in {"javascript", "typescript"} and re.search(
+        r"\\u(?:[0-9A-Fa-f]{4}|\{[0-9A-Fa-f]+\})$",
+        text[max(0, start - 12) : start],
+    ):
+        return False
+    range_dialect = dialect in {"csharp", "groovy", "kotlin"}
+    if before == "." and not (
+        range_dialect and text[max(0, start - 2) : start] == ".."
+    ):
+        return False
+    member_access_safe = (
+        re.match(r"0[xXbBoO]", literal) is not None
+        or (
+            dialect in {"javascript", "typescript"}
+            and literal.endswith("n")
+        )
+        or (
+            dialect == "csharp"
+            and re.search(r"(?i)(?:u?l|l?u)$", literal) is not None
+        )
+    )
+    if after == "." and not member_access_safe:
+        if range_dialect and text[end : end + 2] == "..":
+            return True
+        if not integer_literal_member_access(text, end, dialect=dialect):
+            return False
+    return True
+
+
+def source_secret_member_reference(
+    value: str,
+    *,
+    dialect: str | None,
+) -> bool:
+    if (
+        dialect not in SOURCE_REFERENCE_REVIEW_DIALECTS
+        or SOURCE_SECRET_MEMBER_REFERENCE_PATTERN.fullmatch(value) is None
+    ):
+        return False
+    operators = (
+        r"::|->|\."
+        if dialect == "c-family"
+        else r"::|->|\?\.|\."
+        if dialect == "csharp"
+        else r"::|\?\.|\."
+        if dialect in {"java", "kotlin"}
+        else r"\?\.|\."
+    )
+    components = re.split(operators, value)
+    return any(
+        re.fullmatch(
+            SECRET_ASSIGNMENT_KEY_NAME_PATTERN,
+            component,
+            re.IGNORECASE,
+        )
+        is not None
+        for component in components
+    )
+
+
 def secret_literal_risk(
     expression: str,
     minimum_length: int = 12,
     *,
     javascript_dialect: str | None = None,
+    nesting: int = 0,
 ) -> bool:
+    if nesting > 64:
+        raise SystemExit("refusing review bundle with excessive interpolation nesting")
     if credentialed_uri_risk(expression) or basic_authorization_risk(expression) or any(
         pattern.search(expression) for pattern in SECRET_VALUE_PATTERNS
     ):
         return True
+    if javascript_dialect in {"groovy", "kotlin"} and any(
+        integer_literal_secret(expression[start:end])
+        for start, end in integer_literal_spans(
+            expression,
+            0,
+            len(expression),
+            dialect=javascript_dialect,
+        )
+    ):
+        return True
+    scan_expression = expression
+    prevalidated_literal_spans: tuple[tuple[int, int], ...] = ()
+    if is_javascript_review_dialect(javascript_dialect):
+        template_ranges = javascript_template_literal_ranges(expression)
+        if template_ranges is None:
+            return True
+        for template_start, template_end in template_ranges:
+            numeric_source_spans: list[tuple[int, int]] = []
+            try:
+                spans, comment_spans, parsed_end = javascript_template_value_spans(
+                    expression,
+                    template_start,
+                    template_end,
+                    numeric_source_spans=numeric_source_spans,
+                )
+            except SystemExit:
+                return True
+            numeric_source_set = set(numeric_source_spans)
+            template_values = [expression[start:end] for start, end in spans]
+            if parsed_end != template_end or any(
+                quoted_template_segment_is_risky(
+                    value,
+                    minimum_length,
+                    dialect=javascript_dialect,
+                )
+                for span, value in zip(spans, template_values)
+                if span not in numeric_source_set
+                or numeric_literal_secret(value, dialect=javascript_dialect)
+            ):
+                return True
+            for group in rendered_literal_span_groups(
+                expression,
+                spans,
+                comment_spans,
+                dialect=javascript_dialect,
+            ):
+                combined = combined_review_literal_value(expression, group)
+                if (
+                    len(group) > 1
+                    and not rendered_literal_group_is_numeric_arithmetic(
+                        expression,
+                        group,
+                        numeric_source_set,
+                    )
+                    and quoted_template_segment_is_risky(
+                        combined,
+                        minimum_length,
+                        dialect=javascript_dialect,
+                    )
+                ):
+                    return True
+        scan_expression = mask_ranges(expression, tuple(template_ranges))
+    elif javascript_dialect in {"csharp", "python"}:
+        masked_expression = list(expression)
+        cursor = 0
+        while cursor < len(expression):
+            structured = structured_literal_parts(
+                expression,
+                cursor,
+                len(expression),
+                dialect=javascript_dialect,
+            )
+            if structured is None:
+                cursor += 1
+                continue
+            (
+                value_start,
+                value_end,
+                literal_end,
+                expression_spans,
+                brace_width,
+            ) = structured
+            nested_spans: list[tuple[int, int]] = []
+            nested_comments: list[tuple[int, int]] = []
+            numeric_source_spans: list[tuple[int, int]] = []
+            format_spans: list[tuple[int, int]] = []
+            for expression_start, expression_end in expression_spans:
+                expression_literals, expression_comments = quoted_literal_value_spans(
+                    expression,
+                    expression_start + brace_width,
+                    expression_end - brace_width,
+                    javascript_dialect=javascript_dialect,
+                    collect_all_literals=True,
+                )
+                nested_comments.extend(expression_comments)
+                field_format_spans = interpolation_format_literal_spans(
+                    expression,
+                    expression_start,
+                    expression_end,
+                    dialect=javascript_dialect,
+                    brace_width=brace_width,
+                )
+                format_spans.extend(field_format_spans)
+                expression_literals = sorted(
+                    expression_literals + field_format_spans
+                )
+                nested_spans.extend(expression_literals)
+                numeric_spans = [
+                    span
+                    for span in numeric_literal_spans(
+                        expression,
+                        expression_start + brace_width,
+                        expression_end - brace_width,
+                        dialect=javascript_dialect,
+                    )
+                    if not position_in_ranges(
+                        span[0],
+                        tuple(expression_literals),
+                    )
+                ]
+                nested_spans.extend(numeric_spans)
+                numeric_source_spans.extend(numeric_spans)
+            literal_spans = sorted(
+                spans_outside_ranges(
+                    value_start,
+                    value_end,
+                    expression_spans,
+                )
+                + nested_spans
+            )
+            numeric_source_set = set(numeric_source_spans)
+            literal_values = [expression[start:end] for start, end in literal_spans]
+            if any(
+                quoted_template_segment_is_risky(
+                    value,
+                    minimum_length,
+                    dialect=javascript_dialect,
+                )
+                for span, value in zip(literal_spans, literal_values)
+                if span not in numeric_source_set
+                or numeric_literal_secret(value, dialect=javascript_dialect)
+            ):
+                return True
+            for group in rendered_literal_span_groups(
+                expression,
+                literal_spans,
+                nested_comments,
+                dialect=javascript_dialect,
+            ):
+                combined = combined_review_literal_value(expression, group)
+                if (
+                    len(group) > 1
+                    and not rendered_literal_group_is_numeric_arithmetic(
+                        expression,
+                        group,
+                        numeric_source_set,
+                    )
+                    and quoted_template_segment_is_risky(
+                        combined,
+                        minimum_length,
+                        dialect=javascript_dialect,
+                    )
+                ):
+                    return True
+            # String text and delimiters are data. Keep interpolation source
+            # visible so nested secret-like literals still fail closed.
+            for index in range(cursor, literal_end):
+                masked_expression[index] = " "
+            for start, end in expression_spans:
+                masked_expression[start:end] = expression[start:end]
+            for start, end in format_spans:
+                masked_expression[start:end] = " " * (end - start)
+            cursor = literal_end
+        scan_expression = "".join(masked_expression)
+    elif javascript_dialect in {"c-family", "java"}:
+        literal_spans, _ = quoted_literal_value_spans(
+            expression,
+            0,
+            len(expression),
+            javascript_dialect=javascript_dialect,
+            collect_all_literals=True,
+            nesting=nesting + 1,
+            references_are_source=False,
+        )
+        if any(
+            review_literal_candidate(
+                expression[start:end],
+                dialect=javascript_dialect,
+                references_are_source=False,
+            )
+            or quoted_template_segment_is_risky(
+                expression[start:end],
+                minimum_length,
+                dialect=javascript_dialect,
+                references_are_source=False,
+            )
+            for start, end in literal_spans
+        ):
+            return True
+        for group in rendered_literal_span_groups(
+            expression,
+            literal_spans,
+            dialect=javascript_dialect,
+        ):
+            if len(group) < 2:
+                continue
+            combined = combined_review_literal_value(expression, group)
+            if review_literal_candidate(
+                combined,
+                dialect=javascript_dialect,
+                references_are_source=False,
+            ) or quoted_template_segment_is_risky(
+                combined,
+                minimum_length,
+                dialect=javascript_dialect,
+                references_are_source=False,
+            ):
+                return True
+        prevalidated_literal_spans = tuple(literal_spans)
+    elif javascript_dialect in {"scala", "swift"}:
+        masked_expression = list(expression)
+        cursor = 0
+        while cursor < len(expression):
+            quote = expression.find('"', cursor)
+            if quote < 0:
+                break
+            literal = swift_scala_literal_span(
+                expression,
+                quote,
+                len(expression),
+                dialect=javascript_dialect,
+                nesting=nesting + 1,
+            )
+            if literal is None:
+                cursor = quote + 1
+                continue
+            value_start, value_end, literal_end = literal
+            (
+                literal_spans,
+                nested_comments,
+                numeric_source_spans,
+                _,
+            ) = swift_scala_rendered_literal_parts(
+                expression,
+                value_start,
+                value_end,
+                dialect=javascript_dialect,
+                quote_start=quote,
+                nesting=nesting,
+            )
+            numeric_source_set = set(numeric_source_spans)
+            if any(
+                (
+                    span not in numeric_source_set
+                    or integer_literal_secret(expression[span[0] : span[1]])
+                )
+                and (
+                    review_literal_candidate(
+                        expression[span[0] : span[1]],
+                        dialect=javascript_dialect,
+                        references_are_source=False,
+                    )
+                    or quoted_template_segment_is_risky(
+                        expression[span[0] : span[1]],
+                        minimum_length,
+                        dialect=javascript_dialect,
+                        references_are_source=False,
+                    )
+                )
+                for span in literal_spans
+            ):
+                return True
+            for group in rendered_literal_span_groups(
+                expression,
+                literal_spans,
+                nested_comments,
+                dialect=javascript_dialect,
+            ):
+                combined = combined_review_literal_value(expression, group)
+                if (
+                    len(group) > 1
+                    and not rendered_literal_group_is_numeric_arithmetic(
+                        expression,
+                        group,
+                        numeric_source_set,
+                    )
+                    and quoted_template_segment_is_risky(
+                        combined,
+                        minimum_length,
+                        dialect=javascript_dialect,
+                        references_are_source=False,
+                    )
+                ):
+                    return True
+            opening_start = (
+                quote - swift_string_hash_width(expression, quote)
+                if javascript_dialect == "swift"
+                else quote
+            )
+            masked_expression[opening_start:literal_end] = " " * (
+                literal_end - opening_start
+            )
+            cursor = literal_end
+        scan_expression = "".join(masked_expression)
+    elif javascript_dialect in {None, "groovy", "kotlin"}:
+        masked_expression = list(expression)
+        cursor = 0
+        while cursor < len(expression):
+            quote = expression[cursor : cursor + 1]
+            ordinary = False
+            groovy_slashy = (
+                groovy_slashy_literal_span(
+                    expression,
+                    cursor,
+                    len(expression),
+                )
+                if javascript_dialect == "groovy"
+                else None
+            )
+            literal = groovy_slashy or (
+                triple_quoted_literal_span(
+                    expression,
+                    cursor,
+                    len(expression),
+                    interpolation_dialect=javascript_dialect,
+                )
+                if quote in {'"', "'"}
+                and expression.startswith(quote * 3, cursor)
+                else None
+            )
+            if literal is None:
+                if javascript_dialect not in {"groovy", "kotlin"} or quote not in {
+                    '"',
+                    "'",
+                }:
+                    cursor += 1
+                    continue
+                literal_end = csharp_quoted_literal_end(
+                    expression,
+                    cursor,
+                    verbatim=False,
+                    interpolated=False,
+                ) if quote == "'" else dollar_interpolated_quoted_literal_end(
+                    expression,
+                    cursor,
+                    len(expression),
+                    dialect=javascript_dialect,
+                    nesting=nesting + 1,
+                )
+                if literal_end is None:
+                    return True
+                literal = cursor + 1, literal_end - 1, literal_end
+                ordinary = True
+            value_start, value_end, literal_end = literal
+            if javascript_dialect is None and not ordinary and (
+                SUSPICIOUS_TRIPLE_INTERPOLATION_PATTERN.search(
+                    expression,
+                    value_start,
+                    value_end,
+                )
+                is not None
+            ):
+                return True
+            interpolation_width = dollar_interpolation_width(
+                expression,
+                cursor,
+                dialect=javascript_dialect,
+            ) if javascript_dialect is not None else 1
+            if groovy_slashy is not None:
+                (
+                    literal_spans,
+                    nested_comments,
+                    numeric_source_spans,
+                    interpolation_spans,
+                ) = groovy_slashy_rendered_literal_parts(
+                    expression,
+                    value_start,
+                    value_end,
+                    dollar_slashy=expression.startswith("$/", cursor),
+                    nesting=nesting,
+                )
+            elif quote == '"' and javascript_dialect is not None:
+                (
+                    literal_spans,
+                    nested_comments,
+                    numeric_source_spans,
+                    interpolation_spans,
+                ) = dollar_rendered_literal_parts(
+                    expression,
+                    value_start,
+                    value_end,
+                    dialect=javascript_dialect,
+                    interpolation_width=interpolation_width,
+                    raw=javascript_dialect == "kotlin" and not ordinary,
+                    nesting=nesting,
+                )
+            else:
+                interpolation_spans = []
+                literal_spans = [(value_start, value_end)]
+                nested_comments = []
+                numeric_source_spans = []
+            numeric_source_set = set(numeric_source_spans)
+            if any(
+                (
+                    span not in numeric_source_set
+                    or integer_literal_secret(expression[span[0] : span[1]])
+                )
+                and (
+                    review_literal_candidate(
+                        expression[span[0] : span[1]],
+                        dialect=javascript_dialect,
+                        references_are_source=False,
+                    )
+                    or quoted_template_segment_is_risky(
+                        expression[span[0] : span[1]],
+                        minimum_length,
+                        dialect=javascript_dialect,
+                        references_are_source=False,
+                    )
+                )
+                for span in literal_spans
+            ):
+                return True
+            for group in rendered_literal_span_groups(
+                expression,
+                literal_spans,
+                nested_comments,
+                dialect=javascript_dialect,
+            ):
+                combined = combined_review_literal_value(expression, group)
+                if (
+                    len(group) > 1
+                    and not rendered_literal_group_is_numeric_arithmetic(
+                        expression,
+                        group,
+                        numeric_source_set,
+                    )
+                    and quoted_template_segment_is_risky(
+                        combined,
+                        minimum_length,
+                        dialect=javascript_dialect,
+                        references_are_source=False,
+                    )
+                ):
+                    return True
+            for interpolation_start, interpolation_end in interpolation_spans:
+                if expression.startswith(
+                    "$" * interpolation_width + "{",
+                    interpolation_start,
+                ) and secret_literal_risk(
+                    expression[
+                        interpolation_start + interpolation_width + 1 : interpolation_end - 1
+                    ],
+                    minimum_length=minimum_length,
+                    javascript_dialect=javascript_dialect,
+                    nesting=nesting + 1,
+                ):
+                    return True
+            for index in range(cursor, literal_end):
+                masked_expression[index] = " "
+            for start, end in interpolation_spans:
+                masked_expression[start:end] = expression[start:end]
+            cursor = literal_end
+        scan_expression = "".join(masked_expression)
+    if javascript_dialect in {"kotlin", "scala"}:
+        masked_expression = list(scan_expression)
+        cursor = 0
+        while (identifier_start := scan_expression.find("`", cursor)) >= 0:
+            identifier_end = scan_expression.find("`", identifier_start + 1)
+            if identifier_end < 0 or any(
+                char in SOURCE_LINE_TERMINATORS
+                for char in scan_expression[identifier_start + 1 : identifier_end]
+            ):
+                return True
+            masked_expression[identifier_start : identifier_end + 1] = " " * (
+                identifier_end + 1 - identifier_start
+            )
+            cursor = identifier_end + 1
+        scan_expression = "".join(masked_expression)
+    if javascript_dialect is None or is_javascript_review_dialect(
+        javascript_dialect
+    ):
+        regex_ranges = javascript_regex_literal_ranges(scan_expression)
+        if any(
+            javascript_regex_string_value_risk(
+                scan_expression,
+                start,
+                end,
+                minimum_length=minimum_length,
+                dialect=javascript_dialect,
+            )
+            for start, end in regex_ranges
+        ):
+            return True
+        scan_expression = mask_ranges(
+            scan_expression,
+            tuple(regex_ranges),
+        )
     value_pattern = re.compile(
         rf'"(?P<double>[^"\r\n]{{{minimum_length},}})"'
         rf"|'(?P<single>[^'\r\n]{{{minimum_length},}})'"
         rf"|`(?P<backtick>[^`\r\n]{{{minimum_length},}})`"
         rf"|(?P<bare>[A-Za-z0-9_./+=:@#$%&*!?-]{{{max(20, minimum_length)},}})"
     )
-    for match in value_pattern.finditer(expression):
+    for match in value_pattern.finditer(scan_expression):
+        if any(
+            match.start() < literal_end and literal_start < match.end()
+            for literal_start, literal_end in prevalidated_literal_spans
+        ):
+            continue
         value = next(group for group in match.groups() if group is not None)
-        if value.lower() in SECRET_PLACEHOLDER_VALUES:
+        if secret_placeholder_value(value):
             continue
         if match.group("backtick") is not None and any(
             pattern.fullmatch(value)
@@ -3884,11 +5959,17 @@ def secret_literal_risk(
             if re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", value):
                 continue
             if (
-                javascript_dialect is not None
-                and SOURCE_CODE_REFERENCE_ROOT_PATTERN.fullmatch(value)
+                (
+                    is_javascript_review_dialect(javascript_dialect)
+                    and SOURCE_CODE_REFERENCE_ROOT_PATTERN.fullmatch(value)
+                )
+                or source_secret_member_reference(
+                    value,
+                    dialect=javascript_dialect,
+                )
             ):
                 continue
-            suffix = expression[match.end() :].lstrip()
+            suffix = scan_expression[match.end() :].lstrip()
             if suffix.startswith("("):
                 continue
         return True
@@ -3901,11 +5982,30 @@ def fallback_secret_risk(
     *,
     javascript_dialect: str | None = None,
 ) -> bool:
+    expression = fallback_expression(
+        text,
+        typescript=javascript_dialect == "typescript",
+        dialect=javascript_dialect,
+    )
+    comment_spans: list[tuple[int, int]] = []
+    _literal_spans, comment_candidates = quoted_literal_value_spans(
+        expression,
+        0,
+        len(expression),
+        javascript_dialect=javascript_dialect,
+        allow_incomplete=True,
+        all_comment_spans=comment_spans,
+    )
+    for start, end in comment_candidates:
+        if comment_candidate_is_secret(
+            expression,
+            start,
+            end,
+            dialect=javascript_dialect,
+        ):
+            return True
     return secret_literal_risk(
-        fallback_expression(
-            text,
-            typescript=javascript_dialect == "typescript",
-        ),
+        mask_ranges(expression, tuple(comment_spans)),
         minimum_length=minimum_length,
         javascript_dialect=javascript_dialect,
     )
@@ -3913,7 +6013,7 @@ def fallback_secret_risk(
 
 def synthetic_secret_fixture(value: str, key: str) -> bool:
     normalized = value.casefold()
-    if normalized in SECRET_PLACEHOLDER_VALUES:
+    if secret_placeholder_value(normalized):
         return True
     if len(normalized) > 80:
         return False
@@ -3953,7 +6053,13 @@ def safe_secret_assignment_suffix(
                     cursor += 1
                 while cursor < len(text) and text[cursor] in " \t\r":
                     cursor += 1
-                if text.startswith("//", cursor) or text.startswith("#", cursor):
+                if (
+                    review_dialect_has_slash_comments(javascript_dialect)
+                    and text.startswith("//", cursor)
+                ) or (
+                    review_dialect_has_hash_comments(javascript_dialect)
+                    and text.startswith("#", cursor)
+                ):
                     newline = text.find("\n", cursor)
                     if newline < 0:
                         return True
@@ -3967,6 +6073,11 @@ def safe_secret_assignment_suffix(
                     continue
                 break
             suffix = text[cursor:]
+            if suffix.startswith("#"):
+                return not fallback_secret_risk(
+                    suffix[1:],
+                    javascript_dialect=javascript_dialect,
+                )
             if (
                 suffix.startswith(("||", "&&", "??", "+"))
                 or (suffix.startswith("?") and not suffix.startswith("?."))
@@ -3977,7 +6088,13 @@ def safe_secret_assignment_suffix(
                     javascript_dialect=javascript_dialect,
                 )
             return True
-        if text.startswith("//", cursor) or text.startswith("#", cursor):
+        if (
+            review_dialect_has_slash_comments(javascript_dialect)
+            and text.startswith("//", cursor)
+        ) or (
+            review_dialect_has_hash_comments(javascript_dialect)
+            and text.startswith("#", cursor)
+        ):
             cursor = text.find("\n", cursor)
             if cursor < 0:
                 return True
@@ -3988,6 +6105,11 @@ def safe_secret_assignment_suffix(
                 return False
             cursor = comment_end + 2
             continue
+        if text[cursor] == "#":
+            return not fallback_secret_risk(
+                text[cursor + 1 :],
+                javascript_dialect=javascript_dialect,
+            )
         suffix = text[cursor:]
         if (
             suffix.startswith(("||", "&&", "??", "+"))
@@ -4023,7 +6145,14 @@ def safe_secret_assignment_suffix(
     return True
 
 
-def split_top_level_call_arguments(text: str) -> list[str]:
+def split_top_level_call_arguments(
+    text: str,
+    *,
+    slash_comments: bool = True,
+    regex_literals: bool = True,
+    line_terminators: frozenset[str] = SOURCE_LINE_TERMINATORS,
+    javascript_dialect: str | None = None,
+) -> list[str]:
     arguments: list[str] = []
     start = 0
     stack: list[str] = []
@@ -4037,7 +6166,7 @@ def split_top_level_call_arguments(text: str) -> list[str]:
         char = text[index]
         next_char = text[index + 1] if index + 1 < len(text) else ""
         if line_comment:
-            if char == "\n":
+            if char in line_terminators:
                 line_comment = False
             index += 1
             continue
@@ -4057,10 +6186,79 @@ def split_top_level_call_arguments(text: str) -> list[str]:
                 quote = None
             index += 1
             continue
-        regex_end = javascript_regex_literal_end(text, index)
+        structured_literal = (
+            structured_literal_parts(
+                text,
+                index,
+                len(text),
+                dialect=javascript_dialect,
+            )
+            if javascript_dialect in {"csharp", "python"}
+            and char in {'"', "'"}
+            else None
+        )
+        if structured_literal is not None:
+            index = structured_literal[2]
+            continue
+        swift_scala_literal = (
+            swift_scala_literal_span(
+                text,
+                index,
+                len(text),
+                dialect=javascript_dialect,
+            )
+            if javascript_dialect in {"scala", "swift"} and char == '"'
+            else None
+        )
+        if swift_scala_literal is not None:
+            index = swift_scala_literal[2]
+            continue
+        triple_literal = (
+            triple_quoted_literal_span(
+                text,
+                index,
+                len(text),
+                interpolation_dialect=javascript_dialect,
+            )
+            if javascript_dialect in {"groovy", "kotlin"}
+            and char in {'"', "'"}
+            and text.startswith(char * 3, index)
+            else None
+        )
+        if triple_literal is not None:
+            index = triple_literal[2]
+            continue
+        dollar_literal_end = (
+            dollar_interpolated_quoted_literal_end(
+                text,
+                index,
+                len(text),
+                dialect=javascript_dialect,
+            )
+            if javascript_dialect in {"groovy", "kotlin"} and char == '"'
+            else None
+        )
+        if dollar_literal_end is not None:
+            index = dollar_literal_end
+            continue
+        raw_literal = None
+        if javascript_dialect == "c-family" and char == '"':
+            raw_literal = c_family_raw_literal_span(text, index, len(text))
+        if raw_literal is not None:
+            index = raw_literal[2]
+            continue
+        regex_end = (
+            review_regex_or_slashy_literal_end(
+                text,
+                index,
+                dialect=javascript_dialect,
+            )
+            if regex_literals
+            else None
+        )
         if regex_end is not None:
             index = regex_end
-        elif char == "/" and next_char == "/":
+        elif char == "/" and next_char == "/" and slash_comments:
             line_comment = True
             index += 2
         elif char == "/" and next_char == "*":
@@ -4120,7 +6318,7 @@ def javascript_control_contexts(text: str) -> frozenset[int]:
         char = text[cursor]
         next_char = text[cursor + 1] if cursor + 1 < len(text) else ""
         if line_comment:
-            if char == "\n":
+            if char in JAVASCRIPT_LINE_TERMINATORS:
                 line_comment = False
             cursor += 1
             continue
@@ -4241,18 +6439,18 @@ def javascript_control_condition_closes(text: str) -> frozenset[int]:
     return javascript_control_contexts(text)
 
 
-def javascript_regex_literal_end(
+def javascript_regex_literal_start_allowed(
     text: str,
     start: int,
     *,
     control_conditions: bool = True,
     known_control_closes: set[int] | frozenset[int] | None = None,
-) -> int | None:
+) -> bool:
     if text[start : start + 1] != "/" or text[start + 1 : start + 2] in {
         "/",
         "*",
     }:
-        return None
+        return False
     previous = start - 1
     while previous >= 0 and text[previous].isspace():
         previous -= 1
@@ -4280,32 +6478,18 @@ def javascript_regex_literal_end(
         ):
             word_start -= 1
         keyword = text[word_start + 1 : previous + 1]
-        expression_keyword = keyword in {
-            "case",
-            "default",
-            "delete",
-            "do",
-            "else",
-            "extends",
-            "in",
-            "instanceof",
-            "new",
-            "return",
-            "throw",
-            "typeof",
-            "void",
-        }
+        expression_keyword = keyword in JAVASCRIPT_REGEX_EXPRESSION_KEYWORDS
         if (
             not expression_keyword
             or (word_start >= 0 and text[word_start] == ".")
         ):
-            return None
+            return False
     if (
         previous > 0
         and text[previous] in "+-"
         and text[previous - 1] == text[previous]
     ):
-        return None
+        return False
     if text[previous : previous + 1] == "!":
         before = previous - 1
         while before >= 0 and text[before].isspace():
@@ -4313,13 +6497,30 @@ def javascript_regex_literal_end(
         if before >= 0 and (
             text[before].isalnum() or text[before] in "_$)]}"
         ):
-            return None
+            return False
+    return True
+
+
+def javascript_regex_literal_end(
+    text: str,
+    start: int,
+    *,
+    control_conditions: bool = True,
+    known_control_closes: set[int] | frozenset[int] | None = None,
+) -> int | None:
+    if not javascript_regex_literal_start_allowed(
+        text,
+        start,
+        control_conditions=control_conditions,
+        known_control_closes=known_control_closes,
+    ):
+        return None
     escaped = False
     character_class = False
     cursor = start + 1
     while cursor < len(text):
         char = text[cursor]
-        if char in "\r\n":
+        if char in JAVASCRIPT_LINE_TERMINATORS:
             return None
         if escaped:
             escaped = False
@@ -4338,12 +6539,51 @@ def javascript_regex_literal_end(
     return None
 
 
+def swift_extended_regex_literal_end(
+    text: str,
+    start: int,
+    *,
+    nesting: int = 0,
+) -> int | None:
+    if nesting > 64:
+        raise SystemExit("refusing review bundle with excessive interpolation nesting")
+    if text[start : start + 1] != "#":
+        return None
+    hash_end = repeated_character_end(text, start, len(text), "#")
+    hash_width = hash_end - start
+    if text[hash_end : hash_end + 1] != "/":
+        return None
+    closing = "/" + "#" * hash_width
+    interpolation_marker = "\\" + "#" * hash_width + "("
+    cursor = hash_end + 1
+    while cursor < len(text):
+        if text.startswith(interpolation_marker, cursor):
+            expression_end = balanced_delimiter_end(
+                text,
+                cursor + len(interpolation_marker) - 1,
+                "(",
+                ")",
+                javascript_dialect="swift",
+                nesting=nesting + 1,
+            )
+            if expression_end is None:
+                return None
+            cursor = expression_end
+            continue
+        if text.startswith(closing, cursor):
+            return cursor + len(closing)
+        cursor += 1
+    return None
+
+
 def regex_tail_end(text: str, start: int, limit: int) -> int | None:
     escaped = False
     character_class = False
     cursor = start
     while cursor < limit:
         char = text[cursor]
+        if char in JAVASCRIPT_LINE_TERMINATORS:
+            return None
         if escaped:
             escaped = False
         elif char == "\\":
@@ -4363,6 +6603,8 @@ def previous_regex_delimiter(text: str, start: int, lower: int) -> int | None:
     cursor = start - 1
     while cursor >= lower:
         char = text[cursor]
+        if char in JAVASCRIPT_LINE_TERMINATORS:
+            return None
         backslashes = 0
         previous = cursor - 1
         while previous >= lower and text[previous] == "\\":
@@ -4405,14 +6647,17 @@ def premature_regex_call_tail(
     call_start: int,
     cursor: int,
 ) -> tuple[str, int] | None:
-    line_end = len(text)
-    for delimiter in ("\n", "\r"):
-        found = text.find(delimiter, cursor)
-        if found >= 0:
-            line_end = min(line_end, found)
+    line_end = min(
+        (
+            found
+            for delimiter in JAVASCRIPT_LINE_TERMINATORS
+            if (found := text.find(delimiter, cursor)) >= 0
+        ),
+        default=len(text),
+    )
     line_start = max(
-        text.rfind("\n", 0, cursor),
-        text.rfind("\r", 0, cursor),
+        text.rfind(delimiter, 0, cursor)
+        for delimiter in JAVASCRIPT_LINE_TERMINATORS
     ) + 1
     search_start = max(call_start, line_start)
     nearest = previous_regex_delimiter(text, cursor, search_start)
@@ -4437,7 +6682,7 @@ def premature_regex_call_tail(
             char = text[index]
             next_char = text[index + 1] if index + 1 < len(text) else ""
             if line_comment:
-                if char == "\n":
+                if char in JAVASCRIPT_LINE_TERMINATORS:
                     line_comment = False
                 index += 1
                 continue
@@ -4500,6 +6745,10 @@ def premature_regex_call_tail(
     return None
 
 
+def normalized_call_target(call_target: str) -> str:
+    return re.sub(r"\?\.|->|::", ".", call_target)
+
+
 def safe_credential_lookup_argument(
     call_target: str,
     argument: str,
@@ -4507,7 +6756,7 @@ def safe_credential_lookup_argument(
 ) -> bool:
     if argument_index != 0:
         return False
-    normalized_target = call_target.replace("?.", ".")
+    normalized_target = normalized_call_target(call_target)
     result_lookup = normalized_target in {
         "response.json().get",
         "response.get",
@@ -4602,12 +6851,19 @@ def generic_credential_prompt_is_safe(value: str) -> bool:
     )
 
 
+def public_prompt_call_target(call_target: str) -> bool:
+    normalized = normalized_call_target(call_target)
+    return normalized in PUBLIC_PROMPT_TARGETS
+
+
 def public_call_argument_risk(
     call_target: str,
     argument: str,
     argument_index: int,
+    *,
+    javascript_dialect: str | None = None,
 ) -> bool | None:
-    normalized_target = call_target.replace("?.", ".")
+    normalized_target = normalized_call_target(call_target)
     target_parts = normalized_target.split(".")
     credential_scope_call = (
         len(target_parts) >= 2
@@ -4616,10 +6872,10 @@ def public_call_argument_risk(
     )
     if (
         not credential_scope_call
-        and normalized_target not in PUBLIC_PROMPT_TARGETS
+        and not public_prompt_call_target(call_target)
     ):
         return None
-    if normalized_target == "prompt":
+    if normalized_target.rsplit(".", maxsplit=1)[-1] == "prompt":
         match = re.fullmatch(r"\s*([\"'])([^\"'\r\n]+)\1\s*", argument)
         if (
             argument_index == 0
@@ -4627,7 +6883,11 @@ def public_call_argument_risk(
             and generic_credential_prompt_is_safe(match.group(2))
         ):
             return False
-        return secret_literal_risk(argument, minimum_length=8)
+        return secret_literal_risk(
+            argument,
+            minimum_length=8,
+            javascript_dialect=javascript_dialect,
+        )
     if not credential_scope_call and argument_index != 0:
         return None
     literal_argument = argument
@@ -4698,19 +6958,41 @@ def call_arguments_risk(
     *,
     javascript_dialect: str | None = None,
 ) -> bool:
-    for index, argument in enumerate(split_top_level_call_arguments(arguments)):
-        public_risk = public_call_argument_risk(call_target, argument, index)
+    for index, argument in enumerate(
+        split_top_level_call_arguments(
+            arguments,
+            slash_comments=review_dialect_has_slash_comments(javascript_dialect),
+            regex_literals=review_dialect_has_regex_literals(javascript_dialect),
+            line_terminators=review_line_comment_terminators(javascript_dialect),
+            javascript_dialect=javascript_dialect,
+        )
+    ):
+        public_risk = public_call_argument_risk(
+            call_target,
+            argument,
+            index,
+            javascript_dialect=javascript_dialect,
+        )
         if public_risk is not None:
             if public_risk:
                 return True
             continue
+        argument_risk = (
+            secret_literal_risk(
+                argument,
+                minimum_length=12,
+                javascript_dialect=javascript_dialect,
+            )
+            if javascript_dialect in {"groovy", "kotlin"}
+            else fallback_secret_risk(
+                argument,
+                minimum_length=12,
+                javascript_dialect=javascript_dialect,
+            )
+        )
         if not safe_credential_lookup_argument(
             call_target, argument, index
-        ) and fallback_secret_risk(
-            argument,
-            minimum_length=12,
-            javascript_dialect=javascript_dialect,
-        ):
+        ) and argument_risk:
             return True
     return False
 
@@ -4720,7 +7002,12 @@ def balanced_delimiter_end(
     start: int,
     opener: str,
     closer: str,
+    *,
+    javascript_dialect: str | None = None,
+    nesting: int = 0,
 ) -> int | None:
+    if nesting > 64:
+        raise SystemExit("refusing review bundle with excessive interpolation nesting")
     depth = 0
     quote: str | None = None
     escaped = False
@@ -4731,7 +7018,7 @@ def balanced_delimiter_end(
         char = text[index]
         next_char = text[index + 1] if index + 1 < len(text) else ""
         if line_comment:
-            if char == "\n":
+            if char in review_line_comment_terminators(javascript_dialect):
                 line_comment = False
             index += 1
             continue
@@ -4751,18 +7038,117 @@ def balanced_delimiter_end(
                 quote = None
             index += 1
             continue
-        regex_end = javascript_regex_literal_end(text, index)
+        regex_end = review_regex_or_slashy_literal_end(
+            text,
+            index,
+            dialect=javascript_dialect,
+            nesting=nesting,
+        )
         if regex_end is not None:
             index = regex_end
-        elif char == "/" and next_char == "/":
+        elif (
+            char == "/"
+            and next_char == "/"
+            and review_dialect_has_slash_comments(javascript_dialect)
+        ):
             line_comment = True
             index += 2
         elif char == "/" and next_char == "*":
             block_comment = True
             index += 2
-        elif char == "#" and not javascript_private_member_marker(text, index):
+        elif (
+            char == "#"
+            and review_dialect_has_hash_comments(javascript_dialect)
+            and not javascript_private_member_marker(text, index)
+        ):
             line_comment = True
             index += 1
+        elif char == "`" and is_javascript_review_dialect(javascript_dialect):
+            template_end = javascript_template_literal_end(text, index)
+            if template_end is None:
+                return None
+            index = template_end
+        elif (
+            javascript_dialect in {"csharp", "python"}
+            and char in {'"', "'"}
+            and (
+                structured := structured_literal_parts(
+                    text,
+                    index,
+                    len(text),
+                    dialect=javascript_dialect,
+                    nesting=nesting + 1,
+                )
+            )
+            is not None
+        ):
+            index = structured[2]
+        elif (
+            javascript_dialect == "csharp"
+            and char == '"'
+            and (
+                csharp_raw := csharp_raw_literal_span(
+                    text,
+                    index,
+                    len(text),
+                    nesting=nesting + 1,
+                )
+            )
+            is not None
+        ):
+            index = csharp_raw[2]
+        elif (
+            javascript_dialect in {"scala", "swift"}
+            and char == '"'
+            and (
+                swift_scala_literal := swift_scala_literal_span(
+                    text,
+                    index,
+                    len(text),
+                    dialect=javascript_dialect,
+                    nesting=nesting + 1,
+                )
+            )
+            is not None
+        ):
+            index = swift_scala_literal[2]
+        elif (
+            javascript_dialect == "c-family"
+            and char == '"'
+            and (raw_literal := c_family_raw_literal_span(text, index, len(text)))
+            is not None
+        ):
+            index = raw_literal[2]
+        elif (
+            not is_javascript_review_dialect(javascript_dialect)
+            and char in {'"', "'"}
+            and (
+                triple := triple_quoted_literal_span(
+                    text,
+                    index,
+                    len(text),
+                    nesting=nesting + 1,
+                    interpolation_dialect=javascript_dialect,
+                )
+            )
+            is not None
+        ):
+            index = triple[2]
+        elif (
+            javascript_dialect in {"groovy", "kotlin"}
+            and char == '"'
+            and (
+                dollar_literal_end := dollar_interpolated_quoted_literal_end(
+                    text,
+                    index,
+                    len(text),
+                    dialect=javascript_dialect,
+                    nesting=nesting + 1,
+                )
+            )
+            is not None
+        ):
+            index = dollar_literal_end
         elif char in {'"', "'", "`"}:
             quote = char
             index += 1
@@ -4781,6 +7167,16 @@ def balanced_delimiter_end(
     return None
 
 
+def chained_member_target(current: str, member_name: str) -> str:
+    if current == "response.json()" and member_name == "get":
+        return "response.json().get"
+    if current == "<call-result>" and member_name == "headers":
+        return "<call-result>.headers"
+    if current == "<call-result>.headers" and member_name == "get":
+        return "<call-result>.headers.get"
+    return "<call-result>"
+
+
 def safe_secret_call_suffix(
     text: str,
     end: int,
@@ -4792,7 +7188,19 @@ def safe_secret_call_suffix(
         return False
 
     def safe_call_end(start: int, target: str) -> int | None:
-        cursor = balanced_delimiter_end(text, start, "(", ")")
+        try:
+            cursor = balanced_delimiter_end(
+                text,
+                start,
+                "(",
+                ")",
+                javascript_dialect=javascript_dialect,
+            )
+        except SystemExit:
+            # Per-line redaction sees individual lines from multiline literals.
+            # Treat an incomplete call as unsafe; whole-content validation still
+            # rejects truly unterminated source after redaction.
+            return None
         if cursor is None:
             return None
         arguments = text[start + 1 : cursor - 1]
@@ -4816,26 +7224,26 @@ def safe_secret_call_suffix(
             return False
     chained_target = (
         "response.json()"
-        if call_target.replace("?.", ".") == "response.json"
+        if normalized_call_target(call_target) == "response.json"
         else "<call-result>"
     )
+    member_operator = (
+        r"(?:->|::|\.)"
+        if javascript_dialect == "c-family"
+        else r"(?:->|\?\.|\.)"
+        if javascript_dialect == "csharp"
+        else r"(?:\?\.|\.)"
+    )
     while True:
-        match = re.match(r"\s*(?:\?\.|\.)[A-Za-z_][A-Za-z0-9_]*", text[cursor:])
+        match = re.match(
+            rf"\s*{member_operator}[A-Za-z_][A-Za-z0-9_]*",
+            text[cursor:],
+        )
         if match is not None:
             member = re.search(r"[A-Za-z_][A-Za-z0-9_]*$", match.group(0))
             assert member is not None
             member_name = member.group(0)
-            if chained_target == "response.json()" and member_name == "get":
-                chained_target = "response.json().get"
-            elif chained_target == "<call-result>" and member_name == "headers":
-                chained_target = "<call-result>.headers"
-            elif (
-                chained_target == "<call-result>.headers"
-                and member_name == "get"
-            ):
-                chained_target = "<call-result>.headers.get"
-            else:
-                chained_target = "<call-result>"
+            chained_target = chained_member_target(chained_target, member_name)
             cursor += match.end()
             continue
         whitespace = re.match(r"\s*", text[cursor:])
@@ -4848,12 +7256,34 @@ def safe_secret_call_suffix(
             chained_target = "<call-result>"
             continue
         if call_start < len(text) and text[call_start] == "[":
-            cursor = balanced_delimiter_end(text, call_start, "[", "]")
-            if cursor is None:
+            subscript_end = balanced_delimiter_end(
+                text,
+                call_start,
+                "[",
+                "]",
+                javascript_dialect=javascript_dialect,
+            )
+            if subscript_end is None:
                 return False
+            subscript = text[call_start + 1 : subscript_end - 1]
+            if not safe_credential_lookup_argument(
+                f"{chained_target}.get",
+                subscript,
+                0,
+            ) and secret_literal_risk(
+                subscript,
+                minimum_length=8,
+                javascript_dialect=javascript_dialect,
+            ):
+                return False
+            cursor = subscript_end
             chained_target = "<call-result>"
             continue
-        return safe_secret_assignment_suffix(text, cursor)
+        return safe_secret_assignment_suffix(
+            text,
+            cursor,
+            javascript_dialect=javascript_dialect,
+        )
 
 
 def safe_backtick_literal_segment(value: str) -> bool:
@@ -4903,8 +7333,8 @@ def javascript_template_literal_end(
         next_char = text[cursor + 1] if cursor + 1 < len(text) else ""
         if expression_depth:
             if char == "/" and next_char == "/":
-                line_end = text.find("\n", cursor + 2)
-                cursor = len(text) if line_end < 0 else line_end
+                line_end = javascript_line_terminator_index(text, cursor + 2)
+                cursor = len(text) if line_end is None else line_end
                 continue
             if char == "/" and next_char == "*":
                 comment_end = text.find("*/", cursor + 2)
@@ -4968,8 +7398,8 @@ def mask_reference_declaration_evidence(text: str) -> str:
         char = text[cursor]
         next_char = text[cursor + 1] if cursor + 1 < len(text) else ""
         if char == "/" and next_char == "/":
-            line_end = text.find("\n", cursor + 2)
-            cursor = len(text) if line_end < 0 else line_end
+            line_end = javascript_line_terminator_index(text, cursor + 2)
+            cursor = len(text) if line_end is None else line_end
             continue
         if char == "/" and next_char == "*":
             comment_end = text.find("*/", cursor + 2)
@@ -5191,7 +7621,7 @@ def safe_self_reference_assignment(
     *,
     javascript_dialect: str | None = None,
 ) -> bool:
-    if javascript_dialect is None:
+    if not is_javascript_review_dialect(javascript_dialect):
         return False
     value = (
         match.group("reference_value")
@@ -5234,7 +7664,7 @@ def unsafe_multiline_self_reference_assignment(
     *,
     javascript_dialect: str | None = None,
 ) -> bool:
-    if javascript_dialect is None:
+    if not is_javascript_review_dialect(javascript_dialect):
         return False
     value = (
         match.group("reference_value")
@@ -5263,36 +7693,161 @@ def unsafe_multiline_self_reference_assignment(
     )
 
 
+def swift_interpolated_assignment_value(
+    text: str,
+    match: re.Match[str],
+) -> bool:
+    if "double_value" not in match.groupdict() or match.group("double_value") is None:
+        return False
+    quote_start = match.start("double_value") - 1
+    literal = swift_scala_literal_span(
+        text,
+        quote_start,
+        len(text),
+        dialect="swift",
+    )
+    if literal is None:
+        return False
+    return bool(
+        swift_scala_interpolation_expression_spans(
+            text,
+            literal[0],
+            literal[1],
+            dialect="swift",
+            quote_start=quote_start,
+        )
+    )
+
+
+def groovy_kotlin_interpolated_assignment_value(
+    text: str,
+    match: re.Match[str],
+    *,
+    dialect: str | None,
+) -> bool:
+    if dialect not in {"groovy", "kotlin"}:
+        return False
+    value = match.group("double_value")
+    if value is None:
+        return False
+    quote_start = match.start("double_value") - 1
+    interpolation_width = dollar_interpolation_width(
+        text,
+        quote_start,
+        dialect=dialect,
+    )
+    return bool(
+        dollar_interpolation_expression_spans(
+            text,
+            match.start("double_value"),
+            match.end("double_value"),
+            dialect=dialect,
+            interpolation_width=interpolation_width,
+            raw=False,
+        )
+    )
+
+
+def groovy_slashy_assignment_value(
+    text: str,
+    match: re.Match[str],
+) -> bool:
+    prefix = SECRET_ASSIGNMENT_PREFIX_PATTERN.match(text, match.start())
+    if prefix is None:
+        return False
+    slashy = groovy_slashy_literal_span(text, prefix.end(), len(text))
+    return slashy is not None and match.end() <= slashy[2]
+
+
 def secret_text_risk(
     text: str,
     *,
     javascript_dialect: str | None = None,
 ) -> bool:
+    if javascript_dialect == "java":
+        text = java_unicode_escape_translation(text)
     uri_authorities = uri_authority_ranges(text)
     if credentialed_uri_risk(text, uri_authorities) or basic_authorization_risk(text) or any(
         pattern.search(text) for pattern in SECRET_VALUE_PATTERNS
+    ):
+        return True
+    if standalone_literal_secret_spans(
+        text,
+        javascript_dialect=javascript_dialect,
     ):
         return True
     safe_uri_credentials = interpolated_empty_password_uri_ranges(
         text,
         uri_authorities,
     )
-    assignment_scan_text = mask_ranges(text, safe_uri_credentials)
-    assignment_prefixes = secret_assignment_matches(
-        SECRET_ASSIGNMENT_PREFIX_PATTERN,
+    backtick_identifier_ranges = source_backtick_identifier_spans(
         text,
-        assignment_scan_text,
-        safe_uri_credentials,
+        dialect=javascript_dialect,
     )
+    assignment_scan_text = mask_ranges(
+        text,
+        tuple(safe_uri_credentials) + backtick_identifier_ranges,
+    )
+    assignment_excluded_ranges = source_secret_assignment_excluded_ranges(
+        text,
+        javascript_dialect=javascript_dialect,
+    )
+    assignment_prefixes = tuple(
+        prefix
+        for prefix in secret_assignment_matches(
+            SECRET_ASSIGNMENT_PREFIX_PATTERN,
+            text,
+            assignment_scan_text,
+            safe_uri_credentials,
+        )
+        if not position_in_ranges(prefix.start(), assignment_excluded_ranges)
+    )
+    assignment_matches = list(
+        candidate
+        for candidate in secret_assignment_matches(
+            SECRET_ASSIGNMENT_PATTERN,
+            text,
+            assignment_scan_text,
+            safe_uri_credentials,
+        )
+        if not position_in_ranges(
+            candidate.start(),
+            assignment_excluded_ranges,
+        )
+        and not assignment_uses_source_backtick_identifier(
+            candidate,
+            backtick_identifier_ranges,
+        )
+    )
+    assignment_match_spans = {match.span() for match in assignment_matches}
+    for prefix in assignment_prefixes:
+        candidate = SECRET_ASSIGNMENT_PATTERN.match(text, prefix.start())
+        if (
+            candidate is not None
+            and not assignment_uses_source_backtick_identifier(
+                candidate,
+                backtick_identifier_ranges,
+            )
+            and any(char in prefix.group(0) for char in "\r\n")
+            and candidate.span() not in assignment_match_spans
+        ):
+            assignment_matches.append(candidate)
+            assignment_match_spans.add(candidate.span())
     chained_assignment_positions = top_level_line_assignment_positions(
         text,
         {prefix.start() for prefix in assignment_prefixes},
+        dialect=javascript_dialect,
     )
     source_reference_spans = (
         javascript_reference_spans(text)
-        if javascript_dialect is not None
+        if is_javascript_review_dialect(javascript_dialect)
         else frozenset()
     )
+    if structured_secret_assignment_literal_spans(
+        text,
+        javascript_dialect=javascript_dialect,
+    ):
+        return True
     for prefix in assignment_prefixes:
         assignment = SECRET_ASSIGNMENT_PATTERN.match(text, prefix.start())
         if assignment is not None and safe_self_reference_assignment(
@@ -5313,18 +7868,14 @@ def secret_text_risk(
                 re.search(r"=(?!=|>)\s*$", prefix.group(0)) is not None
                 and prefix.start() in chained_assignment_positions
             ),
+            dialect=javascript_dialect,
         )
         if fallback is not None and fallback_secret_risk(
             fallback,
             javascript_dialect=javascript_dialect,
         ):
             return True
-    for match in secret_assignment_matches(
-        SECRET_ASSIGNMENT_PATTERN,
-        text,
-        assignment_scan_text,
-        safe_uri_credentials,
-    ):
+    for match in assignment_matches:
         quoted = any(
             match.group(name) is not None
             for name in ("double_value", "single_value", "backtick_value")
@@ -5338,6 +7889,22 @@ def secret_text_risk(
             or match.group("bare_value")
         )
         if value is None:
+            continue
+        if javascript_dialect == "swift" and swift_interpolated_assignment_value(
+            text,
+            match,
+        ):
+            continue
+        if groovy_kotlin_interpolated_assignment_value(
+            text,
+            match,
+            dialect=javascript_dialect,
+        ):
+            continue
+        if javascript_dialect == "groovy" and groovy_slashy_assignment_value(
+            text,
+            match,
+        ):
             continue
         key = re.split(r"\s*[:=]\s*", match.group(0), maxsplit=1)[0]
         separator_match = re.search(r"[:=]", match.group(0))
@@ -5418,7 +7985,7 @@ def secret_text_risk(
                 (
                     (source_start, source_end) in source_reference_spans
                     or (
-                        javascript_dialect is not None
+                        is_javascript_review_dialect(javascript_dialect)
                         and SOURCE_CODE_REFERENCE_ROOT_PATTERN.fullmatch(value)
                     )
                 )
@@ -5435,7 +8002,8 @@ def secret_text_risk(
             else UNQUOTED_SECRET_REFERENCE_PATTERNS
         )
         call_target = re.fullmatch(
-            r"[A-Za-z_][A-Za-z0-9_]*(?:(?:\.|\?\.)[A-Za-z_][A-Za-z0-9_]*)*",
+            r"[A-Za-z_][A-Za-z0-9_]*"
+            r"(?:(?:\.|\?\.|::|->)[A-Za-z_][A-Za-z0-9_]*)*",
             value,
         )
         suffix = text[match.end() :]
@@ -5449,8 +8017,7 @@ def secret_text_risk(
         ):
             if (
                 call_target
-                and call_target.group(0).replace("?.", ".")
-                in PUBLIC_PROMPT_TARGETS
+                and public_prompt_call_target(call_target.group(0))
                 and safe_secret_call_suffix(
                     text,
                     call_start,
@@ -5458,6 +8025,12 @@ def secret_text_risk(
                     javascript_dialect=javascript_dialect,
                 )
             ):
+                continue
+            if incomplete_raw_call_literal_spans(
+                text,
+                call_start,
+                javascript_dialect=javascript_dialect,
+            ) == []:
                 continue
             return True
         if (
@@ -5472,7 +8045,27 @@ def secret_text_risk(
                 javascript_dialect=javascript_dialect,
             ):
                 continue
+            if incomplete_raw_call_literal_spans(
+                text,
+                call_start,
+                javascript_dialect=javascript_dialect,
+            ) == []:
+                continue
             return True
+        if (
+            not quoted
+            and not is_javascript_review_dialect(javascript_dialect)
+            and source_secret_member_reference(
+                value,
+                dialect=javascript_dialect,
+            )
+            and safe_secret_assignment_suffix(
+                text,
+                match.end(),
+                javascript_dialect=javascript_dialect,
+            )
+        ):
+            continue
         if any(pattern.fullmatch(value) for pattern in reference_patterns):
             if safe_secret_assignment_suffix(
                 text,
@@ -5518,19 +8111,61 @@ def review_secret_fragments(
     private_fragments = {
         fragment
         for fragment in private_key_body_fragments(text)
-        if fragment.casefold() not in SECRET_PLACEHOLDER_VALUES
+        if not secret_placeholder_value(fragment)
     }
-    fragments = {
-        text[start:end]
-        for start, end in review_repeatable_secret_spans(
+    fragments = review_repeatable_secret_fragments(
+        text,
+        javascript_dialect=javascript_dialect,
+    )
+    fragments.update(private_fragments)
+    return fragments
+
+
+def review_repeatable_secret_fragments(
+    text: str,
+    *,
+    javascript_dialect: str | None = None,
+) -> set[str]:
+    return set(
+        review_repeatable_secret_fragment_values(
             text,
             javascript_dialect=javascript_dialect,
         )
-        if text[start:end]
-        and text[start:end].casefold() not in SECRET_PLACEHOLDER_VALUES
-    }
-    fragments.update(private_fragments)
-    return fragments
+    )
+
+
+def review_repeatable_secret_fragment_values(
+    text: str,
+    *,
+    javascript_dialect: str | None = None,
+) -> list[str]:
+    values: list[str] = []
+    seen: set[str] = set()
+    for start, end in sorted(
+        review_repeatable_secret_spans(
+            text,
+            javascript_dialect=javascript_dialect,
+        )
+    ):
+        value = text[start:end]
+        if not value or secret_placeholder_value(value) or value in seen:
+            continue
+        if integer_literal_syntax(
+            value,
+            dialect=javascript_dialect,
+        ) and not numeric_literal_secret(
+            value,
+            dialect=javascript_dialect,
+        ):
+            continue
+        if len(values) >= MAX_REVIEW_SECRET_FRAGMENTS:
+            raise SystemExit(
+                "refusing review bundle with too many distinct secret-like values "
+                f"(limit {MAX_REVIEW_SECRET_FRAGMENTS})"
+            )
+        seen.add(value)
+        values.append(value)
+    return values
 
 
 def assignment_fallback_literal_spans(
@@ -5539,18 +8174,16 @@ def assignment_fallback_literal_spans(
     *,
     javascript_dialect: str | None = None,
 ) -> list[tuple[int, int]]:
-    line_end_candidates = [
-        position
-        for position in (
-            text.find("\n", match.end()),
-            text.find("\r", match.end()),
-        )
-        if position >= 0
-    ]
-    line_end = min(line_end_candidates, default=len(text))
+    line_end = review_line_terminator_index(
+        text,
+        match.end(),
+        None,
+        javascript_dialect,
+    )
+    line_end = len(text) if line_end is None else line_end
     expression_end = line_end
     if (
-        javascript_dialect is not None
+        is_javascript_review_dialect(javascript_dialect)
         and line_end < len(text)
         and not safe_javascript_reference_suffix(
             text,
@@ -5561,6 +8194,7 @@ def assignment_fallback_literal_spans(
         continued = fallback_expression(
             text[line_end:],
             typescript=javascript_dialect == "typescript",
+            dialect=javascript_dialect,
         )
         expression_end = line_end + len(continued)
     fallback_start = match.end()
@@ -5596,10 +8230,18 @@ def assignment_fallback_literal_spans(
         text,
         fallback_start,
         expression_end,
+        dialect=javascript_dialect,
     )
     if operator_span is None:
-        return []
-    expression_start = operator_span[1]
+        if match.group("call_value") is not None or safe_secret_assignment_suffix(
+            text,
+            match.end(),
+            javascript_dialect=javascript_dialect,
+        ):
+            return []
+        expression_start = match.end()
+    else:
+        expression_start = operator_span[1]
     depth = 0
     quote: str | None = None
     escaped = False
@@ -5630,6 +8272,7 @@ def assignment_fallback_literal_spans(
         text,
         expression_start,
         expression_end,
+        dialect=javascript_dialect,
     )
 
 
@@ -5637,6 +8280,8 @@ def top_level_fallback_operator_span(
     text: str,
     start: int,
     end: int,
+    *,
+    dialect: str | None = None,
 ) -> tuple[int, int] | None:
     stack: list[str] = []
     pairs = {"(": ")", "[": "]", "{": "}"}
@@ -5649,7 +8294,7 @@ def top_level_fallback_operator_span(
         char = text[cursor]
         next_char = text[cursor + 1] if cursor + 1 < end else ""
         if line_comment:
-            if char in "\r\n":
+            if char in review_line_comment_terminators(dialect):
                 line_comment = False
             cursor += 1
             continue
@@ -5669,7 +8314,19 @@ def top_level_fallback_operator_span(
                 quote = None
             cursor += 1
             continue
-        if char == "/" and next_char == "/":
+        regex_end = review_regex_or_slashy_literal_end(
+            text,
+            cursor,
+            dialect=dialect,
+        )
+        if regex_end is not None and regex_end <= end:
+            cursor = regex_end
+            continue
+        if (
+            char == "/"
+            and next_char == "/"
+            and review_dialect_has_slash_comments(dialect)
+        ):
             line_comment = True
             cursor += 2
             continue
@@ -5677,9 +8334,22 @@ def top_level_fallback_operator_span(
             block_comment = True
             cursor += 2
             continue
-        if char == "#":
+        if char == "#" and review_dialect_has_hash_comments(dialect):
             line_comment = True
             cursor += 1
+            continue
+        swift_scala_literal = (
+            swift_scala_literal_span(
+                text,
+                cursor,
+                end,
+                dialect=dialect,
+            )
+            if dialect in {"scala", "swift"} and char == '"'
+            else None
+        )
+        if swift_scala_literal is not None:
+            cursor = swift_scala_literal[2]
             continue
         if char in {'"', "'", "`"}:
             quote = char
@@ -5710,6 +8380,8 @@ def top_level_fallback_value_spans(
     text: str,
     start: int,
     end: int,
+    *,
+    dialect: str | None = None,
 ) -> list[tuple[int, int]]:
     spans: list[tuple[int, int]] = []
     stack: list[str] = []
@@ -5718,25 +8390,105 @@ def top_level_fallback_value_spans(
     while cursor < end:
         char = text[cursor]
         next_char = text[cursor + 1] if cursor + 1 < end else ""
-        if char == "/" and next_char == "/":
-            newline = re.search(r"[\r\n]", text[cursor + 2 : end])
-            if newline is None:
-                break
-            cursor += 2 + newline.end()
+        regex_literal = review_regex_or_slashy_literal_parts(
+            text,
+            cursor,
+            dialect=dialect,
+        )
+        if regex_literal is not None and regex_literal[0] <= end:
+            literal_end, rendered_spans, _expressions = regex_literal
+            if not stack:
+                spans.extend(rendered_spans)
+            cursor = literal_end
+            continue
+        if (
+            char == "/"
+            and next_char == "/"
+            and review_dialect_has_slash_comments(dialect)
+        ):
+            comment_end = review_line_terminator_index(
+                text,
+                cursor + 2,
+                end,
+                dialect,
+            )
+            comment_end = end if comment_end is None else comment_end
+            spans.extend(
+                span
+                for span in comment_secret_candidate_spans(
+                    text,
+                    cursor + 2,
+                    comment_end,
+                    dialect=dialect,
+                )
+                if comment_candidate_is_secret(
+                    text,
+                    span[0],
+                    span[1],
+                    dialect=dialect,
+                )
+            )
+            cursor = min(comment_end + 1, end)
             continue
         if char == "/" and next_char == "*":
             comment_end = text.find("*/", cursor + 2, end)
-            if comment_end < 0:
-                break
-            cursor = comment_end + 2
+            terminated = comment_end >= 0
+            comment_end = end if not terminated else comment_end
+            spans.extend(
+                span
+                for span in comment_secret_candidate_spans(
+                    text,
+                    cursor + 2,
+                    comment_end,
+                    dialect=dialect,
+                )
+                if comment_candidate_is_secret(
+                    text,
+                    span[0],
+                    span[1],
+                    dialect=dialect,
+                )
+            )
+            cursor = min(comment_end + (2 if terminated else 0), end)
             continue
-        if char == "#":
-            newline = re.search(r"[\r\n]", text[cursor + 1 : end])
-            if newline is None:
-                break
-            cursor += 1 + newline.end()
+        if char == "#" and review_dialect_has_hash_comments(dialect):
+            comment_end = review_line_terminator_index(
+                text,
+                cursor + 1,
+                end,
+                dialect,
+            )
+            comment_end = end if comment_end is None else comment_end
+            spans.extend(
+                span
+                for span in comment_secret_candidate_spans(
+                    text,
+                    cursor + 1,
+                    comment_end,
+                    dialect=dialect,
+                )
+                if comment_candidate_is_secret(
+                    text,
+                    span[0],
+                    span[1],
+                    dialect=dialect,
+                )
+            )
+            cursor = min(comment_end + 1, end)
             continue
         if char in {'"', "'", "`"}:
+            if not stack:
+                structured = top_level_fallback_structured_literal_parts(
+                    text,
+                    cursor,
+                    end,
+                    dialect=dialect,
+                )
+                if structured is not None:
+                    literal_end, rendered_spans = structured
+                    spans.extend(rendered_spans)
+                    cursor = literal_end
+                    continue
             quote = char
             value_start = cursor + 1
             cursor = value_start
@@ -5777,40 +8529,2986 @@ def top_level_fallback_value_spans(
     return sorted(set(spans))
 
 
+def top_level_fallback_structured_literal_parts(
+    text: str,
+    start: int,
+    end: int,
+    *,
+    dialect: str | None,
+) -> tuple[int, list[tuple[int, int]]] | None:
+    quote = text[start : start + 1]
+    if dialect == "c-family" and quote == '"':
+        raw = c_family_raw_literal_span(text, start, end)
+        if raw is not None:
+            value_start, value_end, literal_end = raw
+            return literal_end, [(value_start, value_end)]
+    if is_javascript_review_dialect(dialect) and quote == "`":
+        expression_spans: list[tuple[int, int]] = []
+        _spans, _comments, literal_end = javascript_template_value_spans(
+            text,
+            start,
+            end,
+            expression_spans=expression_spans,
+        )
+        return (
+            literal_end,
+            spans_outside_ranges(start + 1, literal_end - 1, expression_spans),
+        )
+    if dialect in {"csharp", "python"} and quote in {'"', "'"}:
+        structured = structured_literal_parts(
+            text,
+            start,
+            end,
+            dialect=dialect,
+        )
+        if structured is None:
+            return None
+        value_start, value_end, literal_end, expressions, _brace_width = structured
+        return literal_end, spans_outside_ranges(value_start, value_end, expressions)
+    if dialect in {"scala", "swift"} and quote == '"':
+        literal = swift_scala_literal_span(
+            text,
+            start,
+            end,
+            dialect=dialect,
+        )
+        if literal is None:
+            return None
+        value_start, value_end, literal_end = literal
+        rendered_spans, _comments, _numeric_spans, _expressions = (
+            swift_scala_rendered_literal_parts(
+                text,
+                value_start,
+                value_end,
+                dialect=dialect,
+                quote_start=start,
+                nesting=0,
+            )
+        )
+        return literal_end, rendered_spans
+    if dialect not in {"groovy", "kotlin"} or quote not in {'"', "'"}:
+        return None
+    triple = triple_quoted_literal_span(
+        text,
+        start,
+        end,
+        interpolation_dialect=dialect,
+    )
+    if triple is not None:
+        value_start, value_end, literal_end = triple
+        raw = dialect == "kotlin"
+    elif quote == '"':
+        literal_end = dollar_interpolated_quoted_literal_end(
+            text,
+            start,
+            end,
+            dialect=dialect,
+        )
+        if literal_end is None:
+            return None
+        value_start, value_end = start + 1, literal_end - 1
+        raw = False
+    else:
+        return None
+    interpolation_width = dollar_interpolation_width(
+        text,
+        start,
+        dialect=dialect,
+    )
+    expressions = dollar_interpolation_expression_spans(
+        text,
+        value_start,
+        value_end,
+        dialect=dialect,
+        interpolation_width=interpolation_width,
+        raw=raw,
+    )
+    return literal_end, spans_outside_ranges(value_start, value_end, expressions)
+
+
+def comment_secret_candidate_spans(
+    text: str,
+    start: int,
+    end: int,
+    *,
+    dialect: str | None,
+) -> list[tuple[int, int]]:
+    spans: list[tuple[int, int]] = []
+    comment = text[start:end]
+    for pattern in SECRET_FALLBACK_LITERAL_PATTERNS:
+        spans.extend(
+            (start + match.start("value"), start + match.end("value"))
+            for match in pattern.finditer(comment)
+            if (
+                review_literal_candidate(
+                    match.group("value"),
+                    dialect=dialect,
+                )
+                or quoted_template_segment_is_risky(
+                    match.group("value"),
+                    12,
+                    dialect=dialect,
+                )
+            )
+        )
+    spans.extend(
+        (start + match.start("value"), start + match.end("value"))
+        for match in SECRET_FALLBACK_UNQUOTED_PATTERN.finditer(comment)
+        if review_literal_candidate(
+            match.group("value"),
+            dialect=dialect,
+        )
+    )
+    return sorted(set(spans))
+
+
+def comment_candidate_is_secret(
+    text: str,
+    start: int,
+    end: int,
+    *,
+    dialect: str | None,
+) -> bool:
+    value = text[start:end]
+    package_name = re.fullmatch(
+        r"[a-z][a-z0-9]*(?:[-./][a-z0-9]+)+",
+        value,
+    ) is not None
+    return (
+        review_literal_candidate(value, dialect=dialect)
+        or credentialed_uri_risk(value)
+        or basic_authorization_risk(value)
+        or any(pattern.search(value) for pattern in SECRET_VALUE_PATTERNS)
+        or (
+            not package_name
+            and quoted_template_segment_is_risky(
+                value,
+                12,
+                dialect=dialect,
+            )
+        )
+    )
+
+
+def javascript_template_value_spans(
+    text: str,
+    start: int,
+    limit: int,
+    *,
+    nesting: int = 0,
+    allow_incomplete: bool = False,
+    all_comment_spans: list[tuple[int, int]] | None = None,
+    numeric_source_spans: list[tuple[int, int]] | None = None,
+    expression_spans: list[tuple[int, int]] | None = None,
+) -> tuple[list[tuple[int, int]], list[tuple[int, int]], int]:
+    if nesting > 64:
+        raise SystemExit("refusing review bundle with excessive template nesting")
+    spans: list[tuple[int, int]] = []
+    comment_spans: list[tuple[int, int]] = []
+    cursor = start + 1
+    literal_start = cursor
+    expression_depth = 0
+    expression_start: int | None = None
+    while cursor < limit:
+        char = text[cursor]
+        next_char = text[cursor + 1] if cursor + 1 < limit else ""
+        if expression_depth:
+            if char == "/" and next_char == "/":
+                comment_end = javascript_line_terminator_index(
+                    text,
+                    cursor + 2,
+                    limit,
+                )
+                comment_end = limit if comment_end is None else comment_end
+                found = comment_secret_candidate_spans(
+                    text,
+                    cursor + 2,
+                    comment_end,
+                    dialect="javascript",
+                )
+                if all_comment_spans is not None:
+                    all_comment_spans.append((cursor + 2, comment_end))
+                spans.extend(found)
+                comment_spans.extend(found)
+                cursor = comment_end
+                continue
+            if char == "/" and next_char == "*":
+                comment_end = text.find("*/", cursor + 2, limit)
+                if comment_end < 0:
+                    if not allow_incomplete:
+                        raise SystemExit(
+                            "refusing review bundle with an unterminated call comment"
+                        )
+                    comment_end = limit
+                    found = comment_secret_candidate_spans(
+                        text,
+                        cursor + 2,
+                        comment_end,
+                        dialect="javascript",
+                    )
+                    if all_comment_spans is not None:
+                        all_comment_spans.append((cursor + 2, comment_end))
+                    spans.extend(found)
+                    comment_spans.extend(found)
+                    cursor = limit
+                    continue
+                found = comment_secret_candidate_spans(
+                    text,
+                    cursor + 2,
+                    comment_end,
+                    dialect="javascript",
+                )
+                if all_comment_spans is not None:
+                    all_comment_spans.append((cursor + 2, comment_end))
+                spans.extend(found)
+                comment_spans.extend(found)
+                cursor = comment_end + 2
+                continue
+            regex_end = javascript_regex_literal_end(text, cursor)
+            if regex_end is not None and regex_end <= limit:
+                body_end = regex_end
+                while body_end > cursor and text[body_end - 1].isalpha():
+                    body_end -= 1
+                if body_end > cursor + 1 and text[body_end - 1] == "/":
+                    spans.append((cursor + 1, body_end - 1))
+                cursor = regex_end
+                continue
+            if char in {'"', "'"}:
+                string_end = csharp_quoted_literal_end(
+                    text,
+                    cursor,
+                    verbatim=False,
+                    interpolated=False,
+                )
+                if string_end is None or string_end > limit:
+                    if allow_incomplete:
+                        if cursor + 1 < limit:
+                            spans.append((cursor + 1, limit))
+                        cursor = limit
+                        continue
+                    raise SystemExit("refusing review bundle with an unterminated call literal")
+                spans.append((cursor + 1, string_end - 1))
+                cursor = string_end
+                continue
+            if char == "`":
+                (
+                    nested_spans,
+                    nested_comment_spans,
+                    nested_end,
+                ) = javascript_template_value_spans(
+                    text,
+                    cursor,
+                    limit,
+                    nesting=nesting + 1,
+                    allow_incomplete=allow_incomplete,
+                    all_comment_spans=all_comment_spans,
+                    numeric_source_spans=numeric_source_spans,
+                )
+                spans.extend(nested_spans)
+                comment_spans.extend(nested_comment_spans)
+                cursor = nested_end
+                continue
+            numeric = JAVASCRIPT_NUMERIC_LITERAL_PATTERN.match(text, cursor, limit)
+            if numeric is not None and integer_literal_token_boundary(
+                text,
+                numeric.start(),
+                numeric.end(),
+                dialect="javascript",
+            ):
+                spans.append(numeric.span())
+                if numeric_source_spans is not None:
+                    numeric_source_spans.append(numeric.span())
+                cursor = numeric.end()
+                continue
+            if char == "{":
+                expression_depth += 1
+            elif char == "}":
+                expression_depth -= 1
+                if expression_depth == 0:
+                    if expression_spans is not None and expression_start is not None:
+                        expression_spans.append((expression_start, cursor + 1))
+                    expression_start = None
+                    literal_start = cursor + 1
+            cursor += 1
+            continue
+        if char == "\\":
+            cursor += 2
+            continue
+        if char == "`":
+            if literal_start < cursor:
+                spans.append((literal_start, cursor))
+            return spans, comment_spans, cursor + 1
+        if char == "$" and next_char == "{":
+            if literal_start < cursor:
+                spans.append((literal_start, cursor))
+            expression_start = cursor
+            expression_depth = 1
+            cursor += 2
+            continue
+        cursor += 1
+    if allow_incomplete:
+        if expression_depth == 0 and literal_start < limit:
+            spans.append((literal_start, limit))
+        return spans, comment_spans, limit
+    raise SystemExit("refusing review bundle with an unterminated call literal")
+
+
+def triple_quoted_literal_span(
+    text: str,
+    start: int,
+    limit: int,
+    *,
+    nesting: int = 0,
+    interpolation_dialect: str | None = None,
+) -> tuple[int, int, int] | None:
+    if nesting > 64:
+        raise SystemExit("refusing review bundle with excessive interpolation nesting")
+    marker = text[start : start + 1] * 3
+    if marker not in {'"""', "'''"} or not text.startswith(marker, start):
+        return None
+    cursor = start + 3
+    python_interpolated = (
+        interpolation_dialect == "python"
+        and python_interpolated_string_prefix(text, start)
+    )
+    while cursor < limit:
+        if (
+            interpolation_dialect == "swift"
+            and text.startswith("\\(", cursor)
+        ):
+            expression_end = balanced_delimiter_end(
+                text,
+                cursor + 1,
+                "(",
+                ")",
+                javascript_dialect="swift",
+                nesting=nesting + 1,
+            )
+            if expression_end is None or expression_end > limit:
+                return None
+            cursor = expression_end
+            continue
+        if (
+            interpolation_dialect in {"groovy", "kotlin", "scala"}
+            and text[cursor] == "$"
+            and (
+                interpolation_dialect != "scala"
+                or scala_interpolated_string_prefix(text, start)
+            )
+        ):
+            if interpolation_dialect == "scala" and text.startswith("$$", cursor):
+                cursor += 2
+                continue
+            run_end = cursor + 1
+            while run_end < limit and text[run_end] == "$":
+                run_end += 1
+            interpolation_width = dollar_interpolation_width(
+                text,
+                start,
+                dialect=interpolation_dialect,
+            )
+            if (
+                run_end - cursor >= interpolation_width
+                and text[run_end : run_end + 1] == "{"
+            ):
+                expression_end = balanced_delimiter_end(
+                    text,
+                    run_end,
+                    "{",
+                    "}",
+                    javascript_dialect=interpolation_dialect,
+                    nesting=nesting + 1,
+                )
+                if expression_end is None or expression_end > limit:
+                    return None
+                cursor = expression_end
+                continue
+        if text.startswith(marker, cursor):
+            if interpolation_dialect == "scala":
+                quote_run_end = repeated_character_end(
+                    text,
+                    cursor,
+                    limit,
+                    marker[0],
+                )
+                return start + 3, quote_run_end - 3, quote_run_end
+            if interpolation_dialect == "kotlin":
+                return start + 3, cursor, cursor + 3
+            backslashes = 0
+            previous = cursor - 1
+            while previous >= start + 3 and text[previous] == "\\":
+                backslashes += 1
+                previous -= 1
+            if backslashes % 2 == 0:
+                return start + 3, cursor, cursor + 3
+            cursor += 1
+            continue
+        if python_interpolated and text[cursor] == "{":
+            if text.startswith("{{", cursor):
+                cursor += 2
+                continue
+            expression_end = balanced_delimiter_end(
+                text,
+                cursor,
+                "{",
+                "}",
+                javascript_dialect="python",
+                nesting=nesting + 1,
+            )
+            if expression_end is None or expression_end > limit:
+                return None
+            cursor = expression_end
+            continue
+        cursor += 1
+    return None
+
+
+def groovy_slashy_literal_span(
+    text: str,
+    start: int,
+    limit: int,
+    *,
+    nesting: int = 0,
+) -> tuple[int, int, int] | None:
+    if nesting > 64:
+        raise SystemExit("refusing review bundle with excessive interpolation nesting")
+    if text.startswith("$/", start):
+        cursor = start + 2
+        while cursor < limit:
+            if text.startswith("$$", cursor):
+                cursor += 2
+                continue
+            if text.startswith("${", cursor):
+                expression_end = balanced_delimiter_end(
+                    text,
+                    cursor + 1,
+                    "{",
+                    "}",
+                    javascript_dialect="groovy",
+                    nesting=nesting + 1,
+                )
+                if expression_end is None or expression_end > limit:
+                    return None
+                cursor = expression_end
+                continue
+            if text.startswith("/$", cursor):
+                preceding_dollars = 0
+                previous = cursor - 1
+                while previous >= start + 2 and text[previous] == "$":
+                    preceding_dollars += 1
+                    previous -= 1
+                if preceding_dollars % 2 == 0:
+                    return start + 2, cursor, cursor + 2
+                cursor += 2
+                continue
+            cursor += 1
+        return None
+    if text[start : start + 1] != "/":
+        return None
+    if not javascript_regex_literal_start_allowed(text, start):
+        return None
+    cursor = start + 1
+    while cursor < limit:
+        if text.startswith("${", cursor):
+            preceding_backslashes = 0
+            previous = cursor - 1
+            while previous >= start + 1 and text[previous] == "\\":
+                preceding_backslashes += 1
+                previous -= 1
+            if preceding_backslashes % 2 == 0:
+                expression_end = balanced_delimiter_end(
+                    text,
+                    cursor + 1,
+                    "{",
+                    "}",
+                    javascript_dialect="groovy",
+                    nesting=nesting + 1,
+                )
+                if expression_end is None or expression_end > limit:
+                    return None
+                cursor = expression_end
+                continue
+        if text[cursor] == "/" and text[cursor - 1 : cursor] != "\\":
+            return start + 1, cursor, cursor + 1
+        cursor += 1
+    return None
+
+
+def review_regex_or_slashy_literal_end(
+    text: str,
+    start: int,
+    *,
+    dialect: str | None,
+    nesting: int = 0,
+) -> int | None:
+    if dialect == "swift":
+        extended = swift_extended_regex_literal_end(
+            text,
+            start,
+            nesting=nesting,
+        )
+        if extended is not None:
+            return extended
+    if dialect == "groovy":
+        slashy = groovy_slashy_literal_span(
+            text,
+            start,
+            len(text),
+            nesting=nesting,
+        )
+        if slashy is not None:
+            return slashy[2]
+    return (
+        javascript_regex_literal_end(text, start)
+        if review_dialect_has_regex_literals(dialect)
+        else None
+    )
+
+
+def review_regex_or_slashy_literal_parts(
+    text: str,
+    start: int,
+    *,
+    dialect: str | None,
+    nesting: int = 0,
+) -> tuple[
+    int,
+    list[tuple[int, int]],
+    list[tuple[int, int]],
+] | None:
+    if dialect == "groovy":
+        slashy = groovy_slashy_literal_span(
+            text,
+            start,
+            len(text),
+            nesting=nesting,
+        )
+        if slashy is not None:
+            value_start, value_end, literal_end = slashy
+            expressions = dollar_interpolation_expression_spans(
+                text,
+                value_start,
+                value_end,
+                dialect="groovy",
+                nesting=nesting + 1,
+                raw=text.startswith("$/", start),
+                doubled_dollars_escape=text.startswith("$/", start),
+            )
+            return (
+                literal_end,
+                spans_outside_ranges(value_start, value_end, expressions),
+                expressions,
+            )
+    if dialect == "swift" and text[start : start + 1] == "#":
+        literal_end = swift_extended_regex_literal_end(
+            text,
+            start,
+            nesting=nesting,
+        )
+        if literal_end is not None:
+            hash_end = repeated_character_end(text, start, len(text), "#")
+            hash_width = hash_end - start
+            value_start = hash_end + 1
+            value_end = literal_end - hash_width - 1
+            marker = "\\" + "#" * hash_width + "("
+            expressions: list[tuple[int, int]] = []
+            cursor = value_start
+            while cursor < value_end:
+                opening = text.find(marker, cursor, value_end)
+                if opening < 0:
+                    break
+                expression_end = balanced_delimiter_end(
+                    text,
+                    opening + len(marker) - 1,
+                    "(",
+                    ")",
+                    javascript_dialect="swift",
+                    nesting=nesting + 1,
+                )
+                if expression_end is None or expression_end > value_end:
+                    break
+                expressions.append((opening, expression_end))
+                cursor = expression_end
+            return (
+                literal_end,
+                spans_outside_ranges(value_start, value_end, expressions),
+                expressions,
+            )
+    literal_end = (
+        javascript_regex_literal_end(text, start)
+        if review_dialect_has_regex_literals(dialect)
+        else None
+    )
+    if literal_end is None:
+        return None
+    closing = literal_end
+    while closing > start and text[closing - 1].isalpha():
+        closing -= 1
+    if closing <= start + 1 or text[closing - 1] != "/":
+        return None
+    value_start = start + 1
+    value_end = closing - 1
+    if dialect != "swift":
+        return literal_end, [(value_start, value_end)], []
+    expressions: list[tuple[int, int]] = []
+    cursor = value_start
+    while cursor < value_end:
+        opening = text.find("\\(", cursor, value_end)
+        if opening < 0:
+            break
+        expression_end = balanced_delimiter_end(
+            text,
+            opening + 1,
+            "(",
+            ")",
+            javascript_dialect="swift",
+            nesting=nesting + 1,
+        )
+        if expression_end is None or expression_end > value_end:
+            break
+        expressions.append((opening, expression_end))
+        cursor = expression_end
+    return (
+        literal_end,
+        spans_outside_ranges(value_start, value_end, expressions),
+        expressions,
+    )
+
+
+def csharp_raw_literal_span(
+    text: str,
+    start: int,
+    limit: int,
+    *,
+    nesting: int = 0,
+) -> tuple[int, int, int] | None:
+    if nesting > 64:
+        raise SystemExit("refusing review bundle with excessive interpolation nesting")
+    if (
+        text[start : start + 1] != '"'
+        or (start > 0 and text[start - 1] == '"')
+    ):
+        return None
+    opening_end = repeated_character_end(text, start, limit, '"')
+    quote_count = opening_end - start
+    if quote_count < 3:
+        return None
+    interpolation_width = csharp_raw_interpolation_width(text, start)
+    cursor = opening_end
+    while cursor < limit:
+        if text[cursor] == '"':
+            run_end = repeated_character_end(text, cursor, limit, '"')
+            if run_end - cursor >= quote_count:
+                delimiter_start = run_end - quote_count
+                return opening_end, delimiter_start, run_end
+            cursor = run_end
+            continue
+        if interpolation_width and text[cursor] == "{":
+            run_end = repeated_character_end(text, cursor, limit, "{")
+            if run_end - cursor < interpolation_width:
+                cursor = run_end
+                continue
+            cursor = run_end - interpolation_width
+            expression_end = csharp_interpolation_end(
+                text,
+                cursor,
+                limit,
+                interpolation_width,
+                nesting=nesting + 1,
+            )
+            if expression_end is None:
+                return None
+            cursor = expression_end
+            continue
+        cursor += 1
+    return None
+
+
+def literal_spans_outside_interpolations(
+    text: str,
+    value_start: int,
+    value_end: int,
+    *,
+    dialect: str,
+    brace_width: int = 1,
+) -> list[tuple[int, int]]:
+    return spans_outside_ranges(
+        value_start,
+        value_end,
+        interpolation_expression_spans(
+            text,
+            value_start,
+            value_end,
+            dialect=dialect,
+            brace_width=brace_width,
+        ),
+    )
+
+
+def interpolation_expression_spans(
+    text: str,
+    value_start: int,
+    value_end: int,
+    *,
+    dialect: str,
+    brace_width: int = 1,
+) -> list[tuple[int, int]]:
+    expressions: list[tuple[int, int]] = []
+    cursor = value_start
+    opener = "{" * brace_width
+    while cursor < value_end:
+        opening = text.find(opener, cursor, value_end)
+        if opening < 0:
+            break
+        if dialect == "csharp" and brace_width > 1:
+            run_end = opening + brace_width
+            while run_end < value_end and text[run_end] == "{":
+                run_end += 1
+            opening = run_end - brace_width
+        if (
+            dialect in {"csharp", "python"}
+            and brace_width == 1
+            and text.startswith("{{", opening)
+        ):
+            cursor = opening + 2
+            continue
+        if brace_width == 1:
+            expression_end = balanced_delimiter_end(
+                text,
+                opening,
+                "{",
+                "}",
+                javascript_dialect=dialect,
+            )
+        else:
+            expression_end = csharp_interpolation_end(
+                text,
+                opening,
+                value_end,
+                brace_width,
+            )
+        if expression_end is None or expression_end > value_end:
+            break
+        expressions.append((opening, expression_end))
+        cursor = expression_end
+    return expressions
+
+
+def spans_outside_ranges(
+    start: int,
+    end: int,
+    excluded: list[tuple[int, int]],
+) -> list[tuple[int, int]]:
+    spans: list[tuple[int, int]] = []
+    cursor = start
+    for opening, expression_end in excluded:
+        if cursor < opening:
+            spans.append((cursor, opening))
+        cursor = expression_end
+    if cursor < end:
+        spans.append((cursor, end))
+    return spans
+
+
+def dollar_interpolation_expression_spans(
+    text: str,
+    start: int,
+    end: int,
+    *,
+    dialect: str,
+    nesting: int = 0,
+    interpolation_width: int = 1,
+    raw: bool = False,
+    doubled_dollars_escape: bool = False,
+) -> list[tuple[int, int]]:
+    if nesting > 64:
+        raise SystemExit("refusing review bundle with excessive interpolation nesting")
+    spans: list[tuple[int, int]] = []
+    cursor = start
+    while cursor < end:
+        dollar = text.find("$", cursor, end)
+        if dollar < 0:
+            break
+        if doubled_dollars_escape and text.startswith("$$", dollar):
+            cursor = dollar + 2
+            continue
+        if dialect == "kotlin" and interpolation_width > 1:
+            run_end = dollar + 1
+            while run_end < end and text[run_end] == "$":
+                run_end += 1
+            if run_end - dollar < interpolation_width:
+                cursor = run_end
+                continue
+            # Extra leading dollars are literal. Kotlin applies the configured
+            # marker width to the trailing dollars in the run.
+            dollar = run_end - interpolation_width
+        marker = "$" * interpolation_width
+        if not text.startswith(marker, dollar):
+            cursor = dollar + 1
+            continue
+        if not raw:
+            backslashes = 0
+            previous = dollar - 1
+            while previous >= start and text[previous] == "\\":
+                backslashes += 1
+                previous -= 1
+            if backslashes % 2:
+                cursor = dollar + interpolation_width
+                continue
+        if text.startswith(marker + "{", dollar):
+            expression_end = balanced_delimiter_end(
+                text,
+                dollar + interpolation_width,
+                "{",
+                "}",
+                javascript_dialect=dialect,
+                nesting=nesting + 1,
+            )
+            if expression_end is None or expression_end > end:
+                spans.append((dollar, end))
+                break
+            spans.append((dollar, expression_end))
+            cursor = expression_end
+            continue
+        identifier_start = dollar + interpolation_width
+        first = text[identifier_start : identifier_start + 1]
+        if not first or not (first == "_" or first.isidentifier()):
+            cursor = identifier_start
+            continue
+        identifier_end = identifier_start + 1
+        while identifier_end < end and identifier_continuation_character(
+            text[identifier_end],
+            dialect=dialect,
+        ):
+            identifier_end += 1
+        if dialect == "groovy":
+            while (
+                text[identifier_end : identifier_end + 1] == "."
+                and (
+                    member_start := text[
+                        identifier_end + 1 : identifier_end + 2
+                    ]
+                )
+                and (member_start == "_" or member_start.isidentifier())
+            ):
+                identifier_end += 2
+                while identifier_end < end and identifier_continuation_character(
+                    text[identifier_end],
+                    dialect=dialect,
+                ):
+                    identifier_end += 1
+        spans.append((dollar, identifier_end))
+        cursor = identifier_end
+    return spans
+
+
+def dollar_interpolation_width(
+    text: str,
+    quote_start: int,
+    *,
+    dialect: str,
+) -> int:
+    if dialect != "kotlin":
+        return 1
+    cursor = quote_start
+    while cursor > 0 and text[cursor - 1] == "$":
+        cursor -= 1
+    return max(1, quote_start - cursor)
+
+
+def dollar_rendered_literal_parts(
+    text: str,
+    value_start: int,
+    value_end: int,
+    *,
+    dialect: str,
+    interpolation_width: int,
+    raw: bool,
+    nesting: int,
+    allow_incomplete: bool = False,
+    all_comment_spans: list[tuple[int, int]] | None = None,
+) -> tuple[
+    list[tuple[int, int]],
+    list[tuple[int, int]],
+    list[tuple[int, int]],
+    list[tuple[int, int]],
+]:
+    expression_spans = dollar_interpolation_expression_spans(
+        text,
+        value_start,
+        value_end,
+        dialect=dialect,
+        nesting=nesting + 1,
+        interpolation_width=interpolation_width,
+        raw=raw,
+    )
+    rendered_spans = spans_outside_ranges(
+        value_start,
+        value_end,
+        expression_spans,
+    )
+    comment_spans: list[tuple[int, int]] = []
+    numeric_source_spans: list[tuple[int, int]] = []
+    marker = "$" * interpolation_width + "{"
+    for expression_start, expression_end in expression_spans:
+        if not text.startswith(marker, expression_start):
+            continue
+        nested_start = expression_start + interpolation_width + 1
+        nested_end = expression_end - 1
+        nested_spans, nested_comments = quoted_literal_value_spans(
+            text,
+            nested_start,
+            nested_end,
+            javascript_dialect=dialect,
+            allow_incomplete=allow_incomplete,
+            collect_all_literals=True,
+            nesting=nesting,
+            all_comment_spans=all_comment_spans,
+        )
+        rendered_spans.extend(nested_spans)
+        comment_spans.extend(nested_comments)
+        numeric_spans = [
+            span
+            for span in integer_literal_spans(
+                text,
+                nested_start,
+                nested_end,
+                dialect=dialect,
+            )
+            if not position_in_ranges(span[0], tuple(nested_spans))
+        ]
+        rendered_spans.extend(numeric_spans)
+        numeric_source_spans.extend(numeric_spans)
+    return (
+        sorted(rendered_spans),
+        sorted(comment_spans),
+        sorted(numeric_source_spans),
+        expression_spans,
+    )
+
+
+def swift_scala_rendered_literal_parts(
+    text: str,
+    value_start: int,
+    value_end: int,
+    *,
+    dialect: str,
+    quote_start: int,
+    nesting: int,
+    allow_incomplete: bool = False,
+    all_comment_spans: list[tuple[int, int]] | None = None,
+) -> tuple[
+    list[tuple[int, int]],
+    list[tuple[int, int]],
+    list[tuple[int, int]],
+    list[tuple[int, int]],
+]:
+    expression_spans = swift_scala_interpolation_expression_spans(
+        text,
+        value_start,
+        value_end,
+        dialect=dialect,
+        quote_start=quote_start,
+        nesting=nesting + 1,
+    )
+    rendered_spans = spans_outside_ranges(
+        value_start,
+        value_end,
+        expression_spans,
+    )
+    comment_spans: list[tuple[int, int]] = []
+    numeric_source_spans: list[tuple[int, int]] = []
+    for expression_start, expression_end in expression_spans:
+        inner = interpolation_expression_inner_bounds(
+            text,
+            expression_start,
+            expression_end,
+            dialect=dialect,
+        )
+        if inner is None:
+            continue
+        nested_spans, nested_comments = quoted_literal_value_spans(
+            text,
+            inner[0],
+            inner[1],
+            javascript_dialect=dialect,
+            allow_incomplete=allow_incomplete,
+            collect_all_literals=True,
+            nesting=nesting + 1,
+            all_comment_spans=all_comment_spans,
+            references_are_source=False,
+        )
+        rendered_spans.extend(nested_spans)
+        comment_spans.extend(nested_comments)
+        numeric_spans = [
+            span
+            for span in integer_literal_spans(
+                text,
+                inner[0],
+                inner[1],
+                dialect=dialect,
+            )
+            if not position_in_ranges(span[0], tuple(nested_spans))
+        ]
+        rendered_spans.extend(numeric_spans)
+        numeric_source_spans.extend(numeric_spans)
+    return (
+        sorted(rendered_spans),
+        sorted(comment_spans),
+        sorted(numeric_source_spans),
+        expression_spans,
+    )
+
+
+def groovy_slashy_rendered_literal_parts(
+    text: str,
+    value_start: int,
+    value_end: int,
+    *,
+    dollar_slashy: bool,
+    nesting: int,
+    collect_all_literals: bool = False,
+    all_comment_spans: list[tuple[int, int]] | None = None,
+) -> tuple[
+    list[tuple[int, int]],
+    list[tuple[int, int]],
+    list[tuple[int, int]],
+    list[tuple[int, int]],
+]:
+    expression_spans = dollar_interpolation_expression_spans(
+        text,
+        value_start,
+        value_end,
+        dialect="groovy",
+        nesting=nesting + 1,
+        raw=dollar_slashy,
+        doubled_dollars_escape=dollar_slashy,
+    )
+    rendered_spans = spans_outside_ranges(
+        value_start,
+        value_end,
+        expression_spans,
+    )
+    comment_spans: list[tuple[int, int]] = []
+    numeric_source_spans: list[tuple[int, int]] = []
+    for expression_start, expression_end in expression_spans:
+        if not text.startswith("${", expression_start):
+            continue
+        nested_start = expression_start + 2
+        nested_end = expression_end - 1
+        nested_spans, nested_comments = quoted_literal_value_spans(
+            text,
+            nested_start,
+            nested_end,
+            javascript_dialect="groovy",
+            collect_all_literals=collect_all_literals,
+            nesting=nesting + 1,
+            all_comment_spans=all_comment_spans,
+            references_are_source=False,
+        )
+        rendered_spans.extend(nested_spans)
+        comment_spans.extend(nested_comments)
+        numeric_spans = [
+            span
+            for span in integer_literal_spans(
+                text,
+                nested_start,
+                nested_end,
+                dialect="groovy",
+            )
+            if not position_in_ranges(span[0], tuple(nested_spans))
+        ]
+        rendered_spans.extend(numeric_spans)
+        numeric_source_spans.extend(numeric_spans)
+    return (
+        sorted(rendered_spans),
+        sorted(comment_spans),
+        sorted(numeric_source_spans),
+        expression_spans,
+    )
+
+
+def dollar_interpolated_quoted_literal_end(
+    text: str,
+    start: int,
+    limit: int,
+    *,
+    dialect: str,
+    nesting: int = 0,
+) -> int | None:
+    if nesting > 64:
+        raise SystemExit("refusing review bundle with excessive interpolation nesting")
+    quote = text[start : start + 1]
+    if quote != '"':
+        return None
+    interpolation_width = dollar_interpolation_width(
+        text,
+        start,
+        dialect=dialect,
+    )
+    interpolation_marker = "$" * interpolation_width + "{"
+    cursor = start + 1
+    while cursor < limit:
+        if text[cursor] == "\\":
+            cursor += 2
+            continue
+        if text.startswith(interpolation_marker, cursor):
+            expression_end = balanced_delimiter_end(
+                text,
+                cursor + interpolation_width,
+                "{",
+                "}",
+                javascript_dialect=dialect,
+                nesting=nesting + 1,
+            )
+            if expression_end is None or expression_end > limit:
+                return None
+            cursor = expression_end
+            continue
+        if dialect == "scala" and text.startswith('$"', cursor):
+            cursor += 2
+            continue
+        if text[cursor] == quote:
+            return cursor + 1
+        if text[cursor] in "\r\n":
+            return None
+        cursor += 1
+    return None
+
+
+def top_level_interpolation_format_start(
+    text: str,
+    start: int,
+    end: int,
+    *,
+    dialect: str,
+) -> int | None:
+    stack: list[str] = []
+    pairs = {"(": ")", "[": "]", "{": "}"}
+    cursor = start
+    while cursor < end:
+        char = text[cursor]
+        next_char = text[cursor + 1] if cursor + 1 < end else ""
+        if char == "/" and next_char == "/" and dialect == "csharp":
+            line_end = review_line_terminator_index(
+                text,
+                cursor + 2,
+                end,
+                dialect,
+            )
+            cursor = end if line_end is None else line_end
+            continue
+        if char == "/" and next_char == "*" and dialect == "csharp":
+            comment_end = text.find("*/", cursor + 2, end)
+            cursor = end if comment_end < 0 else comment_end + 2
+            continue
+        if char == "#" and dialect == "python":
+            line_end = review_line_terminator_index(
+                text,
+                cursor + 1,
+                end,
+                dialect,
+            )
+            cursor = end if line_end is None else line_end
+            continue
+        structured = (
+            structured_literal_parts(
+                text,
+                cursor,
+                end,
+                dialect=dialect,
+            )
+            if char in {'"', "'"}
+            else None
+        )
+        if structured is not None:
+            cursor = structured[2]
+            continue
+        if char in {'"', "'"}:
+            literal_end = csharp_quoted_literal_end(
+                text,
+                cursor,
+                verbatim=False,
+                interpolated=False,
+            )
+            if literal_end is None or literal_end > end:
+                return None
+            cursor = literal_end
+            continue
+        if char in pairs:
+            stack.append(pairs[char])
+            cursor += 1
+            continue
+        if stack and char == stack[-1]:
+            stack.pop()
+            cursor += 1
+            continue
+        if not stack and char == ":":
+            if (
+                dialect == "csharp"
+                and next_char == ":"
+                and re.search(
+                    r"@?[A-Za-z_][A-Za-z0-9_]*\s*$",
+                    text[start:cursor],
+                )
+                is not None
+            ):
+                cursor += 2
+                continue
+            return cursor + 1
+        cursor += 1
+    return None
+
+
+def interpolation_format_literal_spans(
+    text: str,
+    expression_start: int,
+    expression_end: int,
+    *,
+    dialect: str,
+    brace_width: int,
+    nesting: int = 0,
+) -> list[tuple[int, int]]:
+    if nesting > 64:
+        raise SystemExit("refusing review bundle with excessive interpolation nesting")
+    field_end = expression_end - brace_width
+    format_start = top_level_interpolation_format_start(
+        text,
+        expression_start + brace_width,
+        field_end,
+        dialect=dialect,
+    )
+    if format_start is None:
+        return []
+    nested_fields = interpolation_expression_spans(
+        text,
+        format_start,
+        field_end,
+        dialect=dialect,
+    )
+    spans = spans_outside_ranges(
+        format_start,
+        field_end,
+        nested_fields,
+    )
+    for nested_start, nested_end in nested_fields:
+        spans.extend(
+            interpolation_format_literal_spans(
+                text,
+                nested_start,
+                nested_end,
+                dialect=dialect,
+                brace_width=1,
+                nesting=nesting + 1,
+            )
+        )
+    return sorted(spans)
+
+
+def python_string_prefix(text: str, quote_start: int) -> str:
+    for prefix in ("fr", "rf", "tr", "rt", "f", "t", "r"):
+        prefix_start = quote_start - len(prefix)
+        if prefix_start < 0 or text[prefix_start:quote_start].lower() != prefix:
+            continue
+        before = text[prefix_start - 1 : prefix_start]
+        if not identifier_continuation_character(before, dialect="python"):
+            return prefix
+    return ""
+
+
+def python_interpolated_string_prefix(text: str, quote_start: int) -> bool:
+    return python_string_prefix(text, quote_start) in {
+        "f",
+        "fr",
+        "rf",
+        "t",
+        "tr",
+        "rt",
+    }
+
+
+def python_quoted_literal_span(
+    text: str,
+    start: int,
+    limit: int,
+    *,
+    nesting: int = 0,
+) -> tuple[int, int, int] | None:
+    if nesting > 64:
+        raise SystemExit("refusing review bundle with excessive interpolation nesting")
+    quote = text[start : start + 1]
+    if quote not in {'"', "'"} or text.startswith(quote * 3, start):
+        return None
+    prefix = python_string_prefix(text, start)
+    interpolated = prefix in {"f", "fr", "rf", "t", "tr", "rt"}
+    raw = "r" in prefix
+    cursor = start + 1
+    while cursor < limit:
+        char = text[cursor]
+        if interpolated and char == "{":
+            if text.startswith("{{", cursor):
+                cursor += 2
+                continue
+            expression_end = balanced_delimiter_end(
+                text,
+                cursor,
+                "{",
+                "}",
+                javascript_dialect="python",
+                nesting=nesting + 1,
+            )
+            if expression_end is None or expression_end > limit:
+                return None
+            cursor = expression_end
+            continue
+        if char == "\\":
+            cursor += (
+                1
+                if raw or (interpolated and text.startswith("{", cursor + 1))
+                else 2
+            )
+            continue
+        if char == quote:
+            if raw:
+                backslashes = 0
+                previous = cursor - 1
+                while previous >= start + 1 and text[previous] == "\\":
+                    backslashes += 1
+                    previous -= 1
+                if backslashes % 2:
+                    cursor += 1
+                    continue
+            return start + 1, cursor, cursor + 1
+        if char in "\r\n":
+            return None
+        cursor += 1
+    return None
+
+
+def csharp_interpolated_quote_prefix(
+    text: str,
+    quote_start: int,
+) -> tuple[bool, bool]:
+    marker = text[max(0, quote_start - 2) : quote_start]
+    interpolated = marker.endswith("$") or marker.endswith("$@")
+    verbatim = marker.endswith("@") or (interpolated and "@" in marker)
+    return interpolated, verbatim
+
+
+def structured_literal_parts(
+    text: str,
+    start: int,
+    limit: int,
+    *,
+    dialect: str,
+    nesting: int = 0,
+    allow_incomplete_raw: bool = False,
+) -> tuple[int, int, int, list[tuple[int, int]], int] | None:
+    if nesting > 64:
+        raise SystemExit("refusing review bundle with excessive interpolation nesting")
+    if dialect == "csharp" and text[start : start + 1] == '"':
+        raw = csharp_raw_literal_span(
+            text,
+            start,
+            limit,
+            nesting=nesting + 1,
+        )
+        if raw is not None:
+            value_start, value_end, literal_end = raw
+            brace_width = csharp_raw_interpolation_width(text, start)
+            expressions = (
+                interpolation_expression_spans(
+                    text,
+                    value_start,
+                    value_end,
+                    dialect="csharp",
+                    brace_width=brace_width,
+                )
+                if brace_width
+                else []
+            )
+            return value_start, value_end, literal_end, expressions, brace_width
+        if repeated_character_end(text, start, limit, '"') - start >= 3:
+            if allow_incomplete_raw:
+                return None
+            raise SystemExit("refusing review bundle with an unterminated C# raw string")
+        interpolated, verbatim = csharp_interpolated_quote_prefix(text, start)
+        if not interpolated and not verbatim:
+            return None
+        literal_end = csharp_quoted_literal_end(
+            text,
+            start,
+            verbatim=verbatim,
+            interpolated=interpolated,
+            nesting=nesting + 1,
+        )
+        if literal_end is None or literal_end > limit:
+            return None
+        value_start = start + 1
+        value_end = literal_end - 1
+        return (
+            value_start,
+            value_end,
+            literal_end,
+            (
+                interpolation_expression_spans(
+                    text,
+                    value_start,
+                    value_end,
+                    dialect="csharp",
+                )
+                if interpolated
+                else []
+            ),
+            1,
+        )
+    if dialect != "python" or text[start : start + 1] not in {'"', "'"}:
+        return None
+    triple = triple_quoted_literal_span(
+        text,
+        start,
+        limit,
+        nesting=nesting + 1,
+        interpolation_dialect="python",
+    )
+    if triple is not None:
+        value_start, value_end, literal_end = triple
+    elif python_interpolated_string_prefix(text, start):
+        ordinary = python_quoted_literal_span(
+            text,
+            start,
+            limit,
+            nesting=nesting + 1,
+        )
+        if ordinary is None:
+            return None
+        value_start, value_end, literal_end = ordinary
+    else:
+        return None
+    expressions = (
+        interpolation_expression_spans(
+            text,
+            value_start,
+            value_end,
+            dialect="python",
+        )
+        if python_interpolated_string_prefix(text, start)
+        else []
+    )
+    return value_start, value_end, literal_end, expressions, 1
+
+
+def csharp_raw_interpolation_width(text: str, quote_start: int) -> int:
+    cursor = quote_start
+    while cursor > 0 and text[cursor - 1] == "$":
+        cursor -= 1
+    return quote_start - cursor
+
+
+def csharp_interpolation_end(
+    text: str,
+    opening: int,
+    limit: int,
+    brace_width: int,
+    *,
+    nesting: int = 0,
+) -> int | None:
+    if nesting > 64:
+        raise SystemExit("refusing review bundle with excessive interpolation nesting")
+    closer = "}" * brace_width
+    cursor = opening + brace_width
+    depth = 0
+    quote: str | None = None
+    escaped = False
+    line_comment = False
+    block_comment = False
+    while cursor < limit:
+        char = text[cursor]
+        next_char = text[cursor + 1] if cursor + 1 < limit else ""
+        if line_comment:
+            if char in C_SHARP_LINE_TERMINATORS:
+                line_comment = False
+            cursor += 1
+            continue
+        if block_comment:
+            if char == "*" and next_char == "/":
+                block_comment = False
+                cursor += 2
+            else:
+                cursor += 1
+            continue
+        if quote is not None:
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == quote:
+                quote = None
+            cursor += 1
+            continue
+        if depth == 0 and text.startswith(closer, cursor):
+            return cursor + brace_width
+        if char == "/" and next_char == "/":
+            line_comment = True
+            cursor += 2
+            continue
+        if char == "/" and next_char == "*":
+            block_comment = True
+            cursor += 2
+            continue
+        if char in {'"', "'"}:
+            structured = structured_literal_parts(
+                text,
+                cursor,
+                limit,
+                dialect="csharp",
+                nesting=nesting + 1,
+            )
+            if structured is not None:
+                cursor = structured[2]
+                continue
+            quote = char
+            cursor += 1
+            continue
+        if char == "{":
+            depth += 1
+        elif char == "}" and depth > 0:
+            depth -= 1
+        cursor += 1
+    return None
+
+
+def c_family_raw_literal_span(
+    text: str,
+    start: int,
+    limit: int,
+    *,
+    allow_incomplete: bool = False,
+) -> tuple[int, int, int] | None:
+    prefix_start = next(
+        (
+            start - len(prefix)
+            for prefix in ("u8R", "uR", "UR", "LR", "R")
+            if start >= len(prefix)
+            and text[start - len(prefix) : start] == prefix
+            and (
+                start == len(prefix)
+                or not (
+                    text[start - len(prefix) - 1].isalnum()
+                    or text[start - len(prefix) - 1] == "_"
+                )
+            )
+        ),
+        None,
+    )
+    if prefix_start is None:
+        return None
+    delimiter_end = text.find("(", start + 1, min(limit, start + 18))
+    if delimiter_end < 0:
+        return None
+    delimiter = text[start + 1 : delimiter_end]
+    if len(delimiter) > 16 or any(
+        char.isspace() or char in "()\\" for char in delimiter
+    ):
+        return None
+    closing_marker = ")" + delimiter + '"'
+    closing = text.find(closing_marker, delimiter_end + 1, limit)
+    if closing < 0:
+        if allow_incomplete:
+            return delimiter_end + 1, limit, limit
+        raise SystemExit("refusing review bundle with an unterminated C-family raw string")
+    return delimiter_end + 1, closing, closing + len(closing_marker)
+
+
+def quoted_literal_value_spans(
+    text: str,
+    start: int,
+    end: int,
+    *,
+    javascript_dialect: str | None = None,
+    allow_incomplete: bool = False,
+    collect_all_literals: bool = False,
+    nesting: int = 0,
+    all_comment_spans: list[tuple[int, int]] | None = None,
+    references_are_source: bool = True,
+) -> tuple[list[tuple[int, int]], list[tuple[int, int]]]:
+    if nesting > 64:
+        raise SystemExit("refusing review bundle with excessive interpolation nesting")
+    spans: list[tuple[int, int]] = []
+    comment_spans: list[tuple[int, int]] = []
+
+    def nonempty_line_spans(value_start: int, value_end: int) -> list[tuple[int, int]]:
+        value = text[value_start:value_end]
+        return [
+            (value_start + match.start(), value_start + match.end())
+            for match in re.finditer(r"[^\r\n]+", value)
+            if match.group(0).strip()
+        ]
+
+    def scan_comment(start: int, stop: int) -> None:
+        if all_comment_spans is not None:
+            all_comment_spans.append((start, stop))
+        found = comment_secret_candidate_spans(
+            text,
+            start,
+            stop,
+            dialect=javascript_dialect,
+        )
+        spans.extend(found)
+        comment_spans.extend(found)
+
+    def add_candidate_spans(
+        value_spans: list[tuple[int, int]],
+        candidate_comments: list[tuple[int, int]] | None = None,
+        numeric_source_spans: list[tuple[int, int]] | None = None,
+        *,
+        references_are_source: bool = True,
+    ) -> None:
+        selected_spans = (
+            value_spans
+            if collect_all_literals
+            else rendered_literal_candidate_spans(
+                text,
+                value_spans,
+                dialect=javascript_dialect,
+                comment_spans=candidate_comments,
+                numeric_source_spans=numeric_source_spans,
+                references_are_source=references_are_source,
+            )
+        )
+        spans.extend(
+            line_span
+            for start, stop in selected_spans
+            for line_span in nonempty_line_spans(start, stop)
+        )
+
+    def add_candidate_span(value_start: int, value_end: int) -> None:
+        add_candidate_spans(
+            [(value_start, value_end)],
+            references_are_source=references_are_source,
+        )
+
+    def add_opaque_literal_span(value_start: int, value_end: int) -> None:
+        value = text[value_start:value_end]
+        if collect_all_literals or review_literal_candidate(
+            value,
+            dialect=javascript_dialect,
+            references_are_source=False,
+        ) or quoted_template_segment_is_risky(
+            value,
+            12,
+            dialect=javascript_dialect,
+            references_are_source=False,
+        ):
+            spans.extend(nonempty_line_spans(value_start, value_end))
+
+    def scan_interpolation_expressions(
+        expression_spans: list[tuple[int, int]],
+        brace_width: int,
+    ) -> tuple[
+        list[tuple[int, int]],
+        list[tuple[int, int]],
+        list[tuple[int, int]],
+    ]:
+        assert javascript_dialect in {"csharp", "python"}
+        nested_value_spans: list[tuple[int, int]] = []
+        nested_comments: list[tuple[int, int]] = []
+        numeric_source_spans: list[tuple[int, int]] = []
+        for expression_start, expression_end in expression_spans:
+            nested_spans, nested_comment_spans = quoted_literal_value_spans(
+                text,
+                expression_start + brace_width,
+                expression_end - brace_width,
+                javascript_dialect=javascript_dialect,
+                allow_incomplete=allow_incomplete,
+                collect_all_literals=True,
+                nesting=nesting + 1,
+                all_comment_spans=all_comment_spans,
+            )
+            field_format_spans = interpolation_format_literal_spans(
+                text,
+                expression_start,
+                expression_end,
+                dialect=javascript_dialect,
+                brace_width=brace_width,
+            )
+            nested_spans = sorted(nested_spans + field_format_spans)
+            nested_value_spans.extend(nested_spans)
+            numeric_spans = [
+                span
+                for span in numeric_literal_spans(
+                    text,
+                    expression_start + brace_width,
+                    expression_end - brace_width,
+                    dialect=javascript_dialect,
+                )
+                if not position_in_ranges(
+                    span[0],
+                    tuple(nested_spans),
+                )
+            ]
+            nested_value_spans.extend(numeric_spans)
+            numeric_source_spans.extend(numeric_spans)
+            nested_comments.extend(nested_comment_spans)
+        return nested_value_spans, nested_comments, numeric_source_spans
+
+    def add_dollar_interpolated_spans(
+        value_start: int,
+        value_end: int,
+        *,
+        quote_start: int,
+        raw: bool,
+    ) -> None:
+        assert javascript_dialect in {"groovy", "kotlin"}
+        interpolation_width = dollar_interpolation_width(
+            text,
+            quote_start,
+            dialect=javascript_dialect,
+        )
+        (
+            rendered_spans,
+            nested_comments,
+            numeric_source_spans,
+            expression_spans,
+        ) = dollar_rendered_literal_parts(
+            text,
+            value_start,
+            value_end,
+            dialect=javascript_dialect,
+            interpolation_width=interpolation_width,
+            raw=raw,
+            nesting=nesting + 1,
+            allow_incomplete=allow_incomplete,
+            all_comment_spans=all_comment_spans,
+        )
+        if not expression_spans:
+            add_opaque_literal_span(value_start, value_end)
+            return
+        add_candidate_spans(
+            rendered_spans,
+            nested_comments,
+            numeric_source_spans,
+            references_are_source=False,
+        )
+        comment_spans.extend(nested_comments)
+
+    cursor = start
+    while cursor < end:
+        groovy_slashy = (
+            groovy_slashy_literal_span(text, cursor, end)
+            if javascript_dialect == "groovy"
+            else None
+        )
+        if groovy_slashy is not None:
+            slashy_start = cursor
+            value_start, value_end, cursor = groovy_slashy
+            (
+                literal_spans,
+                nested_comments,
+                numeric_source_spans,
+                _expression_spans,
+            ) = groovy_slashy_rendered_literal_parts(
+                text,
+                value_start,
+                value_end,
+                dollar_slashy=text.startswith("$/", slashy_start),
+                nesting=nesting,
+                collect_all_literals=collect_all_literals,
+                all_comment_spans=all_comment_spans,
+            )
+            add_candidate_spans(
+                literal_spans,
+                nested_comments,
+                numeric_source_spans,
+                references_are_source=False,
+            )
+            comment_spans.extend(nested_comments)
+            continue
+        if text.startswith("//", cursor):
+            if review_dialect_has_slash_comments(javascript_dialect):
+                comment_end = review_line_terminator_index(
+                    text,
+                    cursor + 2,
+                    end,
+                    javascript_dialect,
+                )
+                comment_end = end if comment_end is None else comment_end
+                scan_comment(cursor + 2, comment_end)
+                cursor = comment_end
+            else:
+                cursor += 2
+            continue
+        if text.startswith("/*", cursor):
+            comment_end = text.find("*/", cursor + 2, end)
+            if comment_end < 0:
+                comment_end = end
+                scan_comment(cursor + 2, comment_end)
+                cursor = end
+                continue
+            scan_comment(cursor + 2, comment_end)
+            cursor = comment_end + 2
+            continue
+        if text[cursor] == "#" and javascript_dialect in {None, "python"}:
+            newline = re.search(r"[\r\n]", text[cursor + 1 : end])
+            comment_end = end if newline is None else cursor + 1 + newline.start()
+            scan_comment(cursor + 1, comment_end)
+            cursor = comment_end
+            continue
+        if review_dialect_has_regex_literals(javascript_dialect):
+            regex_literal = review_regex_or_slashy_literal_parts(
+                text,
+                cursor,
+                dialect=javascript_dialect,
+                nesting=nesting + 1,
+            )
+            if regex_literal is not None and regex_literal[0] <= end:
+                regex_end, rendered_spans, expression_spans = regex_literal
+                if javascript_dialect == "swift":
+                    nested_spans: list[tuple[int, int]] = []
+                    nested_comments: list[tuple[int, int]] = []
+                    numeric_spans: list[tuple[int, int]] = []
+                    for expression_start, expression_end in expression_spans:
+                        inner = interpolation_expression_inner_bounds(
+                            text,
+                            expression_start,
+                            expression_end,
+                            dialect="swift",
+                        )
+                        if inner is None:
+                            continue
+                        expression_literals, expression_comments = (
+                            quoted_literal_value_spans(
+                                text,
+                                inner[0],
+                                inner[1],
+                                javascript_dialect="swift",
+                                allow_incomplete=allow_incomplete,
+                                collect_all_literals=True,
+                                nesting=nesting + 1,
+                                all_comment_spans=all_comment_spans,
+                                references_are_source=False,
+                            )
+                        )
+                        nested_spans.extend(expression_literals)
+                        nested_comments.extend(expression_comments)
+                        numeric_spans.extend(
+                            span
+                            for span in numeric_literal_spans(
+                                text,
+                                inner[0],
+                                inner[1],
+                                dialect="swift",
+                            )
+                            if not position_in_ranges(
+                                span[0],
+                                tuple(expression_literals),
+                            )
+                        )
+                    add_candidate_spans(
+                        sorted(rendered_spans + nested_spans + numeric_spans),
+                        nested_comments,
+                        numeric_spans,
+                        references_are_source=False,
+                    )
+                    comment_spans.extend(nested_comments)
+                elif (
+                    javascript_dialect is None
+                    or is_javascript_review_dialect(javascript_dialect)
+                ) and javascript_regex_string_value_risk(
+                    text,
+                    cursor,
+                    regex_end,
+                    minimum_length=8,
+                    dialect=javascript_dialect,
+                ):
+                    spans.extend(rendered_spans)
+                cursor = regex_end
+                continue
+        quote = text[cursor]
+        if quote not in {'"', "'", "`"}:
+            cursor += 1
+            continue
+        if quote == "`" and (
+            identifier_end := source_backtick_identifier_end(
+                text,
+                cursor,
+                end,
+                dialect=javascript_dialect,
+            )
+        ) is not None:
+            cursor = identifier_end
+            continue
+        structured = (
+            structured_literal_parts(
+                text,
+                cursor,
+                end,
+                dialect=javascript_dialect,
+                allow_incomplete_raw=allow_incomplete,
+            )
+            if javascript_dialect in {"csharp", "python"}
+            else None
+        )
+        if structured is not None:
+            (
+                value_start,
+                value_end,
+                cursor,
+                expression_spans,
+                brace_width,
+            ) = structured
+            (
+                nested_spans,
+                nested_comments,
+                numeric_source_spans,
+            ) = scan_interpolation_expressions(
+                expression_spans,
+                brace_width,
+            )
+            literal_spans = spans_outside_ranges(
+                value_start,
+                value_end,
+                expression_spans,
+            )
+            if javascript_dialect == "csharp" and brace_width > 1:
+                literal_spans = [
+                    (start, stop)
+                    for start, stop in literal_spans
+                    if text[start:stop].strip("{}")
+                ]
+            add_candidate_spans(
+                sorted(
+                    literal_spans + nested_spans
+                )
+                if expression_spans
+                else [(value_start, value_end)],
+                nested_comments,
+                numeric_source_spans,
+            )
+            comment_spans.extend(nested_comments)
+            continue
+        if (
+            allow_incomplete
+            and javascript_dialect == "csharp"
+            and quote == '"'
+            and text.startswith('"""', cursor)
+        ):
+            quote_run_end = repeated_character_end(text, cursor, end, '"')
+            tail = text[quote_run_end:end]
+            if review_literal_candidate(
+                tail,
+                dialect="csharp",
+                references_are_source=False,
+            ):
+                raise SystemExit(
+                    "refusing review bundle with an unterminated C# raw string"
+                )
+            add_opaque_literal_span(quote_run_end, end)
+            cursor = end
+            continue
+        incomplete_value_start: int | None = None
+        if javascript_dialect == "python":
+            if text.startswith(quote * 3, cursor):
+                incomplete_value_start = cursor + 3
+            elif python_interpolated_string_prefix(text, cursor):
+                incomplete_value_start = cursor + 1
+        elif javascript_dialect == "csharp" and quote == '"':
+            interpolated, verbatim = csharp_interpolated_quote_prefix(text, cursor)
+            if interpolated or verbatim:
+                incomplete_value_start = cursor + 1
+        if incomplete_value_start is not None:
+            add_opaque_literal_span(incomplete_value_start, end)
+            cursor = end
+            continue
+        if (
+            javascript_dialect == "csharp"
+            and quote == '"'
+            and text.startswith('"""', cursor)
+        ):
+            quote_run_end = repeated_character_end(text, cursor, end, '"')
+            if allow_incomplete:
+                add_opaque_literal_span(quote_run_end, end)
+                cursor = end
+                continue
+            if text[quote_run_end:end].strip():
+                raise SystemExit(
+                    "refusing review bundle with an unterminated C# raw string"
+                )
+            cursor = quote_run_end
+            continue
+        swift_scala_literal = (
+            swift_scala_literal_span(
+                text,
+                cursor,
+                end,
+                dialect=javascript_dialect,
+                nesting=nesting + 1,
+            )
+            if javascript_dialect in {"scala", "swift"} and quote == '"'
+            else None
+        )
+        if swift_scala_literal is not None:
+            literal_start = cursor
+            value_start, value_end, cursor = swift_scala_literal
+            (
+                rendered_spans,
+                nested_comments,
+                numeric_source_spans,
+                _,
+            ) = swift_scala_rendered_literal_parts(
+                text,
+                value_start,
+                value_end,
+                dialect=javascript_dialect,
+                quote_start=literal_start,
+                nesting=nesting,
+                allow_incomplete=allow_incomplete,
+                all_comment_spans=all_comment_spans,
+            )
+            add_candidate_spans(
+                rendered_spans,
+                nested_comments,
+                numeric_source_spans,
+                references_are_source=False,
+            )
+            comment_spans.extend(nested_comments)
+            continue
+        raw_literal = (
+            c_family_raw_literal_span(
+                text,
+                cursor,
+                end,
+                allow_incomplete=allow_incomplete,
+            )
+            if javascript_dialect == "c-family" and quote == '"'
+            else None
+        )
+        if raw_literal is not None:
+            value_start, value_end, cursor = raw_literal
+            add_candidate_span(value_start, value_end)
+            continue
+        triple = (
+            triple_quoted_literal_span(
+                text,
+                cursor,
+                end,
+                interpolation_dialect=javascript_dialect,
+            )
+            if javascript_dialect not in {"csharp", "python", "scala", "swift"}
+            and not is_javascript_review_dialect(javascript_dialect)
+            and quote in {'"', "'"}
+            else None
+        )
+        if triple is not None:
+            triple_start = cursor
+            value_start, value_end, cursor = triple
+            if javascript_dialect is None and (
+                SUSPICIOUS_TRIPLE_INTERPOLATION_PATTERN.search(
+                    text,
+                    value_start,
+                    value_end,
+                )
+                is not None
+            ):
+                raise SystemExit(
+                    "refusing review bundle with ambiguous triple-string interpolation"
+                )
+            if javascript_dialect == "kotlin" or (
+                javascript_dialect == "groovy" and quote == '"'
+            ):
+                add_dollar_interpolated_spans(
+                    value_start,
+                    value_end,
+                    quote_start=triple_start,
+                    raw=javascript_dialect == "kotlin",
+                )
+            else:
+                add_opaque_literal_span(value_start, value_end)
+            continue
+        if quote == "`" and is_javascript_review_dialect(javascript_dialect):
+            template_numeric_sources: list[tuple[int, int]] = []
+            (
+                template_spans,
+                template_comment_spans,
+                template_end,
+            ) = javascript_template_value_spans(
+                text,
+                cursor,
+                end,
+                allow_incomplete=allow_incomplete,
+                all_comment_spans=all_comment_spans,
+                numeric_source_spans=template_numeric_sources,
+            )
+            selected_spans = rendered_literal_candidate_spans(
+                text,
+                template_spans,
+                dialect=javascript_dialect,
+                comment_spans=template_comment_spans,
+                numeric_source_spans=template_numeric_sources,
+            )
+            selected_line_spans = [
+                line_span
+                for start, stop in selected_spans
+                for line_span in nonempty_line_spans(start, stop)
+            ]
+            spans.extend(selected_line_spans)
+            comment_spans.extend(
+                span
+                for span in selected_line_spans
+                if any(
+                    comment_start <= span[0] and span[1] <= comment_end
+                    for comment_start, comment_end in template_comment_spans
+                )
+            )
+            cursor = template_end
+            continue
+        value_start = cursor + 1
+        cursor = value_start
+        escaped = False
+        while cursor < end:
+            char = text[cursor]
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif (
+                javascript_dialect in {"groovy", "kotlin"}
+                and quote == '"'
+                and text.startswith("${", cursor)
+            ):
+                expression_end = balanced_delimiter_end(
+                    text,
+                    cursor + 1,
+                    "{",
+                    "}",
+                    javascript_dialect=javascript_dialect,
+                )
+                if expression_end is None or expression_end > end:
+                    cursor = end
+                    continue
+                cursor = expression_end
+                continue
+            elif char == quote:
+                if javascript_dialect == "kotlin" or (
+                    javascript_dialect == "groovy" and quote == '"'
+                ):
+                    add_dollar_interpolated_spans(
+                        value_start,
+                        cursor,
+                        quote_start=value_start - 1,
+                        raw=False,
+                    )
+                elif javascript_dialect == "groovy" and quote == "'":
+                    add_opaque_literal_span(value_start, cursor)
+                else:
+                    add_candidate_span(value_start, cursor)
+                cursor += 1
+                break
+            elif char in "\r\n" and quote != "`":
+                break
+            cursor += 1
+        else:
+            cursor = value_start
+    return sorted(set(spans)), sorted(set(comment_spans))
+
+
+def incomplete_raw_call_literal_spans(
+    text: str,
+    call_start: int,
+    *,
+    javascript_dialect: str | None,
+) -> list[tuple[int, int]] | None:
+    def risky_tail_spans(
+        spans: list[tuple[int, int]],
+    ) -> list[tuple[int, int]]:
+        return [
+            (start, end)
+            for start, end in spans
+            if review_literal_candidate(
+                text[start:end],
+                dialect=javascript_dialect,
+                references_are_source=False,
+            )
+            or credentialed_uri_risk(text[start:end])
+            or basic_authorization_risk(text[start:end])
+            or quoted_template_segment_is_risky(
+                text[start:end],
+                12,
+                dialect=javascript_dialect,
+                references_are_source=False,
+            )
+            or any(
+                pattern.search(text, start, end)
+                for pattern in SECRET_VALUE_PATTERNS
+            )
+        ]
+
+    if javascript_dialect == "csharp":
+        cursor = call_start + 1
+        while cursor < len(text):
+            quote = text.find('"""', cursor)
+            if quote < 0:
+                return None
+            raw = csharp_raw_literal_span(text, quote, len(text))
+            if raw is None:
+                spans, _ = quoted_literal_value_spans(
+                    text,
+                    quote,
+                    len(text),
+                    javascript_dialect="csharp",
+                    allow_incomplete=True,
+                )
+                return risky_tail_spans(spans)
+            cursor = raw[2]
+        return None
+    if javascript_dialect != "c-family":
+        return None
+    for quote in (match.start() for match in re.finditer('"', text[call_start + 1 :])):
+        quote += call_start + 1
+        raw = c_family_raw_literal_span(
+            text,
+            quote,
+            len(text),
+            allow_incomplete=True,
+        )
+        if raw is None or raw[1] != len(text):
+            continue
+        spans, _ = quoted_literal_value_spans(
+            text,
+            quote,
+            len(text),
+            javascript_dialect="c-family",
+            allow_incomplete=True,
+        )
+        return risky_tail_spans(spans)
+    return None
+
+
+def chained_call_literal_spans(
+    text: str,
+    start: int,
+    *,
+    call_target: str,
+    javascript_dialect: str | None,
+) -> list[tuple[int, int]]:
+    spans: list[tuple[int, int]] = []
+    cursor = start
+    chained_target = (
+        "response.json()"
+        if normalized_call_target(call_target) == "response.json"
+        else "<call-result>"
+    )
+    member_operator = (
+        r"(?:->|::|\.)"
+        if javascript_dialect == "c-family"
+        else r"(?:->|\?\.|\.)"
+        if javascript_dialect == "csharp"
+        else r"(?:\?\.|\.)"
+    )
+    while cursor < len(text):
+        whitespace = re.match(r"\s*", text[cursor:])
+        assert whitespace is not None
+        cursor += whitespace.end()
+        member = re.match(
+            rf"{member_operator}[A-Za-z_][A-Za-z0-9_]*",
+            text[cursor:],
+        )
+        if member is not None:
+            member_name = re.search(
+                r"[A-Za-z_][A-Za-z0-9_]*$",
+                member.group(0),
+            )
+            assert member_name is not None
+            chained_target = chained_member_target(
+                chained_target,
+                member_name.group(0),
+            )
+            cursor += member.end()
+            continue
+        opener = text[cursor : cursor + 1]
+        closer = ")" if opener == "(" else "]" if opener == "[" else None
+        if closer is None:
+            break
+        expression_end = balanced_delimiter_end(
+            text,
+            cursor,
+            opener,
+            closer,
+            javascript_dialect=javascript_dialect,
+        )
+        if expression_end is None:
+            break
+        nested_spans, _comments = quoted_literal_value_spans(
+            text,
+            cursor + 1,
+            expression_end - 1,
+            javascript_dialect=javascript_dialect,
+            references_are_source=False,
+        )
+        if opener == "[" and safe_credential_lookup_argument(
+            f"{chained_target}.get",
+            text[cursor + 1 : expression_end - 1],
+            0,
+        ):
+            nested_spans = []
+        elif opener == "(":
+            arguments = text[cursor + 1 : expression_end - 1]
+            argument_offset = 0
+            safe_ranges: list[tuple[int, int]] = []
+            for argument_index, argument in enumerate(
+                split_top_level_call_arguments(
+                    arguments,
+                    slash_comments=review_dialect_has_slash_comments(
+                        javascript_dialect
+                    ),
+                    regex_literals=review_dialect_has_regex_literals(
+                        javascript_dialect
+                    ),
+                    line_terminators=review_line_comment_terminators(
+                        javascript_dialect
+                    ),
+                    javascript_dialect=javascript_dialect,
+                )
+            ):
+                argument_start = cursor + 1 + argument_offset
+                argument_end = argument_start + len(argument)
+                if safe_credential_lookup_argument(
+                    chained_target,
+                    argument,
+                    argument_index,
+                ):
+                    safe_ranges.append((argument_start, argument_end))
+                argument_offset += len(argument) + 1
+            nested_spans = [
+                span
+                for span in nested_spans
+                if not any(
+                    safe_start <= span[0] and span[1] <= safe_end
+                    for safe_start, safe_end in safe_ranges
+                )
+            ]
+        spans.extend(nested_spans)
+        cursor = expression_end
+        chained_target = "<call-result>"
+    return sorted(set(spans))
+
+
 def review_call_literal_spans(
     text: str,
     match: re.Match[str],
     *,
     javascript_dialect: str | None = None,
+    redact_incomplete_call: bool = False,
 ) -> list[tuple[int, int]]:
     whitespace = re.match(r"[ \t]*", text[match.end() :])
     assert whitespace is not None
     call_start = match.end() + whitespace.end()
     if call_start >= len(text) or text[call_start] != "(":
         return []
-    call_end = balanced_delimiter_end(text, call_start, "(", ")")
-    if call_end is None or not secret_text_risk(
-        text[match.start() : call_end],
+    try:
+        call_end = balanced_delimiter_end(
+            text,
+            call_start,
+            "(",
+            ")",
+            javascript_dialect=javascript_dialect,
+        )
+    except SystemExit:
+        # Diff-line redaction can split a valid multiline literal. The complete
+        # side is parsed separately, so this line remains an incomplete call.
+        call_end = None
+    if call_end is None:
+        if not redact_incomplete_call:
+            return []
+        incomplete_raw_spans = incomplete_raw_call_literal_spans(
+            text,
+            call_start,
+            javascript_dialect=javascript_dialect,
+        )
+        if incomplete_raw_spans == []:
+            prefix_spans, _ = quoted_literal_value_spans(
+                text,
+                call_start + 1,
+                len(text),
+                javascript_dialect=javascript_dialect,
+                allow_incomplete=True,
+                references_are_source=javascript_dialect
+                not in {"c-family", "java"},
+            )
+            return prefix_spans
+        quoted_literal_value_spans(
+            text,
+            call_start + 1,
+            len(text),
+            javascript_dialect=javascript_dialect,
+        )
+        raise SystemExit("refusing review bundle with an unterminated secret call")
+    candidates, comment_candidates = quoted_literal_value_spans(
+        text,
+        call_start + 1,
+        call_end - 1,
+        javascript_dialect=javascript_dialect,
+        references_are_source=javascript_dialect not in {"c-family", "java"},
+    )
+    if javascript_dialect in {"c-family", "java"}:
+        all_literals, _ = quoted_literal_value_spans(
+            text,
+            call_start + 1,
+            call_end - 1,
+            javascript_dialect=javascript_dialect,
+            collect_all_literals=True,
+            references_are_source=False,
+        )
+        candidates = sorted(
+            set(
+                rendered_literal_candidate_spans(
+                    text,
+                    all_literals,
+                    dialect=javascript_dialect,
+                    references_are_source=False,
+                )
+                + comment_candidates
+            )
+        )
+    call_target = match.group("call_value")
+    if candidates and call_target is not None:
+        arguments = text[call_start + 1 : call_end - 1]
+        argument_offset = 0
+        safe_argument_ranges: list[tuple[int, int]] = []
+        for argument_index, argument in enumerate(
+            split_top_level_call_arguments(
+                arguments,
+                slash_comments=review_dialect_has_slash_comments(
+                    javascript_dialect
+                ),
+                regex_literals=review_dialect_has_regex_literals(
+                    javascript_dialect
+                ),
+                line_terminators=review_line_comment_terminators(
+                    javascript_dialect
+                ),
+                javascript_dialect=javascript_dialect,
+            )
+        ):
+            argument_start = call_start + 1 + argument_offset
+            argument_end = argument_start + len(argument)
+            if safe_credential_lookup_argument(
+                call_target,
+                argument,
+                argument_index,
+            ):
+                safe_argument_ranges.append((argument_start, argument_end))
+            argument_offset += len(argument) + 1
+        comment_candidate_set = set(comment_candidates)
+        candidates = [
+            span
+            for span in candidates
+            if span in comment_candidate_set
+            or not any(
+                safe_start <= span[0] and span[1] <= safe_end
+                for safe_start, safe_end in safe_argument_ranges
+            )
+        ]
+    if (
+        candidates
+        and call_target is not None
+        and public_prompt_call_target(call_target)
+        and safe_secret_call_suffix(
+            text,
+            call_start,
+            call_target,
+            javascript_dialect=javascript_dialect,
+        )
+    ):
+        return comment_candidates
+    candidates.extend(
+        chained_call_literal_spans(
+            text,
+            call_end,
+            call_target=call_target or "<call-result>",
+            javascript_dialect=javascript_dialect,
+        )
+    )
+    return sorted(set(candidates))
+
+
+def structured_secret_assignment_literal_spans(
+    text: str,
+    *,
+    javascript_dialect: str | None,
+) -> list[tuple[int, int]]:
+    supported_dialects = {
+        "c-family",
+        "csharp",
+        "groovy",
+        "java",
+        "kotlin",
+        "python",
+        "scala",
+        "swift",
+    }
+    if javascript_dialect not in supported_dialects:
+        return []
+
+    def assignment_literal_spans(
+        quote_start: int,
+        literal_end: int,
+        *,
+        allow_incomplete: bool = False,
+    ) -> list[tuple[int, int]]:
+        literal_spans, comment_spans = quoted_literal_value_spans(
+            text,
+            quote_start,
+            literal_end,
+            javascript_dialect=javascript_dialect,
+            allow_incomplete=allow_incomplete,
+            collect_all_literals=True,
+            references_are_source=False,
+        )
+        selected: set[tuple[int, int]] = set()
+        for group in rendered_literal_span_groups(
+            text,
+            literal_spans,
+            comment_spans,
+            dialect=javascript_dialect,
+        ):
+            combined = combined_review_literal_value(text, group)
+            if quoted_template_segment_is_risky(
+                combined,
+                8,
+                dialect=javascript_dialect,
+                references_are_source=False,
+            ):
+                selected.update(group)
+        return sorted(selected)
+
+    def structured_quote_start(literal_start: int) -> int | None:
+        tail = text[literal_start:]
+        if javascript_dialect == "python":
+            prefixes = ("fr", "rf", "tr", "rt", "br", "rb", "f", "t", "r", "b", "u", "")
+            return next(
+                (
+                    literal_start + len(prefix)
+                    for prefix in prefixes
+                    if tail[: len(prefix)].casefold() == prefix
+                    and tail[len(prefix) : len(prefix) + 1] in {'"', "'"}
+                ),
+                None,
+            )
+        if javascript_dialect == "csharp":
+            marker = re.match(r"(?:\$+@?|@\$*)?", tail)
+            assert marker is not None
+            quote_start = literal_start + marker.end()
+            return quote_start if text[quote_start : quote_start + 1] == '"' else None
+        if javascript_dialect == "c-family":
+            prefixes = ("u8R", "uR", "UR", "LR", "R", "u8", "u", "U", "L", "")
+            return next(
+                (
+                    literal_start + len(prefix)
+                    for prefix in prefixes
+                    if tail.startswith(prefix + '"')
+                ),
+                None,
+            )
+        if javascript_dialect == "kotlin":
+            marker = re.match(r"\$*", tail)
+            assert marker is not None
+            quote_start = literal_start + marker.end()
+            return (
+                quote_start
+                if text[quote_start : quote_start + 1] in {'"', "'"}
+                else None
+            )
+        if javascript_dialect == "scala":
+            marker = re.match(r"[A-Za-z_$][A-Za-z0-9_$]*", tail)
+            quote_start = literal_start + (0 if marker is None else marker.end())
+            return quote_start if text[quote_start : quote_start + 1] == '"' else None
+        if javascript_dialect == "swift":
+            marker = re.match(r"#+", tail)
+            quote_start = literal_start + (0 if marker is None else marker.end())
+            return quote_start if text[quote_start : quote_start + 1] == '"' else None
+        return literal_start if tail[:1] in {'"', "'"} else None
+
+    def structured_literal_end(
+        literal_start: int,
+        quote_start: int,
+    ) -> int | None:
+        structured = (
+            structured_literal_parts(
+                text,
+                quote_start,
+                len(text),
+                dialect=javascript_dialect,
+            )
+            if javascript_dialect in {"csharp", "python"}
+            else None
+        )
+        if structured is not None:
+            return structured[2]
+        if javascript_dialect == "python":
+            ordinary = python_quoted_literal_span(
+                text,
+                quote_start,
+                len(text),
+            )
+            if ordinary is not None:
+                return ordinary[2]
+        if javascript_dialect == "c-family":
+            raw = c_family_raw_literal_span(text, quote_start, len(text))
+            if raw is not None:
+                return raw[2]
+        if javascript_dialect in {"scala", "swift"}:
+            literal = swift_scala_literal_span(
+                text,
+                quote_start,
+                len(text),
+                dialect=javascript_dialect,
+            )
+            if literal is not None:
+                return literal[2]
+        if text.startswith(text[quote_start : quote_start + 1] * 3, quote_start):
+            triple = triple_quoted_literal_span(
+                text,
+                quote_start,
+                len(text),
+                interpolation_dialect=javascript_dialect,
+            )
+            if triple is not None:
+                return triple[2]
+        if javascript_dialect in {"groovy", "kotlin"} and text[
+            quote_start : quote_start + 1
+        ] == '"':
+            return dollar_interpolated_quoted_literal_end(
+                text,
+                quote_start,
+                len(text),
+                dialect=javascript_dialect,
+            )
+        if quote_start > literal_start:
+            return csharp_quoted_literal_end(
+                text,
+                quote_start,
+                verbatim=False,
+                interpolated=False,
+            )
+        return None
+
+    spans: list[tuple[int, int]] = []
+    comment_ranges = source_secret_assignment_lexical_spans(
+        text,
+        javascript_dialect=javascript_dialect,
+    )[1]
+    for prefix in source_secret_assignment_prefixes(
+        text,
         javascript_dialect=javascript_dialect,
     ):
-        return []
-    candidates = [
-        literal
-        for pattern in SECRET_FALLBACK_LITERAL_PATTERNS
-        for literal in pattern.finditer(text, call_start + 1, call_end - 1)
-    ]
+        if position_in_ranges(prefix.start(), comment_ranges):
+            continue
+        literal_start = prefix.end()
+        if javascript_dialect == "groovy":
+            slashy = groovy_slashy_literal_span(
+                text,
+                literal_start,
+                len(text),
+            )
+            if slashy is not None:
+                value_start, value_end, _literal_end = slashy
+                (
+                    rendered_spans,
+                    nested_comments,
+                    numeric_spans,
+                    _expressions,
+                ) = groovy_slashy_rendered_literal_parts(
+                    text,
+                    value_start,
+                    value_end,
+                    dollar_slashy=text.startswith("$/", literal_start),
+                    nesting=0,
+                )
+                spans.extend(
+                    rendered_literal_candidate_spans(
+                        text,
+                        rendered_spans,
+                        dialect="groovy",
+                        comment_spans=nested_comments,
+                        numeric_source_spans=numeric_spans,
+                        references_are_source=False,
+                    )
+                )
+                continue
+        quote_start = structured_quote_start(literal_start)
+        if quote_start is None:
+            continue
+        quote = text[quote_start]
+        structured_marker = quote_start > literal_start or text.startswith(
+            quote * 3,
+            quote_start,
+        ) or javascript_dialect == "swift" or (
+            javascript_dialect in {"groovy", "kotlin"} and quote == '"'
+        )
+        if not structured_marker:
+            continue
+        try:
+            literal_end = structured_literal_end(literal_start, quote_start)
+        except SystemExit as exc:
+            if "unterminated" not in str(exc):
+                raise
+            literal_end = None
+        if literal_end is None:
+            spans.extend(
+                assignment_literal_spans(
+                    quote_start,
+                    len(text),
+                    allow_incomplete=True,
+                )
+            )
+            continue
+        spans.extend(assignment_literal_spans(quote_start, literal_end))
+    return sorted(set(spans))
+
+
+@functools.lru_cache(maxsize=8)
+def source_secret_assignment_lexical_spans(
+    text: str,
+    *,
+    javascript_dialect: str | None,
+) -> tuple[
+    tuple[tuple[int, int], ...],
+    tuple[tuple[int, int], ...],
+    tuple[tuple[int, int], ...],
+]:
+    if javascript_dialect is None:
+        return (), (), ()
+    all_comment_spans: list[tuple[int, int]] = []
+    literal_spans, comment_candidate_spans = quoted_literal_value_spans(
+        text,
+        0,
+        len(text),
+        javascript_dialect=javascript_dialect,
+        allow_incomplete=True,
+        collect_all_literals=True,
+        all_comment_spans=all_comment_spans,
+    )
+    comment_candidates = tuple(sorted(set(comment_candidate_spans)))
+    candidate_set = set(comment_candidates)
+    return (
+        tuple(sorted(span for span in literal_spans if span not in candidate_set)),
+        tuple(sorted(all_comment_spans)),
+        comment_candidates,
+    )
+
+
+def source_secret_assignment_excluded_ranges(
+    text: str,
+    *,
+    javascript_dialect: str | None,
+) -> tuple[tuple[int, int], ...]:
+    return source_secret_assignment_lexical_spans(
+        text,
+        javascript_dialect=javascript_dialect,
+    )[0]
+
+
+def standalone_comment_secret_spans(
+    text: str,
+    *,
+    javascript_dialect: str | None,
+) -> tuple[tuple[int, int], ...]:
+    comment_ranges = source_secret_assignment_lexical_spans(
+        text,
+        javascript_dialect=javascript_dialect,
+    )[1]
+    spans: list[tuple[int, int]] = []
+    for comment_start, comment_end in comment_ranges:
+        for match in SECRET_ASSIGNMENT_PATTERN.finditer(
+            text,
+            comment_start,
+            comment_end,
+        ):
+            if not secret_text_risk(
+                match.group(0),
+                javascript_dialect=javascript_dialect,
+            ):
+                continue
+            for name in (
+                "double_value",
+                "single_value",
+                "backtick_value",
+                "bare_value",
+            ):
+                if match.group(name) is not None:
+                    spans.append(match.span(name))
+                    break
+    return tuple(sorted(set(spans)))
+
+
+def standalone_literal_secret_spans(
+    text: str,
+    *,
+    javascript_dialect: str | None,
+) -> tuple[tuple[int, int], ...]:
+    literal_ranges = source_secret_assignment_lexical_spans(
+        text,
+        javascript_dialect=javascript_dialect,
+    )[0]
+    return secret_assignment_value_spans_in_ranges(
+        text,
+        literal_ranges,
+        javascript_dialect=javascript_dialect,
+    )
+
+
+def secret_assignment_value_spans_in_ranges(
+    text: str,
+    ranges: tuple[tuple[int, int], ...],
+    *,
+    javascript_dialect: str | None,
+) -> tuple[tuple[int, int], ...]:
+    spans: list[tuple[int, int]] = []
+    for range_start, range_end in ranges:
+        value = text[range_start:range_end]
+        if SECRET_ASSIGNMENT_PREFIX_PATTERN.search(value) is None:
+            continue
+        spans.extend(
+            (range_start + start, range_start + end)
+            for start, end in review_secret_value_spans(
+                value,
+                javascript_dialect=javascript_dialect,
+            )
+            if not secret_placeholder_value(value[start:end])
+        )
+    return tuple(sorted(set(spans)))
+
+
+def source_secret_assignment_matches(
+    pattern: re.Pattern[str],
+    text: str,
+    *,
+    javascript_dialect: str | None,
+) -> list[re.Match[str]]:
+    excluded_ranges = source_secret_assignment_excluded_ranges(
+        text,
+        javascript_dialect=javascript_dialect,
+    )
+    backtick_identifier_ranges = source_backtick_identifier_spans(
+        text,
+        dialect=javascript_dialect,
+    )
     return [
-        literal.span("value")
-        for literal in candidates
-        if len(literal.group("value")) >= 7
-        and any(char.isalpha() for char in literal.group("value"))
-        and any(char.isdigit() for char in literal.group("value"))
-        and literal.group("value").casefold() not in SECRET_PLACEHOLDER_VALUES
-        and not any(
-            pattern.fullmatch(literal.group("value"))
-            for pattern in QUOTED_SECRET_REFERENCE_PATTERNS
+        match
+        for match in pattern.finditer(text)
+        if not position_in_ranges(match.start(), excluded_ranges)
+        and not assignment_uses_source_backtick_identifier(
+            match,
+            backtick_identifier_ranges,
         )
     ]
+
+
+def source_secret_assignment_prefixes(
+    text: str,
+    *,
+    javascript_dialect: str | None,
+) -> list[re.Match[str]]:
+    return source_secret_assignment_matches(
+        SECRET_ASSIGNMENT_PREFIX_PATTERN,
+        text,
+        javascript_dialect=javascript_dialect,
+    )
+
+
+def secret_assignment_fallback_literal_spans(
+    text: str,
+    *,
+    javascript_dialect: str | None,
+) -> list[tuple[int, int]]:
+    spans: list[tuple[int, int]] = []
+    prefixes = (
+        source_secret_assignment_prefixes(
+            text,
+            javascript_dialect=javascript_dialect,
+        )
+        if javascript_dialect is not None
+        else list(SECRET_ASSIGNMENT_PREFIX_PATTERN.finditer(text))
+    )
+    for prefix in prefixes:
+        spans.extend(
+            python_floor_division_assignment_literal_spans(
+                text,
+                prefix,
+                javascript_dialect=javascript_dialect,
+            )
+        )
+        expression = fallback_expression(
+            text[prefix.end() :],
+            typescript=javascript_dialect == "typescript",
+            dialect=javascript_dialect,
+            allow_incomplete_raw=True,
+        )
+        expression_end = prefix.end() + len(expression)
+        operator_span = top_level_fallback_operator_span(
+            text,
+            prefix.end(),
+            expression_end,
+            dialect=javascript_dialect,
+        )
+        if operator_span is None:
+            continue
+        spans.extend(
+            top_level_fallback_value_spans(
+                text,
+                operator_span[1],
+                expression_end,
+                dialect=javascript_dialect,
+            )
+        )
+    return sorted(set(spans))
+
+
+def python_floor_division_assignment_literal_spans(
+    text: str,
+    match: re.Match[str],
+    *,
+    javascript_dialect: str | None,
+) -> list[tuple[int, int]]:
+    if javascript_dialect != "python":
+        return []
+    expression = fallback_expression(
+        text[match.end() :],
+        dialect="python",
+        allow_incomplete_raw=True,
+    )
+    expression_end = match.end() + len(expression)
+    if "//" not in text[match.end() : expression_end]:
+        return []
+    all_comment_spans: list[tuple[int, int]] = []
+    all_literal_spans, _ = quoted_literal_value_spans(
+        text,
+        match.end(),
+        expression_end,
+        javascript_dialect="python",
+        collect_all_literals=True,
+        all_comment_spans=all_comment_spans,
+    )
+    spans, _ = quoted_literal_value_spans(
+        text,
+        match.end(),
+        expression_end,
+        javascript_dialect="python",
+    )
+    excluded_ranges = tuple(sorted(all_literal_spans + all_comment_spans))
+    spans.extend(
+        span
+        for span in integer_literal_spans(
+            text,
+            match.end(),
+            expression_end,
+            dialect="python",
+        )
+        if not position_in_ranges(span[0], excluded_ranges)
+        and integer_literal_secret(text[span[0] : span[1]])
+    )
+    return sorted(set(spans))
 
 
 def review_repeatable_secret_spans(
@@ -5818,8 +11516,35 @@ def review_repeatable_secret_spans(
     *,
     javascript_dialect: str | None = None,
 ) -> list[tuple[int, int]]:
-    spans: list[tuple[int, int]] = []
-    for match in SECRET_ASSIGNMENT_PATTERN.finditer(text):
+    spans = sorted(
+        set(
+            structured_secret_assignment_literal_spans(
+                text,
+                javascript_dialect=javascript_dialect,
+            )
+            + secret_assignment_fallback_literal_spans(
+                text,
+                javascript_dialect=javascript_dialect,
+            )
+            + list(
+                standalone_literal_secret_spans(
+                    text,
+                    javascript_dialect=javascript_dialect,
+                )
+            )
+            + list(
+                standalone_comment_secret_spans(
+                    text,
+                    javascript_dialect=javascript_dialect,
+                )
+            )
+        )
+    )
+    for match in source_secret_assignment_matches(
+        SECRET_ASSIGNMENT_PATTERN,
+        text,
+        javascript_dialect=javascript_dialect,
+    ):
         selected_name = next(
             (
                 name
@@ -5836,6 +11561,28 @@ def review_repeatable_secret_spans(
             None,
         )
         if selected_name is None:
+            continue
+        if javascript_dialect == "swift" and swift_interpolated_assignment_value(
+            text,
+            match,
+        ):
+            continue
+        if groovy_kotlin_interpolated_assignment_value(
+            text,
+            match,
+            dialect=javascript_dialect,
+        ):
+            continue
+        if javascript_dialect == "groovy" and groovy_slashy_assignment_value(
+            text,
+            match,
+        ):
+            continue
+        if any(
+            match.start(selected_name) <= start
+            and end <= match.end(selected_name)
+            for start, end in spans
+        ):
             continue
         if safe_self_reference_assignment(
             text,
@@ -5855,12 +11602,20 @@ def review_repeatable_secret_spans(
         if fallback_spans:
             spans.extend(fallback_spans)
             continue
+        spans.extend(
+            python_floor_division_assignment_literal_spans(
+                text,
+                match,
+                javascript_dialect=javascript_dialect,
+            )
+        )
         if selected_name == "call_value":
             spans.extend(
                 review_call_literal_spans(
                     text,
                     match,
                     javascript_dialect=javascript_dialect,
+                    redact_incomplete_call=True,
                 )
             )
             continue
@@ -5892,8 +11647,35 @@ def review_secret_value_spans(
     *,
     javascript_dialect: str | None = None,
 ) -> list[tuple[int, int]]:
-    spans: list[tuple[int, int]] = []
-    for match in SECRET_ASSIGNMENT_PATTERN.finditer(text):
+    spans = sorted(
+        set(
+            structured_secret_assignment_literal_spans(
+                text,
+                javascript_dialect=javascript_dialect,
+            )
+            + secret_assignment_fallback_literal_spans(
+                text,
+                javascript_dialect=javascript_dialect,
+            )
+            + list(
+                standalone_literal_secret_spans(
+                    text,
+                    javascript_dialect=javascript_dialect,
+                )
+            )
+            + list(
+                standalone_comment_secret_spans(
+                    text,
+                    javascript_dialect=javascript_dialect,
+                )
+            )
+        )
+    )
+    for match in source_secret_assignment_matches(
+        SECRET_ASSIGNMENT_PATTERN,
+        text,
+        javascript_dialect=javascript_dialect,
+    ):
         for name in (
             "double_value",
             "single_value",
@@ -5903,6 +11685,27 @@ def review_secret_value_spans(
             "bare_value",
         ):
             if match.group(name) is not None:
+                if javascript_dialect == "swift" and swift_interpolated_assignment_value(
+                    text,
+                    match,
+                ):
+                    break
+                if groovy_kotlin_interpolated_assignment_value(
+                    text,
+                    match,
+                    dialect=javascript_dialect,
+                ):
+                    break
+                if javascript_dialect == "groovy" and groovy_slashy_assignment_value(
+                    text,
+                    match,
+                ):
+                    break
+                if any(
+                    match.start(name) <= start and end <= match.end(name)
+                    for start, end in spans
+                ):
+                    break
                 if safe_self_reference_assignment(
                     text,
                     match,
@@ -5921,6 +11724,13 @@ def review_secret_value_spans(
                 if fallback_spans:
                     spans.extend(fallback_spans)
                     break
+                spans.extend(
+                    python_floor_division_assignment_literal_spans(
+                        text,
+                        match,
+                        javascript_dialect=javascript_dialect,
+                    )
+                )
                 if name == "call_value":
                     spans.extend(
                         review_call_literal_spans(
@@ -5974,6 +11784,43 @@ def redact_review_spans(text: str, spans: list[tuple[int, int]]) -> str:
     return "".join(parts)
 
 
+def redact_review_replacements(
+    text: str,
+    spans: list[tuple[int, int]],
+    labeled_spans: list[tuple[int, int, str | None]],
+) -> str:
+    replacements = [(start, end, None) for start, end in spans]
+    replacements.extend(labeled_spans)
+    components: list[tuple[int, int, set[str]]] = []
+    for start, end, label in sorted(replacements, key=lambda item: (item[0], item[1])):
+        if start >= end:
+            continue
+        labels = {label} if label is not None else set()
+        if components and start <= components[-1][1]:
+            previous_start, previous_end, previous_labels = components[-1]
+            components[-1] = (
+                previous_start,
+                max(previous_end, end),
+                previous_labels | labels,
+            )
+        else:
+            components.append((start, end, labels))
+    if not components:
+        return text
+    parts: list[str] = []
+    cursor = 0
+    for start, end, labels in components:
+        replacement = (
+            "redacted-" + "-".join(sorted(labels))
+            if labels
+            else "redacted"
+        )
+        parts.extend((text[cursor:start], replacement))
+        cursor = end
+    parts.append(text[cursor:])
+    return "".join(parts)
+
+
 def known_secret_fragment_pattern(fragments: list[str]) -> re.Pattern[str] | None:
     if not fragments:
         return None
@@ -5990,41 +11837,374 @@ def known_secret_fragment_spans(
     return [match.span("fragment") for match in pattern.finditer(text)]
 
 
-def repeated_secret_fragment_spans(
+def local_spans_by_line(
+    text: str,
+    spans: list[tuple[int, int]],
+) -> dict[int, set[tuple[int, int]]]:
+    line_starts = [0]
+    line_starts.extend(match.end() for match in re.finditer(r"\n", text))
+    by_line: dict[int, set[tuple[int, int]]] = {}
+    for start, end in sorted(spans):
+        cursor = start
+        while cursor < end:
+            line_index = max(0, bisect.bisect_right(line_starts, cursor) - 1)
+            line_start = line_starts[line_index]
+            next_line_start = (
+                line_starts[line_index + 1]
+                if line_index + 1 < len(line_starts)
+                else len(text)
+            )
+            line_end = next_line_start
+            if line_index + 1 < len(line_starts):
+                line_end -= 1
+                if line_end > line_start and text[line_end - 1] == "\r":
+                    line_end -= 1
+            segment_end = min(end, line_end)
+            if cursor < segment_end:
+                by_line.setdefault(line_index, set()).add(
+                    (cursor - line_start, segment_end - line_start)
+                )
+            if end <= line_end or line_index + 1 >= len(line_starts):
+                break
+            cursor = next_line_start
+    return by_line
+
+
+def interpolation_source_ranges(
+    text: str,
+    *,
+    javascript_dialect: str | None,
+) -> tuple[tuple[int, int], ...]:
+    ranges: list[tuple[int, int]] = []
+    if is_javascript_review_dialect(javascript_dialect):
+        template_ranges = javascript_template_literal_ranges(
+            text,
+            allow_incomplete=True,
+        ) or []
+        for template_start, template_end in template_ranges:
+            spans, _, _ = javascript_template_value_spans(
+                text,
+                template_start,
+                template_end,
+                allow_incomplete=True,
+            )
+            ranges.extend(
+                spans_outside_ranges(
+                    template_start,
+                    template_end,
+                    sorted(spans),
+                )
+            )
+        return tuple(ranges)
+    if javascript_dialect in {"scala", "swift"}:
+        cursor = 0
+        while cursor < len(text):
+            quote = text.find('"', cursor)
+            if quote < 0:
+                break
+            literal = swift_scala_literal_span(
+                text,
+                quote,
+                len(text),
+                dialect=javascript_dialect,
+            )
+            if literal is None:
+                cursor = quote + 1
+                continue
+            value_start, value_end, literal_end = literal
+            expression_spans = swift_scala_interpolation_expression_spans(
+                text,
+                value_start,
+                value_end,
+                dialect=javascript_dialect,
+                quote_start=quote,
+            )
+            for expression_start, expression_end in expression_spans:
+                inner = interpolation_expression_inner_bounds(
+                    text,
+                    expression_start,
+                    expression_end,
+                    dialect=javascript_dialect,
+                )
+                if inner is None:
+                    ranges.append((expression_start, expression_end))
+                    continue
+                nested_literals, _ = quoted_literal_value_spans(
+                    text,
+                    inner[0],
+                    inner[1],
+                    javascript_dialect=javascript_dialect,
+                    allow_incomplete=True,
+                    collect_all_literals=True,
+                )
+                ranges.extend(
+                    spans_outside_ranges(
+                        expression_start,
+                        expression_end,
+                        nested_literals,
+                    )
+                )
+            cursor = literal_end
+        return tuple(ranges)
+    if javascript_dialect in {"groovy", "kotlin"}:
+        cursor = 0
+        while cursor < len(text):
+            if text[cursor : cursor + 1] != '"':
+                cursor += 1
+                continue
+            triple = (
+                triple_quoted_literal_span(
+                    text,
+                    cursor,
+                    len(text),
+                    interpolation_dialect=javascript_dialect,
+                )
+                if text.startswith('"""', cursor)
+                else None
+            )
+            if triple is not None:
+                value_start, value_end, literal_end = triple
+            else:
+                literal_end = dollar_interpolated_quoted_literal_end(
+                    text,
+                    cursor,
+                    len(text),
+                    dialect=javascript_dialect,
+                )
+                if literal_end is None:
+                    cursor += 1
+                    continue
+                value_start = cursor + 1
+                value_end = literal_end - 1
+            interpolation_width = dollar_interpolation_width(
+                text,
+                cursor,
+                dialect=javascript_dialect,
+            )
+            expression_spans = dollar_interpolation_expression_spans(
+                text,
+                value_start,
+                value_end,
+                dialect=javascript_dialect,
+                interpolation_width=interpolation_width,
+                raw=javascript_dialect == "kotlin" and triple is not None,
+            )
+            for expression_start, expression_end in expression_spans:
+                if not text.startswith(
+                    "$" * interpolation_width + "{",
+                    expression_start,
+                ):
+                    ranges.append((expression_start, expression_end))
+                    continue
+                nested_literals, _ = quoted_literal_value_spans(
+                    text,
+                    expression_start + interpolation_width + 1,
+                    expression_end - 1,
+                    javascript_dialect=javascript_dialect,
+                    allow_incomplete=True,
+                    collect_all_literals=True,
+                )
+                ranges.extend(
+                    spans_outside_ranges(
+                        expression_start,
+                        expression_end,
+                        nested_literals,
+                    )
+                )
+            cursor = literal_end
+        return tuple(ranges)
+    if javascript_dialect not in {"csharp", "python"}:
+        return ()
+    cursor = 0
+    while cursor < len(text):
+        structured = structured_literal_parts(
+            text,
+            cursor,
+            len(text),
+            dialect=javascript_dialect,
+            allow_incomplete_raw=True,
+        )
+        if structured is None:
+            if javascript_dialect == "csharp" and text[cursor] == '"':
+                quote_run_end = repeated_character_end(
+                    text,
+                    cursor,
+                    len(text),
+                    '"',
+                )
+                if quote_run_end - cursor >= 3:
+                    cursor = quote_run_end
+                    continue
+            cursor += 1
+            continue
+        literal_end = structured[2]
+        spans, _ = quoted_literal_value_spans(
+            text,
+            cursor,
+            literal_end,
+            javascript_dialect=javascript_dialect,
+            allow_incomplete=True,
+            collect_all_literals=True,
+        )
+        ranges.extend(
+            spans_outside_ranges(
+                cursor,
+                literal_end,
+                sorted(spans),
+            )
+        )
+        cursor = literal_end
+    return tuple(ranges)
+
+
+def interpolation_source_fragment_line_spans(
     text: str,
     pattern: re.Pattern[str] | None,
-) -> list[tuple[int, int]]:
+    *,
+    javascript_dialect: str | None,
+) -> dict[int, set[tuple[int, int]]]:
+    source_ranges = interpolation_source_ranges(
+        text,
+        javascript_dialect=javascript_dialect,
+    )
+    source_spans = [
+        (start, end)
+        for start, end in known_secret_fragment_spans(text, pattern)
+        if position_in_ranges(start, source_ranges)
+    ]
+    return local_spans_by_line(text, source_spans)
+
+
+def comment_fragment_line_spans(
+    text: str,
+    pattern: re.Pattern[str] | None,
+    *,
+    javascript_dialect: str | None,
+) -> dict[int, set[tuple[int, int]]]:
+    if pattern is None:
+        return {}
+    fragment_spans = known_secret_fragment_spans(text, pattern)
+    if not fragment_spans:
+        return {}
+    all_comment_spans: list[tuple[int, int]] = []
+    quoted_literal_value_spans(
+        text,
+        0,
+        len(text),
+        javascript_dialect=javascript_dialect,
+        allow_incomplete=True,
+        all_comment_spans=all_comment_spans,
+    )
+    comment_ranges = tuple(all_comment_spans)
+    comment_fragments = [
+        (start, end)
+        for start, end in fragment_spans
+        if position_in_ranges(start, comment_ranges)
+    ]
+    return local_spans_by_line(text, comment_fragments)
+
+
+def repeated_secret_fragment_replacements(
+    text: str,
+    pattern: re.Pattern[str] | None,
+    labels: dict[str, str | None],
+    forced_spans: set[tuple[int, int]] | None = None,
+    source_spans: set[tuple[int, int]] | None = None,
+    *,
+    javascript_dialect: str | None = None,
+) -> list[tuple[int, int, str | None]]:
     matches = known_secret_fragment_spans(text, pattern)
-    contexts = string_contexts_at(text, {start for start, _ in matches})
-    spans: list[tuple[int, int]] = []
+    contexts = string_contexts_at(
+        text,
+        {start for start, _ in matches},
+        javascript_dialect=javascript_dialect,
+    )
+    replacements: list[tuple[int, int, str | None]] = []
     for start, end in matches:
+        value = text[start:end]
+        if (start, end) in (forced_spans or set()):
+            replacements.append((start, end, labels.get(value)))
+            continue
+        if (start, end) in (source_spans or set()):
+            continue
         token_start = start
         while token_start > 0 and re.match(r"[A-Za-z0-9_$.-]", text[token_start - 1]):
             token_start -= 1
         token_end = end
         while token_end < len(text) and re.match(r"[A-Za-z0-9_$.-]", text[token_end]):
             token_end += 1
+        context = contexts[start]
         key_position = re.match(
             r"\s*(?:=(?!=|>)|:(?![:=]))",
             text[token_end:],
         ) is not None
         unquoted_token_substring = (
-            contexts[start] is None
+            context is None
             and (token_start < start or end < token_end)
         )
         unquoted_identifier = (
-            contexts[start] is None
+            context is None
             and token_start == start
             and token_end == end
             and re.fullmatch(r"[A-Za-z_$][A-Za-z0-9_$.-]*", text[start:end])
             is not None
         )
-        if contexts[start] is None and (
+        if context is None and (
             key_position or unquoted_token_substring or unquoted_identifier
         ):
             continue
-        spans.append((start, end))
-    return spans
+        replacements.append((start, end, labels.get(value)))
+    return replacements
+
+
+def forced_secret_line_spans(
+    text: str,
+    *,
+    javascript_dialect: str | None = None,
+) -> dict[int, set[tuple[int, int]]]:
+    spans = review_repeatable_secret_spans(
+        text,
+        javascript_dialect=javascript_dialect,
+    )
+    if not spans:
+        return {}
+    contexts = string_contexts_at(
+        text,
+        {start for start, _ in spans},
+        javascript_dialect=javascript_dialect,
+    )
+    literal_spans, comment_spans = quoted_literal_value_spans(
+        text,
+        0,
+        len(text),
+        javascript_dialect=javascript_dialect,
+        allow_incomplete=True,
+    )
+    literal_span_set = set(literal_spans)
+    comment_span_set = set(comment_spans)
+    fallback_span_set = set(
+        secret_assignment_fallback_literal_spans(
+            text,
+            javascript_dialect=javascript_dialect,
+        )
+    )
+    forced = [
+        (start, end)
+        for start, end in spans
+        if (
+            (start, end) in literal_span_set
+            or (start, end) in comment_span_set
+            or (start, end) in fallback_span_set
+            or (
+                (context := contexts[start]) is not None
+                and (
+                    len(context[0]) >= 3
+                    or any(char in "\r\n" for char in text[context[1] : start])
+                )
+            )
+        )
+    ]
+    return local_spans_by_line(text, forced)
 
 
 def private_key_body_spans(text: str) -> list[tuple[int, int]]:
@@ -6141,12 +12321,25 @@ def orphan_private_key_body_spans(text: str) -> list[tuple[int, int]]:
     return [match.span() for match in matches]
 
 
-def bare_source_identifier_span(text: str, start: int, end: int) -> bool:
+def source_identifier_use_span(
+    text: str,
+    start: int,
+    end: int,
+    *,
+    masked_text: str | None = None,
+    string_context: tuple[str, int] | None = None,
+) -> bool:
     if re.fullmatch(r"[A-Za-z_$][A-Za-z0-9_$]*", text[start:end]) is None:
         return False
-    before = text[:start].rstrip()[-1:]
-    after = text[end:].lstrip()[:1]
-    return before in {"=", "+", "(", "[", "{", ",", ":"} and after in {
+    line_start = max(text.rfind("\n", 0, start), text.rfind("\r", 0, start)) + 1
+    if text[line_start:start].lstrip().startswith(("#", "//", "/*", "*")):
+        return False
+    before = text[:start].rstrip(" \t")[-1:]
+    suffix = text[end:]
+    whitespace = re.match(r"[ \t]*", suffix)
+    assert whitespace is not None
+    after = suffix[whitespace.end() : whitespace.end() + 1]
+    if before in {"=", "+", "(", "[", "{", ",", ":"} and after in {
         "+",
         ")",
         "]",
@@ -6154,7 +12347,41 @@ def bare_source_identifier_span(text: str, start: int, end: int) -> bool:
         ",",
         ";",
         ":",
-    }
+    }:
+        return True
+    masked = (
+        mask_reference_declaration_evidence(text)
+        if masked_text is None
+        else masked_text
+    )
+    if masked[start:end] != text[start:end]:
+        return False
+    suffix = masked[end:]
+    whitespace = re.match(r"[ \t]*", suffix)
+    assert whitespace is not None
+    after = suffix[whitespace.end() : whitespace.end() + 1]
+    return string_context is None and after == "("
+
+
+def private_key_body_only_line_span(text: str, start: int, end: int) -> bool:
+    line_start = max(text.rfind("\n", 0, start), text.rfind("\r", 0, start)) + 1
+    line_end_candidates = [
+        position
+        for position in (text.find("\n", end), text.find("\r", end))
+        if position >= 0
+    ]
+    line_end = min(line_end_candidates, default=len(text))
+    wrapper = text[line_start:start] + text[end:line_end]
+    return re.fullmatch(
+        r"(?:(?:#|//|/\*|\*)\s*)?[\s\\\"'`,;+\[\]]*"
+        r"(?:\*/[\s\\\"'`,;+\[\]]*)?",
+        wrapper.strip(),
+    ) is not None
+
+
+def private_key_line_uses_comment_wrapper(text: str, start: int) -> bool:
+    line_start = max(text.rfind("\n", 0, start), text.rfind("\r", 0, start)) + 1
+    return text[line_start:start].lstrip().startswith(("#", "//", "/*", "*"))
 
 
 def explicit_private_key_body_spans(
@@ -6181,15 +12408,25 @@ def explicit_private_key_body_spans(
     if escaped_body_only:
         return candidates
     contexts = string_contexts_at(text, {start for start, _ in candidates})
-    wrapped = {match.span() for match in wrapped_private_key_body_matches(text)}
+    evidence_spans = set(markerless_private_key_body_spans(text))
+    masked_text = mask_reference_declaration_evidence(text)
     return [
         (start, end)
         for start, end in candidates
-        if not bare_source_identifier_span(text, start, end)
+        if not source_identifier_use_span(
+            text,
+            start,
+            end,
+            masked_text=masked_text,
+            string_context=contexts[start],
+        )
         and (
-            (start, end) in wrapped
-            or contexts[start] is not None
-            or any(char.isdigit() or char in "+/=" for char in text[start:end])
+            contexts[start] is not None
+            or (start, end) in evidence_spans
+            or (
+                private_key_body_only_line_span(text, start, end)
+                and not private_key_line_uses_comment_wrapper(text, start)
+            )
         )
     ]
 
@@ -6482,7 +12719,7 @@ def redact_unbalanced_private_key_hunks(section: str) -> tuple[str, set[str]]:
                 for start, end in spans
                 if (start, end) not in marker_spans
                 and (fragment := normalized_private_key_fragment(content, start, end))
-                and fragment.casefold() not in SECRET_PLACEHOLDER_VALUES
+                and not secret_placeholder_value(fragment)
             )
             redacted[line_index] = (
                 f"{prefix}{redact_review_spans(content, spans)}{ending}"
@@ -6495,6 +12732,7 @@ def redact_secret_like_hunk_headers(
     section: str,
     expected_paths: set[str],
     known_secret_fragments: set[str] | None = None,
+    fragment_labels: dict[str, str | None] | None = None,
 ) -> str:
     old_path, new_path = diff_section_paths(section)
     dialects = {
@@ -6526,10 +12764,16 @@ def redact_secret_like_hunk_headers(
             for pattern in (PRIVATE_KEY_BEGIN_PATTERN, PRIVATE_KEY_END_PATTERN)
             for match in pattern.finditer(raw_header_section)
         ]
-        header_section = redact_review_spans(
+        header_section = redact_review_replacements(
             raw_header_section,
-            marker_spans
-            + known_secret_fragment_spans(raw_header_section, fragment_pattern),
+            marker_spans,
+            [
+                (start, end, (fragment_labels or {}).get(raw_header_section[start:end]))
+                for start, end in known_secret_fragment_spans(
+                    raw_header_section,
+                    fragment_pattern,
+                )
+            ],
         )
         # Never replace a still-risky header wholesale: doing so can hide an
         # unextracted value that repeats in otherwise innocuous diff content.
@@ -6576,14 +12820,14 @@ def review_hunk_header_secret_fragments(
                 fragment = normalized_private_key_fragment(segment, start, end)
                 if (
                     fragment
-                    and fragment.casefold() not in SECRET_PLACEHOLDER_VALUES
+                    and not secret_placeholder_value(fragment)
                 ):
                     fragments.add(fragment)
         for start, end in markerless_private_key_body_spans(header_section):
             fragment = normalized_private_key_fragment(header_section, start, end)
             if (
                 fragment
-                and fragment.casefold() not in SECRET_PLACEHOLDER_VALUES
+                and not secret_placeholder_value(fragment)
             ):
                 fragments.add(fragment)
         for dialect in dialects:
@@ -6607,6 +12851,7 @@ def redact_secret_like_diff_section(
     section: str,
     expected_paths: set[str],
     known_secret_fragments: set[str] | None = None,
+    fragment_labels: dict[str, str | None] | None = None,
 ) -> str:
     old_path, new_path = diff_section_paths(section)
     old_dialect = (
@@ -6621,6 +12866,14 @@ def redact_secret_like_diff_section(
     )
     secret_fragments = set(known_secret_fragments or ())
     old_content, new_content = unified_diff_contents(section)
+    old_forced_spans = forced_secret_line_spans(
+        old_content,
+        javascript_dialect=old_dialect,
+    )
+    new_forced_spans = forced_secret_line_spans(
+        new_content,
+        javascript_dialect=new_dialect,
+    )
     old_risk = secret_text_risk(old_content, javascript_dialect=old_dialect)
     new_risk = secret_text_risk(new_content, javascript_dialect=new_dialect)
     for content, dialect, risk in (
@@ -6645,11 +12898,37 @@ def redact_secret_like_diff_section(
         key=lambda fragment: (-len(fragment), fragment),
     )
     fragment_pattern = known_secret_fragment_pattern(ordered_secret_fragments)
+    old_source_spans = interpolation_source_fragment_line_spans(
+        old_content,
+        fragment_pattern,
+        javascript_dialect=old_dialect,
+    )
+    new_source_spans = interpolation_source_fragment_line_spans(
+        new_content,
+        fragment_pattern,
+        javascript_dialect=new_dialect,
+    )
+    old_comment_spans = comment_fragment_line_spans(
+        old_content,
+        fragment_pattern,
+        javascript_dialect=old_dialect,
+    )
+    new_comment_spans = comment_fragment_line_spans(
+        new_content,
+        fragment_pattern,
+        javascript_dialect=new_dialect,
+    )
+    section_fragment_labels = {
+        fragment: (fragment_labels or {}).get(fragment)
+        for fragment in ordered_secret_fragments
+    }
     redacted: list[str] = []
     lines = literal_lf_lines(section)
     index = 0
     old_pem = False
     new_pem = False
+    old_line_index = 1
+    new_line_index = 1
     while index < len(lines):
         line = lines[index]
         if not line.startswith("@@"):
@@ -6664,6 +12943,8 @@ def redact_secret_like_diff_section(
         assert prefix_match is not None
         prefix_columns = len(prefix_match.group(1)) - 1
         redacted.append(line)
+        old_line_index += 1
+        new_line_index += 1
         for content_line in lines[index + 1 : hunk_end]:
             body = content_line.rstrip("\r\n")
             ending = content_line[len(body) :]
@@ -6674,6 +12955,28 @@ def redact_secret_like_diff_section(
             content = body[prefix_columns:]
             old_line = set(prefix) == {" "} or "-" in prefix
             new_line = set(prefix) == {" "} or "+" in prefix
+            old_side_forced = (
+                old_forced_spans.get(old_line_index, set())
+                | old_comment_spans.get(old_line_index, set())
+                if old_line
+                else set()
+            )
+            new_side_forced = (
+                new_forced_spans.get(new_line_index, set())
+                | new_comment_spans.get(new_line_index, set())
+                if new_line
+                else set()
+            )
+            forced_spans = (
+                old_side_forced & new_side_forced
+                if old_line and new_line and old_dialect != new_dialect
+                else old_side_forced | new_side_forced
+            )
+            source_spans: set[tuple[int, int]] = set()
+            if old_line:
+                source_spans.update(old_source_spans.get(old_line_index, set()))
+            if new_line:
+                source_spans.update(new_source_spans.get(new_line_index, set()))
             spans: list[tuple[int, int]] = []
             line_secret_risk = (
                 old_line
@@ -6685,23 +12988,63 @@ def redact_secret_like_diff_section(
                 and secret_text_risk(content, javascript_dialect=new_dialect)
             )
             if line_secret_risk:
-                dialect = old_dialect if old_line and old_risk else new_dialect
+                dialect = (
+                    new_dialect
+                    if new_line and new_risk
+                    else old_dialect
+                )
                 spans.extend(
                     review_secret_value_spans(
                         content,
                         javascript_dialect=dialect,
                     )
                 )
-            spans.extend(repeated_secret_fragment_spans(content, fragment_pattern))
+            fragment_replacements = repeated_secret_fragment_replacements(
+                content,
+                fragment_pattern,
+                section_fragment_labels,
+                forced_spans,
+                source_spans,
+                javascript_dialect=new_dialect if new_line else old_dialect,
+            )
+            spans.extend(forced_spans - source_spans)
             spans.extend(match.span() for match in PRIVATE_KEY_END_PATTERN.finditer(content))
             if old_line:
                 old_spans, old_pem = pem_line_body_spans(content, old_pem)
                 spans.extend(old_spans)
+                fragment_replacements.extend(
+                    (
+                        start,
+                        end,
+                        section_fragment_labels.get(
+                            normalized_private_key_fragment(content, start, end)
+                        ),
+                    )
+                    for start, end in old_spans
+                )
             if new_line:
                 new_spans, new_pem = pem_line_body_spans(content, new_pem)
                 spans.extend(new_spans)
-            redacted_content = redact_review_spans(content, spans)
+                fragment_replacements.extend(
+                    (
+                        start,
+                        end,
+                        section_fragment_labels.get(
+                            normalized_private_key_fragment(content, start, end)
+                        ),
+                    )
+                    for start, end in new_spans
+                )
+            redacted_content = redact_review_replacements(
+                content,
+                spans,
+                fragment_replacements,
+            )
             redacted.append(f"{prefix}{redacted_content}{ending}")
+            if old_line:
+                old_line_index += 1
+            if new_line:
+                new_line_index += 1
         index = hunk_end
     return "".join(redacted)
 
@@ -6830,6 +13173,22 @@ def javascript_review_dialect(rel: str) -> str | None:
         return "typescript"
     if suffix in {".cjs", ".js", ".jsx", ".mjs"}:
         return "javascript"
+    if suffix in {".py", ".pyi", ".pyw"}:
+        return "python"
+    if suffix == ".cs":
+        return "csharp"
+    if suffix in {".kt", ".kts"}:
+        return "kotlin"
+    if suffix in {".groovy", ".gradle"}:
+        return "groovy"
+    if suffix == ".java":
+        return "java"
+    if suffix == ".swift":
+        return "swift"
+    if suffix in {".scala", ".sc"}:
+        return "scala"
+    if suffix in {".c", ".cc", ".cpp", ".cxx", ".h", ".hh", ".hpp", ".hxx", ".mm"}:
+        return "c-family"
     return None
 
 
@@ -6906,6 +13265,10 @@ def validate_review_patch(
     patch: str,
     limit: int | None = None,
 ) -> str:
+    original_bare_redacted = any(
+        match.group(0).casefold() == "redacted"
+        for match in REDACTED_PLACEHOLDER_CANDIDATE_PATTERN.finditer(patch)
+    )
     blocked = [
         f"{display_escape(rel, 500)} ({risk})"
         for rel in paths
@@ -6949,6 +13312,15 @@ def validate_review_patch(
                 if rel is not None and rel in expected_paths
                 else None
             )
+            if javascript_dialect == "csharp":
+                quoted_literal_value_spans(
+                    content,
+                    0,
+                    len(content),
+                    javascript_dialect="csharp",
+                    allow_incomplete=True,
+                    collect_all_literals=True,
+                )
             all_fragments = review_secret_fragments(
                 content,
                 javascript_dialect=javascript_dialect,
@@ -6962,11 +13334,71 @@ def validate_review_patch(
             "refusing review bundle with too many distinct secret-like values "
             f"({len(known_secret_fragments)}; limit {MAX_REVIEW_SECRET_FRAGMENTS})"
         )
+    identity_fragments: dict[str, None] = {}
+    for unit in units:
+        if not unit.startswith("diff --git "):
+            continue
+        old_path, new_path = diff_section_paths(unit)
+        old_content, new_content = unified_diff_contents(unit)
+        for rel, content in ((old_path, old_content), (new_path, new_content)):
+            javascript_dialect = (
+                javascript_review_dialect(rel)
+                if rel is not None and rel in expected_paths
+                else None
+            )
+            for fragment in review_repeatable_secret_fragment_values(
+                content,
+                javascript_dialect=javascript_dialect,
+            ):
+                if PRIVATE_KEY_BEGIN_PATTERN.fullmatch(
+                    fragment
+                ) or PRIVATE_KEY_END_PATTERN.fullmatch(fragment):
+                    continue
+                identity_fragments.setdefault(fragment, None)
+            for fragment in sorted(
+                private_key_body_fragments(content),
+                key=content.find,
+            ):
+                if not secret_placeholder_value(fragment):
+                    identity_fragments.setdefault(fragment, None)
+        for fragment in sorted(
+            review_hunk_header_secret_fragments(unit, expected_paths),
+            key=lambda value: unit.find(value),
+        ):
+            identity_fragments.setdefault(fragment, None)
+    reserved_labels: set[str] = set()
+    for match in REDACTED_PLACEHOLDER_CANDIDATE_PATTERN.finditer(patch):
+        placeholder = match.group(0)
+        if redacted_placeholder_value(placeholder):
+            reserved_labels.update(placeholder.casefold().split("-")[1:])
+    global_fragment_labels = {
+        fragment: None
+        for fragment in known_secret_fragments
+    }
+    if len(identity_fragments) > 1 or (
+        identity_fragments and original_bare_redacted
+    ):
+        available_labels = [
+            review_fragment_label(index)
+            for index in range(MAX_REVIEW_SECRET_FRAGMENTS)
+            if review_fragment_label(index) not in reserved_labels
+        ]
+        if len(available_labels) < len(identity_fragments):
+            raise SystemExit(
+                "refusing review bundle without enough collision-free redaction labels"
+            )
+        global_fragment_labels.update(
+            {
+                fragment: available_labels[index]
+                for index, fragment in enumerate(identity_fragments)
+            }
+        )
     patch = "".join(
         redact_secret_like_hunk_headers(
             unit,
             expected_paths,
             known_secret_fragments,
+            global_fragment_labels,
         )
         if unit.startswith("diff --git ")
         else unit
@@ -6979,6 +13411,7 @@ def validate_review_patch(
             unit,
             expected_paths,
             known_secret_fragments,
+            global_fragment_labels,
         )
         if unit.startswith("diff --git ")
         else unit

--- a/skills/autoreview/tests/test_autoreview_hardening.py
+++ b/skills/autoreview/tests/test_autoreview_hardening.py
@@ -983,6 +983,18 @@ class AutoreviewHardeningTests(unittest.TestCase):
             with self.subTest(content=content):
                 self.assertTrue(self.helper["secret_text_risk"](content))
 
+    def test_secret_detector_rejects_separated_numeric_template_literal(
+        self,
+    ) -> None:
+        content = "pass" + "word = decode(`${12_345_678}`)"
+
+        self.assertTrue(
+            self.helper["secret_text_risk"](
+                content,
+                javascript_dialect="typescript",
+            )
+        )
+
     def test_secret_detector_rejects_op_backtick_shell_fallbacks(self) -> None:
         content = (
             "pass"
@@ -1011,6 +1023,43 @@ class AutoreviewHardeningTests(unittest.TestCase):
         )
 
         self.assertTrue(self.helper["secret_text_risk"](content))
+
+    def test_secret_detector_allows_supported_credential_member_chains(
+        self,
+    ) -> None:
+        for dialect, value in (
+            ("csharp", "credentials.Value"),
+            ("csharp", "options->Credentials.Value"),
+            ("java", "options.Credentials.Current"),
+            ("java", "credentialStore::getPassword"),
+            ("kotlin", "options.Credentials.Current"),
+            ("kotlin", "credentials::password"),
+            ("python", "credentials.value"),
+            ("c-family", "Credentials::Value"),
+            ("c-family", "options->credentials.Value"),
+        ):
+            with self.subTest(dialect=dialect, value=value):
+                self.assertFalse(
+                    self.helper["secret_text_risk"](
+                        f"password = {value};",
+                        javascript_dialect=dialect,
+                    )
+                )
+
+    def test_secret_detector_scans_c_family_member_call_arguments(self) -> None:
+        fixture_value = "CorrectHorse7" + "Battery"
+        for expression in (
+            f'credentials->get("{fixture_value}")',
+            f'credentials::get("{fixture_value}")',
+            f'credentials->get()->decode("{fixture_value}")',
+        ):
+            with self.subTest(expression=expression):
+                self.assertTrue(
+                    self.helper["secret_text_risk"](
+                        f"password = {expression}",
+                        javascript_dialect="c-family",
+                    )
+                )
 
     def test_secret_detector_rejects_reference_shaped_fallback_literals(self) -> None:
         content = (
@@ -1247,6 +1296,8 @@ class AutoreviewHardeningTests(unittest.TestCase):
             + f'ken = provider.issue_token(value<Array<number>> / total || "{literal_value}"[0] / count)',
             "var await = value; to"
             + f'ken = provider.issue_token(await / total || "{literal_value}"[0] / count)',
+            "function f(await, d) { to"
+            + 'ken = provider.issue_token(await / 2, "Abc\\\\123Def456" / d) }',
             "var yield = value; to"
             + f'ken = provider.issue_token(yield / total || "{literal_value}"[0] / count)',
             "to"
@@ -1413,8 +1464,6 @@ class AutoreviewHardeningTests(unittest.TestCase):
             "to"
             + 'ken = get_token(a / fn(x) / b)\nreport("actual-production-secret")',
             "to"
-            + 'ken = get_token(await /\\)"actual-production-secret"/, process.env.TOKEN)',
-            "to"
             + 'ken = get_token(await /\\)/, /x)"actual-production-secret"/, process.env.TOKEN)',
             "to"
             + "ken = get_token(await /\\)/, process.env.TOKEN) || process.env.FALLBACK",
@@ -1426,8 +1475,10 @@ class AutoreviewHardeningTests(unittest.TestCase):
 
     def test_regex_parser_accepts_expression_keyword_contexts(self) -> None:
         for content in (
+            "async function f() { return await /\\)/; }",
             "class C extends /\\)/.constructor {}",
             "export default /\\)/;",
+            "function* f() { return yield /\\)/; }",
         ):
             with self.subTest(content=content):
                 start = content.index("/")
@@ -1546,6 +1597,8 @@ class AutoreviewHardeningTests(unittest.TestCase):
             "to" + 'ken = input ("Enter API to' + 'ken: ")',
             "api" + 'Key = prompt("Enter API key: ")',
             "api" + 'Key = prompt("Enter API key: ", defaultApiKey)',
+            "pass" + 'word = ui.prompt("Enter password for Service2")',
+            "pass" + 'word = ui?.prompt("Enter password for Service2")',
         ):
             with self.subTest(content=content):
                 self.assertFalse(self.helper["secret_text_risk"](content))
@@ -1593,6 +1646,8 @@ class AutoreviewHardeningTests(unittest.TestCase):
             "pass"
             + "word = in"
             + 'put("correct horse battery staple?")',
+            "pass"
+            + 'word = attacker.prompt("Enter password for Horse7battery")',
             "access_"
             + "to"
             + 'ken = custom_client.get_token("correct-horse-battery-staple")',
@@ -2470,6 +2525,23 @@ class AutoreviewHardeningTests(unittest.TestCase):
             self.helper["javascript_review_dialect"]("module.cts"),
             "typescript",
         )
+        self.assertIsNone(self.helper["javascript_review_dialect"]("module.m"))
+        self.assertEqual(
+            self.helper["javascript_review_dialect"]("module.mm"),
+            "c-family",
+        )
+        for rel, dialect in (
+            ("module.kt", "kotlin"),
+            ("module.kts", "kotlin"),
+            ("module.groovy", "groovy"),
+            ("module.gradle", "groovy"),
+            ("module.java", "java"),
+        ):
+            with self.subTest(rel=rel):
+                self.assertEqual(
+                    self.helper["javascript_review_dialect"](rel),
+                    dialect,
+                )
 
     def test_secret_detector_allows_generated_fixture_credentials(self) -> None:
         property_name = "pass" + "word"
@@ -3878,6 +3950,52 @@ class AutoreviewHardeningTests(unittest.TestCase):
         self.assertNotIn(fixture_value, redacted_patch)
         self.assertIn('+  || "redacted";', redacted_patch)
 
+    def test_review_patch_redacts_multiline_triple_fallback_literal(self) -> None:
+        first = "Prod" + "Secret123"
+        second = "Tail" + "456"
+        key = "password"
+        quote = '"' * 3
+        patch = (
+            "diff --git a/runtime.py b/runtime.py\n"
+            "--- a/runtime.py\n"
+            "+++ b/runtime.py\n"
+            "@@ -0,0 +1,2 @@\n"
+            f"+{key} = primary or {quote}{first}\n"
+            f"+{second}{quote}\n"
+        )
+
+        redacted_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["runtime.py"],
+            patch,
+        )
+
+        self.assertNotIn(first, redacted_patch)
+        self.assertNotIn(second, redacted_patch)
+        self.assertIn(f"{quote}redacted\n+redacted{quote}", redacted_patch)
+
+    def test_review_patch_preserves_python_fallback_interpolation_source(
+        self,
+    ) -> None:
+        key = "pass" + "word"
+        source = f'{key} = primary or f"{{exfiltrate()}}"'
+        patch = (
+            "diff --git a/runtime.py b/runtime.py\n"
+            "--- a/runtime.py\n"
+            "+++ b/runtime.py\n"
+            "@@ -0,0 +1 @@\n"
+            f"+{source}\n"
+        )
+
+        self.assertEqual(
+            self.helper["validate_review_patch"](
+                "local unstaged diff",
+                ["runtime.py"],
+                patch,
+            ),
+            patch,
+        )
+
     def test_review_patch_preserves_and_rejects_ambiguous_multiline_call_value(
         self,
     ) -> None:
@@ -3912,6 +4030,4609 @@ class AutoreviewHardeningTests(unittest.TestCase):
         self.assertIn("+pass" + "word = decode(", validated_patch)
         self.assertIn('+    "redacted",', validated_patch)
 
+    def test_review_patch_redacts_valid_multiline_template_call(self) -> None:
+        first = "".join(("Abc", "123"))
+        second = "".join(("Def", "456"))
+        key = "pass" + "word"
+        source = f"{key} = decode(`{first}\n{second}`);"
+        patch = (
+            "diff --git a/runtime.ts b/runtime.ts\n"
+            "--- a/runtime.ts\n"
+            "+++ b/runtime.ts\n"
+            "@@ -0,0 +1,2 @@\n"
+            + "".join(f"+{line}\n" for line in source.splitlines())
+        )
+
+        redacted_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["runtime.ts"],
+            patch,
+        )
+
+        self.assertNotIn(first, redacted_patch)
+        self.assertNotIn(second, redacted_patch)
+        self.assertIn("decode(`redacted-a\n+redacted-b`)", redacted_patch)
+
+    def test_review_patch_redacts_complete_escaped_call_literal(self) -> None:
+        fixture_value = 'abc123\\"); /*SensitiveTail9*/ //'
+        patch = (
+            "diff --git a/runtime.ts b/runtime.ts\n"
+            "--- a/runtime.ts\n"
+            "+++ b/runtime.ts\n"
+            "@@ -0,0 +1 @@\n"
+            + "+pass"
+            + f'word = decode("{fixture_value}");\n'
+        )
+
+        redacted_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["runtime.ts"],
+            patch,
+        )
+
+        self.assertNotIn("SensitiveTail9", redacted_patch)
+        self.assertIn('decode("redacted")', redacted_patch)
+
+    def test_review_patch_redacts_nested_template_call_literal(self) -> None:
+        patch = (
+            "diff --git a/runtime.ts b/runtime.ts\n"
+            "--- a/runtime.ts\n"
+            "+++ b/runtime.ts\n"
+            "@@ -0,0 +1 @@\n"
+            + "+pass"
+            + "word = decode(`abc1234${`SensitiveTail9${exfiltrate()}`}`);\n"
+        )
+
+        redacted_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["runtime.ts"],
+            patch,
+        )
+
+        self.assertNotIn("SensitiveTail9", redacted_patch)
+        self.assertIn("exfiltrate()", redacted_patch)
+        self.assertIn(
+            "decode(`redacted-a${`redacted-b${exfiltrate()}`}`)",
+            redacted_patch,
+        )
+
+    def test_review_patch_redacts_multiline_template_literal_per_line(self) -> None:
+        first = "Abc123"
+        second = "Def456"
+        patch = (
+            "diff --git a/runtime.ts b/runtime.ts\n"
+            "--- a/runtime.ts\n"
+            "+++ b/runtime.ts\n"
+            "@@ -0,0 +1,2 @@\n"
+            + "+pass"
+            + f"word = decode(`{first}\n"
+            + f"+{second}`);\n"
+        )
+
+        redacted_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["runtime.ts"],
+            patch,
+        )
+
+        self.assertNotIn(first, redacted_patch)
+        self.assertNotIn(second, redacted_patch)
+        self.assertIn("decode(`redacted-a\n+redacted-b`)", redacted_patch)
+
+    def test_review_patch_redacts_bigint_template_interpolation_literal(self) -> None:
+        bigint = "12345678901234567890n"
+        patch = (
+            "diff --git a/runtime.ts b/runtime.ts\n"
+            "--- a/runtime.ts\n"
+            "+++ b/runtime.ts\n"
+            "@@ -0,0 +1 @@\n"
+            + "+pass"
+            + f"word = decode(`prefix${{{bigint}}}`);\n"
+        )
+
+        redacted_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["runtime.ts"],
+            patch,
+        )
+
+        self.assertNotIn(bigint, redacted_patch)
+        self.assertIn("${redacted-b}", redacted_patch)
+
+    def test_review_patch_redacts_numeric_looking_template_text(self) -> None:
+        fixture_value = "123456789012.0"
+        patch = (
+            "diff --git a/runtime.ts b/runtime.ts\n"
+            "--- a/runtime.ts\n"
+            "+++ b/runtime.ts\n"
+            "@@ -0,0 +1 @@\n"
+            + "+pass"
+            + f"word = decode(`{fixture_value}`);\n"
+        )
+
+        redacted_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["runtime.ts"],
+            patch,
+        )
+
+        self.assertNotIn(fixture_value, redacted_patch)
+        self.assertIn("decode(`redacted`)", redacted_patch)
+
+    def test_review_patch_repeats_numeric_looking_template_redaction(self) -> None:
+        fixture_value = "123456789012.0"
+        patch = (
+            "diff --git a/runtime.ts b/runtime.ts\n"
+            "--- a/runtime.ts\n"
+            "+++ b/runtime.ts\n"
+            "@@ -0,0 +1,2 @@\n"
+            f"+password = decode(`{fixture_value}`);\n"
+            f'+log("{fixture_value}");\n'
+        )
+
+        redacted_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["runtime.ts"],
+            patch,
+        )
+
+        self.assertNotIn(fixture_value, redacted_patch)
+        self.assertIn('+log("redacted");', redacted_patch)
+
+    def test_review_patch_redacts_integral_javascript_decimal_literals(
+        self,
+    ) -> None:
+        for fixture_value in ("12345678.0", "1.2345678e7"):
+            with self.subTest(fixture_value=fixture_value):
+                patch = (
+                    "diff --git a/runtime.ts b/runtime.ts\n"
+                    "--- a/runtime.ts\n"
+                    "+++ b/runtime.ts\n"
+                    "@@ -0,0 +1 @@\n"
+                    f"+password = decode(`${{{fixture_value}}}`);\n"
+                )
+
+                redacted_patch = self.helper["validate_review_patch"](
+                    "local unstaged diff",
+                    ["runtime.ts"],
+                    patch,
+                )
+
+                self.assertNotIn(fixture_value, redacted_patch)
+                self.assertIn("decode(`${redacted}`)", redacted_patch)
+
+    def test_review_patch_preserves_numeric_source_beside_secret_literal(
+        self,
+    ) -> None:
+        numeric_source = "0.123456789012"
+        fixture_value = "ProdSecret123"
+        patch = (
+            "diff --git a/runtime.ts b/runtime.ts\n"
+            "--- a/runtime.ts\n"
+            "+++ b/runtime.ts\n"
+            "@@ -0,0 +1 @@\n"
+            + "+pass"
+            + f'word = decode(`${{{numeric_source}}}`, "{fixture_value}");\n'
+        )
+
+        redacted_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["runtime.ts"],
+            patch,
+        )
+
+        self.assertIn(f"${{{numeric_source}}}", redacted_patch)
+        self.assertNotIn(fixture_value, redacted_patch)
+        self.assertIn('"redacted"', redacted_patch)
+
+    def test_review_patch_redacts_bigint_before_member_access(self) -> None:
+        fixture_value = "12345678n"
+        patch = (
+            "diff --git a/runtime.ts b/runtime.ts\n"
+            "--- a/runtime.ts\n"
+            "+++ b/runtime.ts\n"
+            "@@ -0,0 +1 @@\n"
+            + "+pass"
+            + "word = decode(`${"
+            + fixture_value
+            + ".toString()}`);\n"
+        )
+
+        redacted_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["runtime.ts"],
+            patch,
+        )
+
+        self.assertNotIn(fixture_value, redacted_patch)
+        self.assertIn("${redacted.toString()}", redacted_patch)
+
+    def test_review_patch_redacts_decimal_integer_before_member_access(self) -> None:
+        fixture_value = "12345678"
+        cases = (
+            (
+                "runtime.ts",
+                "`prefix${" + fixture_value + "..toString()}`",
+                "..toString()}",
+            ),
+            (
+                "runtime.cs",
+                '$"prefix{' + fixture_value + '.ToString()}"',
+                ".ToString()}",
+            ),
+            (
+                "runtime.kt",
+                '"prefix${' + fixture_value + '.toString()}"',
+                ".toString()}",
+            ),
+            (
+                "runtime.groovy",
+                '"prefix${' + fixture_value + '.toString()}"',
+                ".toString()}",
+            ),
+        )
+        for rel, literal, expected in cases:
+            with self.subTest(rel=rel):
+                patch = (
+                    f"diff --git a/{rel} b/{rel}\n"
+                    f"--- a/{rel}\n"
+                    f"+++ b/{rel}\n"
+                    "@@ -0,0 +1 @@\n"
+                    + "+pass"
+                    + f"word = decode({literal})\n"
+                )
+
+                redacted_patch = self.helper["validate_review_patch"](
+                    "local unstaged diff",
+                    [rel],
+                    patch,
+                )
+
+                self.assertNotIn(fixture_value, redacted_patch)
+                self.assertIn("redacted", redacted_patch)
+                self.assertIn(expected, redacted_patch)
+
+    def test_review_patch_preserves_template_interpolation_source_expression(self) -> None:
+        literal = "10000000"
+        expression = f"process.env.API_TOKEN+{literal}"
+        patch = (
+            "diff --git a/runtime.ts b/runtime.ts\n"
+            "--- a/runtime.ts\n"
+            "+++ b/runtime.ts\n"
+            "@@ -0,0 +1 @@\n"
+            + "+pass"
+            + f"word = decode(`${{{expression}}}`);\n"
+        )
+
+        redacted_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["runtime.ts"],
+            patch,
+        )
+
+        self.assertNotIn(literal, redacted_patch)
+        self.assertIn("${process.env.API_TOKEN+redacted}", redacted_patch)
+
+    def test_review_patch_redacts_template_comment_and_regex_literals(self) -> None:
+        fixture_value = "Abc123Def456"
+        for expression, expected in (
+            (f"value /* {fixture_value} */", "value /* redacted */"),
+            (f"/{fixture_value}/.source", "/redacted/.source"),
+            (f"await /{fixture_value}/", "await /redacted/"),
+            (f"yield /{fixture_value}/", "yield /redacted/"),
+        ):
+            with self.subTest(expression=expression):
+                patch = (
+                    "diff --git a/runtime.ts b/runtime.ts\n"
+                    "--- a/runtime.ts\n"
+                    "+++ b/runtime.ts\n"
+                    "@@ -0,0 +1 @@\n"
+                    + "+pass"
+                    + f"word = decode(`${{{expression}}}`);\n"
+                )
+
+                redacted_patch = self.helper["validate_review_patch"](
+                    "local unstaged diff",
+                    ["runtime.ts"],
+                    patch,
+                )
+
+                self.assertNotIn(fixture_value, redacted_patch)
+                self.assertIn(expected, redacted_patch)
+
+    def test_review_patch_redacts_javascript_regex_source(self) -> None:
+        fixture_value = "Abc123Def456"
+        patch = (
+            "diff --git a/runtime.ts b/runtime.ts\n"
+            "--- a/runtime.ts\n"
+            "+++ b/runtime.ts\n"
+            "@@ -0,0 +1 @@\n"
+            f"+password = decode(/{fixture_value}/.source);\n"
+        )
+
+        redacted_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["runtime.ts"],
+            patch,
+        )
+
+        self.assertNotIn(fixture_value, redacted_patch)
+        self.assertIn("decode(/redacted/.source)", redacted_patch)
+
+    def test_review_patch_stops_javascript_regex_at_unicode_terminator(
+        self,
+    ) -> None:
+        fixture_value = "Abc" + "1234"
+        key = "pass" + "word"
+        separator = chr(0x2028)
+        source = f"{key} = decode(/x{separator}`{fixture_value}`/)"
+        patch = (
+            "diff --git a/runtime.ts b/runtime.ts\n"
+            "--- a/runtime.ts\n"
+            "+++ b/runtime.ts\n"
+            "@@ -0,0 +1 @@\n"
+            f"+{source}\n"
+        )
+
+        redacted_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["runtime.ts"],
+            patch,
+        )
+
+        self.assertNotIn(fixture_value, redacted_patch)
+        self.assertIn(separator, redacted_patch)
+
+    def test_review_patch_redacts_aggregated_java_and_c_family_literals(
+        self,
+    ) -> None:
+        key = "password"
+        first = "abc" + "123"
+        second = "def" + "456"
+        cases = (
+            (
+                "Runtime.java",
+                f'{key} = decode("{first}" + "{second}");',
+            ),
+            (
+                "runtime.cpp",
+                f'{key} = decode("{first}" "{second}");',
+            ),
+        )
+        for rel, source in cases:
+            with self.subTest(rel=rel):
+                patch = (
+                    f"diff --git a/{rel} b/{rel}\n"
+                    f"--- a/{rel}\n"
+                    f"+++ b/{rel}\n"
+                    "@@ -0,0 +1 @@\n"
+                    f"+{source}\n"
+                )
+
+                redacted_patch = self.helper["validate_review_patch"](
+                    "local unstaged diff",
+                    [rel],
+                    patch,
+                )
+
+                self.assertNotIn(first, redacted_patch)
+                self.assertNotIn(second, redacted_patch)
+
+    def test_review_patch_redacts_alphabetic_template_comment_literal(self) -> None:
+        fixture_value = "abcdefghijklmnop"
+        patch = (
+            "diff --git a/runtime.ts b/runtime.ts\n"
+            "--- a/runtime.ts\n"
+            "+++ b/runtime.ts\n"
+            "@@ -0,0 +1 @@\n"
+            + "+pass"
+            + f'word = decode(`${{value /* "{fixture_value}" */}}`)\n'
+        )
+
+        redacted_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["runtime.ts"],
+            patch,
+        )
+
+        self.assertNotIn(fixture_value, redacted_patch)
+        self.assertIn('/* "redacted" */', redacted_patch)
+
+    def test_review_patch_preserves_benign_template_interpolation_comments(
+        self,
+    ) -> None:
+        comment = "credential comes from the vault"
+        patch = (
+            "diff --git a/runtime.ts b/runtime.ts\n"
+            "--- a/runtime.ts\n"
+            "+++ b/runtime.ts\n"
+            "@@ -0,0 +1 @@\n"
+            + "+pass"
+            + f"word = decode(`${{value /* {comment} */}}`);\n"
+        )
+
+        redacted_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["runtime.ts"],
+            patch,
+        )
+
+        self.assertIn(comment, redacted_patch)
+
+    def test_review_patch_redacts_public_call_template_comment(self) -> None:
+        fixture_value = "Abc1234"
+        patch = (
+            "diff --git a/runtime.ts b/runtime.ts\n"
+            "--- a/runtime.ts\n"
+            "+++ b/runtime.ts\n"
+            "@@ -0,0 +1 @@\n"
+            + "+pass"
+            + f"word = prompt(`${{value/*{fixture_value}*/}}`);\n"
+        )
+
+        redacted_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["runtime.ts"],
+            patch,
+        )
+
+        self.assertNotIn(fixture_value, redacted_patch)
+        self.assertIn("${value/*redacted*/}", redacted_patch)
+
+    def test_review_patch_preserves_qualified_public_prompt_text(self) -> None:
+        for target in ("ui.prompt", "ui?.prompt"):
+            source = f'{target}("Enter password for Service2")'
+            with self.subTest(target=target):
+                patch = (
+                    "diff --git a/runtime.ts b/runtime.ts\n"
+                    "--- a/runtime.ts\n"
+                    "+++ b/runtime.ts\n"
+                    "@@ -0,0 +1 @@\n"
+                    + "+pass"
+                    + f"word = {source};\n"
+                )
+
+                redacted_patch = self.helper["validate_review_patch"](
+                    "local unstaged diff",
+                    ["runtime.ts"],
+                    patch,
+                )
+
+                self.assertIn(source, redacted_patch)
+
+    def test_review_patch_redacts_structured_public_prompt_literals(self) -> None:
+        fixture_value = "Abc123" + "Def456"
+        key = "password"
+        quote = '"' * 3
+        cases = (
+            (
+                "Runtime.java",
+                f"String {key} = ui.prompt({quote}\n{fixture_value}\n{quote});",
+                f"{quote}\n+redacted\n+{quote}",
+            ),
+            (
+                "runtime.cpp",
+                f'auto {key} = ui.prompt(R"({fixture_value})");',
+                'R"(redacted)"',
+            ),
+        )
+        for rel, source, expected in cases:
+            with self.subTest(rel=rel):
+                added_source = "+" + source.replace("\n", "\n+")
+                line_count = source.count("\n") + 1
+                patch = (
+                    f"diff --git a/{rel} b/{rel}\n"
+                    f"--- a/{rel}\n"
+                    f"+++ b/{rel}\n"
+                    f"@@ -0,0 +1,{line_count} @@\n"
+                    f"{added_source}\n"
+                )
+
+                redacted_patch = self.helper["validate_review_patch"](
+                    "local unstaged diff",
+                    [rel],
+                    patch,
+                )
+
+                self.assertNotIn(fixture_value, redacted_patch)
+                self.assertIn(expected, redacted_patch)
+
+    def test_review_patch_preserves_safe_credential_lookup_arguments(self) -> None:
+        key = "password"
+        source = f'{key} = headers.get("Authorization")'
+        patch = (
+            "diff --git a/runtime.ts b/runtime.ts\n"
+            "--- a/runtime.ts\n"
+            "+++ b/runtime.ts\n"
+            "@@ -0,0 +1 @@\n"
+            f"+{source}\n"
+        )
+
+        self.assertEqual(
+            self.helper["validate_review_patch"](
+                "local unstaged diff",
+                ["runtime.ts"],
+                patch,
+            ),
+            patch,
+        )
+
+    def test_review_patch_redacts_noninterpolating_reference_literals(
+        self,
+    ) -> None:
+        key = "password"
+        literal = "${VERY_LONG_" + "PASSWORD_ENVIRONMENT_VARIABLE}"
+        for rel in ("Runtime.java", "runtime.cpp"):
+            with self.subTest(rel=rel):
+                source = f'{key} = decode("{literal}")'
+                patch = (
+                    f"diff --git a/{rel} b/{rel}\n"
+                    f"--- a/{rel}\n"
+                    f"+++ b/{rel}\n"
+                    "@@ -0,0 +1 @@\n"
+                    f"+{source}\n"
+                )
+
+                redacted_patch = self.helper["validate_review_patch"](
+                    "local unstaged diff",
+                    [rel],
+                    patch,
+                )
+
+                self.assertNotIn(literal, redacted_patch)
+                self.assertIn('decode("redacted")', redacted_patch)
+
+    def test_review_patch_allows_template_continuing_beyond_hunk(self) -> None:
+        patch = (
+            "diff --git a/runtime.ts b/runtime.ts\n"
+            "--- a/runtime.ts\n"
+            "+++ b/runtime.ts\n"
+            "@@ -0,0 +1 @@\n"
+            "+const text = `value ${name}\n"
+        )
+
+        redacted_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["runtime.ts"],
+            patch,
+        )
+
+        self.assertIn("`value ${name}", redacted_patch)
+
+    def test_review_patch_redacts_known_secret_in_incomplete_template_tail(
+        self,
+    ) -> None:
+        fixture_value = "ProdSecret123"
+        patch = (
+            "diff --git a/runtime.ts b/runtime.ts\n"
+            "--- a/runtime.ts\n"
+            "+++ b/runtime.ts\n"
+            "@@ -1 +1 @@\n"
+            + "-pass"
+            + f'word = "{fixture_value}"\n'
+            + f"+const text = `prefix {fixture_value}\n"
+        )
+
+        redacted_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["runtime.ts"],
+            patch,
+        )
+
+        self.assertNotIn(fixture_value, redacted_patch)
+        self.assertIn("+const text = `prefix redacted", redacted_patch)
+
+    def test_review_patch_allows_inner_string_continuing_beyond_hunk(self) -> None:
+        patch = (
+            "diff --git a/runtime.ts b/runtime.ts\n"
+            "--- a/runtime.ts\n"
+            "+++ b/runtime.ts\n"
+            "@@ -0,0 +1 @@\n"
+            "+const text = `value ${\"continued\\\n"
+        )
+
+        redacted_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["runtime.ts"],
+            patch,
+        )
+
+        self.assertIn('`value ${"continued\\', redacted_patch)
+
+    def test_review_patch_redacts_known_secret_in_incomplete_inner_string(
+        self,
+    ) -> None:
+        fixture_value = "ProdSecret123"
+        patch = (
+            "diff --git a/runtime.ts b/runtime.ts\n"
+            "--- a/runtime.ts\n"
+            "+++ b/runtime.ts\n"
+            "@@ -1 +1 @@\n"
+            f'-password = "{fixture_value}"\n'
+            f'+const text = `prefix ${{"{fixture_value}\n'
+        )
+
+        redacted_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["runtime.ts"],
+            patch,
+        )
+
+        self.assertNotIn(fixture_value, redacted_patch)
+        self.assertIn('${"redacted', redacted_patch)
+
+    def test_review_patch_handles_javascript_template_comment_terminators(
+        self,
+    ) -> None:
+        fixture_value = "Abc1234"
+        for terminator in ("\r", "\u2028", "\u2029"):
+            with self.subTest(terminator=repr(terminator)):
+                patch = (
+                    "diff --git a/runtime.ts b/runtime.ts\n"
+                    "--- a/runtime.ts\n"
+                    "+++ b/runtime.ts\n"
+                    "@@ -0,0 +1 @@\n"
+                    + "+pass"
+                    + f"word = decode(`${{value//{fixture_value}{terminator}}}suffix`);\n"
+                )
+
+                redacted_patch = self.helper["validate_review_patch"](
+                    "local unstaged diff",
+                    ["runtime.ts"],
+                    patch,
+                )
+
+                self.assertNotIn(fixture_value, redacted_patch)
+                self.assertIn(
+                    f"//redacted{terminator}}}suffix",
+                    redacted_patch,
+                )
+
+    def test_review_patch_handles_unicode_terminator_in_javascript_call_comment(
+        self,
+    ) -> None:
+        fixture_value = "Abc1234"
+        terminator = "\u2028"
+        patch = (
+            "diff --git a/runtime.ts b/runtime.ts\n"
+            "--- a/runtime.ts\n"
+            "+++ b/runtime.ts\n"
+            "@@ -0,0 +1 @@\n"
+            + "+pass"
+            + f'word = runCommand(value, // note{terminator}"{fixture_value}");\n'
+        )
+
+        redacted_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["runtime.ts"],
+            patch,
+        )
+
+        self.assertNotIn(fixture_value, redacted_patch)
+        self.assertIn(f'// note{terminator}"redacted"', redacted_patch)
+
+    def test_review_patch_redacts_combined_short_template_literals(self) -> None:
+        first = "Abc123"
+        second = "Def456"
+        interpolations = '${"' + first + '"}${"' + second + '"}'
+        patch = (
+            "diff --git a/runtime.ts b/runtime.ts\n"
+            "--- a/runtime.ts\n"
+            "+++ b/runtime.ts\n"
+            "@@ -0,0 +1 @@\n"
+            + "+pass"
+            + f"word = decode(`{interpolations}`);\n"
+        )
+
+        redacted_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["runtime.ts"],
+            patch,
+        )
+
+        self.assertNotIn(first, redacted_patch)
+        self.assertNotIn(second, redacted_patch)
+        self.assertIn("decode(`${\"redacted-a\"}${\"redacted-b\"}`)", redacted_patch)
+
+    def test_review_patch_aggregates_template_literals_across_comments(
+        self,
+    ) -> None:
+        key = "password"
+        first = "Abc" + "123"
+        second = "Def" + "456"
+        expressions = (
+            f'${{"{first}" /* note */ + "{second}"}}',
+            f'${{"{first}" // note\n + "{second}"}}',
+        )
+        for expression in expressions:
+            with self.subTest(expression=expression):
+                source = f"{key} = decode(`{expression}`);"
+                lines = source.splitlines()
+                patch = (
+                    "diff --git a/runtime.ts b/runtime.ts\n"
+                    "--- a/runtime.ts\n"
+                    "+++ b/runtime.ts\n"
+                    f"@@ -0,0 +1,{len(lines)} @@\n"
+                    + "".join(f"+{line}\n" for line in lines)
+                )
+
+                redacted_patch = self.helper["validate_review_patch"](
+                    "local unstaged diff",
+                    ["runtime.ts"],
+                    patch,
+                )
+
+                self.assertNotIn(first, redacted_patch)
+                self.assertNotIn(second, redacted_patch)
+                self.assertIn("note", redacted_patch)
+
+    def test_review_patch_redacts_combined_short_numeric_template_literals(self) -> None:
+        first = "1234"
+        second = "5678"
+        patch = (
+            "diff --git a/runtime.ts b/runtime.ts\n"
+            "--- a/runtime.ts\n"
+            "+++ b/runtime.ts\n"
+            "@@ -0,0 +1 @@\n"
+            + "+pass"
+            + f"word = decode(`${{{first}}}${{{second}}}`);\n"
+        )
+
+        redacted_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["runtime.ts"],
+            patch,
+        )
+
+        self.assertNotIn(first, redacted_patch)
+        self.assertNotIn(second, redacted_patch)
+        self.assertIn("decode(`${redacted}${redacted}`)", redacted_patch)
+
+    def test_review_patch_redacts_literals_inside_call_comments(self) -> None:
+        fixture_value = "ProdSecret123"
+        patch = (
+            "diff --git a/runtime.ts b/runtime.ts\n"
+            "--- a/runtime.ts\n"
+            "+++ b/runtime.ts\n"
+            "@@ -0,0 +1 @@\n"
+            + "+pass"
+            + f'word = decode(/* "{fixture_value}" */ value);\n'
+        )
+
+        redacted_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["runtime.ts"],
+            patch,
+        )
+
+        self.assertNotIn(fixture_value, redacted_patch)
+        self.assertIn('decode(/* "redacted" */ value)', redacted_patch)
+
+    def test_review_patch_allows_block_comment_continuing_beyond_hunk(self) -> None:
+        patch = (
+            "diff --git a/runtime.ts b/runtime.ts\n"
+            "--- a/runtime.ts\n"
+            "+++ b/runtime.ts\n"
+            "@@ -0,0 +1 @@\n"
+            "+run(value /* comment continues beyond available context\n"
+        )
+
+        redacted_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["runtime.ts"],
+            patch,
+        )
+
+        self.assertIn("comment continues beyond available context", redacted_patch)
+
+    def test_review_patch_redacts_distinct_literals_inside_public_call_comments(
+        self,
+    ) -> None:
+        first = "Abc1234"
+        second = "Def5678"
+        patch = (
+            "diff --git a/runtime.ts b/runtime.ts\n"
+            "--- a/runtime.ts\n"
+            "+++ b/runtime.ts\n"
+            "@@ -0,0 +1,2 @@\n"
+            + f'+password = prompt(/* "{first}" */);\n'
+            + "+to"
+            + f'ken = prompt(/* "{second}" */);\n'
+        )
+
+        redacted_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["runtime.ts"],
+            patch,
+        )
+
+        self.assertNotIn(first, redacted_patch)
+        self.assertNotIn(second, redacted_patch)
+        self.assertIn('prompt(/* "redacted-a" */)', redacted_patch)
+        self.assertIn('prompt(/* "redacted-b" */)', redacted_patch)
+
+    def test_review_patch_scans_after_python_floor_division(self) -> None:
+        fixture_value = "ProdSecret123"
+        patch = (
+            "diff --git a/runtime.py b/runtime.py\n"
+            "--- a/runtime.py\n"
+            "+++ b/runtime.py\n"
+            "@@ -0,0 +1 @@\n"
+            + "+pass"
+            + f'word = decode(100 // 25, "{fixture_value}")\n'
+        )
+
+        redacted_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["runtime.py"],
+            patch,
+        )
+
+        self.assertNotIn(fixture_value, redacted_patch)
+        self.assertIn('decode(100 // 25, "redacted")', redacted_patch)
+
+    def test_review_patch_preserves_identifier_after_python_floor_division(self) -> None:
+        identifier = "ProdSecret123"
+        patch = (
+            "diff --git a/runtime.py b/runtime.py\n"
+            "--- a/runtime.py\n"
+            "+++ b/runtime.py\n"
+            "@@ -0,0 +1 @@\n"
+            + "+pass"
+            + f"word = decode(total // {identifier})\n"
+        )
+
+        redacted_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["runtime.py"],
+            patch,
+        )
+
+        self.assertIn(identifier, redacted_patch)
+
+    def test_review_patch_redacts_secret_after_python_assignment_floor_division(
+        self,
+    ) -> None:
+        fixture_value = "Prod" + "Secret123"
+        key = "pass" + "word"
+        source = f'{key} = seed // divisor + decode("{fixture_value}")'
+        patch = (
+            "diff --git a/runtime.py b/runtime.py\n"
+            "--- a/runtime.py\n"
+            "+++ b/runtime.py\n"
+            "@@ -0,0 +1 @@\n"
+            f"+{source}\n"
+        )
+
+        redacted_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["runtime.py"],
+            patch,
+        )
+
+        self.assertNotIn(fixture_value, redacted_patch)
+        self.assertIn('// divisor + decode("redacted")', redacted_patch)
+
+    def test_review_patch_bounds_python_floor_division_at_semicolon(self) -> None:
+        fixture_value = "Prod" + "Secret123"
+        key = "pass" + "word"
+        source = f'{key} = total // 2; log("{fixture_value}")'
+        patch = (
+            "diff --git a/runtime.py b/runtime.py\n"
+            "--- a/runtime.py\n"
+            "+++ b/runtime.py\n"
+            "@@ -0,0 +1 @@\n"
+            f"+{source}\n"
+        )
+
+        self.assertEqual(
+            self.helper["validate_review_patch"](
+                "local unstaged diff",
+                ["runtime.py"],
+                patch,
+            ),
+            patch,
+        )
+
+    def test_review_patch_redacts_python_floor_division_integer_secrets(
+        self,
+    ) -> None:
+        fixture_value = "12345678"
+        cases = (
+            f"password = primary // {fixture_value}",
+            f"password = decode(total // {fixture_value})",
+        )
+        for source in cases:
+            with self.subTest(source=source):
+                patch = (
+                    "diff --git a/runtime.py b/runtime.py\n"
+                    "--- a/runtime.py\n"
+                    "+++ b/runtime.py\n"
+                    "@@ -0,0 +1 @@\n"
+                    f"+{source}\n"
+                )
+
+                redacted_patch = self.helper["validate_review_patch"](
+                    "local unstaged diff",
+                    ["runtime.py"],
+                    patch,
+                )
+
+                self.assertNotIn(fixture_value, redacted_patch)
+                self.assertIn("redacted", redacted_patch)
+
+    def test_review_patch_redacts_python_call_floor_division_suffix(self) -> None:
+        fixture_value = "Prod" + "Secret123"
+        source = f'password = get_value() // divisor + "{fixture_value}"'
+        patch = (
+            "diff --git a/runtime.py b/runtime.py\n"
+            "--- a/runtime.py\n"
+            "+++ b/runtime.py\n"
+            "@@ -0,0 +1 @@\n"
+            f"+{source}\n"
+        )
+
+        redacted_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["runtime.py"],
+            patch,
+        )
+
+        self.assertNotIn(fixture_value, redacted_patch)
+        self.assertIn(' + "redacted"', redacted_patch)
+
+    def test_review_patch_redacts_fallback_after_javascript_private_field(
+        self,
+    ) -> None:
+        fixture_value = "Prod" + "Secret123"
+        key = "pass" + "word"
+        source = f'{key} = this.#primary || "{fixture_value}";'
+        patch = (
+            "diff --git a/runtime.ts b/runtime.ts\n"
+            "--- a/runtime.ts\n"
+            "+++ b/runtime.ts\n"
+            "@@ -0,0 +1 @@\n"
+            f"+{source}\n"
+        )
+
+        redacted_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["runtime.ts"],
+            patch,
+        )
+
+        self.assertNotIn(fixture_value, redacted_patch)
+        self.assertIn('this.#primary || "redacted"', redacted_patch)
+
+    def test_review_patch_preserves_slash_comment_delimiters(self) -> None:
+        fixture_value = "Prod123"
+        for path in ("runtime.cc", "runtime.scala"):
+            with self.subTest(path=path):
+                patch = (
+                    f"diff --git a/{path} b/{path}\n"
+                    + f"--- a/{path}\n"
+                    + f"+++ b/{path}\n"
+                    + "@@ -0,0 +1,2 @@\n"
+                    + "+pass"
+                    + "word = runCommand(value, // apparent close )\n"
+                    + f'+  "{fixture_value}");\n'
+                )
+
+                redacted_patch = self.helper["validate_review_patch"](
+                    "local unstaged diff",
+                    [path],
+                    patch,
+                )
+
+                self.assertNotIn(fixture_value, redacted_patch)
+                self.assertIn('// apparent close )\n+  "redacted"', redacted_patch)
+
+    def test_review_patch_keeps_unicode_separator_inside_java_comment(self) -> None:
+        fixture_value = "ProdSecret123"
+        separator = "\u2028"
+        patch = (
+            "diff --git a/runtime.java b/runtime.java\n"
+            "--- a/runtime.java\n"
+            "+++ b/runtime.java\n"
+            "@@ -0,0 +1,2 @@\n"
+            + "+pass"
+            + f"word = runCommand(value, // apparent close {separator})\n"
+            + f'+  "{fixture_value}");\n'
+        )
+
+        redacted_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["runtime.java"],
+            patch,
+        )
+
+        self.assertNotIn(fixture_value, redacted_patch)
+        self.assertIn(
+            f"// apparent close {separator})\n+  \"redacted\"",
+            redacted_patch,
+        )
+
+    def test_review_patch_skips_regex_delimiters_in_ruby_and_swift(self) -> None:
+        fixture_value = "Prod123"
+        for path in ("runtime.rb", "runtime.swift"):
+            with self.subTest(path=path):
+                patch = (
+                    f"diff --git a/{path} b/{path}\n"
+                    + f"--- a/{path}\n"
+                    + f"+++ b/{path}\n"
+                    + "@@ -0,0 +1 @@\n"
+                    + "+pass"
+                    + f'word = runCommand(/[)]/, "{fixture_value}")\n'
+                )
+
+                redacted_patch = self.helper["validate_review_patch"](
+                    "local unstaged diff",
+                    [path],
+                    patch,
+                )
+
+                self.assertNotIn(fixture_value, redacted_patch)
+                self.assertIn('runCommand(/[)]/, "redacted")', redacted_patch)
+
+    def test_review_patch_splits_ruby_regex_and_call_arguments_independently(
+        self,
+    ) -> None:
+        fixture_value = "Abc123,Def456"
+        patch = (
+            "diff --git a/runtime.rb b/runtime.rb\n"
+            "--- a/runtime.rb\n"
+            "+++ b/runtime.rb\n"
+            "@@ -0,0 +1 @@\n"
+            + "+pass"
+            + f'word = prompt(/"/, "{fixture_value}")\n'
+        )
+
+        redacted_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["runtime.rb"],
+            patch,
+        )
+
+        self.assertNotIn(fixture_value, redacted_patch)
+        self.assertIn('prompt(/"/, "redacted")', redacted_patch)
+
+    def test_review_patch_preserves_regex_parsing_for_unclassified_language(
+        self,
+    ) -> None:
+        fixture_value = "Abc123,Def456"
+        patch = (
+            "diff --git a/runtime.groovy b/runtime.groovy\n"
+            "--- a/runtime.groovy\n"
+            "+++ b/runtime.groovy\n"
+            "@@ -0,0 +1 @@\n"
+            + "+pass"
+            + f'word = prompt(/[)]/, "{fixture_value}")\n'
+        )
+
+        redacted_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["runtime.groovy"],
+            patch,
+        )
+
+        self.assertNotIn(fixture_value, redacted_patch)
+        self.assertIn('prompt(/[)]/, "redacted")', redacted_patch)
+
+    def test_review_patch_redacts_groovy_slashy_credentials(self) -> None:
+        for literal, expected in (
+            ("/ProdSecret123/", "/redacted/"),
+            ("$/ProdSecret123/$", "$/redacted/$"),
+        ):
+            with self.subTest(literal=literal):
+                patch = (
+                    "diff --git a/runtime.groovy b/runtime.groovy\n"
+                    "--- a/runtime.groovy\n"
+                    "+++ b/runtime.groovy\n"
+                    "@@ -0,0 +1 @@\n"
+                    f"+password = decode({literal})\n"
+                )
+
+                redacted_patch = self.helper["validate_review_patch"](
+                    "local unstaged diff",
+                    ["runtime.groovy"],
+                    patch,
+                )
+
+                self.assertNotIn("ProdSecret123", redacted_patch)
+                self.assertIn(expected, redacted_patch)
+
+    def test_review_patch_redacts_repeated_secret_in_groovy_slashy(self) -> None:
+        fixture_value = "Prod" + "Secret123"
+        for literal, expected in (
+            (f"/{fixture_value}/", "/redacted/"),
+            (f"$/{fixture_value}/$", "$/redacted/$"),
+        ):
+            with self.subTest(literal=literal):
+                patch = (
+                    "diff --git a/runtime.groovy b/runtime.groovy\n"
+                    "--- a/runtime.groovy\n"
+                    "+++ b/runtime.groovy\n"
+                    "@@ -1 +1 @@\n"
+                    f'-password = "{fixture_value}"\n'
+                    f"+def copy = {literal}\n"
+                )
+
+                redacted_patch = self.helper["validate_review_patch"](
+                    "local unstaged diff",
+                    ["runtime.groovy"],
+                    patch,
+                )
+
+                self.assertNotIn(fixture_value, redacted_patch)
+                self.assertIn(f"+def copy = {expected}", redacted_patch)
+
+    def test_review_patch_redacts_multiline_groovy_slashy_credential(
+        self,
+    ) -> None:
+        patch = (
+            "diff --git a/runtime.groovy b/runtime.groovy\n"
+            "--- a/runtime.groovy\n"
+            "+++ b/runtime.groovy\n"
+            "@@ -0,0 +1,2 @@\n"
+            "+pass"
+            "word = decode(/ProdSecret123\n"
+            "+more/)\n"
+        )
+
+        redacted_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["runtime.groovy"],
+            patch,
+        )
+
+        self.assertNotIn("ProdSecret123", redacted_patch)
+        self.assertIn("decode(/redacted-a\n+redacted-b/)", redacted_patch)
+
+    def test_review_patch_balances_groovy_dollar_slashy_arguments(self) -> None:
+        fixture_value = "Abc123,Def456"
+        patch = (
+            "diff --git a/runtime.groovy b/runtime.groovy\n"
+            "--- a/runtime.groovy\n"
+            "+++ b/runtime.groovy\n"
+            "@@ -0,0 +1 @@\n"
+            + "+pass"
+            + f'word = prompt($/[)]/$, "{fixture_value}")\n'
+        )
+
+        redacted_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["runtime.groovy"],
+            patch,
+        )
+
+        self.assertNotIn(fixture_value, redacted_patch)
+        self.assertIn('prompt($/[)]/$, "redacted")', redacted_patch)
+
+    def test_review_patch_redacts_groovy_slashy_interpolation(self) -> None:
+        for literal in (
+            "/ProdSecret123${exfiltrate()}/",
+            "$/ProdSecret123${exfiltrate()}/$",
+        ):
+            with self.subTest(literal=literal):
+                patch = (
+                    "diff --git a/runtime.groovy b/runtime.groovy\n"
+                    "--- a/runtime.groovy\n"
+                    "+++ b/runtime.groovy\n"
+                    "@@ -0,0 +1 @@\n"
+                    f"+password = decode({literal})\n"
+                )
+
+                redacted_patch = self.helper["validate_review_patch"](
+                    "local unstaged diff",
+                    ["runtime.groovy"],
+                    patch,
+                )
+
+                self.assertNotIn("ProdSecret123", redacted_patch)
+                self.assertIn("${exfiltrate()}", redacted_patch)
+
+    def test_review_patch_redacts_groovy_slashy_after_interpolation_division(
+        self,
+    ) -> None:
+        fixture_value = "Abcdefgh" + "1234"
+        for literal in (
+            f"/${{10 / 2}}{fixture_value}/",
+            f"$/${{10 / 2}}{fixture_value}/$",
+        ):
+            with self.subTest(literal=literal):
+                patch = (
+                    "diff --git a/runtime.groovy b/runtime.groovy\n"
+                    "--- a/runtime.groovy\n"
+                    "+++ b/runtime.groovy\n"
+                    "@@ -0,0 +1 @@\n"
+                    f"+password = decode({literal})\n"
+                )
+
+                redacted_patch = self.helper["validate_review_patch"](
+                    "local unstaged diff",
+                    ["runtime.groovy"],
+                    patch,
+                )
+
+                self.assertNotIn(fixture_value, redacted_patch)
+                self.assertIn("${10 / ", redacted_patch)
+
+    def test_review_patch_preserves_groovy_slashy_escaped_parenthesis(
+        self,
+    ) -> None:
+        source = r"def pattern = /\(/"
+        patch = (
+            "diff --git a/runtime.groovy b/runtime.groovy\n"
+            "--- a/runtime.groovy\n"
+            "+++ b/runtime.groovy\n"
+            "@@ -0,0 +1 @@\n"
+            f"+{source}\n"
+        )
+
+        self.assertEqual(
+            self.helper["validate_review_patch"](
+                "local unstaged diff",
+                ["runtime.groovy"],
+                patch,
+            ),
+            patch,
+        )
+
+    def test_review_patch_preserves_benign_groovy_slashy_interpolation(
+        self,
+    ) -> None:
+        source = "def greeting = /hello $name/"
+        patch = (
+            "diff --git a/runtime.groovy b/runtime.groovy\n"
+            "--- a/runtime.groovy\n"
+            "+++ b/runtime.groovy\n"
+            "@@ -0,0 +1 @@\n"
+            f"+{source}\n"
+        )
+
+        self.assertEqual(
+            self.helper["validate_review_patch"](
+                "local unstaged diff",
+                ["runtime.groovy"],
+                patch,
+            ),
+            patch,
+        )
+
+    def test_review_patch_preserves_unrelated_groovy_slashy_interpolation(
+        self,
+    ) -> None:
+        fixture_value = "Prod" + "Secret123"
+        key = "pass" + "word"
+        source = (
+            f'{key} = "{fixture_value}"\n'
+            "def greeting = /hello $name/"
+        )
+        patch = (
+            "diff --git a/runtime.groovy b/runtime.groovy\n"
+            "--- a/runtime.groovy\n"
+            "+++ b/runtime.groovy\n"
+            "@@ -0,0 +1,2 @@\n"
+            + "".join(f"+{line}\n" for line in source.splitlines())
+        )
+
+        redacted_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["runtime.groovy"],
+            patch,
+        )
+
+        self.assertNotIn(fixture_value, redacted_patch)
+        self.assertIn("def greeting = /hello $name/", redacted_patch)
+
+    def test_review_patch_redacts_groovy_slashy_after_double_backslash(self) -> None:
+        patch = (
+            "diff --git a/runtime.groovy b/runtime.groovy\n"
+            "--- a/runtime.groovy\n"
+            "+++ b/runtime.groovy\n"
+            "@@ -0,0 +1 @@\n"
+            + "+pass"
+            + 'word = decode(/prefix\\\\/ProdSecret123/)\n'
+        )
+
+        redacted_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["runtime.groovy"],
+            patch,
+        )
+
+        self.assertNotIn("ProdSecret123", redacted_patch)
+        self.assertIn("decode(/redacted/)", redacted_patch)
+
+    def test_review_patch_preserves_escaped_dollar_slashy_value(self) -> None:
+        source = "def home = $/$$HOME/$"
+        patch = (
+            "diff --git a/runtime.groovy b/runtime.groovy\n"
+            "--- a/runtime.groovy\n"
+            "+++ b/runtime.groovy\n"
+            "@@ -0,0 +1 @@\n"
+            f"+{source}\n"
+        )
+
+        self.assertEqual(
+            self.helper["validate_review_patch"](
+                "local unstaged diff",
+                ["runtime.groovy"],
+                patch,
+            ),
+            patch,
+        )
+
+    def test_review_patch_preserves_regex_parsing_for_php_mixed_content(self) -> None:
+        fixture_value = "ProdSecret123"
+        patch = (
+            "diff --git a/runtime.php b/runtime.php\n"
+            "--- a/runtime.php\n"
+            "+++ b/runtime.php\n"
+            "@@ -0,0 +1 @@\n"
+            + "+pass"
+            + f'word = runCommand(/[)]/, "{fixture_value}");\n'
+        )
+
+        redacted_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["runtime.php"],
+            patch,
+        )
+
+        self.assertNotIn(fixture_value, redacted_patch)
+        self.assertIn('runCommand(/[)]/, "redacted")', redacted_patch)
+
+    def test_review_patch_redacts_python_triple_quoted_call_literal(self) -> None:
+        fixture_value = "AlphaSecret123LongEnough999"
+        patch = (
+            "diff --git a/runtime.py b/runtime.py\n"
+            "--- a/runtime.py\n"
+            "+++ b/runtime.py\n"
+            "@@ -0,0 +1,2 @@\n"
+            + "+pass"
+            + f'word = decode("""{fixture_value}\n'
+            + '+more""")\n'
+        )
+
+        redacted_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["runtime.py"],
+            patch,
+        )
+
+        self.assertNotIn(fixture_value, redacted_patch)
+        self.assertIn('decode("""redacted-a\n+redacted-b""")', redacted_patch)
+
+    def test_review_patch_redacts_every_python_triple_quoted_literal_line(self) -> None:
+        alphabetic_fragment = "SuperSecretAlphabeticFragment"
+        numeric_fragment = "version123"
+        patch = (
+            "diff --git a/runtime.py b/runtime.py\n"
+            "--- a/runtime.py\n"
+            "+++ b/runtime.py\n"
+            "@@ -0,0 +1,2 @@\n"
+            + "+pass"
+            + f'word = decode("""{alphabetic_fragment}\n'
+            + f'+{numeric_fragment}""")\n'
+        )
+
+        redacted_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["runtime.py"],
+            patch,
+        )
+
+        self.assertNotIn(alphabetic_fragment, redacted_patch)
+        self.assertNotIn(numeric_fragment, redacted_patch)
+        self.assertIn('decode("""redacted-a\n+redacted-b""")', redacted_patch)
+
+    def test_review_patch_preserves_python_fstring_expression(self) -> None:
+        fixture_value = "Abc1234"
+        patch = (
+            "diff --git a/runtime.py b/runtime.py\n"
+            "--- a/runtime.py\n"
+            "+++ b/runtime.py\n"
+            "@@ -0,0 +1,2 @@\n"
+            + "+pass"
+            + f'word = decode(f"""{fixture_value}\n'
+            + '+{exfiltrate()}""")\n'
+        )
+
+        redacted_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["runtime.py"],
+            patch,
+        )
+
+        self.assertNotIn(fixture_value, redacted_patch)
+        self.assertIn('f"""redacted\n+{exfiltrate()}"""', redacted_patch)
+
+    def test_review_patch_preserves_whitespace_only_multiline_literal_line(
+        self,
+    ) -> None:
+        first = "Abc1234"
+        second = "Def5678"
+        patch = (
+            "diff --git a/runtime.py b/runtime.py\n"
+            "--- a/runtime.py\n"
+            "+++ b/runtime.py\n"
+            "@@ -0,0 +1,3 @@\n"
+            + "+pass"
+            + f'word = decode("""{first}\n'
+            + "+   \n"
+            + f'+{second}""")\n'
+        )
+
+        redacted_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["runtime.py"],
+            patch,
+        )
+
+        self.assertNotIn(first, redacted_patch)
+        self.assertNotIn(second, redacted_patch)
+        self.assertIn('"""redacted-a\n+   \n+redacted-b"""', redacted_patch)
+
+    def test_review_patch_rejects_source_matching_multiline_fragment(self) -> None:
+        source_identifier = "SharedIdentifier"
+        patch = (
+            "diff --git a/runtime.py b/runtime.py\n"
+            "--- a/runtime.py\n"
+            "+++ b/runtime.py\n"
+            "@@ -0,0 +1,3 @@\n"
+            + "+pass"
+            + 'word = decode("""Alpha123\n'
+            + f'+{source_identifier}""")\n'
+            + f"+{source_identifier} = value\n"
+        )
+
+        with self.assertRaisesRegex(SystemExit, "known secret-like value"):
+            self.helper["validate_review_patch"](
+                "local unstaged diff",
+                ["runtime.py"],
+                patch,
+            )
+
+    def test_review_patch_redacts_c_family_raw_multiline_call_literal(self) -> None:
+        fixture_value = "AlphaSecret123LongEnough999"
+        patch = (
+            "diff --git a/runtime.cc b/runtime.cc\n"
+            "--- a/runtime.cc\n"
+            "+++ b/runtime.cc\n"
+            "@@ -0,0 +1,2 @@\n"
+            + "+pass"
+            + f'word = decode(R"tag({fixture_value}\n'
+            + '+more)tag");\n'
+        )
+
+        redacted_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["runtime.cc"],
+            patch,
+        )
+
+        self.assertNotIn(fixture_value, redacted_patch)
+        self.assertIn('decode(R"tag(redacted-a\n+redacted-b)tag")', redacted_patch)
+
+    def test_review_patch_redacts_adjacent_prefixed_c_family_literals(self) -> None:
+        first = "".join(("Abc", "123"))
+        second = "".join(("Def", "456"))
+        literals = (
+            f'u8"{first}" u8"{second}"',
+            f'u8R"tag({first})tag" u8R"({second})"',
+        )
+        for literal in literals:
+            with self.subTest(literal=literal):
+                patch = (
+                    "diff --git a/runtime.cpp b/runtime.cpp\n"
+                    "--- a/runtime.cpp\n"
+                    "+++ b/runtime.cpp\n"
+                    "@@ -0,0 +1 @@\n"
+                    "+pass"
+                    + f"word = decode({literal});\n"
+                )
+
+                redacted_patch = self.helper["validate_review_patch"](
+                    "local unstaged diff",
+                    ["runtime.cpp"],
+                    patch,
+                )
+
+                self.assertNotIn(first, redacted_patch)
+                self.assertNotIn(second, redacted_patch)
+
+    def test_review_patch_allows_partial_benign_c_family_raw_hunks(self) -> None:
+        sources = (
+            'auto payload = R"tag(\nordinary text',
+            'ordinary text\n)tag";',
+        )
+        for source in sources:
+            with self.subTest(source=source):
+                lines = source.splitlines()
+                patch = (
+                    "diff --git a/runtime.cpp b/runtime.cpp\n"
+                    "--- a/runtime.cpp\n"
+                    "+++ b/runtime.cpp\n"
+                    f"@@ -0,0 +1,{len(lines)} @@\n"
+                    + "".join(f"+{line}\n" for line in lines)
+                )
+
+                self.assertEqual(
+                    self.helper["validate_review_patch"](
+                        "local unstaged diff",
+                        ["runtime.cpp"],
+                        patch,
+                    ),
+                    patch,
+                )
+
+    def test_review_patch_allows_partial_benign_raw_secret_calls(self) -> None:
+        key = "pass" + "word"
+        cases = (
+            ("runtime.cs", f'{key} = decode("""\nordinary'),
+            ("runtime.cpp", f'{key} = decode(R"tag(\nordinary'),
+        )
+        for rel, source in cases:
+            with self.subTest(rel=rel):
+                lines = source.splitlines()
+                patch = (
+                    f"diff --git a/{rel} b/{rel}\n"
+                    f"--- a/{rel}\n"
+                    f"+++ b/{rel}\n"
+                    f"@@ -0,0 +1,{len(lines)} @@\n"
+                    + "".join(f"+{line}\n" for line in lines)
+                )
+
+                self.assertEqual(
+                    self.helper["validate_review_patch"](
+                        "local unstaged diff",
+                        [rel],
+                        patch,
+                    ),
+                    patch,
+                )
+
+    def test_review_patch_scans_arguments_before_partial_raw_literal(self) -> None:
+        fixture_value = "Abc123Def456"
+        cases = (
+            ("runtime.cs", f'password = decode("{fixture_value}", """ok'),
+            ("runtime.cpp", f'password = decode("{fixture_value}", R"tag(ok'),
+        )
+        for rel, source in cases:
+            with self.subTest(rel=rel):
+                patch = (
+                    f"diff --git a/{rel} b/{rel}\n"
+                    f"--- a/{rel}\n"
+                    f"+++ b/{rel}\n"
+                    "@@ -0,0 +1 @@\n"
+                    f"+{source}\n"
+                )
+
+                redacted_patch = self.helper["validate_review_patch"](
+                    "local unstaged diff",
+                    [rel],
+                    patch,
+                )
+
+                self.assertNotIn(fixture_value, redacted_patch)
+                self.assertIn('decode("redacted", ', redacted_patch)
+
+    def test_review_patch_rejects_partial_alphabetic_raw_secret_calls(
+        self,
+    ) -> None:
+        key = "pass" + "word"
+        for fixture_value in (
+            "abcdefghijklmnop",
+            "correct horse battery staple",
+        ):
+            cases = (
+                ("runtime.cs", f'{key} = decode("""{fixture_value}'),
+                ("runtime.cpp", f'{key} = decode(R"tag({fixture_value}'),
+            )
+            for rel, source in cases:
+                with self.subTest(rel=rel, fixture_value=fixture_value):
+                    patch = (
+                        f"diff --git a/{rel} b/{rel}\n"
+                        f"--- a/{rel}\n"
+                        f"+++ b/{rel}\n"
+                        "@@ -0,0 +1 @@\n"
+                        f"+{source}\n"
+                    )
+
+                    with self.assertRaisesRegex(
+                        SystemExit,
+                        "secret-like content|unterminated.*raw string",
+                    ):
+                        self.helper["validate_review_patch"](
+                            "local unstaged diff",
+                            [rel],
+                            patch,
+                        )
+
+    def test_review_patch_handles_variable_length_csharp_raw_string(self) -> None:
+        fixture_value = "ProdSecret123"
+        patch = (
+            "diff --git a/runtime.cs b/runtime.cs\n"
+            "--- a/runtime.cs\n"
+            "+++ b/runtime.cs\n"
+            "@@ -0,0 +1 @@\n"
+            + "+pass"
+            + f'word = runCommand(""""payload"""", "{fixture_value}");\n'
+        )
+
+        redacted_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["runtime.cs"],
+            patch,
+        )
+
+        self.assertNotIn(fixture_value, redacted_patch)
+        self.assertIn('runCommand(""""payload"""", "redacted")', redacted_patch)
+
+    def test_review_patch_redacts_csharp_repeated_separator_integer(self) -> None:
+        fixture_value = "12__345__678"
+        patch = (
+            "diff --git a/runtime.cs b/runtime.cs\n"
+            "--- a/runtime.cs\n"
+            "+++ b/runtime.cs\n"
+            "@@ -0,0 +1 @@\n"
+            + "+pass"
+            + f'word = decode($"{{{fixture_value}}}");\n'
+        )
+
+        redacted_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["runtime.cs"],
+            patch,
+        )
+
+        self.assertNotIn(fixture_value, redacted_patch)
+        self.assertIn('decode($"{redacted}")', redacted_patch)
+
+    def test_csharp_integer_syntax_accepts_repeated_separators(self) -> None:
+        syntax = self.helper["integer_literal_syntax"]
+
+        for literal in ("12__345__678", "0B__111", "0x__abc"):
+            with self.subTest(literal=literal):
+                self.assertTrue(syntax(literal, dialect="csharp"))
+        for literal in ("12__", "0B111__", "0xabc__"):
+            with self.subTest(literal=literal):
+                self.assertFalse(syntax(literal, dialect="csharp"))
+
+    def test_scala_integer_syntax_accepts_long_and_repeated_separators(
+        self,
+    ) -> None:
+        syntax = self.helper["integer_literal_syntax"]
+
+        for literal in ("12__345__678L", "0B__111l", "0x__abcL"):
+            with self.subTest(literal=literal):
+                self.assertTrue(syntax(literal, dialect="scala"))
+        for literal in ("12__", "123u", "0o777", "0B111__L", "0xabc__L"):
+            with self.subTest(literal=literal):
+                self.assertFalse(syntax(literal, dialect="scala"))
+
+    def test_review_patch_redacts_scala_long_interpolation(self) -> None:
+        fixture_value = "12__345__678L"
+        source = f'password = decode(s"${{{fixture_value}}}")'
+        patch = (
+            "diff --git a/runtime.scala b/runtime.scala\n"
+            "--- a/runtime.scala\n"
+            "+++ b/runtime.scala\n"
+            "@@ -0,0 +1 @@\n"
+            f"+{source}\n"
+        )
+
+        redacted_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["runtime.scala"],
+            patch,
+        )
+
+        self.assertNotIn(fixture_value, redacted_patch)
+        self.assertIn('decode(s"${redacted}")', redacted_patch)
+
+    def test_review_patch_scans_scala_hash_operator_suffix(self) -> None:
+        fixture_value = "Horse7battery"
+        patch = (
+            "diff --git a/runtime.scala b/runtime.scala\n"
+            "--- a/runtime.scala\n"
+            "+++ b/runtime.scala\n"
+            "@@ -0,0 +1 @@\n"
+            f'+password = credentials.value # "{fixture_value}"\n'
+        )
+
+        redacted_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["runtime.scala"],
+            patch,
+        )
+
+        self.assertNotIn(fixture_value, redacted_patch)
+        self.assertIn('# "redacted"', redacted_patch)
+
+    def test_c_family_preprocessor_string_keeps_string_context(self) -> None:
+        text = '#define TOKEN "Horse7battery"'
+        value_start = text.index("Horse7battery")
+
+        contexts = self.helper["string_contexts_at"](
+            text,
+            {value_start},
+            javascript_dialect="c-family",
+        )
+
+        self.assertIsNotNone(contexts[value_start])
+
+    def test_review_patch_redacts_csharp_integer_beside_range_operator(
+        self,
+    ) -> None:
+        fixture_value = "12345678"
+        patch = (
+            "diff --git a/runtime.cs b/runtime.cs\n"
+            "--- a/runtime.cs\n"
+            "+++ b/runtime.cs\n"
+            "@@ -0,0 +1 @@\n"
+            + "+pass"
+            + f'word = decode($"{{..{fixture_value}}}:{{{fixture_value}..}}");\n'
+        )
+
+        redacted_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["runtime.cs"],
+            patch,
+        )
+
+        self.assertNotIn(fixture_value, redacted_patch)
+        self.assertIn("{..redacted-a}", redacted_patch)
+        self.assertIn("{redacted-a..}", redacted_patch)
+
+    def test_csharp_integer_scan_excludes_decimal_points(self) -> None:
+        text = "0.12345678 12345678.0"
+
+        spans = self.helper["integer_literal_spans"](
+            text,
+            0,
+            len(text),
+            dialect="csharp",
+        )
+
+        self.assertEqual(spans, [])
+
+    def test_csharp_raw_literal_closes_at_end_of_quote_run(self) -> None:
+        text = '"""safe"""", "ProdSecret123"'
+
+        raw = self.helper["csharp_raw_literal_span"](
+            text,
+            0,
+            len(text),
+        )
+        spans, _ = self.helper["quoted_literal_value_spans"](
+            text,
+            0,
+            len(text),
+            javascript_dialect="csharp",
+            collect_all_literals=True,
+        )
+
+        self.assertIsNotNone(raw)
+        assert raw is not None
+        self.assertEqual(text[raw[0] : raw[1]], 'safe"')
+        self.assertEqual(text[raw[2] :], ', "ProdSecret123"')
+        self.assertIn("ProdSecret123", [text[start:end] for start, end in spans])
+
+    def test_csharp_raw_context_consumes_exact_literal_boundary(self) -> None:
+        text = '"""safe""""; ProdSecret123()'
+        raw_value = text.index("safe")
+        call_target = text.index("ProdSecret123")
+
+        contexts = self.helper["string_contexts_at"](
+            text,
+            {raw_value, call_target},
+            javascript_dialect="csharp",
+        )
+
+        self.assertIsNotNone(contexts[raw_value])
+        self.assertIsNone(contexts[call_target])
+
+    def test_review_patch_splits_csharp_raw_public_call_argument(self) -> None:
+        fixture_value = "ProdSecret123,tail"
+        patch = (
+            "diff --git a/runtime.cs b/runtime.cs\n"
+            "--- a/runtime.cs\n"
+            "+++ b/runtime.cs\n"
+            "@@ -0,0 +1 @@\n"
+            + "+pass"
+            + f'word = prompt(""""{fixture_value}"""");\n'
+        )
+
+        redacted_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["runtime.cs"],
+            patch,
+        )
+
+        self.assertNotIn(fixture_value, redacted_patch)
+        self.assertIn('prompt(""""redacted"""")', redacted_patch)
+
+    def test_review_patch_preserves_csharp_raw_interpolation_expression(self) -> None:
+        fixture_value = "Abc1234"
+        patch = (
+            "diff --git a/runtime.cs b/runtime.cs\n"
+            "--- a/runtime.cs\n"
+            "+++ b/runtime.cs\n"
+            "@@ -0,0 +1,2 @@\n"
+            + "+pass"
+            + f'word = decode($""""{fixture_value}\n'
+            + '+{exfiltrate()}"""");\n'
+        )
+
+        redacted_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["runtime.cs"],
+            patch,
+        )
+
+        self.assertNotIn(fixture_value, redacted_patch)
+        self.assertIn('$""""redacted\n+{exfiltrate()}""""', redacted_patch)
+
+    def test_review_patch_balances_nested_csharp_raw_interpolation_braces(self) -> None:
+        fixture_value = "Abc1234"
+        expression = "(new A { B = new B { X = 1 }}).Exfiltrate()"
+        patch = (
+            "diff --git a/runtime.cs b/runtime.cs\n"
+            "--- a/runtime.cs\n"
+            "+++ b/runtime.cs\n"
+            "@@ -0,0 +1 @@\n"
+            + "+pass"
+            + f'word = decode($$""""{fixture_value} {{{{{expression}}}}}"""");\n'
+        )
+
+        redacted_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["runtime.cs"],
+            patch,
+        )
+
+        self.assertNotIn(fixture_value, redacted_patch)
+        self.assertIn(f'$$""""redacted{{{{{expression}}}}}""""', redacted_patch)
+
+    def test_review_patch_parses_verbatim_string_inside_csharp_raw_interpolation(
+        self,
+    ) -> None:
+        fixture_value = "Abc1234"
+        expression = r'Get(@"C:\")'
+        patch = (
+            "diff --git a/runtime.cs b/runtime.cs\n"
+            "--- a/runtime.cs\n"
+            "+++ b/runtime.cs\n"
+            "@@ -0,0 +1 @@\n"
+            + "+pass"
+            + f'word = decode($"""{fixture_value}{{{expression}}}""");\n'
+        )
+
+        redacted_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["runtime.cs"],
+            patch,
+        )
+
+        self.assertNotIn(fixture_value, redacted_patch)
+        self.assertIn("C:\\", redacted_patch)
+        self.assertIn(f'$"""redacted{{{expression}}}"""', redacted_patch)
+
+    def test_review_patch_groups_excess_csharp_raw_braces_from_inside(self) -> None:
+        fixture_value = "ProdSecret123"
+        patch = (
+            "diff --git a/runtime.cs b/runtime.cs\n"
+            "--- a/runtime.cs\n"
+            "+++ b/runtime.cs\n"
+            "@@ -0,0 +1 @@\n"
+            + "+pass"
+            + f'word = decode($$"""{{{{{{value:{fixture_value}}}}}}}""");\n'
+        )
+
+        redacted_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["runtime.cs"],
+            patch,
+        )
+
+        self.assertNotIn(fixture_value, redacted_patch)
+        self.assertIn('$$"""{{{value:redacted}}}"""', redacted_patch)
+
+    def test_review_patch_preserves_python_template_string_source(self) -> None:
+        fixture_value = "Abc1234"
+        expression = "exfiltrate1234()"
+        for prefix in ("t", "tr", "rt"):
+            with self.subTest(prefix=prefix):
+                patch = (
+                    "diff --git a/runtime.py b/runtime.py\n"
+                    "--- a/runtime.py\n"
+                    "+++ b/runtime.py\n"
+                    "@@ -0,0 +1 @@\n"
+                    + "+pass"
+                    + f'word = decode({prefix}"{fixture_value}{{{expression}}}")\n'
+                )
+
+                redacted_patch = self.helper["validate_review_patch"](
+                    "local unstaged diff",
+                    ["runtime.py"],
+                    patch,
+                )
+
+                self.assertNotIn(fixture_value, redacted_patch)
+                self.assertIn(f'{prefix}"redacted{{{expression}}}"', redacted_patch)
+
+    def test_review_patch_preserves_raw_fstring_field_after_backslash(self) -> None:
+        expression = 'Evil1234("arg")'
+        source = f'rf"\\{{{expression}}}"'
+        patch = (
+            "diff --git a/runtime.py b/runtime.py\n"
+            "--- a/runtime.py\n"
+            "+++ b/runtime.py\n"
+            "@@ -0,0 +1 @@\n"
+            + "+pass"
+            + f"word = decode({source})\n"
+        )
+
+        redacted_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["runtime.py"],
+            patch,
+        )
+
+        self.assertIn(source, redacted_patch)
+
+    def test_review_patch_closes_raw_fstring_after_even_backslashes(self) -> None:
+        fixture_value = "Secret123"
+        expression = "exfiltrate()"
+        source = f'rf"{fixture_value}{{{expression}}}\\\\"'
+        patch = (
+            "diff --git a/runtime.py b/runtime.py\n"
+            "--- a/runtime.py\n"
+            "+++ b/runtime.py\n"
+            "@@ -0,0 +1 @@\n"
+            + "+pass"
+            + f"word = decode({source})\n"
+        )
+
+        redacted_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["runtime.py"],
+            patch,
+        )
+
+        self.assertNotIn(fixture_value, redacted_patch)
+        self.assertIn(f'rf"redacted{{{expression}}}\\\\"', redacted_patch)
+
+    def test_secret_detector_checks_csharp_raw_interpolation_source(self) -> None:
+        content = (
+            'pass'
+            + 'word = decode($$""""redacted {{Get("hardcodedcredential")}}"""")'
+        )
+
+        self.assertTrue(
+            self.helper["secret_text_risk"](
+                content,
+                javascript_dialect="csharp",
+            )
+        )
+
+    def test_secret_detector_allows_non_javascript_member_interpolation(
+        self,
+    ) -> None:
+        cases = (
+            (
+                "python",
+                'pass' + 'word = decode(f"{credential_store.authentication_token}")',
+            ),
+            (
+                "csharp",
+                'pass' + 'word = decode($"{credentialStore.AuthenticationToken}")',
+            ),
+        )
+
+        for dialect, content in cases:
+            with self.subTest(dialect=dialect):
+                self.assertFalse(
+                    self.helper["secret_text_risk"](
+                        content,
+                        javascript_dialect=dialect,
+                    )
+                )
+
+    def test_review_patch_preserves_non_javascript_member_interpolation(
+        self,
+    ) -> None:
+        cases = (
+            (
+                "runtime.py",
+                'pass' + 'word = decode(f"{credential_store.authentication_token}")',
+            ),
+            (
+                "runtime.cs",
+                'pass' + 'word = decode($"{credentialStore.AuthenticationToken}");',
+            ),
+        )
+
+        for rel, source in cases:
+            with self.subTest(rel=rel):
+                patch = (
+                    f"diff --git a/{rel} b/{rel}\n"
+                    f"--- a/{rel}\n"
+                    f"+++ b/{rel}\n"
+                    "@@ -0,0 +1 @@\n"
+                    f"+{source}\n"
+                )
+
+                redacted_patch = self.helper["validate_review_patch"](
+                    "local unstaged diff",
+                    [rel],
+                    patch,
+                )
+
+                self.assertIn(source, redacted_patch)
+
+    def test_review_patch_preserves_java_member_credential_reference(self) -> None:
+        key = "password"
+        source = f"{key} = credentialStore.authenticationToken;"
+        patch = (
+            "diff --git a/Runtime.java b/Runtime.java\n"
+            "--- a/Runtime.java\n"
+            "+++ b/Runtime.java\n"
+            "@@ -0,0 +1 @@\n"
+            f"+{source}\n"
+        )
+
+        self.assertEqual(
+            self.helper["validate_review_patch"](
+                "local unstaged diff",
+                ["Runtime.java"],
+                patch,
+            ),
+            patch,
+        )
+
+    def test_review_patch_rejects_java_unicode_escapes(self) -> None:
+        key = "password"
+        quote_escape = "\\" + "u0022"
+        fixture_value = "Prod" + "Secret123"
+        source = (
+            f"{key} = {quote_escape}"
+            + fixture_value
+            + f"{quote_escape};"
+        )
+        patch = (
+            "diff --git a/Runtime.java b/Runtime.java\n"
+            "--- a/Runtime.java\n"
+            "+++ b/Runtime.java\n"
+            "@@ -0,0 +1 @@\n"
+            f"+{source}\n"
+        )
+
+        with self.assertRaisesRegex(SystemExit, "secret-like content"):
+            self.helper["validate_review_patch"](
+                "local unstaged diff",
+                ["Runtime.java"],
+                patch,
+            )
+
+    def test_java_unicode_translation_tracks_translated_backslashes(self) -> None:
+        escape = lambda digits: "\\" + "u" + digits
+        source = escape("005c") + "\\" + escape("006e")
+
+        self.assertEqual(
+            self.helper["java_unicode_escape_translation"](source),
+            "\\\\n",
+        )
+
+    def test_review_patch_rejects_java_escape_after_translated_backslash(
+        self,
+    ) -> None:
+        escape = lambda digits: "\\" + "u" + digits
+        fixture_value = "Prod" + "Secret123"
+        source = (
+            'password = "'
+            + fixture_value
+            + escape("005c")
+            + "\\"
+            + escape("0022")
+            + ";"
+        )
+        patch = (
+            "diff --git a/Runtime.java b/Runtime.java\n"
+            "--- a/Runtime.java\n"
+            "+++ b/Runtime.java\n"
+            "@@ -0,0 +1 @@\n"
+            f"+{source}\n"
+        )
+
+        with self.assertRaisesRegex(SystemExit, "secret-like content"):
+            self.helper["validate_review_patch"](
+                "local unstaged diff",
+                ["Runtime.java"],
+                patch,
+            )
+
+    def test_review_patch_preserves_harmless_java_unicode_escape(self) -> None:
+        escape = "\\" + "u00A9"
+        source = f'String copyright = "{escape}";'
+        patch = (
+            "diff --git a/Runtime.java b/Runtime.java\n"
+            "--- a/Runtime.java\n"
+            "+++ b/Runtime.java\n"
+            "@@ -0,0 +1 @@\n"
+            f"+{source}\n"
+        )
+
+        self.assertEqual(
+            self.helper["validate_review_patch"](
+                "local unstaged diff",
+                ["Runtime.java"],
+                patch,
+            ),
+            patch,
+        )
+
+    def test_review_patch_preserves_kotlin_backtick_call_target(self) -> None:
+        fixture_value = "Prod" + "Secret123"
+        source = f'password = decode("${{obj.`{fixture_value}`()}}")'
+        patch = (
+            "diff --git a/Runtime.kt b/Runtime.kt\n"
+            "--- a/Runtime.kt\n"
+            "+++ b/Runtime.kt\n"
+            "@@ -0,0 +1 @@\n"
+            f"+{source}\n"
+        )
+
+        self.assertEqual(
+            self.helper["validate_review_patch"](
+                "local unstaged diff",
+                ["Runtime.kt"],
+                patch,
+            ),
+            patch,
+        )
+
+    def test_review_patch_preserves_jvm_backtick_identifier_assignments(
+        self,
+    ) -> None:
+        fixture_value = "Prod" + "Secret123"
+        for rel in ("Runtime.kt", "Runtime.scala"):
+            with self.subTest(rel=rel):
+                source = f"password = `{fixture_value}`"
+                patch = (
+                    f"diff --git a/{rel} b/{rel}\n"
+                    f"--- a/{rel}\n"
+                    f"+++ b/{rel}\n"
+                    "@@ -0,0 +1 @@\n"
+                    f"+{source}\n"
+                )
+
+                self.assertEqual(
+                    self.helper["validate_review_patch"](
+                        "local unstaged diff",
+                        [rel],
+                        patch,
+                    ),
+                    patch,
+                )
+
+    def test_kotlin_backtick_target_does_not_hide_nested_literal(self) -> None:
+        fixture_value = "Prod" + "Secret123"
+        source = f'password = decode("${{obj.`safe target`("{fixture_value}")}}")'
+
+        spans, _ = self.helper["quoted_literal_value_spans"](
+            source,
+            0,
+            len(source),
+            javascript_dialect="kotlin",
+        )
+
+        self.assertIn(fixture_value, {source[start:end] for start, end in spans})
+        self.assertNotIn("safe target", {source[start:end] for start, end in spans})
+
+    def test_review_patch_preserves_scala_backtick_call_argument(self) -> None:
+        fixture_value = "Prod" + "Secret123"
+        source = f"password = decode(`{fixture_value}`)"
+        patch = (
+            "diff --git a/Runtime.scala b/Runtime.scala\n"
+            "--- a/Runtime.scala\n"
+            "+++ b/Runtime.scala\n"
+            "@@ -0,0 +1 @@\n"
+            f"+{source}\n"
+        )
+
+        self.assertEqual(
+            self.helper["validate_review_patch"](
+                "local unstaged diff",
+                ["Runtime.scala"],
+                patch,
+            ),
+            patch,
+        )
+
+    def test_review_patch_preserves_known_triple_interpolation_source(
+        self,
+    ) -> None:
+        def kotlin_triple_source(value: str, interpolation: str) -> str:
+            key = "pass" + "word"
+            return f'{key} = decode("""{value} {interpolation}""")'
+
+        interpolations = (
+            "${" + "".join(("exfil", "trate()")) + "}",
+            "$" + "凭据变量" + str(12345678),
+        )
+        for interpolation in interpolations:
+            with self.subTest(interpolation=interpolation):
+                source = kotlin_triple_source("ProdSecret123", interpolation)
+                lines = source.splitlines()
+                patch = (
+                    "diff --git a/runtime.kt b/runtime.kt\n"
+                    "--- a/runtime.kt\n"
+                    "+++ b/runtime.kt\n"
+                    f"@@ -0,0 +1,{len(lines)} @@\n"
+                    + "".join(f"+{line}\n" for line in lines)
+                )
+
+                redacted_patch = self.helper["validate_review_patch"](
+                    "local unstaged diff",
+                    ["runtime.kt"],
+                    patch,
+                )
+
+                self.assertNotIn("ProdSecret123", redacted_patch)
+                self.assertIn(interpolation, redacted_patch)
+
+    def test_review_patch_redacts_nested_kotlin_raw_string_literal(self) -> None:
+        key = "password"
+        quote = '"' * 3
+        fixture_value = "Prod" + "Secret123"
+        source = (
+            f"{key} = decode({quote}"
+            + "${id("
+            + quote
+            + fixture_value
+            + quote
+            + ")}"
+            + f"{quote})"
+        )
+        patch = (
+            "diff --git a/runtime.kt b/runtime.kt\n"
+            "--- a/runtime.kt\n"
+            "+++ b/runtime.kt\n"
+            "@@ -0,0 +1 @@\n"
+            f"+{source}\n"
+        )
+
+        redacted_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["runtime.kt"],
+            patch,
+        )
+
+        self.assertNotIn(fixture_value, redacted_patch)
+        self.assertIn("${id(", redacted_patch)
+
+    def test_review_patch_redacts_nested_groovy_triple_string_literal(self) -> None:
+        key = "pass" + "word"
+        quote = '"' * 3
+        fixture_value = "Prod" + "Secret123"
+        source = (
+            f"{key} = decode({quote}"
+            + "${id("
+            + quote
+            + fixture_value
+            + quote
+            + ")}"
+            + f"{quote})"
+        )
+        patch = (
+            "diff --git a/runtime.groovy b/runtime.groovy\n"
+            "--- a/runtime.groovy\n"
+            "+++ b/runtime.groovy\n"
+            "@@ -0,0 +1 @@\n"
+            f"+{source}\n"
+        )
+
+        redacted_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["runtime.groovy"],
+            patch,
+        )
+
+        self.assertNotIn(fixture_value, redacted_patch)
+        self.assertIn("${id(", redacted_patch)
+
+    def test_review_patch_ignores_triple_assignment_text_in_comments(self) -> None:
+        source = '// password = """'
+        for rel in ("runtime.kt", "runtime.groovy"):
+            with self.subTest(rel=rel):
+                patch = (
+                    f"diff --git a/{rel} b/{rel}\n"
+                    f"--- a/{rel}\n"
+                    f"+++ b/{rel}\n"
+                    "@@ -0,0 +1 @@\n"
+                    f"+{source}\n"
+                )
+
+                self.assertEqual(
+                    self.helper["validate_review_patch"](
+                        "local unstaged diff",
+                        [rel],
+                        patch,
+                    ),
+                    patch,
+                )
+
+    def test_review_patch_preserves_reference_only_swift_scala_triples(
+        self,
+    ) -> None:
+        cases = (
+            ("runtime.swift", 'password = decode("""\\(value)""")'),
+            ("runtime.scala", 'password = decode(s"""$value""")'),
+        )
+        for rel, source in cases:
+            with self.subTest(rel=rel):
+                patch = (
+                    f"diff --git a/{rel} b/{rel}\n"
+                    f"--- a/{rel}\n"
+                    f"+++ b/{rel}\n"
+                    "@@ -0,0 +1 @@\n"
+                    f"+{source}\n"
+                )
+
+                self.assertEqual(
+                    self.helper["validate_review_patch"](
+                        "local unstaged diff",
+                        [rel],
+                        patch,
+                    ),
+                    patch,
+                )
+
+    def test_review_patch_preserves_swift_scala_triple_interpolation_source(
+        self,
+    ) -> None:
+        fixture_value = "Prod" + "Secret123"
+        cases = (
+            (
+                "runtime.swift",
+                f'password = decode("""{fixture_value} \\(value)""")',
+                "\\(value)",
+            ),
+            (
+                "runtime.scala",
+                f'password = decode(s"""{fixture_value} $value""")',
+                "$value",
+            ),
+        )
+        for rel, source, interpolation in cases:
+            with self.subTest(rel=rel):
+                patch = (
+                    f"diff --git a/{rel} b/{rel}\n"
+                    f"--- a/{rel}\n"
+                    f"+++ b/{rel}\n"
+                    "@@ -0,0 +1 @@\n"
+                    f"+{source}\n"
+                )
+
+                redacted_patch = self.helper["validate_review_patch"](
+                    "local unstaged diff",
+                    [rel],
+                    patch,
+                )
+
+                self.assertNotIn(fixture_value, redacted_patch)
+                self.assertIn(interpolation, redacted_patch)
+
+    def test_review_patch_preserves_swift_scala_ordinary_interpolation_source(
+        self,
+    ) -> None:
+        fixture_value = "Prod" + "Secret123"
+        cases = (
+            (
+                "runtime.swift",
+                f'password = decode("{fixture_value} \\(value)")',
+                "\\(value)",
+            ),
+            (
+                "runtime.swift",
+                f'password = decode(#"{fixture_value} \\#(value)"#)',
+                "\\#(value)",
+            ),
+            (
+                "runtime.scala",
+                f'password = decode(s"{fixture_value} $value")',
+                "$value",
+            ),
+        )
+        for rel, source, interpolation in cases:
+            with self.subTest(rel=rel, source=source):
+                patch = (
+                    f"diff --git a/{rel} b/{rel}\n"
+                    f"--- a/{rel}\n"
+                    f"+++ b/{rel}\n"
+                    "@@ -0,0 +1 @@\n"
+                    f"+{source}\n"
+                )
+
+                redacted_patch = self.helper["validate_review_patch"](
+                    "local unstaged diff",
+                    [rel],
+                    patch,
+                )
+
+                self.assertNotIn(fixture_value, redacted_patch)
+                self.assertIn(interpolation, redacted_patch)
+
+    def test_review_patch_rejects_swift_scala_interpolation_source_collision(
+        self,
+    ) -> None:
+        fixture_value = "Evil" + "1234"
+        cases = (
+            ("runtime.swift", f'"""\\({fixture_value}())"""'),
+            ("runtime.scala", f's"""${{{fixture_value}()}}"""'),
+        )
+        for rel, interpolation in cases:
+            with self.subTest(rel=rel):
+                source = f'password = "{fixture_value}"\nlet copy = {interpolation}'
+                patch = (
+                    f"diff --git a/{rel} b/{rel}\n"
+                    f"--- a/{rel}\n"
+                    f"+++ b/{rel}\n"
+                    "@@ -0,0 +1,2 @@\n"
+                    + "".join(f"+{line}\n" for line in source.splitlines())
+                )
+
+                with self.assertRaisesRegex(
+                    SystemExit,
+                    "known secret-like value",
+                ):
+                    self.helper["validate_review_patch"](
+                        "local unstaged diff",
+                        [rel],
+                        patch,
+                    )
+
+    def test_review_patch_rejects_swift_scala_ordinary_source_collision(
+        self,
+    ) -> None:
+        fixture_value = "Evil" + "1234"
+        cases = (
+            ("runtime.swift", f'"\\({fixture_value}())"'),
+            ("runtime.swift", f'#"\\#({fixture_value}())"#'),
+            ("runtime.scala", f's"${{{fixture_value}()}}"'),
+        )
+        for rel, interpolation in cases:
+            with self.subTest(rel=rel, interpolation=interpolation):
+                source = f'password = "{fixture_value}"\nlet copy = {interpolation}'
+                patch = (
+                    f"diff --git a/{rel} b/{rel}\n"
+                    f"--- a/{rel}\n"
+                    f"+++ b/{rel}\n"
+                    "@@ -0,0 +1,2 @@\n"
+                    + "".join(f"+{line}\n" for line in source.splitlines())
+                )
+
+                with self.assertRaisesRegex(
+                    SystemExit,
+                    "known secret-like value",
+                ):
+                    self.helper["validate_review_patch"](
+                        "local unstaged diff",
+                        [rel],
+                        patch,
+                    )
+
+    def test_scala_triple_quote_closes_after_backslash(self) -> None:
+        marker = '"' * 3
+        source = "s" + marker + "value" + "\\" + marker + "; exfiltrate()"
+
+        span = self.helper["triple_quoted_literal_span"](
+            source,
+            1,
+            len(source),
+            interpolation_dialect="scala",
+        )
+
+        self.assertIsNotNone(span)
+        assert span is not None
+        self.assertEqual(span[2], source.index(";"))
+
+    def test_scala_interpolated_quote_escape_does_not_close_literal(self) -> None:
+        source = 'password = decode(s"safe$"text")'
+        patch = (
+            "diff --git a/runtime.scala b/runtime.scala\n"
+            "--- a/runtime.scala\n"
+            "+++ b/runtime.scala\n"
+            "@@ -0,0 +1 @@\n"
+            f"+{source}\n"
+        )
+
+        self.assertEqual(
+            self.helper["validate_review_patch"](
+                "local unstaged diff",
+                ["runtime.scala"],
+                patch,
+            ),
+            patch,
+        )
+
+    def test_scala_triple_quote_closes_at_end_of_quote_run(self) -> None:
+        marker = '"' * 3
+        source = "s" + marker + "value" + '"' * 4
+
+        span = self.helper["triple_quoted_literal_span"](
+            source,
+            1,
+            len(source),
+            interpolation_dialect="scala",
+        )
+
+        self.assertEqual(span, (4, len(source) - 3, len(source)))
+
+    def test_swift_scala_triple_string_contexts_exclude_interpolation_source(
+        self,
+    ) -> None:
+        cases = (
+            (
+                "swift",
+                '"""literal \\(credentialCall("nested value"))"""',
+            ),
+            (
+                "scala",
+                's"""literal ${credentialCall("nested value")}"""',
+            ),
+        )
+        for dialect, source in cases:
+            with self.subTest(dialect=dialect):
+                positions = {
+                    source.index("literal"),
+                    source.index("credentialCall"),
+                    source.index("nested value"),
+                }
+                contexts = self.helper["string_contexts_at"](
+                    source,
+                    positions,
+                    javascript_dialect=dialect,
+                )
+
+                self.assertIsNotNone(contexts[source.index("literal")])
+                self.assertIsNone(contexts[source.index("credentialCall")])
+                self.assertIsNotNone(contexts[source.index("nested value")])
+
+    def test_swift_scala_ordinary_contexts_exclude_interpolation_source(
+        self,
+    ) -> None:
+        cases = (
+            (
+                "swift",
+                '#"literal \\#(credentialCall("nested value"))"#',
+            ),
+            (
+                "scala",
+                's"literal ${credentialCall("nested value")}"',
+            ),
+        )
+        for dialect, source in cases:
+            with self.subTest(dialect=dialect):
+                positions = {
+                    source.index("literal"),
+                    source.index("credentialCall"),
+                    source.index("nested value"),
+                }
+                contexts = self.helper["string_contexts_at"](
+                    source,
+                    positions,
+                    javascript_dialect=dialect,
+                )
+
+                self.assertIsNotNone(contexts[source.index("literal")])
+                self.assertIsNone(contexts[source.index("credentialCall")])
+                self.assertIsNotNone(contexts[source.index("nested value")])
+
+    def test_review_patch_redacts_standalone_comment_credential(self) -> None:
+        fixture_value = "Prod" + "Secret123"
+        key = "pass" + "word"
+        source = f'// {key} = "{fixture_value}"'
+        patch = (
+            "diff --git a/runtime.ts b/runtime.ts\n"
+            "--- a/runtime.ts\n"
+            "+++ b/runtime.ts\n"
+            "@@ -0,0 +1 @@\n"
+            f"+{source}\n"
+        )
+
+        redacted_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["runtime.ts"],
+            patch,
+        )
+
+        self.assertNotIn(fixture_value, redacted_patch)
+        self.assertIn(f'// {key} = "redacted"', redacted_patch)
+
+    def test_review_patch_redacts_assignment_embedded_in_literal(self) -> None:
+        fixture_value = "CorrectHorse7" + "Battery"
+        source = f'''const cmd = 'password="{fixture_value}"';'''
+        patch = (
+            "diff --git a/runtime.ts b/runtime.ts\n"
+            "--- a/runtime.ts\n"
+            "+++ b/runtime.ts\n"
+            "@@ -0,0 +1 @@\n"
+            f"+{source}\n"
+        )
+
+        redacted_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["runtime.ts"],
+            patch,
+        )
+
+        self.assertNotIn(fixture_value, redacted_patch)
+        self.assertIn('password="redacted"', redacted_patch)
+
+    def test_review_patch_redacts_complex_assignment_embedded_in_literal(
+        self,
+    ) -> None:
+        fixture_value = "CorrectHorse7" + "Battery"
+        for value in (
+            f'decode("{fixture_value}")',
+            f'primary || "{fixture_value}"',
+        ):
+            with self.subTest(value=value):
+                source = f"const cmd = 'password = {value}';"
+                patch = (
+                    "diff --git a/runtime.ts b/runtime.ts\n"
+                    "--- a/runtime.ts\n"
+                    "+++ b/runtime.ts\n"
+                    "@@ -0,0 +1 @@\n"
+                    f"+{source}\n"
+                )
+
+                redacted_patch = self.helper["validate_review_patch"](
+                    "local unstaged diff",
+                    ["runtime.ts"],
+                    patch,
+                )
+
+                self.assertNotIn(fixture_value, redacted_patch)
+                self.assertIn("redacted", redacted_patch)
+
+    def test_review_patch_rejects_secret_collision_in_triple_source(self) -> None:
+        fixture_value = "EvilSecret123"
+        source = "pass" + f'word = "{fixture_value}"\n"""${{{fixture_value}()}}"""'
+        patch = (
+            "diff --git a/runtime.kt b/runtime.kt\n"
+            "--- a/runtime.kt\n"
+            "+++ b/runtime.kt\n"
+            "@@ -0,0 +1,2 @@\n"
+            + "".join(f"+{line}\n" for line in source.splitlines())
+        )
+
+        with self.assertRaisesRegex(SystemExit, "known secret-like value"):
+            self.helper["validate_review_patch"](
+                "local unstaged diff",
+                ["runtime.kt"],
+                patch,
+            )
+
+    def test_review_patch_redacts_python_field_after_backslash(self) -> None:
+        fixture_value = "ProdSecret123"
+        source = f'password = decode(f"\\{{get(\"{fixture_value}\")}}")'
+        patch = (
+            "diff --git a/runtime.py b/runtime.py\n"
+            "--- a/runtime.py\n"
+            "+++ b/runtime.py\n"
+            "@@ -0,0 +1 @@\n"
+            f"+{source}\n"
+        )
+
+        redacted_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["runtime.py"],
+            patch,
+        )
+
+        self.assertNotIn(fixture_value, redacted_patch)
+        self.assertIn('f"\\{get("redacted")}"', redacted_patch)
+
+    def test_review_patch_redacts_grouped_short_numeric_fields(self) -> None:
+        for rel, literal in (
+            ("runtime.py", 'f"{1234}{5678}"'),
+            ("runtime.cs", '$"{1234}{5678}"'),
+        ):
+            with self.subTest(rel=rel):
+                patch = (
+                    f"diff --git a/{rel} b/{rel}\n"
+                    f"--- a/{rel}\n"
+                    f"+++ b/{rel}\n"
+                    "@@ -0,0 +1 @@\n"
+                    + "+pass"
+                    + f"word = decode({literal})\n"
+                )
+
+                redacted_patch = self.helper["validate_review_patch"](
+                    "local unstaged diff",
+                    [rel],
+                    patch,
+                )
+
+                self.assertNotIn("1234", redacted_patch)
+                self.assertNotIn("5678", redacted_patch)
+
+    def test_review_patch_redacts_concatenated_short_template_literals(self) -> None:
+        patch = (
+            "diff --git a/runtime.ts b/runtime.ts\n"
+            "--- a/runtime.ts\n"
+            "+++ b/runtime.ts\n"
+            "@@ -0,0 +1 @@\n"
+            + "+pass"
+            + 'word = decode(`${"Abc123" + "Def456"}`)\n'
+        )
+
+        redacted_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["runtime.ts"],
+            patch,
+        )
+
+        self.assertNotIn("Abc123", redacted_patch)
+        self.assertNotIn("Def456", redacted_patch)
+
+    def test_review_patch_redacts_prefixed_nested_string_fragments(self) -> None:
+        patch = (
+            "diff --git a/runtime.py b/runtime.py\n"
+            "--- a/runtime.py\n"
+            "+++ b/runtime.py\n"
+            "@@ -0,0 +1 @@\n"
+            + "+pass"
+            + 'word = decode(f\'{f"Abc123"}{f"Def456"}\')\n'
+        )
+
+        redacted_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["runtime.py"],
+            patch,
+        )
+
+        self.assertNotIn("Abc123", redacted_patch)
+        self.assertNotIn("Def456", redacted_patch)
+
+    def test_review_patch_checks_placeholder_as_part_of_template_value(self) -> None:
+        patch = (
+            "diff --git a/runtime.ts b/runtime.ts\n"
+            "--- a/runtime.ts\n"
+            "+++ b/runtime.ts\n"
+            "@@ -0,0 +1 @@\n"
+            + "+pass"
+            + 'word = decode(`redacted${"123456"}`)\n'
+        )
+
+        redacted_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["runtime.ts"],
+            patch,
+        )
+
+        self.assertNotIn("123456", redacted_patch)
+
+    def test_review_patch_redacts_kotlin_triple_prompt_argument(self) -> None:
+        fixture_value = 'Prod"Secret123,Abc456'
+        patch = (
+            "diff --git a/runtime.kt b/runtime.kt\n"
+            "--- a/runtime.kt\n"
+            "+++ b/runtime.kt\n"
+            "@@ -0,0 +1 @@\n"
+            + "+pass"
+            + f'word = ui.prompt("""{fixture_value}""")\n'
+        )
+
+        redacted_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["runtime.kt"],
+            patch,
+        )
+
+        self.assertNotIn(fixture_value, redacted_patch)
+        self.assertIn('ui.prompt("""redacted""")', redacted_patch)
+
+    def test_review_patch_rejects_incomplete_csharp_raw_string(self) -> None:
+        for prefix in ("", "$", "$$"):
+            with self.subTest(prefix=prefix):
+                patch = (
+                    "diff --git a/runtime.cs b/runtime.cs\n"
+                    "--- a/runtime.cs\n"
+                    "+++ b/runtime.cs\n"
+                    "@@ -0,0 +1,2 @@\n"
+                    + "+pass"
+                    + f'word = decode({prefix}"""\n'
+                    "+ProdSecret123\n"
+                )
+
+                with self.assertRaisesRegex(
+                    SystemExit,
+                    "unterminated C# raw string",
+                ):
+                    self.helper["validate_review_patch"](
+                        "local unstaged diff",
+                        ["runtime.cs"],
+                        patch,
+                    )
+
+    def test_review_patch_allows_partial_benign_csharp_raw_string_hunks(
+        self,
+    ) -> None:
+        quote = '"' * 3
+        sources = (
+            f"const payload = {quote}\nordinary text",
+            f"ordinary text\n{quote};",
+        )
+        for source in sources:
+            with self.subTest(source=source):
+                lines = source.splitlines()
+                patch = (
+                    "diff --git a/runtime.cs b/runtime.cs\n"
+                    "--- a/runtime.cs\n"
+                    "+++ b/runtime.cs\n"
+                    f"@@ -0,0 +1,{len(lines)} @@\n"
+                    + "".join(f"+{line}\n" for line in lines)
+                )
+
+                self.assertEqual(
+                    self.helper["validate_review_patch"](
+                        "local unstaged diff",
+                        ["runtime.cs"],
+                        patch,
+                    ),
+                    patch,
+                )
+
+    def test_review_patch_rejects_truncated_interpolated_csharp_raw_literal(
+        self,
+    ) -> None:
+        fixture_value = "ProdSecret123"
+        patch = (
+            "diff --git a/runtime.cs b/runtime.cs\n"
+            "--- a/runtime.cs\n"
+            "+++ b/runtime.cs\n"
+            "@@ -0,0 +1 @@\n"
+            + f'+const payload = $"""{fixture_value}\n'
+        )
+
+        with self.assertRaisesRegex(
+            SystemExit,
+            "unterminated C# raw string",
+        ):
+            self.helper["validate_review_patch"](
+                "local unstaged diff",
+                ["runtime.cs"],
+                patch,
+            )
+
+    def test_review_patch_rejects_truncated_structured_literals(self) -> None:
+        fixture_value = "a" * 19
+        for rel, source in (
+            (
+                "runtime.py",
+                "".join(("pass", f'word = decode("""{fixture_value}')),
+            ),
+            (
+                "runtime.cs",
+                "".join(("pass", f'word = decode($@"{fixture_value}')),
+            ),
+        ):
+            with self.subTest(rel=rel):
+                patch = (
+                    f"diff --git a/{rel} b/{rel}\n"
+                    f"--- a/{rel}\n"
+                    f"+++ b/{rel}\n"
+                    "@@ -0,0 +1 @@\n"
+                    f"+{source}\n"
+                )
+
+                with self.assertRaisesRegex(
+                    SystemExit,
+                    "unterminated secret call",
+                ):
+                    self.helper["validate_review_patch"](
+                        "local unstaged diff",
+                        [rel],
+                        patch,
+                    )
+
+    def test_review_patch_rejects_multiline_truncated_call_tail(self) -> None:
+        fixture_value = "a" * 19
+        source_lines = (
+            "".join(("pass", "word = decode(")),
+            f'    """{fixture_value}',
+        )
+        patch = (
+            "diff --git a/runtime.py b/runtime.py\n"
+            "--- a/runtime.py\n"
+            "+++ b/runtime.py\n"
+            "@@ -0,0 +1,2 @@\n"
+            + "".join(f"+{line}\n" for line in source_lines)
+        )
+
+        with self.assertRaisesRegex(
+            SystemExit,
+            "unterminated secret call",
+        ):
+            self.helper["validate_review_patch"](
+                "local unstaged diff",
+                ["runtime.py"],
+                patch,
+            )
+
+    def test_review_patch_rejects_two_word_truncated_raw_secret_call(self) -> None:
+        patch = (
+            "diff --git a/runtime.py b/runtime.py\n"
+            "--- a/runtime.py\n"
+            "+++ b/runtime.py\n"
+            "@@ -0,0 +1,2 @@\n"
+            "+password = decode(\"\"\"\n"
+            "+alphabet soup\n"
+        )
+
+        with self.assertRaisesRegex(
+            SystemExit,
+            "unterminated secret call",
+        ):
+            self.helper["validate_review_patch"](
+                "local unstaged diff",
+                ["runtime.py"],
+                patch,
+            )
+
+    def test_review_patch_redacts_direct_structured_secret_assignments(
+        self,
+    ) -> None:
+        fixture_value = "Abc123" + "Def456"
+        cases = (
+            ("runtime.py", f'password = \"\"\"{fixture_value}\"\"\"'),
+            ("runtime.py", f'password = f\"{fixture_value}\"'),
+            ("runtime.cs", f'password = $\"\"\"{fixture_value}\"\"\";'),
+            ("runtime.cpp", f'password = R\"tag({fixture_value})tag\";'),
+            ("runtime.swift", f'password = #\"{fixture_value}\"#'),
+            ("runtime.scala", f'password = s\"{fixture_value}\"'),
+        )
+        for rel, source in cases:
+            with self.subTest(rel=rel):
+                patch = (
+                    f"diff --git a/{rel} b/{rel}\n"
+                    f"--- a/{rel}\n"
+                    f"+++ b/{rel}\n"
+                    "@@ -0,0 +1 @@\n"
+                    f"+{source}\n"
+                )
+
+                redacted_patch = self.helper["validate_review_patch"](
+                    "local unstaged diff",
+                    [rel],
+                    patch,
+                )
+
+                self.assertNotIn(fixture_value, redacted_patch)
+                self.assertIn("redacted", redacted_patch)
+
+    def test_review_patch_applies_assignment_minimum_to_structured_literals(
+        self,
+    ) -> None:
+        fixture_value = "abcdefgh"
+        cases = (
+            ("runtime.py", f'password = b"{fixture_value}"'),
+            ("runtime.cs", f'password = $"{fixture_value}";'),
+            ("runtime.cs", f'password = """{fixture_value}""";'),
+        )
+        for rel, source in cases:
+            with self.subTest(rel=rel, source=source):
+                patch = (
+                    f"diff --git a/{rel} b/{rel}\n"
+                    f"--- a/{rel}\n"
+                    f"+++ b/{rel}\n"
+                    "@@ -0,0 +1 @@\n"
+                    f"+{source}\n"
+                )
+
+                redacted_patch = self.helper["validate_review_patch"](
+                    "local unstaged diff",
+                    [rel],
+                    patch,
+                )
+
+                self.assertNotIn(fixture_value, redacted_patch)
+                self.assertIn("redacted", redacted_patch)
+
+    def test_review_patch_redacts_after_swift_scala_nested_delimiters(
+        self,
+    ) -> None:
+        fixture_value = "Prod" + "Secret123"
+        cases = (
+            (
+                "runtime.swift",
+                f'password = decode(#"safe )" inside"#, "{fixture_value}")',
+            ),
+            (
+                "runtime.scala",
+                f'password = decode(s"${{format("safe )")}}", "{fixture_value}")',
+            ),
+        )
+        for rel, source in cases:
+            with self.subTest(rel=rel):
+                patch = (
+                    f"diff --git a/{rel} b/{rel}\n"
+                    f"--- a/{rel}\n"
+                    f"+++ b/{rel}\n"
+                    "@@ -0,0 +1 @@\n"
+                    f"+{source}\n"
+                )
+
+                redacted_patch = self.helper["validate_review_patch"](
+                    "local unstaged diff",
+                    [rel],
+                    patch,
+                )
+
+                self.assertNotIn(fixture_value, redacted_patch)
+                self.assertIn("redacted", redacted_patch)
+
+    def test_review_patch_redacts_after_swift_extended_regex(self) -> None:
+        fixture_value = "Prod" + "Secret123"
+        source = f'password = decode(#/)/#, "{fixture_value}")'
+        patch = (
+            "diff --git a/runtime.swift b/runtime.swift\n"
+            "--- a/runtime.swift\n"
+            "+++ b/runtime.swift\n"
+            "@@ -0,0 +1 @@\n"
+            f"+{source}\n"
+        )
+
+        redacted_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["runtime.swift"],
+            patch,
+        )
+
+        self.assertNotIn(fixture_value, redacted_patch)
+        self.assertIn('#/)/#, "redacted"', redacted_patch)
+
+    def test_review_patch_prioritizes_c_family_raw_delimiter(self) -> None:
+        fixture_value = "Abc" + "12345"
+        source = f'password = decode(R"""(safe"""{fixture_value})""");'
+        patch = (
+            "diff --git a/runtime.cpp b/runtime.cpp\n"
+            "--- a/runtime.cpp\n"
+            "+++ b/runtime.cpp\n"
+            "@@ -0,0 +1 @@\n"
+            f"+{source}\n"
+        )
+
+        redacted_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["runtime.cpp"],
+            patch,
+        )
+
+        self.assertNotIn(fixture_value, redacted_patch)
+        self.assertIn("redacted", redacted_patch)
+
+    def test_review_patch_redacts_incomplete_direct_structured_assignments(
+        self,
+    ) -> None:
+        fixture_value = "alphabet soup"
+        cases = (
+            ("runtime.py", f'password = """{fixture_value}'),
+            ("runtime.cs", f'password = """{fixture_value}'),
+            ("runtime.cpp", f'password = R"tag({fixture_value}'),
+        )
+        for rel, source in cases:
+            with self.subTest(rel=rel):
+                patch = (
+                    f"diff --git a/{rel} b/{rel}\n"
+                    f"--- a/{rel}\n"
+                    f"+++ b/{rel}\n"
+                    "@@ -0,0 +1 @@\n"
+                    f"+{source}\n"
+                )
+
+                redacted_patch = self.helper["validate_review_patch"](
+                    "local unstaged diff",
+                    [rel],
+                    patch,
+                )
+
+                self.assertNotIn(fixture_value, redacted_patch)
+                self.assertIn("redacted", redacted_patch)
+
+    def test_review_patch_closes_kotlin_raw_string_after_backslash(self) -> None:
+        patch = (
+            "diff --git a/runtime.kt b/runtime.kt\n"
+            "--- a/runtime.kt\n"
+            "+++ b/runtime.kt\n"
+            "@@ -0,0 +1 @@\n"
+            + "+pass"
+            + 'word = decode("""ProdSecret123\\"""); exfiltrate()\n'
+        )
+
+        redacted_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["runtime.kt"],
+            patch,
+        )
+
+        self.assertNotIn("ProdSecret123", redacted_patch)
+        self.assertIn("exfiltrate()", redacted_patch)
+
+    def test_review_patch_redacts_literals_inside_non_javascript_interpolations(
+        self,
+    ) -> None:
+        fixture_value = "Abc1234"
+        cases = (
+            (
+                "runtime.cs",
+                "pass"
+                + f'word = decode($$""""{{{{Get("{fixture_value}")}}}}"""")',
+            ),
+            (
+                "runtime.py",
+                "pass"
+                + f'word = decode(f"""{{get("{fixture_value}")}}""")',
+            ),
+        )
+        for rel, source in cases:
+            with self.subTest(rel=rel):
+                patch = (
+                    f"diff --git a/{rel} b/{rel}\n"
+                    f"--- a/{rel}\n"
+                    f"+++ b/{rel}\n"
+                    "@@ -0,0 +1 @@\n"
+                    f"+{source}\n"
+                )
+
+                redacted_patch = self.helper["validate_review_patch"](
+                    "local unstaged diff",
+                    [rel],
+                    patch,
+                )
+
+                self.assertNotIn(fixture_value, redacted_patch)
+                expected = (
+                    'Get("redacted")'
+                    if rel.endswith(".cs")
+                    else 'get("redacted")'
+                )
+                self.assertIn(expected, redacted_patch)
+
+    def test_review_patch_aggregates_non_javascript_interpolation_fragments(
+        self,
+    ) -> None:
+        cases = (
+            ("runtime.cs", 'pass' + 'word = decode($"""Abc123{"Def456"}""");'),
+            ("runtime.py", 'pass' + 'word = decode(f"""Abc123{"Def456"}""")'),
+        )
+        for rel, source in cases:
+            with self.subTest(rel=rel):
+                patch = (
+                    f"diff --git a/{rel} b/{rel}\n"
+                    f"--- a/{rel}\n"
+                    f"+++ b/{rel}\n"
+                    "@@ -0,0 +1 @@\n"
+                    f"+{source}\n"
+                )
+
+                redacted_patch = self.helper["validate_review_patch"](
+                    "local unstaged diff",
+                    [rel],
+                    patch,
+                )
+
+                self.assertNotIn("Abc123", redacted_patch)
+                self.assertNotIn("Def456", redacted_patch)
+                self.assertIn('redacted-a{"redacted-b"}', redacted_patch)
+
+    def test_review_patch_aggregates_swift_interpolation_fragments(self) -> None:
+        cases = (
+            'password = decode("\\("Abc123")\\("Def456")")',
+            'password = decode(#"\\#("Abc123")\\#("Def456")"#)',
+        )
+        for source in cases:
+            with self.subTest(source=source):
+                patch = (
+                    "diff --git a/runtime.swift b/runtime.swift\n"
+                    "--- a/runtime.swift\n"
+                    "+++ b/runtime.swift\n"
+                    "@@ -0,0 +1 @@\n"
+                    f"+{source}\n"
+                )
+
+                redacted_patch = self.helper["validate_review_patch"](
+                    "local unstaged diff",
+                    ["runtime.swift"],
+                    patch,
+                )
+
+                self.assertNotIn("Abc123", redacted_patch)
+                self.assertNotIn("Def456", redacted_patch)
+
+    def test_review_patch_preserves_calls_before_nested_multiline_literals(
+        self,
+    ) -> None:
+        fixture_value = "Abc1234"
+        cases = (
+            (
+                "runtime.cs",
+                'pass'
+                + f'word = decode($"""{fixture_value}'
+                + '{Evil1234("""nested""")}""");',
+            ),
+            (
+                "runtime.py",
+                'pass'
+                + f'word = decode(f"""{fixture_value}'
+                + '{Evil1234("""nested""")}""")',
+            ),
+        )
+        for rel, source in cases:
+            with self.subTest(rel=rel):
+                patch = (
+                    f"diff --git a/{rel} b/{rel}\n"
+                    f"--- a/{rel}\n"
+                    f"+++ b/{rel}\n"
+                    "@@ -0,0 +1 @@\n"
+                    f"+{source}\n"
+                )
+
+                redacted_patch = self.helper["validate_review_patch"](
+                    "local unstaged diff",
+                    [rel],
+                    patch,
+                )
+
+                self.assertNotIn(fixture_value, redacted_patch)
+                self.assertIn('Evil1234("""nested""")', redacted_patch)
+
+    def test_review_patch_preserves_ordinary_interpolation_expressions(
+        self,
+    ) -> None:
+        fixture_value = "Abc1234"
+        cases = (
+            (
+                "runtime.py",
+                'pass' + f'word = decode(f"{fixture_value}{{exfiltrate()}}")',
+                'f"redacted{exfiltrate()}"',
+            ),
+            (
+                "runtime.cs",
+                'pass' + f'word = decode($"{fixture_value}{{exfiltrate()}}");',
+                '$"redacted{exfiltrate()}"',
+            ),
+        )
+        for rel, source, expected in cases:
+            with self.subTest(rel=rel):
+                patch = (
+                    f"diff --git a/{rel} b/{rel}\n"
+                    f"--- a/{rel}\n"
+                    f"+++ b/{rel}\n"
+                    "@@ -0,0 +1 @@\n"
+                    f"+{source}\n"
+                )
+
+                redacted_patch = self.helper["validate_review_patch"](
+                    "local unstaged diff",
+                    [rel],
+                    patch,
+                )
+
+                self.assertNotIn(fixture_value, redacted_patch)
+                self.assertIn(expected, redacted_patch)
+
+    def test_review_patch_preserves_direct_groovy_kotlin_interpolation(
+        self,
+    ) -> None:
+        fixture_value = "ProdSecret123"
+        for rel in ("runtime.groovy", "runtime.kt"):
+            with self.subTest(rel=rel):
+                patch = (
+                    f"diff --git a/{rel} b/{rel}\n"
+                    f"--- a/{rel}\n"
+                    f"+++ b/{rel}\n"
+                    "@@ -0,0 +1 @@\n"
+                    f'+password = "{fixture_value}${{runDangerousOperation()}}"\n'
+                )
+
+                redacted_patch = self.helper["validate_review_patch"](
+                    "local unstaged diff",
+                    [rel],
+                    patch,
+                )
+
+                self.assertNotIn(fixture_value, redacted_patch)
+                self.assertIn(
+                    '"redacted${runDangerousOperation()}"',
+                    redacted_patch,
+                )
+
+    def test_review_patch_preserves_groovy_gstring_expression(self) -> None:
+        fixture_value = "ProdSecret123"
+        patch = (
+            "diff --git a/runtime.groovy b/runtime.groovy\n"
+            "--- a/runtime.groovy\n"
+            "+++ b/runtime.groovy\n"
+            "@@ -0,0 +1 @@\n"
+            + "+pass"
+            + f'word = decode("{fixture_value}${{exfiltrate()}}")\n'
+        )
+
+        redacted_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["runtime.groovy"],
+            patch,
+        )
+
+        self.assertNotIn(fixture_value, redacted_patch)
+        self.assertIn('"redacted${exfiltrate()}"', redacted_patch)
+
+    def test_review_patch_redacts_nested_dollar_interpolation_literal(self) -> None:
+        fixture_value = "ProdSecret123"
+        for rel in ("runtime.kt", "runtime.groovy"):
+            with self.subTest(rel=rel):
+                patch = (
+                    f"diff --git a/{rel} b/{rel}\n"
+                    f"--- a/{rel}\n"
+                    f"+++ b/{rel}\n"
+                    "@@ -0,0 +1 @@\n"
+                    + "+pass"
+                    + f'word = decode("${{lookup("{fixture_value}")}}")\n'
+                )
+
+                redacted_patch = self.helper["validate_review_patch"](
+                    "local unstaged diff",
+                    [rel],
+                    patch,
+                )
+
+                self.assertNotIn(fixture_value, redacted_patch)
+                self.assertIn('${lookup("redacted")}', redacted_patch)
+
+    def test_review_patch_balances_dollar_interpolation_call_arguments(self) -> None:
+        fixture_value = "ProdSecret123"
+        for rel in ("runtime.kt", "runtime.groovy"):
+            with self.subTest(rel=rel):
+                source = (
+                    'password = decode("${lookup(")")}", "'
+                    + fixture_value
+                    + '")'
+                )
+                patch = (
+                    f"diff --git a/{rel} b/{rel}\n"
+                    f"--- a/{rel}\n"
+                    f"+++ b/{rel}\n"
+                    "@@ -0,0 +1 @@\n"
+                    f"+{source}\n"
+                )
+
+                redacted_patch = self.helper["validate_review_patch"](
+                    "local unstaged diff",
+                    [rel],
+                    patch,
+                )
+
+                self.assertNotIn(fixture_value, redacted_patch)
+                self.assertIn('${lookup(")")}', redacted_patch)
+                self.assertIn(', "redacted")', redacted_patch)
+
+    def test_review_patch_redacts_dollar_interpolation_integer(self) -> None:
+        for rel in ("runtime.kt", "runtime.groovy"):
+            with self.subTest(rel=rel):
+                patch = (
+                    f"diff --git a/{rel} b/{rel}\n"
+                    f"--- a/{rel}\n"
+                    f"+++ b/{rel}\n"
+                    "@@ -0,0 +1 @@\n"
+                    + "+pass"
+                    + 'word = decode("${12345678}")\n'
+                )
+
+                redacted_patch = self.helper["validate_review_patch"](
+                    "local unstaged diff",
+                    [rel],
+                    patch,
+                )
+
+                self.assertNotIn("12345678", redacted_patch)
+                self.assertIn("${redacted}", redacted_patch)
+
+    def test_review_patch_redacts_integer_before_escaped_member_access(
+        self,
+    ) -> None:
+        key = "password"
+        first = "1234"
+        second = "5678"
+        cases = (
+            ("runtime.kt", f"`toString`", "${redacted.`toString`()}"),
+            ("runtime.groovy", "'toString'", "${redacted.'toString'()}"),
+        )
+        for rel, member, expected in cases:
+            with self.subTest(rel=rel):
+                source = (
+                    f'{key} = decode("${{'
+                    + first
+                    + second
+                    + f".{member}()}}\")"
+                )
+                patch = (
+                    f"diff --git a/{rel} b/{rel}\n"
+                    f"--- a/{rel}\n"
+                    f"+++ b/{rel}\n"
+                    "@@ -0,0 +1 @@\n"
+                    f"+{source}\n"
+                )
+
+                redacted_patch = self.helper["validate_review_patch"](
+                    "local unstaged diff",
+                    [rel],
+                    patch,
+                )
+
+                self.assertNotIn(first + second, redacted_patch)
+                self.assertIn(expected, redacted_patch)
+
+    def test_review_patch_redacts_integer_range_interpolations(self) -> None:
+        key = "password"
+        number = "1234" + "5678"
+        for rel in ("runtime.kt", "runtime.groovy"):
+            with self.subTest(rel=rel):
+                source = f'{key} = decode("${{({number}..{number}).first}}")'
+                patch = (
+                    f"diff --git a/{rel} b/{rel}\n"
+                    f"--- a/{rel}\n"
+                    f"+++ b/{rel}\n"
+                    "@@ -0,0 +1 @@\n"
+                    f"+{source}\n"
+                )
+
+                redacted_patch = self.helper["validate_review_patch"](
+                    "local unstaged diff",
+                    [rel],
+                    patch,
+                )
+
+                self.assertNotIn(number, redacted_patch)
+
+    def test_review_patch_redacts_aggregated_dollar_interpolation_integers(
+        self,
+    ) -> None:
+        key = "password"
+        first = "12" + "34"
+        second = "56" + "78"
+        for rel in ("runtime.kt", "runtime.groovy"):
+            with self.subTest(rel=rel):
+                source = f'{key} = decode("${{{first}}}${{{second}}}")'
+                patch = (
+                    f"diff --git a/{rel} b/{rel}\n"
+                    f"--- a/{rel}\n"
+                    f"+++ b/{rel}\n"
+                    "@@ -0,0 +1 @@\n"
+                    f"+{source}\n"
+                )
+
+                redacted_patch = self.helper["validate_review_patch"](
+                    "local unstaged diff",
+                    [rel],
+                    patch,
+                )
+
+                self.assertNotIn("1234", redacted_patch)
+                self.assertNotIn("5678", redacted_patch)
+                self.assertIn('${redacted}${redacted}', redacted_patch)
+
+    def test_review_patch_scans_groovy_single_quoted_dollars_as_literals(
+        self,
+    ) -> None:
+        fixture_value = "$ProdSecret123"
+        for marker in ("'", "'''"):
+            with self.subTest(marker=marker):
+                source = "pass" + f"word = runCommand({marker}{fixture_value}{marker})"
+                patch = (
+                    "diff --git a/runtime.groovy b/runtime.groovy\n"
+                    "--- a/runtime.groovy\n"
+                    "+++ b/runtime.groovy\n"
+                    "@@ -0,0 +1 @@\n"
+                    f"+{source}\n"
+                )
+
+                redacted_patch = self.helper["validate_review_patch"](
+                    "local unstaged diff",
+                    ["runtime.groovy"],
+                    patch,
+                )
+
+                self.assertNotIn(fixture_value, redacted_patch)
+                self.assertIn(f"runCommand({marker}redacted{marker})", redacted_patch)
+
+    def test_review_patch_preserves_benign_dollar_triple_strings(self) -> None:
+        cases = (
+            ("runtime.kt", 'val greeting = """hello $name"""'),
+            ("runtime.groovy", 'def greeting = """hello $name"""'),
+            ("runtime.kt", r'val regex = """\("""'),
+        )
+        for rel, source in cases:
+            with self.subTest(rel=rel, source=source):
+                patch = (
+                    f"diff --git a/{rel} b/{rel}\n"
+                    f"--- a/{rel}\n"
+                    f"+++ b/{rel}\n"
+                    "@@ -0,0 +1 @@\n"
+                    f"+{source}\n"
+                )
+
+                self.assertEqual(
+                    self.helper["validate_review_patch"](
+                        "local unstaged diff",
+                        [rel],
+                        patch,
+                    ),
+                    patch,
+                )
+
+    def test_review_patch_preserves_java_text_block_placeholder(self) -> None:
+        quote = '"' * 3
+        patch = (
+            "diff --git a/Runtime.java b/Runtime.java\n"
+            "--- a/Runtime.java\n"
+            "+++ b/Runtime.java\n"
+            "@@ -0,0 +1,3 @@\n"
+            f"+String template = {quote}\n"
+            "+hello ${name}\n"
+            f"+{quote};\n"
+        )
+
+        self.assertEqual(
+            self.helper["validate_review_patch"](
+                "local unstaged diff",
+                ["Runtime.java"],
+                patch,
+            ),
+            patch,
+        )
+
+    def test_review_patch_redacts_dollar_triple_string_literal_segments(
+        self,
+    ) -> None:
+        fixture_value = "ProdSecret123"
+        for rel in ("runtime.kt", "runtime.groovy"):
+            with self.subTest(rel=rel):
+                source = "pass" + f'word = """{fixture_value} $name"""'
+                patch = (
+                    f"diff --git a/{rel} b/{rel}\n"
+                    f"--- a/{rel}\n"
+                    f"+++ b/{rel}\n"
+                    "@@ -0,0 +1 @@\n"
+                    f"+{source}\n"
+                )
+
+                redacted_patch = self.helper["validate_review_patch"](
+                    "local unstaged diff",
+                    [rel],
+                    patch,
+                )
+
+                self.assertNotIn(fixture_value, redacted_patch)
+                self.assertIn('"""redacted$name"""', redacted_patch)
+
+    def test_review_patch_honors_kotlin_multi_dollar_interpolation(self) -> None:
+        key = "password"
+        fixture_value = "$Abc1234"
+        literal_source = f'{key} = decode($$"""{fixture_value}""")'
+        interpolation_source = (
+            f'{key} = decode($$"""'
+            + "$${credentialStore.authenticationToken}"
+            + '""")'
+        )
+        for source, expected_redaction in (
+            (literal_source, '$$"""redacted"""'),
+            (interpolation_source, None),
+        ):
+            with self.subTest(source=source):
+                patch = (
+                    "diff --git a/runtime.kt b/runtime.kt\n"
+                    "--- a/runtime.kt\n"
+                    "+++ b/runtime.kt\n"
+                    "@@ -0,0 +1 @@\n"
+                    f"+{source}\n"
+                )
+
+                redacted_patch = self.helper["validate_review_patch"](
+                    "local unstaged diff",
+                    ["runtime.kt"],
+                    patch,
+                )
+
+                if expected_redaction is None:
+                    self.assertEqual(redacted_patch, patch)
+                else:
+                    self.assertNotIn(fixture_value, redacted_patch)
+                    self.assertIn(expected_redaction, redacted_patch)
+
+    def test_review_patch_redacts_direct_kotlin_multi_dollar_assignment(
+        self,
+    ) -> None:
+        fixture_value = "Abc123Def456"
+        source = f'password = $$"""{fixture_value}"""'
+        patch = (
+            "diff --git a/runtime.kt b/runtime.kt\n"
+            "--- a/runtime.kt\n"
+            "+++ b/runtime.kt\n"
+            "@@ -0,0 +1 @@\n"
+            f"+{source}\n"
+        )
+
+        redacted_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["runtime.kt"],
+            patch,
+        )
+
+        self.assertNotIn(fixture_value, redacted_patch)
+        self.assertIn('password = $$"""redacted"""', redacted_patch)
+
+    def test_review_patch_uses_trailing_kotlin_multi_dollar_marker(self) -> None:
+        key = "password"
+        fixture_value = "Prod" + "Secret123"
+        interpolation = "$${" + "exfiltrate()" + "}"
+        source = (
+            f'{key} = decode($$"""{fixture_value} '
+            + "$"
+            + interpolation
+            + '""")'
+        )
+        patch = (
+            "diff --git a/runtime.kt b/runtime.kt\n"
+            "--- a/runtime.kt\n"
+            "+++ b/runtime.kt\n"
+            "@@ -0,0 +1 @@\n"
+            f"+{source}\n"
+        )
+
+        redacted_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["runtime.kt"],
+            patch,
+        )
+
+        self.assertNotIn(fixture_value, redacted_patch)
+        self.assertIn(interpolation, redacted_patch)
+
+    def test_review_patch_preserves_kotlin_raw_backslash_interpolation(
+        self,
+    ) -> None:
+        key = "password"
+        fixture_value = "Abc1234"
+        interpolation = "${exfiltrate()}"
+        source = f'{key} = decode("""{fixture_value}\\{interpolation}""")'
+        patch = (
+            "diff --git a/runtime.kt b/runtime.kt\n"
+            "--- a/runtime.kt\n"
+            "+++ b/runtime.kt\n"
+            "@@ -0,0 +1 @@\n"
+            f"+{source}\n"
+        )
+
+        redacted_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["runtime.kt"],
+            patch,
+        )
+
+        self.assertNotIn(fixture_value, redacted_patch)
+        self.assertIn(interpolation, redacted_patch)
+
+    def test_review_patch_preserves_dollar_member_credential_references(
+        self,
+    ) -> None:
+        key = "password"
+        for rel in ("runtime.kt", "runtime.groovy"):
+            with self.subTest(rel=rel):
+                source = (
+                    f'{key} = decode("'
+                    + "${credentialStore.authenticationToken}"
+                    + '")'
+                )
+                patch = (
+                    f"diff --git a/{rel} b/{rel}\n"
+                    f"--- a/{rel}\n"
+                    f"+++ b/{rel}\n"
+                    "@@ -0,0 +1 @@\n"
+                    f"+{source}\n"
+                )
+
+                self.assertEqual(
+                    self.helper["validate_review_patch"](
+                        "local unstaged diff",
+                        [rel],
+                        patch,
+                    ),
+                    patch,
+                )
+
+    def test_review_patch_redacts_python_fallback_after_floor_division(
+        self,
+    ) -> None:
+        fixture_value = "ProdSecret123"
+        key = "password"
+        source = " ".join(
+            (
+                key,
+                "=",
+                "primary",
+                "/" * 2,
+                "divisor",
+                "or",
+                repr(fixture_value),
+            )
+        )
+        patch = (
+            "diff --git a/runtime.py b/runtime.py\n"
+            "--- a/runtime.py\n"
+            "+++ b/runtime.py\n"
+            "@@ -0,0 +1 @@\n"
+            f"+{source}\n"
+        )
+
+        redacted_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["runtime.py"],
+            patch,
+        )
+
+        self.assertNotIn(fixture_value, redacted_patch)
+        self.assertIn("or 'redacted'", redacted_patch)
+
+    def test_review_patch_rejects_excessive_dollar_interpolation_nesting(
+        self,
+    ) -> None:
+        expression = '"safe"'
+        for _ in range(66):
+            expression = '"${' + expression + '}"'
+
+        with self.assertRaisesRegex(
+            SystemExit,
+            "excessive interpolation nesting",
+        ):
+            self.helper["secret_literal_risk"](
+                expression,
+                javascript_dialect="kotlin",
+            )
+
+    def test_review_patch_preserves_benign_kotlin_interpolation(self) -> None:
+        source = 'val greeting = "hello $name"'
+        patch = (
+            "diff --git a/runtime.kt b/runtime.kt\n"
+            "--- a/runtime.kt\n"
+            "+++ b/runtime.kt\n"
+            "@@ -0,0 +1 @@\n"
+            f"+{source}\n"
+        )
+
+        self.assertEqual(
+            self.helper["validate_review_patch"](
+                "local unstaged diff",
+                ["runtime.kt"],
+                patch,
+            ),
+            patch,
+        )
+
+    def test_review_patch_rejects_dollar_interpolation_source_collision(
+        self,
+    ) -> None:
+        fixture_value = "exfiltrate1234"
+        key = "pass" + "word"
+        for rel in ("runtime.kt", "runtime.groovy"):
+            with self.subTest(rel=rel):
+                source_lines = (
+                    f'{key} = "{fixture_value}"',
+                    'output = "${' + fixture_value + '()}"',
+                )
+                patch = (
+                    f"diff --git a/{rel} b/{rel}\n"
+                    f"--- a/{rel}\n"
+                    f"+++ b/{rel}\n"
+                    "@@ -0,0 +1,2 @@\n"
+                    + "".join(f"+{line}\n" for line in source_lines)
+                )
+
+                with self.assertRaisesRegex(
+                    SystemExit,
+                    "known secret-like value",
+                ):
+                    self.helper["validate_review_patch"](
+                        "local unstaged diff",
+                        [rel],
+                        patch,
+                    )
+
+    def test_review_patch_rejects_secret_collision_in_interpolation_source(
+        self,
+    ) -> None:
+        fixture_value = "Abc1234"
+        cases = (
+            (
+                "runtime.ts",
+                'pass'
+                + f'word = decode(`{fixture_value}${{{fixture_value}()}}`);',
+            ),
+            (
+                "runtime.py",
+                'pass'
+                + f'word = decode(f"{fixture_value}{{{fixture_value}()}}")',
+            ),
+            (
+                "runtime.cs",
+                'pass'
+                + f'word = decode($"{fixture_value}{{{fixture_value}()}}");',
+            ),
+        )
+        for rel, source in cases:
+            with self.subTest(rel=rel):
+                patch = (
+                    f"diff --git a/{rel} b/{rel}\n"
+                    f"--- a/{rel}\n"
+                    f"+++ b/{rel}\n"
+                    "@@ -0,0 +1 @@\n"
+                    f"+{source}\n"
+                )
+
+                with self.assertRaisesRegex(SystemExit, "known secret-like value"):
+                    self.helper["validate_review_patch"](
+                        "local unstaged diff",
+                        [rel],
+                        patch,
+                    )
+
+    def test_review_patch_rejects_empty_literal_interpolation_source_collision(
+        self,
+    ) -> None:
+        fixture_value = "Evil1234"
+        patch = (
+            "diff --git a/runtime.ts b/runtime.ts\n"
+            "--- a/runtime.ts\n"
+            "+++ b/runtime.ts\n"
+            "@@ -0,0 +1,2 @@\n"
+            + "+pass"
+            + f'word = "{fixture_value}";\n'
+            + f"+const out = `${{{fixture_value}()}}`;\n"
+        )
+
+        with self.assertRaisesRegex(SystemExit, "known secret-like value"):
+            self.helper["validate_review_patch"](
+                "local unstaged diff",
+                ["runtime.ts"],
+                patch,
+            )
+
+    def test_review_patch_rejects_multiline_interpolation_source_collision(
+        self,
+    ) -> None:
+        fixture_value = "Evil1234"
+        patch = (
+            "diff --git a/runtime.ts b/runtime.ts\n"
+            "--- a/runtime.ts\n"
+            "+++ b/runtime.ts\n"
+            "@@ -0,0 +1,3 @@\n"
+            + "+pass"
+            + f'word = "{fixture_value}";\n'
+            + f"+const out = `${{{fixture_value}(\n"
+            + "+  value)}`;\n"
+        )
+
+        with self.assertRaisesRegex(SystemExit, "known secret-like value"):
+            self.helper["validate_review_patch"](
+                "local unstaged diff",
+                ["runtime.ts"],
+                patch,
+            )
+
+    def test_review_patch_retains_source_proof_before_incomplete_javascript(
+        self,
+    ) -> None:
+        fixture_value = "Evil1234"
+        patch = (
+            "diff --git a/runtime.ts b/runtime.ts\n"
+            "--- a/runtime.ts\n"
+            "+++ b/runtime.ts\n"
+            "@@ -0,0 +1,4 @@\n"
+            + "+pass"
+            + f'word = "{fixture_value}";\n'
+            + f"+const out = `${{{fixture_value}(\n"
+            + "+  value)}`;\n"
+            + "+/* incomplete\n"
+        )
+
+        with self.assertRaisesRegex(SystemExit, "known secret-like value"):
+            self.helper["validate_review_patch"](
+                "local unstaged diff",
+                ["runtime.ts"],
+                patch,
+            )
+
+    def test_review_patch_bounds_interpolation_nesting(self) -> None:
+        nested = '"Abc1234"'
+        for _ in range(70):
+            nested = f'f"{{{nested}}}"'
+
+        with self.assertRaisesRegex(SystemExit, "excessive interpolation nesting"):
+            self.helper["quoted_literal_value_spans"](
+                nested,
+                0,
+                len(nested),
+                javascript_dialect="python",
+            )
+
+    def test_review_patch_parses_nested_csharp_prompt_argument_commas(self) -> None:
+        fixture_value = "Alpha123,Beta456"
+        patch = (
+            "diff --git a/runtime.cs b/runtime.cs\n"
+            "--- a/runtime.cs\n"
+            "+++ b/runtime.cs\n"
+            "@@ -0,0 +1 @@\n"
+            + "+pass"
+            + f'word = prompt($"{{Get("{fixture_value}")}}");\n'
+        )
+
+        redacted_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["runtime.cs"],
+            patch,
+        )
+
+        self.assertNotIn(fixture_value, redacted_patch)
+        self.assertIn('prompt($"{Get("redacted")}")', redacted_patch)
+
+    def test_review_patch_redacts_numeric_non_javascript_interpolations(
+        self,
+    ) -> None:
+        fixture_value = "12345678"
+        cases = (
+            ("runtime.py", f'pass' + f'word = decode(f"{{{fixture_value}}}")'),
+            ("runtime.cs", f'pass' + f'word = decode($"{{{fixture_value}}}");'),
+        )
+        for rel, source in cases:
+            with self.subTest(rel=rel):
+                patch = (
+                    f"diff --git a/{rel} b/{rel}\n"
+                    f"--- a/{rel}\n"
+                    f"+++ b/{rel}\n"
+                    "@@ -0,0 +1 @@\n"
+                    f"+{source}\n"
+                )
+
+                redacted_patch = self.helper["validate_review_patch"](
+                    "local unstaged diff",
+                    [rel],
+                    patch,
+                )
+
+                self.assertNotIn(fixture_value, redacted_patch)
+                self.assertIn("{redacted}", redacted_patch)
+
+    def test_review_patch_redacts_floating_point_interpolation_credentials(
+        self,
+    ) -> None:
+        cases = (
+            ("runtime.py", 'pass' + 'word = decode(f"{0.12345678}")'),
+            ("runtime.py", 'pass' + 'word = decode(f"{12345678.0}")'),
+            ("runtime.py", 'pass' + 'word = decode(f"{.12345678}")'),
+            ("runtime.py", 'pass' + 'word = decode(f"{12345678.}")'),
+            ("runtime.py", 'pass' + 'word = decode(f"{12345678.e10}")'),
+            ("runtime.cs", 'pass' + 'word = decode($"{0.12345678}");'),
+            ("runtime.cs", 'pass' + 'word = decode($"{12345678.0}");'),
+            ("runtime.cs", 'pass' + 'word = decode($"{.12345678}");'),
+            ("runtime.cs", 'pass' + 'word = decode($"{12345678.}");'),
+        )
+        for rel, source in cases:
+            with self.subTest(rel=rel, source=source):
+                patch = (
+                    f"diff --git a/{rel} b/{rel}\n"
+                    f"--- a/{rel}\n"
+                    f"+++ b/{rel}\n"
+                    "@@ -0,0 +1 @@\n"
+                    f"+{source}\n"
+                )
+
+                redacted_patch = self.helper["validate_review_patch"](
+                    "local unstaged diff",
+                    [rel],
+                    patch,
+                )
+
+                self.assertNotIn(source, redacted_patch)
+                self.assertIn("{redacted}", redacted_patch)
+
+    def test_review_patch_preserves_python_floor_division_interpolation(
+        self,
+    ) -> None:
+        source = 'password = decode(f"{1234 // 5678}")'
+        patch = (
+            "diff --git a/runtime.py b/runtime.py\n"
+            "--- a/runtime.py\n"
+            "+++ b/runtime.py\n"
+            "@@ -0,0 +1 @@\n"
+            f"+{source}\n"
+        )
+
+        self.assertEqual(
+            self.helper["validate_review_patch"](
+                "local unstaged diff",
+                ["runtime.py"],
+                patch,
+            ),
+            patch,
+        )
+
+    def test_review_patch_preserves_below_threshold_separator_integers(self) -> None:
+        fixture_value = "1_2_3_4_5_6_7"
+        cases = (
+            (
+                "runtime.ts",
+                'pass' + f'word = decode(`${{{fixture_value}}}`);',
+            ),
+            (
+                "runtime.py",
+                'pass' + f'word = decode(f"{{{fixture_value}}}")',
+            ),
+            (
+                "runtime.cs",
+                'pass' + f'word = decode($"{{{fixture_value}}}");',
+            ),
+        )
+        for rel, source in cases:
+            with self.subTest(rel=rel):
+                patch = (
+                    f"diff --git a/{rel} b/{rel}\n"
+                    f"--- a/{rel}\n"
+                    f"+++ b/{rel}\n"
+                    "@@ -0,0 +1 @@\n"
+                    f"+{source}\n"
+                )
+
+                redacted_patch = self.helper["validate_review_patch"](
+                    "local unstaged diff",
+                    [rel],
+                    patch,
+                )
+
+                self.assertIn(source, redacted_patch)
+
+    def test_review_patch_preserves_independent_interpolation_arithmetic(self) -> None:
+        cases = (
+            ("runtime.ts", 'pass' + 'word = decode(`${1234 + 5678}`);'),
+            ("runtime.py", 'pass' + 'word = decode(f"{1234 + 5678}")'),
+            ("runtime.cs", 'pass' + 'word = decode($"{1234 + 5678}");'),
+        )
+        for rel, source in cases:
+            with self.subTest(rel=rel):
+                patch = (
+                    f"diff --git a/{rel} b/{rel}\n"
+                    f"--- a/{rel}\n"
+                    f"+++ b/{rel}\n"
+                    "@@ -0,0 +1 @@\n"
+                    f"+{source}\n"
+                )
+
+                redacted_patch = self.helper["validate_review_patch"](
+                    "local unstaged diff",
+                    [rel],
+                    patch,
+                )
+
+                self.assertIn(source, redacted_patch)
+
+    def test_review_patch_preserves_formatted_interpolation_arithmetic(
+        self,
+    ) -> None:
+        cases = (
+            ("runtime.py", 'password = decode(f"{1234 + 5678:04d}")'),
+            ("runtime.cs", 'password = decode($"{1234 + 5678:D4}");'),
+            ("runtime.py", 'password = decode(f"{1234 + 5678=!r}")'),
+        )
+        for rel, source in cases:
+            with self.subTest(rel=rel):
+                patch = (
+                    f"diff --git a/{rel} b/{rel}\n"
+                    f"--- a/{rel}\n"
+                    f"+++ b/{rel}\n"
+                    "@@ -0,0 +1 @@\n"
+                    f"+{source}\n"
+                )
+
+                self.assertEqual(
+                    self.helper["validate_review_patch"](
+                        "local unstaged diff",
+                        [rel],
+                        patch,
+                    ),
+                    patch,
+                )
+
+    def test_review_patch_redacts_numeric_string_coercion(self) -> None:
+        patch = (
+            "diff --git a/runtime.ts b/runtime.ts\n"
+            "--- a/runtime.ts\n"
+            "+++ b/runtime.ts\n"
+            "@@ -0,0 +1 @@\n"
+            + "+pass"
+            + 'word = decode(`${String(1234)+5678}`);\n'
+        )
+
+        redacted_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["runtime.ts"],
+            patch,
+        )
+
+        self.assertNotIn("1234", redacted_patch)
+        self.assertNotIn("5678", redacted_patch)
+
+    def test_review_patch_redacts_numeric_array_coercion(self) -> None:
+        patch = (
+            "diff --git a/runtime.ts b/runtime.ts\n"
+            "--- a/runtime.ts\n"
+            "+++ b/runtime.ts\n"
+            "@@ -0,0 +1 @@\n"
+            + "+pass"
+            + "word = decode(`${[] + 1234 + 5678}`);\n"
+        )
+
+        redacted_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["runtime.ts"],
+            patch,
+        )
+
+        self.assertNotIn("1234", redacted_patch)
+        self.assertNotIn("5678", redacted_patch)
+
+    def test_review_patch_redacts_numeric_fields_after_unary_plus(self) -> None:
+        patch = (
+            "diff --git a/runtime.ts b/runtime.ts\n"
+            "--- a/runtime.ts\n"
+            "+++ b/runtime.ts\n"
+            "@@ -0,0 +1 @@\n"
+            + "+pass"
+            + "word = decode(`${1234}${+5678}`);\n"
+        )
+
+        redacted_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["runtime.ts"],
+            patch,
+        )
+
+        self.assertNotIn("1234", redacted_patch)
+        self.assertNotIn("5678", redacted_patch)
+
+    def test_review_patch_redacts_based_non_javascript_interpolation_integers(
+        self,
+    ) -> None:
+        cases = (
+            ("runtime.py", "0xA1B2C3D4"),
+            ("runtime.py", "0x_A1B2C3D4"),
+            ("runtime.py", "0b10101010110011001111000011110000"),
+            ("runtime.py", "0b_10101010110011001111000011110000"),
+            ("runtime.py", "0o12345670123"),
+            ("runtime.py", "0o_12345670123"),
+            ("runtime.cs", "0xA1B2C3D4"),
+            ("runtime.cs", "0x_A1B2C3D4"),
+            ("runtime.cs", "0b10101010110011001111000011110000"),
+            ("runtime.cs", "0b_10101010110011001111000011110000"),
+        )
+        for rel, fixture_value in cases:
+            marker = "f" if rel.endswith(".py") else "$"
+            terminator = "" if rel.endswith(".py") else ";"
+            source = (
+                "pass"
+                + f'word = decode({marker}"{{{fixture_value}}}"){terminator}'
+            )
+            with self.subTest(rel=rel, fixture_value=fixture_value):
+                patch = (
+                    f"diff --git a/{rel} b/{rel}\n"
+                    f"--- a/{rel}\n"
+                    f"+++ b/{rel}\n"
+                    "@@ -0,0 +1 @@\n"
+                    f"+{source}\n"
+                )
+
+                redacted_patch = self.helper["validate_review_patch"](
+                    "local unstaged diff",
+                    [rel],
+                    patch,
+                )
+
+                self.assertNotIn(fixture_value, redacted_patch)
+                self.assertIn("{redacted}", redacted_patch)
+
+    def test_review_patch_redacts_based_integers_rendering_as_eight_digits(
+        self,
+    ) -> None:
+        fixture_value = "0xFFFFFF"
+        cases = (
+            (
+                "runtime.ts",
+                'pass' + f'word = decode(`${{{fixture_value}}}`);',
+            ),
+            (
+                "runtime.py",
+                'pass' + f'word = decode(f"{{{fixture_value}}}")',
+            ),
+            (
+                "runtime.cs",
+                'pass' + f'word = decode($"{{{fixture_value}}}");',
+            ),
+        )
+        for rel, source in cases:
+            with self.subTest(rel=rel):
+                patch = (
+                    f"diff --git a/{rel} b/{rel}\n"
+                    f"--- a/{rel}\n"
+                    f"+++ b/{rel}\n"
+                    "@@ -0,0 +1 @@\n"
+                    f"+{source}\n"
+                )
+
+                redacted_patch = self.helper["validate_review_patch"](
+                    "local unstaged diff",
+                    [rel],
+                    patch,
+                )
+
+                self.assertNotIn(fixture_value, redacted_patch)
+                self.assertIn("{redacted}", redacted_patch)
+
+    def test_review_patch_redacts_interpolation_format_spec_literals(self) -> None:
+        fixture_value = "Abc123Def456"
+        cases = (
+            (
+                "runtime.py",
+                'pass'
+                + f'word = prompt(f"{{value:{{width}}{fixture_value}}}")',
+            ),
+            (
+                "runtime.cs",
+                'pass' + f'word = prompt($"{{value:{fixture_value}}}");',
+            ),
+        )
+        for rel, source in cases:
+            with self.subTest(rel=rel):
+                patch = (
+                    f"diff --git a/{rel} b/{rel}\n"
+                    f"--- a/{rel}\n"
+                    f"+++ b/{rel}\n"
+                    "@@ -0,0 +1 @@\n"
+                    f"+{source}\n"
+                )
+
+                redacted_patch = self.helper["validate_review_patch"](
+                    "local unstaged diff",
+                    [rel],
+                    patch,
+                )
+
+                self.assertNotIn(fixture_value, redacted_patch)
+                self.assertIn("redacted", redacted_patch)
+
+    def test_review_patch_redacts_format_specs_beginning_with_punctuation(
+        self,
+    ) -> None:
+        fixture_value = "Abc123Def456"
+        cases = (
+            ("runtime.py", f'pass' + f'word = decode(f"{{value:={fixture_value}}}")'),
+            ("runtime.py", f'pass' + f'word = decode(f"{{value::{fixture_value}}}")'),
+            ("runtime.cs", f'pass' + f'word = decode($"{{value:={fixture_value}}}");'),
+        )
+        for rel, source in cases:
+            with self.subTest(rel=rel, source=source):
+                patch = (
+                    f"diff --git a/{rel} b/{rel}\n"
+                    f"--- a/{rel}\n"
+                    f"+++ b/{rel}\n"
+                    "@@ -0,0 +1 @@\n"
+                    f"+{source}\n"
+                )
+
+                redacted_patch = self.helper["validate_review_patch"](
+                    "local unstaged diff",
+                    [rel],
+                    patch,
+                )
+
+                self.assertNotIn(fixture_value, redacted_patch)
+                self.assertIn("redacted", redacted_patch)
+
+    def test_review_patch_preserves_csharp_alias_qualifier_colons(self) -> None:
+        for expression in (
+            "global::Namespace.Value",
+            "Vendor::Namespace.Value",
+            "@vendor::Namespace.Value",
+            "new global::VeryLongNamespace.Type()",
+            "Get<global::VeryLongNamespace.Type>()",
+        ):
+            with self.subTest(expression=expression):
+                format_start = self.helper["top_level_interpolation_format_start"](
+                    expression,
+                    0,
+                    len(expression),
+                    dialect="csharp",
+                )
+
+                self.assertIsNone(format_start)
+
+    def test_review_patch_preserves_csharp_alias_qualifier_source(self) -> None:
+        expression = "new global::VeryLongNamespace.Type()"
+        source = "pass" + f'word = decode($"{{{expression}}}");'
+        patch = (
+            "diff --git a/runtime.cs b/runtime.cs\n"
+            "--- a/runtime.cs\n"
+            "+++ b/runtime.cs\n"
+            "@@ -0,0 +1 @@\n"
+            f"+{source}\n"
+        )
+
+        self.assertEqual(
+            self.helper["validate_review_patch"](
+                "local unstaged diff",
+                ["runtime.cs"],
+                patch,
+            ),
+            patch,
+        )
+
+    def test_review_patch_redacts_csharp_format_starting_with_colon(self) -> None:
+        fixture_value = "Abc123Def456"
+        patch = (
+            "diff --git a/runtime.cs b/runtime.cs\n"
+            "--- a/runtime.cs\n"
+            "+++ b/runtime.cs\n"
+            "@@ -0,0 +1 @@\n"
+            + "+pass"
+            + 'word = decode($"{(x)::'
+            + fixture_value
+            + '}");\n'
+        )
+
+        redacted_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["runtime.cs"],
+            patch,
+        )
+
+        self.assertNotIn(fixture_value, redacted_patch)
+        self.assertIn('$"{(x):redacted}"', redacted_patch)
+
+    def test_review_patch_preserves_csharp_conditional_colon_as_source(self) -> None:
+        source = (
+            "pass"
+            + 'word = decode($"{(flag ? SafeIdentifier1234 : OtherIdentifier5678)}");'
+        )
+        patch = (
+            "diff --git a/runtime.cs b/runtime.cs\n"
+            "--- a/runtime.cs\n"
+            "+++ b/runtime.cs\n"
+            "@@ -0,0 +1 @@\n"
+            f"+{source}\n"
+        )
+
+        redacted_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["runtime.cs"],
+            patch,
+        )
+
+        self.assertIn(source, redacted_patch)
+
+    def test_review_patch_redacts_csharp_format_after_nullable_generic(self) -> None:
+        fixture_value = "ProdSecret123"
+        patch = (
+            "diff --git a/runtime.cs b/runtime.cs\n"
+            "--- a/runtime.cs\n"
+            "+++ b/runtime.cs\n"
+            "@@ -0,0 +1 @@\n"
+            + "+pass"
+            + f'word = decode($"{{Get<int?>():{fixture_value}}}");\n'
+        )
+
+        redacted_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["runtime.cs"],
+            patch,
+        )
+
+        self.assertNotIn(fixture_value, redacted_patch)
+        self.assertIn('{Get<int?>():redacted}', redacted_patch)
+
+    def test_review_patch_preserves_unicode_interpolation_identifiers(self) -> None:
+        identifier = "变量12345678"
+        cases = (
+            ("runtime.ts", 'pass' + f'word = decode(`${{{identifier}}}`);'),
+            ("runtime.py", 'pass' + f'word = decode(f"{{{identifier}}}")'),
+            ("runtime.cs", 'pass' + f'word = decode($"{{{identifier}}}");'),
+            (
+                "runtime.ts",
+                r"password = decode(`${\u{53D8}\u{91CF}12345678}`);",
+            ),
+        )
+        for rel, source in cases:
+            with self.subTest(rel=rel, source=source):
+                patch = (
+                    f"diff --git a/{rel} b/{rel}\n"
+                    f"--- a/{rel}\n"
+                    f"+++ b/{rel}\n"
+                    "@@ -0,0 +1 @@\n"
+                    f"+{source}\n"
+                )
+
+                redacted_patch = self.helper["validate_review_patch"](
+                    "local unstaged diff",
+                    [rel],
+                    patch,
+                )
+
+                self.assertIn(source, redacted_patch)
+
+    def test_review_patch_balances_ordinary_interpolated_call_parentheses(
+        self,
+    ) -> None:
+        fixture_value = "Prod)Secret123"
+        cases = (
+            (
+                "runtime.py",
+                'pass'
+                + f'word = runCommand(f"{{get("{fixture_value}")}}")',
+            ),
+            (
+                "runtime.cs",
+                'pass'
+                + f'word = runCommand($"{{Get("{fixture_value}")}}");',
+            ),
+        )
+        for rel, source in cases:
+            with self.subTest(rel=rel):
+                patch = (
+                    f"diff --git a/{rel} b/{rel}\n"
+                    f"--- a/{rel}\n"
+                    f"+++ b/{rel}\n"
+                    "@@ -0,0 +1 @@\n"
+                    f"+{source}\n"
+                )
+
+                redacted_patch = self.helper["validate_review_patch"](
+                    "local unstaged diff",
+                    [rel],
+                    patch,
+                )
+
+                self.assertNotIn(fixture_value, redacted_patch)
+                self.assertIn('("redacted")', redacted_patch)
+
+    def test_review_patch_parses_non_interpolated_csharp_verbatim_strings(
+        self,
+    ) -> None:
+        fixture_value = "ProdSecret123"
+        patch = (
+            "diff --git a/runtime.cs b/runtime.cs\n"
+            "--- a/runtime.cs\n"
+            "+++ b/runtime.cs\n"
+            "@@ -0,0 +1 @@\n"
+            + "+pass"
+            + f'word = runCommand(@"C:\\\", "{fixture_value}");\n'
+        )
+
+        redacted_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["runtime.cs"],
+            patch,
+        )
+
+        self.assertNotIn(fixture_value, redacted_patch)
+        self.assertIn('runCommand(@"C:\\\", "redacted")', redacted_patch)
+
+    def test_review_patch_handles_csharp_interpolation_comment_terminator(
+        self,
+    ) -> None:
+        fixture_value = "Abc1234"
+        terminator = "\u0085"
+        patch = (
+            "diff --git a/runtime.cs b/runtime.cs\n"
+            "--- a/runtime.cs\n"
+            "+++ b/runtime.cs\n"
+            "@@ -0,0 +1 @@\n"
+            + "+pass"
+            + f'word = decode($"{fixture_value}'
+            + f'{{Get(value // note{terminator} ?? fallback)}}");\n'
+        )
+
+        redacted_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["runtime.cs"],
+            patch,
+        )
+
+        self.assertNotIn(fixture_value, redacted_patch)
+        self.assertIn(
+            f'{{Get(value // note{terminator} ?? fallback)}}',
+            redacted_patch,
+        )
+
+    def test_review_patch_handles_unicode_terminator_in_csharp_call_comment(
+        self,
+    ) -> None:
+        fixture_value = "ProdSecret123"
+        terminator = "\u0085"
+        patch = (
+            "diff --git a/runtime.cs b/runtime.cs\n"
+            "--- a/runtime.cs\n"
+            "+++ b/runtime.cs\n"
+            "@@ -0,0 +1 @@\n"
+            + "+pass"
+            + f'word = runCommand(value, // note{terminator}"{fixture_value}");\n'
+        )
+
+        redacted_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["runtime.cs"],
+            patch,
+        )
+
+        self.assertNotIn(fixture_value, redacted_patch)
+        self.assertIn(f'// note{terminator}"redacted"', redacted_patch)
+
+    def test_review_patch_does_not_parse_python_raw_string_as_c_family(self) -> None:
+        fixture_value = "Abc123(payload)Abc123"
+        patch = (
+            "diff --git a/runtime.py b/runtime.py\n"
+            "--- a/runtime.py\n"
+            "+++ b/runtime.py\n"
+            "@@ -0,0 +1 @@\n"
+            + "+pass"
+            + f'word = prompt(R"{fixture_value}")\n'
+        )
+
+        redacted_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["runtime.py"],
+            patch,
+        )
+
+        self.assertNotIn(fixture_value, redacted_patch)
+        self.assertIn('prompt(R"redacted")', redacted_patch)
+
+    def test_review_patch_preserves_prose_comment_inside_pem_context(self) -> None:
+        identifier = "AuthenticationConfigurationIdentifier"
+        body = "MIIEowIBAAKCAQEAcommented0123456789ABCDEF"
+        patch = (
+            "diff --git a/fixture.cc b/fixture.cc\n"
+            "--- a/fixture.cc\n"
+            "+++ b/fixture.cc\n"
+            "@@ -0,0 +1,4 @@\n"
+            "+// -----BEGIN "
+            + "PRIVATE KEY-----\n"
+            + f"+// note {identifier} stays visible\n"
+            + f"+// {body}\n"
+            + "+// -----END "
+            + "PRIVATE KEY-----\n"
+        )
+
+        redacted_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["fixture.cc"],
+            patch,
+        )
+
+        self.assertIn(identifier, redacted_patch)
+        self.assertIn("+// redacted", redacted_patch)
+
     def test_review_patch_redacts_short_and_unquoted_fallbacks(self) -> None:
         for fallback in ('"hunter2"', "12345678"):
             with self.subTest(fallback=fallback):
@@ -3937,6 +8658,42 @@ class AutoreviewHardeningTests(unittest.TestCase):
                     redacted_patch,
                 )
 
+    def test_review_patch_redacts_fallbacks_after_unicode_line_comments(
+        self,
+    ) -> None:
+        fixture_value = "Secret" + "123"
+        key = "password"
+        cases = (
+            ("runtime.ts", "\u2028", "||"),
+            ("runtime.js", "\u2029", "||"),
+            ("runtime.cs", "\u0085", "??"),
+        )
+        for rel, terminator, operator in cases:
+            with self.subTest(rel=rel):
+                source = (
+                    f"{key} = primary // note{terminator} "
+                    f'{operator} "{fixture_value}"'
+                )
+                patch = (
+                    f"diff --git a/{rel} b/{rel}\n"
+                    f"--- a/{rel}\n"
+                    f"+++ b/{rel}\n"
+                    "@@ -0,0 +1 @@\n"
+                    f"+{source}\n"
+                )
+
+                redacted_patch = self.helper["validate_review_patch"](
+                    "local unstaged diff",
+                    [rel],
+                    patch,
+                )
+
+                self.assertNotIn(fixture_value, redacted_patch)
+                self.assertIn(
+                    f'{terminator} {operator} "redacted"',
+                    redacted_patch,
+                )
+
     def test_review_patch_preserves_redaction_placeholder_fallback(self) -> None:
         patch = (
             "diff --git a/runtime.py b/runtime.py\n"
@@ -3955,6 +8712,26 @@ class AutoreviewHardeningTests(unittest.TestCase):
             ),
             patch,
         )
+
+    def test_review_patch_rejects_arbitrary_redacted_prefix_as_placeholder(self) -> None:
+        arbitrary_value = "redacted-production"
+        patch = (
+            "diff --git a/runtime.py b/runtime.py\n"
+            "--- a/runtime.py\n"
+            "+++ b/runtime.py\n"
+            "@@ -0,0 +1 @@\n"
+            + "+pass"
+            + f'word = "{arbitrary_value}"\n'
+        )
+
+        redacted_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["runtime.py"],
+            patch,
+        )
+
+        self.assertNotIn(arbitrary_value, redacted_patch)
+        self.assertIn('pass' + 'word = "redacted"', redacted_patch)
 
     def test_review_patch_ignores_nested_fallback_operator_text(self) -> None:
         fixture_value = realistic_secret_value()
@@ -3976,6 +8753,212 @@ class AutoreviewHardeningTests(unittest.TestCase):
         self.assertNotIn(fixture_value, redacted_patch)
         self.assertIn('defaults["x || y"] || "redacted"', redacted_patch)
 
+    def test_review_patch_ignores_fallback_operator_inside_regex(self) -> None:
+        source = "password = /Abc123||Def456/;"
+        patch = (
+            "diff --git a/runtime.ts b/runtime.ts\n"
+            "--- a/runtime.ts\n"
+            "+++ b/runtime.ts\n"
+            "@@ -0,0 +1 @@\n"
+            f"+{source}\n"
+        )
+
+        self.assertEqual(
+            self.helper["validate_review_patch"](
+                "local unstaged diff",
+                ["runtime.ts"],
+                patch,
+            ),
+            patch,
+        )
+
+    def test_review_patch_redacts_composed_template_literals(self) -> None:
+        first = "Abc123"
+        second = "Def456"
+        source = (
+            'password = decode(`${"'
+            + first
+            + '".concat("'
+            + second
+            + '")}`)'
+        )
+        patch = (
+            "diff --git a/runtime.ts b/runtime.ts\n"
+            "--- a/runtime.ts\n"
+            "+++ b/runtime.ts\n"
+            "@@ -0,0 +1 @@\n"
+            f"+{source}\n"
+        )
+
+        redacted_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["runtime.ts"],
+            patch,
+        )
+
+        self.assertNotIn(first, redacted_patch)
+        self.assertNotIn(second, redacted_patch)
+        self.assertIn(".concat(", redacted_patch)
+
+    def test_review_patch_preserves_regex_delimiters_during_redaction(self) -> None:
+        fixture_value = "Abc12345Def67890"
+        patch = (
+            "diff --git a/runtime.ts b/runtime.ts\n"
+            "--- a/runtime.ts\n"
+            "+++ b/runtime.ts\n"
+            "@@ -0,0 +1 @@\n"
+            f"+password = primary || /{fixture_value}/i;\n"
+        )
+
+        redacted_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["runtime.ts"],
+            patch,
+        )
+
+        self.assertNotIn(fixture_value, redacted_patch)
+        self.assertIn("password = primary || /redacted/i;", redacted_patch)
+
+    def test_review_patch_preserves_groovy_slashy_assignment_delimiters(
+        self,
+    ) -> None:
+        fixture_value = "ProdSecret123"
+        cases = (
+            (
+                f"password = /{fixture_value}/",
+                "password = /redacted/",
+            ),
+            (
+                f"password = $/{fixture_value}/$",
+                "password = $/redacted/$",
+            ),
+            (
+                f"password = /{fixture_value}${{name}}/",
+                "password = /redacted${name}/",
+            ),
+        )
+        for source, expected in cases:
+            with self.subTest(source=source):
+                patch = (
+                    "diff --git a/runtime.groovy b/runtime.groovy\n"
+                    "--- a/runtime.groovy\n"
+                    "+++ b/runtime.groovy\n"
+                    "@@ -0,0 +1 @@\n"
+                    f"+{source}\n"
+                )
+
+                redacted_patch = self.helper["validate_review_patch"](
+                    "local unstaged diff",
+                    ["runtime.groovy"],
+                    patch,
+                )
+
+                self.assertNotIn(fixture_value, redacted_patch)
+                self.assertIn(expected, redacted_patch)
+
+    def test_review_patch_scans_subscript_after_member_call(self) -> None:
+        fixture_value = "CorrectHorse7Battery"
+        source = f'password = credentials->get()["{fixture_value}"]'
+        patch = (
+            "diff --git a/runtime.cpp b/runtime.cpp\n"
+            "--- a/runtime.cpp\n"
+            "+++ b/runtime.cpp\n"
+            "@@ -0,0 +1 @@\n"
+            f"+{source}\n"
+        )
+
+        redacted_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["runtime.cpp"],
+            patch,
+        )
+
+        self.assertNotIn(fixture_value, redacted_patch)
+        self.assertIn('credentials->get()["redacted"]', redacted_patch)
+
+    def test_review_patch_preserves_chained_credential_lookup_keys(self) -> None:
+        for lookup in ('["access_token"]', '.get("access_token")'):
+            with self.subTest(lookup=lookup):
+                patch = (
+                    "diff --git a/runtime.ts b/runtime.ts\n"
+                    "--- a/runtime.ts\n"
+                    "+++ b/runtime.ts\n"
+                    "@@ -0,0 +1 @@\n"
+                    f"+password = response.json(){lookup};\n"
+                )
+
+                self.assertEqual(
+                    self.helper["validate_review_patch"](
+                        "local unstaged diff",
+                        ["runtime.ts"],
+                        patch,
+                    ),
+                    patch,
+                )
+
+    def test_review_patch_scans_csharp_pointer_member_call(self) -> None:
+        fixture_value = "CorrectHorse7Battery"
+        source = f'password = provider->Get()->Decode("{fixture_value}")'
+        patch = (
+            "diff --git a/runtime.cs b/runtime.cs\n"
+            "--- a/runtime.cs\n"
+            "+++ b/runtime.cs\n"
+            "@@ -0,0 +1 @@\n"
+            f"+{source}\n"
+        )
+
+        redacted_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["runtime.cs"],
+            patch,
+        )
+
+        self.assertNotIn(fixture_value, redacted_patch)
+        self.assertIn('provider->Get()->Decode("redacted")', redacted_patch)
+
+    def test_review_patch_scans_fallback_after_swift_raw_string(self) -> None:
+        fixture_value = "CorrectHorse7Battery"
+        patch = (
+            "diff --git a/runtime.swift b/runtime.swift\n"
+            "--- a/runtime.swift\n"
+            "+++ b/runtime.swift\n"
+            "@@ -0,0 +1 @@\n"
+            f'+password = (#"safe"# as String?) ?? "{fixture_value}"\n'
+        )
+
+        redacted_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["runtime.swift"],
+            patch,
+        )
+
+        self.assertNotIn(fixture_value, redacted_patch)
+        self.assertIn('(#"safe"# as String?) ?? "redacted"', redacted_patch)
+
+    def test_review_patch_redacts_swift_regex_inside_interpolation(self) -> None:
+        fixture_value = "CorrectHorse7Battery"
+        source = (
+            'password = "\\(String(describing: #/'
+            + fixture_value
+            + '/#))"'
+        )
+        patch = (
+            "diff --git a/runtime.swift b/runtime.swift\n"
+            "--- a/runtime.swift\n"
+            "+++ b/runtime.swift\n"
+            "@@ -0,0 +1 @@\n"
+            f"+{source}\n"
+        )
+
+        redacted_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["runtime.swift"],
+            patch,
+        )
+
+        self.assertNotIn(fixture_value, redacted_patch)
+        self.assertIn("#/redacted/#", redacted_patch)
+
     def test_review_patch_ignores_fallback_literals_inside_comments(self) -> None:
         patch = (
             "diff --git a/runtime.ts b/runtime.ts\n"
@@ -3995,12 +8978,33 @@ class AutoreviewHardeningTests(unittest.TestCase):
             fragments,
         )
         self.assertIn('+import("evil-package");', redacted_patch)
-        with self.assertRaisesRegex(SystemExit, "secret-like content"):
+        self.assertEqual(
             self.helper["validate_review_patch"](
                 "local unstaged diff",
                 ["runtime.ts"],
                 patch,
-            )
+            ),
+            patch,
+        )
+
+    def test_review_patch_redacts_secret_like_fallback_comment(self) -> None:
+        fixture_value = "CorrectHorse7Battery"
+        patch = (
+            "diff --git a/runtime.ts b/runtime.ts\n"
+            "--- a/runtime.ts\n"
+            "+++ b/runtime.ts\n"
+            "@@ -0,0 +1 @@\n"
+            f'+password = primary || secondary // "{fixture_value}"\n'
+        )
+
+        redacted_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["runtime.ts"],
+            patch,
+        )
+
+        self.assertNotIn(fixture_value, redacted_patch)
+        self.assertIn('// "redacted"', redacted_patch)
 
     def test_review_patch_learns_bearer_credential_without_prefix(self) -> None:
         bearer_value = "AbcdEFGHijklMNOPqrstUVWX+SensitiveTail123=="
@@ -4156,6 +9160,33 @@ class AutoreviewHardeningTests(unittest.TestCase):
         self.assertNotIn("AB12", redacted)
         self.assertNotIn("CDef3456GHij7890", redacted)
 
+    def test_review_patch_redacts_short_known_private_key_chunk_in_comment(
+        self,
+    ) -> None:
+        patch = (
+            "diff --git a/fixture.ts b/fixture.ts\n"
+            "--- a/fixture.ts\n"
+            "+++ b/fixture.ts\n"
+            "@@ -0,0 +1,5 @@\n"
+            "+-----BEGIN "
+            + "PRIVATE KEY-----\n"
+            "+AB12\n"
+            "+-----END "
+            + "PRIVATE KEY-----\n"
+            "+// AB12\n"
+            "+const output = `${value /* AB12 */}`;\n"
+        )
+
+        redacted = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["fixture.ts"],
+            patch,
+        )
+
+        self.assertNotIn("AB12", redacted)
+        self.assertIn("+// redacted", redacted)
+        self.assertIn("`${value /* redacted */}`", redacted)
+
     def test_review_patch_redacts_padded_private_key_tail_quanta(self) -> None:
         for tail in ("AQ==", "AQI="):
             with self.subTest(tail=tail):
@@ -4197,8 +9228,11 @@ class AutoreviewHardeningTests(unittest.TestCase):
         )
 
         self.assertNotIn(chunks, redacted)
-        self.assertIn("+redacted redacted redacted", redacted)
-        self.assertIn('+log("redacted redacted redacted")', redacted)
+        self.assertIn("+redacted-a redacted-b redacted-c", redacted)
+        self.assertIn(
+            '+log("redacted-a redacted-b redacted-c")',
+            redacted,
+        )
 
     def test_review_patch_redacts_markerless_private_key_body_in_string(self) -> None:
         body = "MIIEvQIBADANBgkqhkiG9w0BAQEFAASC1234567890abcdef"
@@ -4352,6 +9386,50 @@ class AutoreviewHardeningTests(unittest.TestCase):
                 patch,
             )
 
+    def test_review_patch_redacts_known_secret_after_python_floor_division(
+        self,
+    ) -> None:
+        fixture_value = "ProdSecret123"
+        patch = (
+            "diff --git a/runtime.py b/runtime.py\n"
+            "--- a/runtime.py\n"
+            "+++ b/runtime.py\n"
+            "@@ -1 +1 @@\n"
+            + "-pass"
+            + f'word = "{fixture_value}"\n'
+            + f'+values = [total // divisor, "{fixture_value}"]\n'
+        )
+
+        redacted = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["runtime.py"],
+            patch,
+        )
+
+        self.assertNotIn(fixture_value, redacted)
+        self.assertIn('+values = [total // divisor, "redacted"]', redacted)
+
+    def test_review_patch_rejects_cross_dialect_comment_source_collision(
+        self,
+    ) -> None:
+        fixture_value = "Evil1234"
+        patch = (
+            "diff --git a/runtime.ts b/runtime.py\n"
+            "--- a/runtime.ts\n"
+            "+++ b/runtime.py\n"
+            "@@ -1,2 +1,2 @@\n"
+            + " pass"
+            + f'word = "{fixture_value}"\n'
+            + f" value // {fixture_value}\n"
+        )
+
+        with self.assertRaisesRegex(SystemExit, "known secret-like value"):
+            self.helper["validate_review_patch"](
+                "local unstaged diff",
+                ["runtime.ts", "runtime.py"],
+                patch,
+            )
+
     def test_review_patch_redacts_known_secret_in_hunk_header(self) -> None:
         fixture_value = realistic_secret_value()
         patch = (
@@ -4395,7 +9473,163 @@ class AutoreviewHardeningTests(unittest.TestCase):
         self.assertNotIn(prefix, redacted_patch)
         self.assertNotIn(longer, redacted_patch)
         self.assertNotIn("SensitiveTail9", redacted_patch)
-        self.assertIn('+log("redacted");', redacted_patch)
+        self.assertRegex(redacted_patch, r'\+log\("redacted-[a-z-]+"\);')
+
+    def test_review_patch_keeps_distinct_secret_fragment_identity(self) -> None:
+        old_value = "AlphaSecret123"
+        new_value = "MuchLongerBetaSecret456" + "Value"
+        patch = (
+            "diff --git a/runtime.ts b/runtime.ts\n"
+            "--- a/runtime.ts\n"
+            "+++ b/runtime.ts\n"
+            "@@ -1,2 +1,2 @@\n"
+            + f'-pass{"word"} = "{old_value}";\n'
+            + f'-runCommand("{old_value}");\n'
+            + f'+pass{"word"} = "{new_value}";\n'
+            + f'+runCommand("{new_value}");\n'
+        )
+
+        redacted_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["runtime.ts"],
+            patch,
+        )
+
+        old_pattern = r'-pass' + r'word = "(redacted-[a-z]+)";'
+        new_pattern = r'\+pass' + r'word = "(redacted-[a-z]+)";'
+        old_match = re.search(old_pattern, redacted_patch)
+        new_match = re.search(new_pattern, redacted_patch)
+        self.assertIsNotNone(old_match)
+        self.assertIsNotNone(new_match)
+        assert old_match is not None and new_match is not None
+        old_label = old_match.group(1)
+        new_label = new_match.group(1)
+        self.assertEqual(old_label, "redacted-a")
+        self.assertEqual(new_label, "redacted-b")
+        self.assertIn(f'-runCommand("{old_label}");', redacted_patch)
+        self.assertIn(f'+runCommand("{new_label}");', redacted_patch)
+
+    def test_review_patch_keeps_private_key_body_identity(self) -> None:
+        old_body = "AB12cd34EF56"
+        new_body = "ZX98yx76WV54"
+        private_key_end = "END " + "PRIVATE KEY"
+        patch = (
+            "diff --git a/runtime.ts b/runtime.ts\n"
+            "--- a/runtime.ts\n"
+            "+++ b/runtime.ts\n"
+            "@@ -1,3 +1,6 @@\n"
+            f" -----{PRIVATE_KEY_BEGIN_TEXT}-----\n"
+            f"-{old_body}\n"
+            f"+{new_body}\n"
+            f" -----{private_key_end}-----\n"
+            f"+-----{PRIVATE_KEY_BEGIN_TEXT}-----\n"
+            f"+{old_body}\n"
+            f"+-----{private_key_end}-----\n"
+        )
+
+        redacted_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["runtime.ts"],
+            patch,
+        )
+
+        self.assertNotIn(old_body, redacted_patch)
+        self.assertNotIn(new_body, redacted_patch)
+        self.assertEqual(redacted_patch.count("redacted-a"), 2)
+        self.assertEqual(redacted_patch.count("redacted-b"), 1)
+
+    def test_review_patch_keeps_secret_identity_across_files(self) -> None:
+        first = "AlphaSecret123"
+        second = "MuchLongerBetaSecret456Value"
+        patch = (
+            "diff --git a/a.ts b/a.ts\n"
+            "--- a/a.ts\n"
+            "+++ b/a.ts\n"
+            "@@ -1 +1 @@\n"
+            + f'-pass{"word"} = "{first}";\n'
+            + f'+pass{"word"} = "{second}";\n'
+            + "diff --git a/b.ts b/b.ts\n"
+            + "--- a/b.ts\n"
+            + "+++ b/b.ts\n"
+            + "@@ -1 +1 @@\n"
+            + f'-pass{"word"} = "{second}";\n'
+            + f'+pass{"word"} = "{first}";\n'
+        )
+
+        redacted_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["a.ts", "b.ts"],
+            patch,
+        )
+
+        self.assertEqual(redacted_patch.count('pass' + 'word = "redacted-a";'), 2)
+        self.assertEqual(redacted_patch.count('pass' + 'word = "redacted-b";'), 2)
+
+    def test_review_patch_reserves_existing_placeholder_labels(self) -> None:
+        first = "AlphaSecret123"
+        second = "BetaSecret456"
+        patch = (
+            "diff --git a/runtime.ts b/runtime.ts\n"
+            "--- a/runtime.ts\n"
+            "+++ b/runtime.ts\n"
+            "@@ -1 +1,2 @@\n"
+            + f'-pass{"word"} = "{first}";\n'
+            + f'+pass{"word"} = "{second}";\n'
+            + '+const marker = "redacted-a";\n'
+        )
+
+        redacted_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["runtime.ts"],
+            patch,
+        )
+
+        self.assertIn('const marker = "redacted-a";', redacted_patch)
+        self.assertIn('pass' + 'word = "redacted-b";', redacted_patch)
+        self.assertIn('pass' + 'word = "redacted-c";', redacted_patch)
+
+    def test_review_patch_labels_lone_secret_beside_bare_placeholder(self) -> None:
+        fixture_value = "ProdSecret123"
+        patch = (
+            "diff --git a/runtime.ts b/runtime.ts\n"
+            "--- a/runtime.ts\n"
+            "+++ b/runtime.ts\n"
+            "@@ -0,0 +1,2 @@\n"
+            '+const marker = "redacted";\n'
+            + f'+pass{"word"} = "{fixture_value}";\n'
+        )
+
+        redacted_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["runtime.ts"],
+            patch,
+        )
+
+        self.assertIn('const marker = "redacted";', redacted_patch)
+        self.assertIn('pass' + 'word = "redacted-a";', redacted_patch)
+
+    def test_review_patch_keeps_hunk_header_fragment_identity(self) -> None:
+        first = "AlphaSecret123"
+        second = "BetaSecret456"
+        patch = (
+            "diff --git a/runtime.ts b/runtime.ts\n"
+            "--- a/runtime.ts\n"
+            "+++ b/runtime.ts\n"
+            + f'@@ -0,0 +1,2 @@ pass{"word"} = "{first}"\n'
+            + f'+pass{"word"} = "{first}";\n'
+            + "+to"
+            + f'ken = "{second}";\n'
+        )
+
+        redacted_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["runtime.ts"],
+            patch,
+        )
+
+        self.assertIn('@@ -0,0 +1,2 @@ password = "redacted-a"', redacted_patch)
+        self.assertIn('+password = "redacted-a";', redacted_patch)
+        self.assertIn('+token = "redacted-b";', redacted_patch)
 
     def test_review_patch_learns_secret_from_hunk_header(self) -> None:
         fixture_value = realistic_secret_value()
@@ -4455,7 +9689,7 @@ class AutoreviewHardeningTests(unittest.TestCase):
 
         self.assertNotIn(body, redacted_patch)
         self.assertNotIn(PRIVATE_KEY_BEGIN_TEXT, redacted_patch)
-        self.assertIn('+log("redacted");', redacted_patch)
+        self.assertIn('+log("redacted-a");', redacted_patch)
 
     def test_review_patch_redacts_escaped_alphabetic_explicit_pem_body(self) -> None:
         body = "AbCdEfGh" + "IjKlMnOp"
@@ -4555,6 +9789,75 @@ class AutoreviewHardeningTests(unittest.TestCase):
         )
 
         self.assertIn(identifier, redacted_patch)
+
+    def test_review_patch_preserves_call_target_inside_explicit_pem_context(self) -> None:
+        identifier = "evilCall" + "1234"
+        patch = (
+            "diff --git a/runtime.ts b/runtime.ts\n"
+            "--- a/runtime.ts\n"
+            "+++ b/runtime.ts\n"
+            "@@ -0,0 +1,3 @@\n"
+            "+// -----BEGIN "
+            + "PRIVATE KEY-----\n"
+            + f"+{identifier}();\n"
+            + "+// -----END "
+            + "PRIVATE KEY-----\n"
+        )
+
+        redacted_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["runtime.ts"],
+            patch,
+        )
+
+        self.assertIn(f"+{identifier}();", redacted_patch)
+
+    def test_review_patch_redacts_call_like_private_key_text_inside_string(
+        self,
+    ) -> None:
+        body = "AbCdEfGhIjKlMnOpQrStUvWxYz" + "012345"
+        patch = (
+            "diff --git a/runtime.ts b/runtime.ts\n"
+            "--- a/runtime.ts\n"
+            "+++ b/runtime.ts\n"
+            "@@ -0,0 +1,3 @@\n"
+            "+// -----BEGIN PRIVATE KEY-----\n"
+            f'+const payload = "{body}(";\n'
+            "+// -----END PRIVATE KEY-----\n"
+        )
+
+        redacted_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["runtime.ts"],
+            patch,
+        )
+
+        self.assertNotIn(body, redacted_patch)
+        self.assertIn('"redacted("', redacted_patch)
+
+    def test_review_patch_redacts_pem_body_before_later_parenthesis(self) -> None:
+        body = "AbCdEfGh1234" + "IjKlMnOp"
+        patch = (
+            "diff --git a/runtime.ts b/runtime.ts\n"
+            "--- a/runtime.ts\n"
+            "+++ b/runtime.ts\n"
+            "@@ -0,0 +1,4 @@\n"
+            "+// -----BEGIN "
+            + "PRIVATE KEY-----\n"
+            + f"+{body}\n"
+            + "+(\n"
+            + "+// -----END "
+            + "PRIVATE KEY-----\n"
+        )
+
+        redacted_patch = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["runtime.ts"],
+            patch,
+        )
+
+        self.assertNotIn(body, redacted_patch)
+        self.assertIn("+redacted\n+(\n", redacted_patch)
 
     def test_review_patch_rejects_residual_hunk_header_secret_risk(self) -> None:
         primary = "CorrectHorse7" + "Battery"
@@ -6829,6 +12132,139 @@ class AutoreviewHardeningTests(unittest.TestCase):
 
         self.assertLess(time.monotonic() - started, 5.0)
 
+    def test_csharp_interpolation_source_scan_bounds_unterminated_quote_run(
+        self,
+    ) -> None:
+        content = '"' * 100_000
+        started = time.monotonic()
+
+        self.helper["interpolation_source_ranges"](
+            content,
+            javascript_dialect="csharp",
+        )
+
+        self.assertLess(time.monotonic() - started, 5.0)
+
+    def test_csharp_string_context_scan_bounds_unterminated_quote_run(
+        self,
+    ) -> None:
+        quote_run = '"' * 100_000
+        content = quote_run + "ProdSecret123"
+        position = len(quote_run)
+        started = time.monotonic()
+
+        contexts = self.helper["string_contexts_at"](
+            content,
+            {position},
+            javascript_dialect="csharp",
+        )
+
+        self.assertIsNone(contexts[position])
+        self.assertLess(time.monotonic() - started, 5.0)
+
+    def test_csharp_string_context_scan_bounds_many_raw_literals(self) -> None:
+        parts: list[str] = []
+        positions: set[int] = set()
+        cursor = 0
+        for index in range(4_000):
+            if parts:
+                parts.append(";")
+                cursor += 1
+            literal = f'"""Value{index:08d}"""'
+            positions.add(cursor + 3)
+            parts.append(literal)
+            cursor += len(literal)
+        content = "".join(parts)
+        started = time.monotonic()
+
+        contexts = self.helper["string_contexts_at"](
+            content,
+            positions,
+            javascript_dialect="csharp",
+        )
+
+        self.assertTrue(all(contexts[position] is not None for position in positions))
+        self.assertLess(time.monotonic() - started, 5.0)
+
+    def test_csharp_raw_scan_bounds_near_delimiter_quote_run(self) -> None:
+        width = 20_000
+        text = '"' * width + "x" + '"' * (width - 1) + "x" + '"' * width
+        started = time.monotonic()
+
+        literal = self.helper["csharp_raw_literal_span"](
+            text,
+            0,
+            len(text),
+        )
+
+        self.assertIsNotNone(literal)
+        self.assertLess(time.monotonic() - started, 5.0)
+
+    def test_c_family_raw_scan_rejects_many_unterminated_openers_once(self) -> None:
+        content = 'R"x(' * 25_000
+        started = time.monotonic()
+
+        with self.assertRaisesRegex(
+            SystemExit,
+            "unterminated C-family raw string",
+        ):
+            self.helper["quoted_literal_value_spans"](
+                content,
+                0,
+                len(content),
+                javascript_dialect="c-family",
+            )
+
+        self.assertLess(time.monotonic() - started, 5.0)
+
+    def test_csharp_comment_fragment_scan_bounds_unterminated_quote_run(
+        self,
+    ) -> None:
+        content = '"' * 100_000
+        started = time.monotonic()
+
+        self.helper["comment_fragment_line_spans"](
+            content,
+            None,
+            javascript_dialect="csharp",
+        )
+
+        self.assertLess(time.monotonic() - started, 5.0)
+
+    def test_comment_fragment_scan_skips_text_without_fragment(self) -> None:
+        scanner = mock.Mock()
+        helper = self.helper["comment_fragment_line_spans"]
+        with mock.patch.dict(
+            helper.__globals__,
+            {"quoted_literal_value_spans": scanner},
+        ):
+            spans = helper(
+                '"""${ambiguous}"""',
+                re.compile("missing-fragment"),
+                javascript_dialect=None,
+            )
+
+        self.assertEqual(spans, {})
+        scanner.assert_not_called()
+
+    def test_private_key_body_scan_reuses_reference_mask(self) -> None:
+        content = "\n".join(
+            f"Chunk{index:04d}AbcDef1234"
+            for index in range(100)
+        )
+        masker = mock.Mock(
+            wraps=self.helper["mask_reference_declaration_evidence"]
+        )
+        scanner = self.helper["explicit_private_key_body_spans"]
+
+        with mock.patch.dict(
+            scanner.__globals__,
+            {"mask_reference_declaration_evidence": masker},
+        ):
+            scanner(content, in_pem=True)
+
+        masker.assert_called_once_with(content)
+
     def test_csharp_context_scan_is_bounded_across_many_uris(self) -> None:
         content = "\n".join(
             f'void Run{index}() {{ dsn=$@"https://user:'
@@ -7349,6 +12785,28 @@ class AutoreviewHardeningTests(unittest.TestCase):
                 "pass"
                 + 'word = response.get("CORRECTHORSE'
                 + 'BATTERYSTAPLE")'
+            )
+        )
+
+    def test_secret_detector_normalizes_c_family_member_operators(self) -> None:
+        for content in (
+            'password = headers->get("Authorization")',
+            'password = headers::get("Authorization")',
+            'password = ui->prompt("Enter password for Service2")',
+        ):
+            with self.subTest(content=content):
+                self.assertFalse(
+                    self.helper["secret_text_risk"](
+                        content,
+                        javascript_dialect="c-family",
+                    )
+                )
+
+    def test_secret_detector_allows_csharp_alias_qualified_reference(self) -> None:
+        self.assertFalse(
+            self.helper["secret_text_risk"](
+                "password = global::Credentials.Value;",
+                javascript_dialect="csharp",
             )
         )
 


### PR DESCRIPTION
## Summary

- make autoreview redact secret-like diff content while preserving executable source for review
- add dialect-aware literal, interpolation, regex, numeric, comment, call-chain, and fallback parsing
- preserve stable secret identities across files and hunk headers without leaking original values
- fail closed on ambiguous source while allowing known credential references and lookup keys

## Proof

- `python3 -m unittest skills.autoreview.tests.test_autoreview_hardening -k review_patch` (281 passed)
- `python3 -m unittest skills.autoreview.tests.test_autoreview_hardening -k secret_detector` (86 passed)
- `PYTHONPATH=/tmp/agent-skills-validate-deps scripts/validate-skills` (6 skills validated)
- `git diff --check`
- mandatory two-pass autoreview completed; final reported C# numeric-member finding was disproved by the existing focused regression and direct span output `(0, 8)`

## Local full-suite note

The full 520-test run passed 515 tests and skipped 1. Four JVM-home tests failed only because this Mac has no Java runtime; GitHub CI runs on Java-equipped Ubuntu and Windows images.
