### PR TITLE
fix(autoreview): fail closed on scanner recursion

### DIFF
--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -7350,30 +7350,33 @@ def review_secret_fragments(
     *,
     javascript_dialect: str | None = None,
 ) -> set[str]:
-    if DIFF_HUNK_CONTENT_BOUNDARY in text:
-        return set().union(
-            *(
-                review_secret_fragments(
+    fragments: set[str] = set()
+    segments = (
+        text.split(DIFF_HUNK_CONTENT_BOUNDARY)
+        if DIFF_HUNK_CONTENT_BOUNDARY in text
+        else (text,)
+    )
+    try:
+        for segment in segments:
+            fragments.update(
+                segment[start:end]
+                for start, end in review_repeatable_secret_spans(
                     segment,
                     javascript_dialect=javascript_dialect,
                 )
-                for segment in text.split(DIFF_HUNK_CONTENT_BOUNDARY)
+                if segment[start:end]
+                and segment[start:end].casefold() not in SECRET_PLACEHOLDER_VALUES
             )
-        )
-    fragments = {
-        text[start:end]
-        for start, end in review_repeatable_secret_spans(
-            text,
-            javascript_dialect=javascript_dialect,
-        )
-        if text[start:end]
-        and text[start:end].casefold() not in SECRET_PLACEHOLDER_VALUES
-    }
-    fragments.update(
-        fragment
-        for fragment in private_key_body_fragments(text)
-        if fragment.casefold() not in SECRET_PLACEHOLDER_VALUES
-    )
+            fragments.update(
+                fragment
+                for fragment in private_key_body_fragments(segment)
+                if fragment.casefold() not in SECRET_PLACEHOLDER_VALUES
+            )
+    except RecursionError:
+        raise SystemExit(
+            "refusing review bundle because secret scanning exceeded its safe "
+            "recursion limit; split the review target or simplify pathological syntax"
+        ) from None
     return fragments
 
 

--- a/skills/autoreview/tests/test_autoreview_hardening.py
+++ b/skills/autoreview/tests/test_autoreview_hardening.py
@@ -3288,6 +3288,51 @@ class AutoreviewHardeningTests(unittest.TestCase):
 
         self.assertEqual(len(spans), regex_count)
 
+    def test_review_secret_fragments_handles_large_regex_heavy_diff(self) -> None:
+        value = realistic_secret_value()
+        hunk_count = 5_000
+        segment = (
+            "if (ready) /fixture-token/.test(value);\n"
+            f'const apiKey = "{value}";'
+        )
+        source = self.helper["DIFF_HUNK_CONTENT_BOUNDARY"].join(
+            segment for _ in range(hunk_count)
+        )
+
+        fragments = self.helper["review_secret_fragments"](
+            source,
+            javascript_dialect="typescript",
+        )
+
+        self.assertEqual(fragments, {value})
+
+    def test_review_secret_fragments_fails_closed_on_lexer_recursion(self) -> None:
+        def recursive_lexer(
+            text: str,
+            *,
+            javascript_dialect: str | None = None,
+        ) -> list[tuple[int, int]]:
+            return recursive_lexer(
+                text,
+                javascript_dialect=javascript_dialect,
+            )
+
+        scanner_globals = self.helper["review_secret_fragments"].__globals__
+        with (
+            mock.patch.dict(
+                scanner_globals,
+                {"review_repeatable_secret_spans": recursive_lexer},
+            ),
+            self.assertRaisesRegex(
+                SystemExit,
+                "secret scanning exceeded its safe recursion limit",
+            ),
+        ):
+            self.helper["review_secret_fragments"](
+                "if (ready) /fixture-token/.test(value);",
+                javascript_dialect="typescript",
+            )
+
     def test_lifecycle_reference_scan_is_bounded_for_non_matching_identifier(self) -> None:
         source = "const value = resolved" + "A" * 100_000 + "X;"
 


### PR DESCRIPTION
## Summary

- record that the deletion-only secret refusal was already fixed on `main` by #154, so this PR does not duplicate that implementation
- scan synthetic diff-hunk segments iteratively instead of recursively
- fail closed with a stable message when a deeper secret lexer exceeds Python's recursion limit

## Findings and repro

### Bug 1: deletion-only secret-like values

Fresh `origin/main` already contains #154 (`08a28a6`). Its regression coverage proves that values found only on deleted lines of entirely removed files are redacted without changing line count, while added/context reuse and added-line credentials remain refused. No additional Bug 1 code is included here.

### Bug 2: pre-model scanner traceback

The preserved OpenClaw run log identifies the failure as:

```text
RecursionError: maximum recursion depth exceeded
```

The installed in-progress scanner cycled through regex-literal detection and comment masking. Replaying the exact TypeScript source slices against current `main` does not recurse because `main` has an older lexer shape, but its fragment collector still recursively dispatched synthetic hunk segments and did not guard deeper lexer recursion.

This PR makes segment dispatch iterative and converts a lexer `RecursionError` into a clean fail-closed `SystemExit`. The regression uses 5,000 regex-heavy TypeScript hunk segments and an intentionally recursive lexer to prove both the normal and failure paths before model invocation.

## Behavior

| Input | Result |
| --- | --- |
| Secret-like value only in an entirely deleted file | Reviewable; value redacted, deletion line structure preserved (already #154) |
| Secret-like value on an added line | Refused (already #154) |
| Same value on deleted and added/context lines | Refused (already #154) |
| Large regex-heavy multi-hunk TypeScript patch | Scanned iteratively |
| Pathological lexer recursion | Clean fail-closed message; no raw traceback |

## Validation

- `scripts/validate-skills`
- documented Python compile and self-test matrix
- `python -m unittest skills/autoreview/scripts/autoreview_test.py skills.autoreview.tests.test_autoreview_hardening` — 302 passed, 1 skipped
- documented Node syntax checks and tests — 79 passed
- `skills/autoreview/scripts/test-review-harness --fixture benign --engine codex` — clean
- `skills/autoreview/scripts/autoreview --mode local` — clean, no accepted/actionable findings
