### PR TITLE
fix(autoreview): secure snapshot path traversal

### DIFF
--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -1985,6 +1985,7 @@ def materialize_index_snapshot(repo: Path, root: Path, paths: list[str]) -> int:
         return 0
     records = git_bytes(
         repo,
+        "--literal-pathspecs",
         "ls-files",
         "--stage",
         "-z",
@@ -2025,6 +2026,7 @@ def materialize_tree_snapshot(
         return 0
     records = git_bytes(
         repo,
+        "--literal-pathspecs",
         "ls-tree",
         "-rz",
         ref,
@@ -2051,44 +2053,108 @@ def materialize_tree_snapshot(
     return count
 
 
-def copy_worktree_file(repo: Path, root: Path, rel: str) -> bool:
-    source = repo.joinpath(*PurePosixPath(rel).parts)
+def open_worktree_parent(repo: Path, rel_path: Path) -> int | bool | None:
+    required_dir_fd = {os.open, os.stat, os.readlink}
+    if not required_dir_fd <= os.supports_dir_fd:
+        return None
+    flags = (
+        os.O_RDONLY
+        | getattr(os, "O_BINARY", 0)
+        | getattr(os, "O_CLOEXEC", 0)
+        | getattr(os, "O_DIRECTORY", 0)
+        | getattr(os, "O_NOFOLLOW", 0)
+    )
+    descriptor = os.open(repo.resolve(), flags)
     try:
-        source_stat = source.lstat()
-    except (FileNotFoundError, NotADirectoryError):
-        return False
+        for part in rel_path.parts[:-1]:
+            try:
+                component = os.stat(
+                    part,
+                    dir_fd=descriptor,
+                    follow_symlinks=False,
+                )
+            except (FileNotFoundError, NotADirectoryError):
+                os.close(descriptor)
+                return False
+            if stat.S_ISLNK(component.st_mode):
+                raise OSError("symlinked parent directory")
+            if not stat.S_ISDIR(component.st_mode):
+                os.close(descriptor)
+                return False
+            next_descriptor = os.open(part, flags, dir_fd=descriptor)
+            os.close(descriptor)
+            descriptor = next_descriptor
+        return descriptor
     except OSError as exc:
+        os.close(descriptor)
         raise SystemExit(
-            "unable to read changed content for the TruffleHog scan: "
+            "refusing to snapshot changed content through a symlinked or unstable parent directory: "
             f"{display_escape(exc, 500)}"
         ) from exc
-    if stat.S_ISLNK(source_stat.st_mode):
+
+
+def copy_worktree_file(repo: Path, root: Path, rel: str) -> bool:
+    rel_path = Path(*PurePosixPath(rel).parts)
+    parent_descriptor = open_worktree_parent(repo, rel_path)
+    if parent_descriptor is False:
+        return False
+    if parent_descriptor is not None:
         try:
-            content = os.fsencode(os.readlink(source))
+            source_stat = os.stat(
+                rel_path.name,
+                dir_fd=parent_descriptor,
+                follow_symlinks=False,
+            )
+        except (FileNotFoundError, NotADirectoryError):
+            os.close(parent_descriptor)
+            return False
         except OSError as exc:
+            os.close(parent_descriptor)
             raise SystemExit(
-                "unable to read changed symlink for the TruffleHog scan: "
+                "unable to read changed content for the TruffleHog scan: "
                 f"{display_escape(exc, 500)}"
             ) from exc
-        write_snapshot_blob(root, rel, content)
-        return True
-    if stat.S_ISDIR(source_stat.st_mode):
-        return False
-    if not stat.S_ISREG(source_stat.st_mode):
-        raise SystemExit(
-            "changed content is not a regular file; remove it or resolve the repository state before rerunning autoreview"
-        )
-    destination = snapshot_destination(root, rel)
-    descriptor: int | None = None
-    try:
-        destination.parent.mkdir(parents=True, exist_ok=True)
-        descriptor = os.open(
-            source,
+        if stat.S_ISLNK(source_stat.st_mode):
+            try:
+                content = os.fsencode(
+                    os.readlink(rel_path.name, dir_fd=parent_descriptor)
+                )
+            except OSError as exc:
+                raise SystemExit(
+                    "unable to read changed symlink for the TruffleHog scan: "
+                    f"{display_escape(exc, 500)}"
+                ) from exc
+            finally:
+                os.close(parent_descriptor)
+            write_snapshot_blob(root, rel, content)
+            return True
+        if stat.S_ISDIR(source_stat.st_mode):
+            os.close(parent_descriptor)
+            return False
+        if not stat.S_ISREG(source_stat.st_mode):
+            os.close(parent_descriptor)
+            raise SystemExit(
+                "changed content is not a regular file; remove it or resolve the repository state before rerunning autoreview"
+            )
+        flags = (
             os.O_RDONLY
             | getattr(os, "O_BINARY", 0)
             | getattr(os, "O_CLOEXEC", 0)
-            | getattr(os, "O_NOFOLLOW", 0),
+            | getattr(os, "O_NOFOLLOW", 0)
         )
+        try:
+            descriptor = os.open(
+                rel_path.name,
+                flags,
+                dir_fd=parent_descriptor,
+            )
+        except OSError as exc:
+            raise SystemExit(
+                "unable to snapshot changed content for the TruffleHog scan: "
+                f"{display_escape(exc, 500)}"
+            ) from exc
+        finally:
+            os.close(parent_descriptor)
         opened = os.fstat(descriptor)
         if not stat.S_ISREG(opened.st_mode) or (
             source_stat.st_dev,
@@ -2097,30 +2163,64 @@ def copy_worktree_file(repo: Path, root: Path, rel: str) -> bool:
             opened.st_dev,
             opened.st_ino,
         ):
-            raise OSError("file changed while opening")
-        with destination.open("wb") as output:
-            while chunk := os.read(descriptor, 1024 * 1024):
-                output.write(chunk)
-        after = os.fstat(descriptor)
-        if (
-            opened.st_mode,
-            opened.st_size,
-            opened.st_mtime_ns,
-        ) != (
-            after.st_mode,
-            after.st_size,
-            after.st_mtime_ns,
-        ):
-            raise OSError("file changed while reading")
-    except OSError as exc:
-        destination.unlink(missing_ok=True)
-        raise SystemExit(
-            "unable to snapshot changed content for the TruffleHog scan: "
-            f"{display_escape(exc, 500)}"
-        ) from exc
-    finally:
-        if descriptor is not None:
             os.close(descriptor)
+            raise SystemExit(
+                "unable to snapshot changed content for the TruffleHog scan: file changed while opening"
+            )
+        destination = snapshot_destination(root, rel)
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            with destination.open("wb") as output:
+                while chunk := os.read(descriptor, 1024 * 1024):
+                    output.write(chunk)
+            after = os.fstat(descriptor)
+            if (
+                opened.st_mode,
+                opened.st_size,
+                opened.st_mtime_ns,
+            ) != (
+                after.st_mode,
+                after.st_size,
+                after.st_mtime_ns,
+            ):
+                raise OSError("file changed while reading")
+        except OSError as exc:
+            destination.unlink(missing_ok=True)
+            raise SystemExit(
+                "unable to snapshot changed content for the TruffleHog scan: "
+                f"{display_escape(exc, 500)}"
+            ) from exc
+        finally:
+            os.close(descriptor)
+        return True
+
+    source = repo / rel_path
+    if rel_path.parent != Path(".") and raw_repo_path_has_symlink_component(
+        repo,
+        rel_path.parent,
+    ):
+        raise SystemExit(
+            "refusing to snapshot changed content through a symlinked parent directory"
+        )
+    try:
+        source_stat = source.lstat()
+    except (FileNotFoundError, NotADirectoryError):
+        return False
+    if stat.S_ISLNK(source_stat.st_mode):
+        write_snapshot_blob(root, rel, os.fsencode(os.readlink(source)))
+        return True
+    if stat.S_ISDIR(source_stat.st_mode):
+        return False
+    if not stat.S_ISREG(source_stat.st_mode):
+        raise SystemExit(
+            "changed content is not a regular file; remove it or resolve the repository state before rerunning autoreview"
+        )
+    content = source.read_bytes()
+    if source.lstat() != source_stat:
+        raise SystemExit(
+            "unable to snapshot changed content for the TruffleHog scan: file changed while reading"
+        )
+    write_snapshot_blob(root, rel, content)
     return True
 
 

--- a/skills/autoreview/tests/test_autoreview_hardening.py
+++ b/skills/autoreview/tests/test_autoreview_hardening.py
@@ -330,6 +330,66 @@ class AutoreviewHardeningTests(unittest.TestCase):
                     "file\n",
                 )
 
+    def test_trufflehog_snapshot_treats_git_paths_as_literals(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo = init_repo(Path(tempdir))
+            rel = ":(exclude).txt"
+            source = repo / rel
+            source.write_text("base\n", encoding="utf-8")
+            git(repo, "--literal-pathspecs", "add", "--", rel)
+            git(repo, "commit", "-q", "-m", "base")
+            source.write_text("staged\n", encoding="utf-8")
+            git(repo, "--literal-pathspecs", "add", "--", rel)
+
+            with tempfile.TemporaryDirectory() as index_dir:
+                index_root = Path(index_dir)
+                self.helper["materialize_index_snapshot"](
+                    repo,
+                    index_root,
+                    [rel],
+                )
+                self.assertEqual(
+                    (index_root / rel).read_text(encoding="utf-8"),
+                    "staged\n",
+                )
+
+            git(repo, "commit", "-q", "-m", "staged")
+            with tempfile.TemporaryDirectory() as tree_dir:
+                tree_root = Path(tree_dir)
+                self.helper["materialize_tree_snapshot"](
+                    repo,
+                    tree_root,
+                    "HEAD",
+                    [rel],
+                )
+                self.assertEqual(
+                    (tree_root / rel).read_text(encoding="utf-8"),
+                    "staged\n",
+                )
+
+    def test_trufflehog_snapshot_rejects_symlinked_parent_directories(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            root = Path(tempdir)
+            repo = init_repo(root)
+            outside = root / "outside"
+            outside.mkdir()
+            (outside / "review.txt").write_text("outside\n", encoding="utf-8")
+            parent = repo / "nested"
+            try:
+                parent.symlink_to(outside, target_is_directory=True)
+            except OSError as exc:
+                if os.name == "nt" and getattr(exc, "winerror", None) == 1314:
+                    self.skipTest("Windows symlink privilege is not available")
+                raise
+
+            with tempfile.TemporaryDirectory() as snapshot_dir:
+                with self.assertRaisesRegex(SystemExit, "symlinked parent"):
+                    self.helper["copy_worktree_file"](
+                        repo,
+                        Path(snapshot_dir),
+                        "nested/review.txt",
+                    )
+
     def test_local_trufflehog_snapshot_supports_path_type_transitions(self) -> None:
         for transition in ("directory-to-file", "file-to-directory"):
             with self.subTest(transition=transition), tempfile.TemporaryDirectory() as tempdir:

--- a/skills/autoreview/tests/test_autoreview_hardening.py
+++ b/skills/autoreview/tests/test_autoreview_hardening.py
@@ -330,6 +330,7 @@ class AutoreviewHardeningTests(unittest.TestCase):
                     "file\n",
                 )
 
+    @unittest.skipIf(os.name == "nt", "Windows filenames cannot use Git pathspec magic prefixes")
     def test_trufflehog_snapshot_treats_git_paths_as_literals(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:
             repo = init_repo(Path(tempdir))


### PR DESCRIPTION
## What Problem This Solves

Crafted Git filenames could be interpreted as pathspec magic while building TruffleHog snapshots, and a symlinked parent directory could redirect a worktree read outside the reviewed checkout.

## Why This Change Was Made

Index and tree materialization now use literal Git pathspecs. On POSIX systems, worktree files are traversed and opened relative to stable directory descriptors with `O_DIRECTORY` and `O_NOFOLLOW`; the fallback rejects symlinked parent components.

## User Impact

The mandatory TruffleHog preflight cannot silently omit pathspec-shaped filenames or read host files through symlinked parent directories.

## Evidence

- `python3 skills/autoreview/scripts/autoreview_test.py` (31 passed)
- hardening suite excluding the two unavailable local Java tests (252 passed, 1 skipped)
- targeted literal-path and symlinked-parent regression tests
- `skills/autoreview/scripts/autoreview --mode local --stream-engine-output` (clean)
- `git diff --check`
