### PR TITLE
fix(autoreview): handle local path transitions

### DIFF
--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -2055,7 +2055,7 @@ def copy_worktree_file(repo: Path, root: Path, rel: str) -> bool:
     source = repo.joinpath(*PurePosixPath(rel).parts)
     try:
         source_stat = source.lstat()
-    except FileNotFoundError:
+    except (FileNotFoundError, NotADirectoryError):
         return False
     except OSError as exc:
         raise SystemExit(
@@ -2072,6 +2072,8 @@ def copy_worktree_file(repo: Path, root: Path, rel: str) -> bool:
             ) from exc
         write_snapshot_blob(root, rel, content)
         return True
+    if stat.S_ISDIR(source_stat.st_mode):
+        return False
     if not stat.S_ISREG(source_stat.st_mode):
         raise SystemExit(
             "changed content is not a regular file; remove it or resolve the repository state before rerunning autoreview"

--- a/skills/autoreview/tests/test_autoreview_hardening.py
+++ b/skills/autoreview/tests/test_autoreview_hardening.py
@@ -330,6 +330,54 @@ class AutoreviewHardeningTests(unittest.TestCase):
                     "file\n",
                 )
 
+    def test_local_trufflehog_snapshot_supports_path_type_transitions(self) -> None:
+        for transition in ("directory-to-file", "file-to-directory"):
+            with self.subTest(transition=transition), tempfile.TemporaryDirectory() as tempdir:
+                repo = init_repo(Path(tempdir))
+                entry = repo / "entry"
+                nested = entry / "nested.txt"
+                if transition == "directory-to-file":
+                    entry.mkdir()
+                    nested.write_text("nested\n", encoding="utf-8")
+                    git(repo, "add", "entry/nested.txt")
+                else:
+                    entry.write_text("file\n", encoding="utf-8")
+                    git(repo, "add", "entry")
+                git(repo, "commit", "-q", "-m", "base")
+
+                if transition == "directory-to-file":
+                    nested.unlink()
+                    entry.rmdir()
+                    entry.write_text("file\n", encoding="utf-8")
+                    expected_path = "entry"
+                    expected_content = "file\n"
+                else:
+                    entry.unlink()
+                    entry.mkdir()
+                    nested.write_text("nested\n", encoding="utf-8")
+                    expected_path = "entry/nested.txt"
+                    expected_content = "nested\n"
+
+                with tempfile.TemporaryDirectory() as scan_dir:
+                    scan_repo = Path(scan_dir)
+                    self.helper["prepare_trufflehog_history"](
+                        repo,
+                        "local",
+                        None,
+                        "HEAD",
+                        scan_repo,
+                    )
+                    commits = git(
+                        scan_repo,
+                        "log",
+                        "--reverse",
+                        "--format=%H",
+                    ).splitlines()
+                    self.assertEqual(
+                        git(scan_repo, "show", f"{commits[2]}:{expected_path}"),
+                        expected_content,
+                    )
+
     def test_trufflehog_findings_and_errors_do_not_leak_scanner_output(self) -> None:
         for returncode, expected in (
             (


### PR DESCRIPTION
## What Problem This Solves

The mandatory local TruffleHog snapshot could abort on valid file-to-directory, directory-to-file, and submodule-pointer changes because worktree directories were treated as invalid changed files.

## Why This Change Was Made

Directory entries are not file contents for the parent repository. The worktree snapshot now skips directories and treats a path hidden by a new non-directory ancestor as absent, while continuing to scan nested files and regular-file or symlink content.

## User Impact

Autoreview can scan ordinary local path-type transitions and submodule pointer updates instead of failing before review.

## Evidence

- `python3 skills/autoreview/scripts/autoreview_test.py` (31 passed)
- hardening suite excluding the two unavailable local Java tests (250 passed, 1 skipped)
- targeted local directory-to-file and file-to-directory regression proof
- `skills/autoreview/scripts/autoreview --mode local --stream-engine-output` (clean)
- `git diff --check`
