### PR TITLE
fix(autoreview): allow typed resolution references

### DIFF
--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -553,6 +553,7 @@ SOURCE_CODE_REFERENCE_VALUES = {
     "driverPassword",
     "recoveryDevice.accessToken",
     "recoveryDevice.password",
+    "resolution.value",
 }
 SOURCE_CODE_REFERENCE_PATTERN = re.compile(
     r"(?<![A-Za-z0-9_$?.])(?:" + "|".join(

--- a/skills/autoreview/tests/test_autoreview_hardening.py
+++ b/skills/autoreview/tests/test_autoreview_hardening.py
@@ -2349,6 +2349,45 @@ class AutoreviewHardeningTests(unittest.TestCase):
         ):
             self.assertIn(reference, validated)
 
+    def test_secret_detector_allows_typescript_member_reference_assignment(self) -> None:
+        source = "legacyXSearchResolvedRecord.apiKey = resolution.value;"
+        patch = (
+            "diff --git a/src/runtime-web-tools.ts b/src/runtime-web-tools.ts\n"
+            "--- a/src/runtime-web-tools.ts\n"
+            "+++ b/src/runtime-web-tools.ts\n"
+            "@@ -20,2 +20,3 @@ function resolveLegacySearch() {\n"
+            f" {source}\n"
+            "+const contractDigest = digestRuntimeWebOwnerContract(contract);\n"
+        )
+
+        self.assertFalse(
+            self.helper["secret_text_risk"](
+                source,
+                javascript_dialect="typescript",
+            )
+        )
+        self.assertEqual(
+            self.helper["validate_review_patch"](
+                "typescript member reference assignment",
+                ["src/runtime-web-tools.ts"],
+                patch,
+            ),
+            patch,
+        )
+
+        fake_literal = next(
+            line
+            for line in (FIXTURES / "typescript-sensitive-literals.ts")
+            .read_text(encoding="utf-8")
+            .splitlines()
+            if line.strip()
+        )
+        self.assertTrue(
+            self.helper["secret_text_risk"](
+                fake_literal,
+                javascript_dialect="typescript",
+            )
+        )
     def test_review_bundle_preserves_typescript_config_paths(self) -> None:
         source = (FIXTURES / "typescript-benign-config-path-references.ts").read_text(
             encoding="utf-8"


### PR DESCRIPTION
## Summary

- allow the canonical TypeScript resolver member reference `resolution.value` when the secret scanner inspects source-code assignments
- keep the exemption exact and source-code-only through the existing reference-value path
- add regression coverage for the blocked OpenClaw assignment while retaining the fake sensitive-literal fixture corpus

## Safety proof

- `python3 -m unittest skills/autoreview/scripts/autoreview_test.py skills.autoreview.tests.test_autoreview_hardening` — 325 tests passed, 1 skipped
- `scripts/validate-skills` — 6 skills validated
- `skills/autoreview/scripts/autoreview --mode uncommitted` — clean
- exact OpenClaw patch validation — accepted without weakening literal detection

The reverse-direction regression reads the existing obviously-fake TypeScript sensitive-literal fixture and confirms it still flags. Known key formats, entropy checks, and assignments of literal credential values are unchanged.
