### PR TITLE
fix(autoreview): allow OpenClaw redaction sentinel

### DIFF
--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -334,6 +334,7 @@ class ReviewChunk(NamedTuple):
     content: str
     context: str = ""
 SECRET_PLACEHOLDER_VALUES = {
+    "__openclaw_redacted__",
     "changeme",
     "decoy-token",
     "dummy",

--- a/skills/autoreview/tests/test_autoreview_hardening.py
+++ b/skills/autoreview/tests/test_autoreview_hardening.py
@@ -3275,6 +3275,11 @@ class AutoreviewHardeningTests(unittest.TestCase):
 
         self.assertTrue(self.helper["secret_text_risk"](content))
 
+    def test_secret_detector_allows_openclaw_redaction_sentinel(self) -> None:
+        self.assertFalse(
+            self.helper["secret_text_risk"]('token: "__OPENCLAW_REDACTED__"')
+        )
+
     def test_normalized_secret_scan_does_not_cross_hunks(self) -> None:
         patch = (
             "@@ -1 +1 @@\n"


### PR DESCRIPTION
## Summary

- allow the public OpenClaw `__OPENCLAW_REDACTED__` sentinel in the autoreview secret-placeholder allowlist
- preserve fail-closed scanning for other secret-like values
- cover token-field usage with a regression test

## Validation

- `.venv/bin/python scripts/validate-skills`
- `.venv/bin/python -m unittest skills/autoreview/scripts/autoreview_test.py skills.autoreview.tests.test_autoreview_hardening` (323 tests, 1 skipped)
- `skills/autoreview/scripts/autoreview --mode local --stream-engine-output` (clean)
