### PR TITLE
autoreview: converge fixes by root cause

### DIFF
--- a/skills/autoreview/SKILL.md
+++ b/skills/autoreview/SKILL.md
@@ -50,6 +50,19 @@ Do not require autoreview for a change whose entire diff is prose-only internal 
 - If Gitcrawl reports a portable manifest mismatch, source/runtime DB health error, or stale portable-store checkout, run `gitcrawl doctor --json` and inspect `source_db_health`, `runtime_db_health`, and `portable_store_status` before falling back to live GitHub.
 - Do not push just to review. Push only when the user requested push/ship/PR update.
 
+## Finding Convergence
+
+Before editing, cluster accepted findings by violated invariant, trust boundary, or state transition. Do not patch findings one by one when they are manifestations of the same root cause.
+
+For each cluster:
+
+- Build the smallest useful failure matrix inside the frozen scope. Check sibling paths governed by the same boundary and relevant lifecycle variants such as create, update, delete, retry, recovery, migration, rollback, concurrency, or restart. Skip states the diff cannot affect.
+- Make one coherent fix at the owning boundary. Avoid condition-by-condition patches when a shared invariant can make the whole cluster correct.
+- Add regression proof for the reported case and the affected sibling variants. Stateful fixes need at least one multi-run or recovery test when that is how the defect can recur.
+- Re-read the final diff against the cluster's invariant before requesting confirmation review.
+
+If confirmation review finds another manifestation of the same root-cause family, do not apply another narrow patch immediately. Reconstruct the invariant and failure matrix, then reclassify the remaining work under the Scope Governor. Continue only when the coherent fix remains in scope; otherwise stop and escalate or preserve it as follow-up work.
+
 ## Scope Governor
 
 Autoreview is a closeout gate, not permission to rewrite the task.

--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -8630,6 +8630,9 @@ def render_review_prompt(
         - Report only actionable defects introduced or exposed by this change.
         - Prefer high-signal findings over style feedback.
         - Report EVERY distinct actionable defect in this single pass, ordered most severe first. Each review round costs the caller a full fix-test-review cycle; withholding a known defect until a later round wastes one.
+        - For each defect, identify the violated invariant, trust boundary, or state transition. Before returning, sweep every changed path governed by that same cause for sibling manifestations.
+        - Report all actionable manifestations of the same root cause in this pass, including lifecycle, retry, recovery, migration, rollback, concurrency, or restart variants directly evidenced by the bundle. Do not invent defects that require unavailable unchanged context.
+        - When multiple findings share a root cause, say so in each finding body and name the related changed paths or conditions so the caller can repair the owning boundary once.
         - Before returning, sweep the bundle once more for independent defects in other files or failure modes that you may have stopped scanning for after an earlier find.
         - Include security findings: injection, secret leaks, authz/authn bypass, path traversal, unsafe deserialization, unsafe filesystem or shell use, privacy leaks, and credential handling.
         - Do not reject legitimate functionality merely because it touches shell, filesystem, network, auth, or sensitive data. Report a security finding only when the patch creates a concrete exploitable risk, removes an important safety check, or lacks validation at a trust boundary.

--- a/skills/autoreview/scripts/test-review-harness.py
+++ b/skills/autoreview/scripts/test-review-harness.py
@@ -154,6 +154,8 @@ def validate_prompt_policy(repo: Path, autoreview: Path) -> None:
         "Do not turn a narrow patch into a broad",
         "If this is release-branch or release-process work",
         "Non-blocking design,",
+        "identify the violated invariant",
+        "manifestations of the same root cause",
     )
     missing = [needle for needle in required if needle not in prompt]
     if missing:

--- a/skills/autoreview/tests/test_autoreview_hardening.py
+++ b/skills/autoreview/tests/test_autoreview_hardening.py
@@ -701,6 +701,30 @@ class AutoreviewHardeningTests(unittest.TestCase):
 
         self.assertTrue(prompt.endswith(bundle))
 
+    def test_review_prompt_requires_root_cause_family_sweep(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo = init_repo(Path(tempdir))
+            prompt = self.helper["render_review_prompt"](
+                repo,
+                "commit",
+                "HEAD",
+                self.helper["ReviewChunk"]("# Commit Diff\n+changed\n"),
+                "",
+                "",
+            )
+
+        self.assertIn("identify the violated invariant", prompt)
+        self.assertIn("manifestations of the same root cause", prompt)
+        self.assertIn("repair the owning boundary once", prompt)
+
+    def test_skill_requires_root_cause_repair_convergence(self) -> None:
+        skill = SCRIPT.parent.parent.joinpath("SKILL.md").read_text(encoding="utf-8")
+
+        self.assertIn("cluster accepted findings", skill)
+        self.assertIn("one coherent fix at the owning boundary", skill)
+        self.assertIn("multi-run or recovery test", skill)
+        self.assertIn("another manifestation of the same root-cause family", skill)
+
     def test_review_pass_count_is_bounded(self) -> None:
         builder = self.helper["build_review_prompts"]
         with tempfile.TemporaryDirectory() as tempdir:


### PR DESCRIPTION
## Summary

- make reviewers identify the violated invariant, trust boundary, or state transition and report every evidenced manifestation of the same root cause in one pass
- make repair agents cluster accepted findings and apply one coherent fix at the owning boundary
- require sibling-state and multi-run or recovery regression proof where relevant
- stop repeated narrow patches when confirmation review finds the same root-cause family again
- add regression assertions for both reviewer and repair-agent instructions

## Why

Autoreview already asks for every independent defect and says to fix a bug class when practical. It did not turn that intent into a concrete convergence protocol. A reviewer could report one manifestation, the repair agent could patch that line, and later reviews could expose sibling lifecycle or recovery variants of the same violated invariant.

This change connects both halves of the loop while preserving the existing frozen-scope and Scope Governor boundaries.

## Validation

- `scripts/validate-skills`
- Python compile checks for the changed scripts
- shell syntax check for the POSIX harness
- all built-in autoreview self-tests
- focused root-cause convergence policy tests
- core `autoreview_test.py` suite: 31 passed
- medium-effort autoreview of the final diff: no actionable findings

The combined 340-test suite completed except for four existing JVM-home tests, which could not run because the local machine has no Java runtime; all failures reported only that missing runtime.
