### PR TITLE
fix(autoreview): use current Codex exec flags

### DIFF
--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -9227,9 +9227,13 @@ def codex_command(
     *,
     force_file_auth: bool = False,
 ) -> list[str]:
-    cmd = [resolve_command(args.codex_bin, source_repo), "--ask-for-approval", "never"]
-    if args.web_search:
-        cmd.append("--search")
+    # Current Codex exposes approval/sandbox control through the `exec`
+    # subcommand (`--sandbox`/`-s`), not the retired top-level
+    # `--ask-for-approval` flag.  Likewise, web search is configured by the
+    # Codex runtime rather than an `exec --search` switch.  Passing either
+    # retired flag makes modern Codex exit before producing the structured
+    # output file, leaving autoreview with no validated receipt.
+    cmd = [resolve_command(args.codex_bin, source_repo)]
     if model:
         cmd.extend(["--model", model])
     # User overrides go before the isolation flags so isolation stays authoritative on conflicts.

--- a/skills/autoreview/scripts/autoreview_test.py
+++ b/skills/autoreview/scripts/autoreview_test.py
@@ -205,6 +205,37 @@ class AutoreviewCompatibilityTests(unittest.TestCase):
         with self.assertRaises(SystemExit):
             namespace["parse_args"](["--engine", "cursor"])
 
+    def test_codex_command_uses_current_exec_flags(self) -> None:
+        args = argparse.Namespace(
+            codex_bin="codex",
+            web_search=True,
+            model="gpt-5.5",
+            codex_config=None,
+            thinking="high",
+            codex_speed=None,
+            stream_engine_output=False,
+        )
+        with mock.patch.object(AUTOREVIEW, "resolve_command", return_value="/usr/bin/codex"), mock.patch.object(
+            AUTOREVIEW, "codex_config_isolation_flags", return_value=[]
+        ), mock.patch.object(AUTOREVIEW, "codex_auth_config_flags", return_value=[]), mock.patch.object(
+            AUTOREVIEW, "codex_exec_isolation_flags", return_value=["-s", "read-only"]
+        ):
+            command = AUTOREVIEW.codex_command(
+                args,
+                Path("/tmp/source-repo"),
+                Path("/tmp/review-root"),
+                Path("/tmp/runtime-root"),
+                Path("/tmp/schema.json"),
+                Path("/tmp/output.json"),
+                "gpt-5.5",
+            )
+
+        self.assertNotIn("--ask-for-approval", command)
+        self.assertNotIn("--search", command)
+        self.assertIn("--ephemeral", command)
+        self.assertIn("-s", command)
+        self.assertIn("read-only", command)
+
     def test_cursor_agent_bin_cli_alias(self) -> None:
         with mock.patch.object(
             sys,


### PR DESCRIPTION
The autoreview helper passed retired Codex CLI flags (`--ask-for-approval` and `exec --search`), causing current Codex to exit before producing the structured output receipt.

This removes the retired flags and adds a regression test asserting the current exec isolation flags remain present.

Validation:
- python skills/autoreview/scripts/autoreview_test.py
- python -m pytest -q skills/autoreview/tests/test_autoreview_hardening.py
- End-to-end Codex autoreview: clean validated receipt