### PR TITLE
fix(autoreview): preserve safe URI userinfo

### DIFF
--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -3172,18 +3172,7 @@ def credentialed_uri_risk(
             )
         ):
             return True
-        if uri_password_is_interpolated(
-            text,
-            credential.scheme_start,
-            credential.value,
-            credential.host,
-            credential.context,
-        ):
-            continue
-        if credential.has_password or uri_userinfo_literal_risk(
-            credential.value,
-            allow_plus_address=True,
-        ):
+        if uri_credential_value_risk(text, credential):
             return True
     return False
 
@@ -3775,6 +3764,24 @@ def uri_password_is_format_placeholder(
         ):
             return True
     return False
+
+
+def uri_credential_value_risk(
+    text: str,
+    credential: UriAuthorityCredential,
+) -> bool:
+    if uri_password_is_interpolated(
+        text,
+        credential.scheme_start,
+        credential.value,
+        credential.host,
+        credential.context,
+    ):
+        return False
+    return credential.has_password or uri_userinfo_literal_risk(
+        credential.value,
+        allow_plus_address=True,
+    )
 
 
 def format_arguments_are_references(arguments: str) -> bool:
@@ -6275,7 +6282,11 @@ def review_repeatable_secret_spans(
     )
     for authority_range in uri_authority_ranges(text):
         credential = uri_authority_credential(text, authority_range)
-        if credential is not None and credential.value:
+        if (
+            credential is not None
+            and credential.value
+            and uri_credential_value_risk(text, credential)
+        ):
             spans.append((credential.value_start, credential.value_end))
     return spans
 
@@ -6356,7 +6367,11 @@ def review_secret_value_spans(
     )
     for authority_range in uri_authority_ranges(text):
         credential = uri_authority_credential(text, authority_range)
-        if credential is not None and credential.value:
+        if (
+            credential is not None
+            and credential.value
+            and uri_credential_value_risk(text, credential)
+        ):
             spans.append((credential.value_start, credential.value_end))
     return spans
 

--- a/skills/autoreview/tests/test_autoreview_hardening.py
+++ b/skills/autoreview/tests/test_autoreview_hardening.py
@@ -3271,6 +3271,50 @@ class AutoreviewHardeningTests(unittest.TestCase):
             with self.subTest(content=content):
                 self.assertFalse(self.helper["secret_text_risk"](content))
 
+    def test_review_patch_preserves_safe_uri_userinfo(self) -> None:
+        safe_lines = (
+            'url = f"ssh://{ssh_user}@git.example.invalid/org/repo.git"',
+            'url = "https://alice@github.com/example/repo"',
+            'url = "https://username:@host/repo"',
+            'remote = "ssh://git@github.com/org/repo.git"',
+        )
+        for line in safe_lines:
+            with self.subTest(line=line):
+                patch = (
+                    "diff --git a/fixture.py b/fixture.py\n"
+                    "--- a/fixture.py\n"
+                    "+++ b/fixture.py\n"
+                    "@@ -0,0 +1 @@\n"
+                    f"+{line}\n"
+                )
+
+                validated = self.helper["validate_review_patch"](
+                    "local unstaged diff",
+                    ["fixture.py"],
+                    patch,
+                )
+
+                self.assertIn(f"+{line}", validated)
+                self.assertNotIn("redacted@", validated)
+
+    def test_review_patch_still_redacts_uri_passwords(self) -> None:
+        patch = (
+            "diff --git a/fixture.py b/fixture.py\n"
+            "--- a/fixture.py\n"
+            "+++ b/fixture.py\n"
+            "@@ -0,0 +1 @@\n"
+            '+dsn = "postgres://user:hunter2pass@db.example/app"\n'
+        )
+
+        validated = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["fixture.py"],
+            patch,
+        )
+
+        self.assertIn("postgres://user:redacted@db.example/app", validated)
+        self.assertNotIn("hunter2pass", validated)
+
     def test_secret_detector_allows_referenced_uri_credentials(self) -> None:
         for content in (
             "postgres:" + "//user:password@localhost/db",


### PR DESCRIPTION
## Summary

- preserve ordinary username-only URI authorities and interpolated userinfo in review bundles
- keep literal URI passwords redacted
- make both review span collectors share the same credential-risk predicate as the existing detector

Fixes #133.

## Root cause

The URI risk detector already distinguished safe username-only authorities from credential-bearing authorities, but both secret-span collectors unconditionally selected every non-empty userinfo value for redaction. That disagreement rewrote benign source such as `ssh://{ssh_user}@host` and could omit ordinary `ssh://git@github.com/...` hunks entirely.

## Validation

- focused URI hardening suite: 18 passed
- core autoreview suite: 31 passed
- full hardening suite: 304 passed, 1 skipped; four failures were the known local missing-Java-runtime cases
- repository validator and validator/install-script tests in a disposable environment: 6 skills validated, 15 tests passed
- repository self-tests, Python compile checks, shell syntax check, Node syntax check, and 32 Node tests passed
- exact before/after probe preserves four safe authorities and still rewrites `postgres://user:hunter2pass@...` to `postgres://user:redacted@...`
- canonical AutoReview: clean, no accepted/actionable findings; patch correct, confidence 0.90

No changelog file exists in this repository; the regression coverage is included with the implementation.
