### PR TITLE
fix(autoreview): force-stage scan snapshots

### DIFF
--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -2238,7 +2238,7 @@ def clear_snapshot_paths(root: Path, paths: list[str]) -> None:
 
 
 def commit_snapshot(repo: Path, label: str) -> str:
-    git(repo, "add", "-A")
+    git(repo, "add", "-A", "-f")
     git(
         repo,
         "-c",

--- a/skills/autoreview/tests/test_autoreview_hardening.py
+++ b/skills/autoreview/tests/test_autoreview_hardening.py
@@ -368,6 +368,19 @@ class AutoreviewHardeningTests(unittest.TestCase):
                     "staged\n",
                 )
 
+    def test_trufflehog_snapshot_force_stages_ignored_materialized_files(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo = init_repo(Path(tempdir))
+            (repo / ".gitignore").write_text("ignored.txt\n", encoding="utf-8")
+            (repo / "ignored.txt").write_text("review me\n", encoding="utf-8")
+
+            commit = self.helper["commit_snapshot"](repo, "snapshot")
+
+            self.assertEqual(
+                git(repo, "show", f"{commit}:ignored.txt"),
+                "review me\n",
+            )
+
     def test_trufflehog_snapshot_rejects_symlinked_parent_directories(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:
             root = Path(tempdir)


### PR DESCRIPTION
## What Problem This Solves

A changed `.gitignore` could cause a force-added file from the real repository to be omitted when autoreview rebuilt the controlled TruffleHog scan history.

## Why This Change Was Made

Snapshot commits now force-stage the temporary scan repository. That repository contains only paths materialized by autoreview, so ignore rules cannot remove reviewed content from the scan.

## User Impact

Changed ignore rules cannot bypass the mandatory TruffleHog preflight.

## Evidence

- `python3 skills/autoreview/scripts/autoreview_test.py` (31 passed)
- hardening suite excluding the two unavailable local Java tests (253 passed, 1 skipped)
- ignored-materialized-file regression test
- `git diff --check`
