### PR TITLE
fix(agent-transcript): redact Windows and Linux local paths

### DIFF
--- a/skills/agent-transcript/scripts/agent-transcript
+++ b/skills/agent-transcript/scripts/agent-transcript
@@ -259,7 +259,8 @@ function redact(input, stats) {
     [/\b(?:Bearer|Basic)\s+[A-Za-z0-9._~+/=-]{16,}/gi, "[REDACTED_AUTH_HEADER]"],
     [/[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/gi, "[REDACTED_EMAIL]"],
     [/\b(?:\+?\d[\d .()-]{7,}\d)\b/g, "[REDACTED_PHONE]"],
-    [/\/Users\/[^\s`"'>)]+/g, "[LOCAL_PATH]"],
+    [/[A-Za-z]:[\\/](?:Users|home)[\\/][^\s`"'>)]+/gi, "[LOCAL_PATH]"],
+    [/\/(?:Users|home)\/[^\s`"'>)]+/g, "[LOCAL_PATH]"],
     [/~\/[^\s`"'>)]+/g, "[HOME_PATH]"],
     [/([?&](?:token|key|secret|signature|sig|access_token|auth)=)[^\s`"'>&]+/gi, "$1[REDACTED]"],
   ];

--- a/skills/agent-transcript/scripts/agent-transcript.test.mjs
+++ b/skills/agent-transcript/scripts/agent-transcript.test.mjs
@@ -50,6 +50,37 @@ test("render redacts common secrets and local identifiers", () => {
   assert.doesNotMatch(output, /abcdefghijklmnopqrstuvwxyz123456/);
 });
 
+test("render redacts Windows, Linux and WSL local paths", () => {
+  const dir = tempDir();
+  const session = path.join(dir, "session.jsonl");
+  writeJsonl(session, [
+    {
+      type: "response_item",
+      payload: {
+        role: "user",
+        content: [
+          {
+            type: "text",
+            text: [
+              "windows C:\\Users\\ahmed\\Desktop\\notes.txt",
+              "windows-lower c:/users/ahmed/notes.txt",
+              "linux /home/ahmed/work/private.env",
+              "wsl /mnt/c/Users/ahmed/secret.txt",
+            ].join(" | "),
+          },
+        ],
+      },
+    },
+    { type: "response_item", payload: { role: "assistant", content: [{ type: "text", text: "Done." }] } },
+  ]);
+
+  const output = run(["render", "--session", session]);
+  assert.doesNotMatch(output, /ahmed/);
+  assert.doesNotMatch(output, /notes\.txt/);
+  assert.doesNotMatch(output, /private\.env/);
+  assert.doesNotMatch(output, /secret\.txt/);
+});
+
 test("render drops raw tool outputs but keeps a compact tool summary", () => {
   const dir = tempDir();
   const session = path.join(dir, "session.jsonl");


### PR DESCRIPTION
## Summary

- the `redact()` table in `skills/agent-transcript/scripts/agent-transcript` only matched `/Users/...` and `~/...`
- Windows (`C:\Users\...`) and Linux (`/home/...`) paths were emitted verbatim, while the header still asserted `redaction: local paths` / `omitted: ... local paths` and the run still reported `safe: true` — `unsafe()` has no path pattern, so nothing fails closed
- this output is pasted into public PR bodies, and `AGENTS.md` requires keeping private paths out
- adds a drive-letter rule and extends the POSIX rule to `/home/`
- the drive-letter rule is case-insensitive because Windows paths are (`c:/users/...` is as real as `C:\Users\...`); the POSIX rule stays case-sensitive, since `/users/` is not a real directory on Linux or macOS
- the drive-letter rule is ordered first so a forward-slash Windows path is consumed whole rather than leaving a dangling `D:`

This closes an inconsistency rather than introducing new policy: the sibling session-viewer skill in this repo already matches `/home/` at `skills/session-viewer/scripts/html.ts:572`.

## Evidence

One transcript line containing five path shapes, rendered through the CLI:

```
before  win C:\Users\ahmed\Desktop\private\notes.txt | winlower c:/users/ahmed/x.txt |
        linux /home/ahmed/work/private.env | wsl /mnt/c[LOCAL_PATH] | mac [LOCAL_PATH]

after   win [LOCAL_PATH] | winlower [LOCAL_PATH] |
        linux [LOCAL_PATH] | wsl /mnt/c[LOCAL_PATH] | mac [LOCAL_PATH]
```

WSL paths are covered through their `/Users/` segment; the surviving `/mnt/c` prefix carries no user-identifying component.

One deliberate consequence worth naming: a URL whose path contains `/home/` or `/Users/` is now also rewritten to `[LOCAL_PATH]`. That over-redaction already existed for `/Users/` on `main`, and the rule is kept in the safe direction — a redactor should over-redact rather than under-redact. A lookbehind that exempted URLs was tried and rejected because it silently stopped matching `/mnt/c/Users/...`.

## Validation

- `python scripts/validate-skills` — validated 6 skills
- `node --check skills/agent-transcript/scripts/agent-transcript` — clean
- `node --test skills/agent-transcript/scripts/agent-transcript.test.mjs skills/session-viewer/scripts/session-viewer.test.ts` — 33 tests, 33 pass, 0 fail (32 before, 1 added)
- `python scripts/install-skills.test.py` — 6 tests, OK
- `python scripts/validate-skills.test.py` — 9 tests, OK

Regression coverage: added `render redacts Windows, Linux and WSL local paths`, asserting the username and each filename are absent from the render. It was confirmed to fail against the unmodified script and pass with it, so it is not a vacuous assertion. CI has a `windows-latest` leg but no Windows-path redaction coverage today.

Run on Windows; commands issued through both PowerShell and a POSIX shell.
