### PR TITLE
fix(autoreview): isolate secret scans by diff hunk

### DIFF
--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -51,6 +51,7 @@ SAFE_GIT_CONFIG_ARGS = (
     "pager.show=cat",
 )
 SAFE_DIFF_FLAGS = ("--no-ext-diff", "--no-textconv", "--no-renames")
+DIFF_HUNK_CONTENT_BOUNDARY = "\0autoreview-diff-hunk-boundary\0"
 ENGINE_GIT_CONFIG_OVERRIDES = (
     ("core.fsmonitor", "false"),
     ("core.pager", "cat"),
@@ -5519,6 +5520,11 @@ def secret_text_risk(
     *,
     javascript_dialect: str | None = None,
 ) -> bool:
+    if DIFF_HUNK_CONTENT_BOUNDARY in text:
+        return any(
+            secret_text_risk(segment, javascript_dialect=javascript_dialect)
+            for segment in text.split(DIFF_HUNK_CONTENT_BOUNDARY)
+        )
     uri_authorities = uri_authority_ranges(text)
     if credentialed_uri_risk(text, uri_authorities) or basic_authorization_risk(text) or any(
         pattern.search(text) for pattern in SECRET_VALUE_PATTERNS
@@ -5783,6 +5789,13 @@ def review_secret_fragments(
     *,
     javascript_dialect: str | None = None,
 ) -> set[str]:
+    if DIFF_HUNK_CONTENT_BOUNDARY in text:
+        return set().union(
+            *(
+                review_secret_fragments(segment, javascript_dialect=javascript_dialect)
+                for segment in text.split(DIFF_HUNK_CONTENT_BOUNDARY)
+            )
+        )
     private_fragments = {
         fragment
         for fragment in private_key_body_fragments(text)
@@ -6667,14 +6680,14 @@ def unified_diff_contents(patch: str) -> tuple[str, str]:
         line = line.removesuffix("\r")
         hunk_header = re.match(r"^(@{2,})", line)
         if hunk_header:
-            old_content.append(";")
-            new_content.append(";")
+            old_content.append(DIFF_HUNK_CONTENT_BOUNDARY)
+            new_content.append(DIFF_HUNK_CONTENT_BOUNDARY)
             in_hunk = True
             prefix_columns = len(hunk_header.group(1)) - 1
             continue
         if line.startswith("diff --"):
-            old_content.append(";")
-            new_content.append(";")
+            old_content.append(DIFF_HUNK_CONTENT_BOUNDARY)
+            new_content.append(DIFF_HUNK_CONTENT_BOUNDARY)
             in_hunk = False
             continue
         prefix = line[:prefix_columns]

--- a/skills/autoreview/tests/test_autoreview_hardening.py
+++ b/skills/autoreview/tests/test_autoreview_hardening.py
@@ -3290,6 +3290,100 @@ class AutoreviewHardeningTests(unittest.TestCase):
             )
         )
 
+    def test_typescript_credential_property_scan_does_not_cross_hunks(self) -> None:
+        patch = (
+            "diff --git a/src/runtime-web-tools.ts b/src/runtime-web-tools.ts\n"
+            "--- a/src/runtime-web-tools.ts\n"
+            "+++ b/src/runtime-web-tools.ts\n"
+            "@@ -85,12 +84,9 @@ type RuntimeWebProviderSelectionParams<\n"
+            "     toolConfig: TToolConfig;\n"
+            "   }) => { path: string; value: unknown } | undefined;\n"
+            "   /** Resolves inline/env/SecretRef credentials and reports the winning source. */\n"
+            "-  resolveSecretInput: (params: {\n"
+            "-    providerId: string;\n"
+            "-    value: unknown;\n"
+            "-    path: string;\n"
+            "-    envVars: string[];\n"
+            "-  }) => Promise<SecretResolutionResult<TSource>>;\n"
+            "+  resolveSecretInput: (\n"
+            "+    params: RuntimeWebResolveSecretInputParams,\n"
+            "+  ) => Promise<SecretResolutionResult<TSource>>;\n"
+            "   /** Writes the selected credential into the resolved runtime config snapshot. */\n"
+            "   setResolvedCredential: (params: {\n"
+            "     resolvedConfig: OpenClawConfig;\n"
+            "@@ -418,6 +414,7 @@ function resolveRuntimeWebProviderSelection() {\n"
+            "     let keylessFallbackProvider: TProvider | undefined;\n"
+            " \n"
+            "     for (const provider of candidates) {\n"
+            "+      const contractDigest = resolveProviderContractDigest(provider.id);\n"
+            "       const isKeyless = provider.requiresCredential === false;\n"
+            "       if (isKeyless) {\n"
+            "         if (!params.configuredProvider && !params.allowKeylessAutoSelect) {\n"
+            "@@ -440,6 +437,7 @@ function resolveRuntimeWebProviderSelection() {\n"
+            "         value,\n"
+            "         path,\n"
+            "         envVars: getProviderEnvVars(provider),\n"
+            "+        contractDigest,\n"
+            "       });\n"
+            "       let selectedCandidatePath = path;\n"
+            "       let selectedCandidateResolution = resolution;\n"
+            "@@ -457,6 +455,7 @@ function resolveRuntimeWebProviderSelection() {\n"
+            "             value: fallback.value,\n"
+            "             path: fallback.path,\n"
+            "             envVars: getProviderEnvVars(provider),\n"
+            "+            contractDigest,\n"
+            "           });\n"
+            "         }\n"
+            "       } else if (resolution.source === \"env\" && !resolution.secretRefConfigured) {\n"
+        )
+
+        old_content, new_content = self.helper["unified_diff_contents"](patch)
+        self.assertFalse(
+            self.helper["secret_text_risk"](
+                old_content,
+                javascript_dialect="typescript",
+            )
+        )
+        self.assertFalse(
+            self.helper["secret_text_risk"](
+                new_content,
+                javascript_dialect="typescript",
+            )
+        )
+        self.assertEqual(
+            self.helper["validate_review_patch"](
+                "typescript credential property diff",
+                ["src/runtime-web-tools.ts"],
+                patch,
+            ),
+            patch,
+        )
+
+    def test_typescript_hunk_scan_still_flags_sensitive_literal_fixture(self) -> None:
+        sensitive_line = next(
+            line
+            for line in (FIXTURES / "typescript-sensitive-literals.ts")
+            .read_text(encoding="utf-8")
+            .splitlines()
+            if line.strip()
+        )
+        patch = (
+            "@@ -1 +1 @@\n"
+            "+const tokenRef: SecretRef | undefined = candidate.tokenRef;\n"
+            "@@ -20 +20 @@\n"
+            f"+{sensitive_line}\n"
+        )
+
+        self.assertTrue(
+            any(
+                self.helper["secret_text_risk"](
+                    content,
+                    javascript_dialect="typescript",
+                )
+                for content in self.helper["unified_diff_contents"](patch)
+            )
+        )
+
     def test_normalized_secret_scan_handles_combined_diff_prefixes(self) -> None:
         value = "Correct-Horse!" + "@Battery$Staple"
         patch = (


### PR DESCRIPTION
## Summary

- scan reconstructed old/new diff content one hunk at a time
- prevent an incomplete TypeScript credential property/type declaration from consuming later hunks as credential content
- keep same-hunk literal and known-format secret detection unchanged

## Regression coverage

- exact multi-hunk TypeScript `SecretRef`/credential-plumbing shape from the blocked OpenClaw diff now passes
- the existing obviously-fake sensitive literal fixture corpus still flags, including when a benign reference appears in another hunk

## Validation

- `scripts/validate-skills`
- `python3 -m unittest skills/autoreview/scripts/autoreview_test.py skills.autoreview.tests.test_autoreview_hardening` (324 tests, 1 skipped)
- exact blocked OpenClaw diff through `validate_review_patch`
- autoreview clean
