### PR TITLE
fix(autoreview): scan deleted credentials

### DIFF
--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -1965,14 +1965,13 @@ def snapshot_destination(root: Path, rel: str) -> Path:
         or any(part in {"", ".", ".."} for part in path.parts)
     ):
         raise SystemExit("Git returned an unsafe path while preparing the TruffleHog scan")
-    destination = root.joinpath(*path.parts)
-    destination.parent.mkdir(parents=True, exist_ok=True)
-    return destination
+    return root.joinpath(*path.parts)
 
 
 def write_snapshot_blob(root: Path, rel: str, content: bytes) -> None:
     destination = snapshot_destination(root, rel)
     try:
+        destination.parent.mkdir(parents=True, exist_ok=True)
         destination.write_bytes(content)
     except OSError as exc:
         raise SystemExit(
@@ -2080,6 +2079,7 @@ def copy_worktree_file(repo: Path, root: Path, rel: str) -> bool:
     destination = snapshot_destination(root, rel)
     descriptor: int | None = None
     try:
+        destination.parent.mkdir(parents=True, exist_ok=True)
         descriptor = os.open(
             source,
             os.O_RDONLY
@@ -2221,6 +2221,15 @@ def prepare_trufflehog_history(
         clear_snapshot_paths(root, paths)
         materialize_worktree_snapshot(repo, root, paths)
         commit_snapshot(root, "working")
+        # TruffleHog's Git parser scans additions only. Reverse commits make
+        # deleted bytes additions without exposing unchanged baseline content.
+        clear_snapshot_paths(root, paths)
+        materialize_index_snapshot(repo, root, paths)
+        commit_snapshot(root, "reverse staged")
+        clear_snapshot_paths(root, paths)
+        if head:
+            materialize_tree_snapshot(repo, root, head, paths)
+        commit_snapshot(root, "reverse baseline")
         return base_commit
 
     if target == "branch":
@@ -2262,6 +2271,12 @@ def prepare_trufflehog_history(
     clear_snapshot_paths(root, paths)
     materialize_tree_snapshot(repo, root, reviewed_ref, paths)
     commit_snapshot(root, "reviewed")
+    # Scan the reverse diff too so deleted bytes become additions for
+    # TruffleHog without scanning unchanged content from the baseline.
+    clear_snapshot_paths(root, paths)
+    if base_ref:
+        materialize_tree_snapshot(repo, root, base_ref, paths)
+    commit_snapshot(root, "reverse baseline")
     return base_commit
 
 
@@ -7363,7 +7378,7 @@ def omit_tracked_sensitive_diff_units(
     ]
     if len(diff_indexes) != len(paths):
         return REVIEW_SECURITY_REDACTION + "\n"
-    path_by_unit = dict(zip(diff_indexes, paths, strict=True))
+    path_by_unit = dict(zip(diff_indexes, paths))
     retained = [
         unit
         for index, unit in enumerate(units)

--- a/skills/autoreview/tests/test_autoreview_hardening.py
+++ b/skills/autoreview/tests/test_autoreview_hardening.py
@@ -228,7 +228,7 @@ class AutoreviewHardeningTests(unittest.TestCase):
                         "--format=%H",
                     ).splitlines()
                     self.assertEqual(commits[0], base_commit)
-                    self.assertEqual(len(commits), 2)
+                    self.assertEqual(len(commits), 3)
                     self.assertEqual(
                         git(
                             scan_repo,
@@ -250,6 +250,85 @@ class AutoreviewHardeningTests(unittest.TestCase):
                             stderr=subprocess.PIPE,
                             text=True,
                         )
+
+    def test_trufflehog_history_scans_deleted_content_in_reverse_commit(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo = init_repo(Path(tempdir))
+            source = repo / "removed.txt"
+            source.write_text("removed baseline content\n", encoding="utf-8")
+            git(repo, "add", "removed.txt")
+            git(repo, "commit", "-q", "-m", "base")
+            base = git(repo, "rev-parse", "HEAD").strip()
+            source.unlink()
+            git(repo, "add", "removed.txt")
+            git(repo, "commit", "-q", "-m", "remove credential")
+
+            with tempfile.TemporaryDirectory() as scan_dir:
+                scan_repo = Path(scan_dir)
+                scan_base = self.helper["prepare_trufflehog_history"](
+                    repo,
+                    "branch",
+                    base,
+                    "HEAD",
+                    scan_repo,
+                )
+                commits = git(
+                    scan_repo,
+                    "log",
+                    "--reverse",
+                    "--format=%H",
+                ).splitlines()
+
+                self.assertEqual(commits[0], scan_base)
+                self.assertEqual(len(commits), 3)
+                self.assertEqual(
+                    git(scan_repo, "show", f"{commits[2]}:removed.txt"),
+                    "removed baseline content\n",
+                )
+                with self.assertRaises(subprocess.CalledProcessError):
+                    subprocess.run(
+                        ["git", "show", f"{commits[1]}:removed.txt"],
+                        cwd=scan_repo,
+                        check=True,
+                        stdout=subprocess.PIPE,
+                        stderr=subprocess.PIPE,
+                        text=True,
+                    )
+
+    def test_trufflehog_snapshot_supports_directory_to_file_transition(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo = init_repo(Path(tempdir))
+            nested = repo / "entry" / "nested.txt"
+            nested.parent.mkdir()
+            nested.write_text("nested\n", encoding="utf-8")
+            git(repo, "add", "entry/nested.txt")
+            git(repo, "commit", "-q", "-m", "directory")
+            base = git(repo, "rev-parse", "HEAD").strip()
+            nested.unlink()
+            nested.parent.rmdir()
+            (repo / "entry").write_text("file\n", encoding="utf-8")
+            git(repo, "add", "-A")
+            git(repo, "commit", "-q", "-m", "file")
+
+            with tempfile.TemporaryDirectory() as scan_dir:
+                scan_repo = Path(scan_dir)
+                self.helper["prepare_trufflehog_history"](
+                    repo,
+                    "branch",
+                    base,
+                    "HEAD",
+                    scan_repo,
+                )
+                commits = git(
+                    scan_repo,
+                    "log",
+                    "--reverse",
+                    "--format=%H",
+                ).splitlines()
+                self.assertEqual(
+                    git(scan_repo, "show", f"{commits[1]}:entry"),
+                    "file\n",
+                )
 
     def test_trufflehog_findings_and_errors_do_not_leak_scanner_output(self) -> None:
         for returncode, expected in (


### PR DESCRIPTION
## What Problem This Solves

Autoreview's TruffleHog history scanned added content but could miss credentials that appeared only on deleted lines. The canonical helper also used a Python 3.10-only `zip(..., strict=True)` call and could fail on directory-to-file transitions while building its temporary scan history.

## Why This Change Was Made

TruffleHog's Git parser scans additions. The temporary history now appends reverse commits, turning deleted bytes into additions without scanning unchanged baseline content or restoring heuristic secret matching. Snapshot path validation no longer creates parent directories as a side effect, and the equal-length mapping uses Python 3.9-compatible `zip`.

## User Impact

Autoreview blocks verified or unknown credentials even when the credential is being deleted, continues to avoid variable-name false positives, works on Python 3.9, and handles directory-to-file changes.

## Evidence

- `python3 skills/autoreview/scripts/autoreview_test.py` (31 passed)
- hardening suite excluding the two unavailable local Java tests (249 passed, 1 skipped)
- real local integration: a deleted credential-like URI was blocked by TruffleHog before reviewer invocation
- `skills/autoreview/scripts/autoreview --mode local --stream-engine-output` (clean)
- `git diff --check`
