### PR TITLE
fix(autoreview): scan Windows snapshots reliably

### DIFF
--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -2124,8 +2124,8 @@ def open_worktree_parent(repo: Path, rel_path: Path) -> int | bool | None:
         ) from exc
 
 
-def snapshot_stat_signature(metadata: os.stat_result) -> tuple[int, ...]:
-    """Return mutation-relevant metadata without read-side access time."""
+def posix_snapshot_stat_signature(metadata: os.stat_result) -> tuple[int, ...]:
+    """Return POSIX mutation-relevant metadata without read-side access time."""
     return (
         metadata.st_dev,
         metadata.st_ino,
@@ -2134,6 +2134,52 @@ def snapshot_stat_signature(metadata: os.stat_result) -> tuple[int, ...]:
         metadata.st_mtime_ns,
         metadata.st_ctime_ns,
     )
+
+
+def open_windows_snapshot_file(source: Path) -> io.BufferedReader:
+    """Open a Windows snapshot source while denying concurrent writes or deletes."""
+    if os.name != "nt":
+        raise OSError("Windows snapshot handles are only available on Windows")
+
+    import ctypes
+    import msvcrt
+    from ctypes import wintypes
+
+    generic_read = 0x80000000
+    file_share_read = 0x00000001
+    open_existing = 3
+    file_attribute_normal = 0x00000080
+    invalid_handle_value = ctypes.c_void_p(-1).value
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    create_file = kernel32.CreateFileW
+    create_file.argtypes = (
+        wintypes.LPCWSTR,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        ctypes.c_void_p,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        wintypes.HANDLE,
+    )
+    create_file.restype = wintypes.HANDLE
+    handle = create_file(
+        str(source),
+        generic_read,
+        file_share_read,
+        None,
+        open_existing,
+        file_attribute_normal,
+        None,
+    )
+    if handle == invalid_handle_value:
+        raise ctypes.WinError(ctypes.get_last_error())
+
+    descriptor = msvcrt.open_osfhandle(handle, os.O_RDONLY | getattr(os, "O_BINARY", 0))
+    try:
+        return os.fdopen(descriptor, "rb")
+    except OSError:
+        os.close(descriptor)
+        raise
 
 
 def copy_worktree_file(repo: Path, root: Path, rel: str) -> bool:
@@ -2217,7 +2263,7 @@ def copy_worktree_file(repo: Path, root: Path, rel: str) -> bool:
                 while chunk := os.read(descriptor, 1024 * 1024):
                     output.write(chunk)
             after = os.fstat(descriptor)
-            if snapshot_stat_signature(opened) != snapshot_stat_signature(after):
+            if posix_snapshot_stat_signature(opened) != posix_snapshot_stat_signature(after):
                 raise OSError("file changed while reading")
         except OSError as exc:
             destination.unlink(missing_ok=True)
@@ -2250,12 +2296,22 @@ def copy_worktree_file(repo: Path, root: Path, rel: str) -> bool:
         raise SystemExit(
             "changed content is not a regular file; remove it or resolve the repository state before rerunning autoreview"
         )
-    content = source.read_bytes()
-    after = source.lstat()
-    if snapshot_stat_signature(source_stat) != snapshot_stat_signature(after):
-        raise SystemExit(
-            "unable to snapshot changed content for the TruffleHog scan: file changed while reading"
-        )
+    if os.name == "nt":
+        try:
+            with open_windows_snapshot_file(source) as snapshot_source:
+                content = snapshot_source.read()
+        except OSError as exc:
+            raise SystemExit(
+                "unable to snapshot changed content for the TruffleHog scan: "
+                f"{display_escape(exc, 500)}"
+            ) from exc
+    else:
+        content = source.read_bytes()
+        after = source.lstat()
+        if posix_snapshot_stat_signature(source_stat) != posix_snapshot_stat_signature(after):
+            raise SystemExit(
+                "unable to snapshot changed content for the TruffleHog scan: file changed while reading"
+            )
     write_snapshot_blob(root, rel, content)
     return True
 

--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -2247,7 +2247,20 @@ def copy_worktree_file(repo: Path, root: Path, rel: str) -> bool:
             "changed content is not a regular file; remove it or resolve the repository state before rerunning autoreview"
         )
     content = source.read_bytes()
-    if source.lstat() != source_stat:
+    after = source.lstat()
+    if (
+        source_stat.st_dev,
+        source_stat.st_ino,
+        source_stat.st_mode,
+        source_stat.st_size,
+        source_stat.st_mtime_ns,
+    ) != (
+        after.st_dev,
+        after.st_ino,
+        after.st_mode,
+        after.st_size,
+        after.st_mtime_ns,
+    ):
         raise SystemExit(
             "unable to snapshot changed content for the TruffleHog scan: file changed while reading"
         )
@@ -2535,7 +2548,7 @@ def run_trufflehog_preflight(
             [
                 trufflehog_bin,
                 "git",
-                scan_repo.resolve().as_uri(),
+                "file://.",
                 "--since-commit",
                 base_commit,
                 "--branch",
@@ -2548,7 +2561,7 @@ def run_trufflehog_preflight(
                 "--fail",
                 "--fail-on-scan-errors",
             ],
-            repo,
+            scan_repo,
             check=False,
             env=safe_trufflehog_env(repo),
         )

--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -2124,6 +2124,18 @@ def open_worktree_parent(repo: Path, rel_path: Path) -> int | bool | None:
         ) from exc
 
 
+def snapshot_stat_signature(metadata: os.stat_result) -> tuple[int, ...]:
+    """Return mutation-relevant metadata without read-side access time."""
+    return (
+        metadata.st_dev,
+        metadata.st_ino,
+        metadata.st_mode,
+        metadata.st_size,
+        metadata.st_mtime_ns,
+        metadata.st_ctime_ns,
+    )
+
+
 def copy_worktree_file(repo: Path, root: Path, rel: str) -> bool:
     rel_path = Path(*PurePosixPath(rel).parts)
     parent_descriptor = open_worktree_parent(repo, rel_path)
@@ -2205,15 +2217,7 @@ def copy_worktree_file(repo: Path, root: Path, rel: str) -> bool:
                 while chunk := os.read(descriptor, 1024 * 1024):
                     output.write(chunk)
             after = os.fstat(descriptor)
-            if (
-                opened.st_mode,
-                opened.st_size,
-                opened.st_mtime_ns,
-            ) != (
-                after.st_mode,
-                after.st_size,
-                after.st_mtime_ns,
-            ):
+            if snapshot_stat_signature(opened) != snapshot_stat_signature(after):
                 raise OSError("file changed while reading")
         except OSError as exc:
             destination.unlink(missing_ok=True)
@@ -2248,19 +2252,7 @@ def copy_worktree_file(repo: Path, root: Path, rel: str) -> bool:
         )
     content = source.read_bytes()
     after = source.lstat()
-    if (
-        source_stat.st_dev,
-        source_stat.st_ino,
-        source_stat.st_mode,
-        source_stat.st_size,
-        source_stat.st_mtime_ns,
-    ) != (
-        after.st_dev,
-        after.st_ino,
-        after.st_mode,
-        after.st_size,
-        after.st_mtime_ns,
-    ):
+    if snapshot_stat_signature(source_stat) != snapshot_stat_signature(after):
         raise SystemExit(
             "unable to snapshot changed content for the TruffleHog scan: file changed while reading"
         )

--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -2299,6 +2299,15 @@ def copy_worktree_file(repo: Path, root: Path, rel: str) -> bool:
     if os.name == "nt":
         try:
             with open_windows_snapshot_file(source) as snapshot_source:
+                opened = os.fstat(snapshot_source.fileno())
+                if not stat.S_ISREG(opened.st_mode) or (
+                    source_stat.st_dev,
+                    source_stat.st_ino,
+                ) != (
+                    opened.st_dev,
+                    opened.st_ino,
+                ):
+                    raise OSError("file changed while opening")
                 content = snapshot_source.read()
         except OSError as exc:
             raise SystemExit(

--- a/skills/autoreview/tests/test_autoreview_hardening.py
+++ b/skills/autoreview/tests/test_autoreview_hardening.py
@@ -701,6 +701,38 @@ class AutoreviewHardeningTests(unittest.TestCase):
                 self.assertIsInstance(writer_result["error"], PermissionError)
                 self.assertEqual(reader.read(), original)
 
+    @unittest.skipUnless(os.name == "nt", "Windows handle identity is required")
+    def test_worktree_snapshot_rejects_file_replaced_before_windows_open(self) -> None:
+        with (
+            tempfile.TemporaryDirectory() as tempdir,
+            tempfile.TemporaryDirectory() as snapshot_dir,
+        ):
+            repo = Path(tempdir)
+            source = repo / "review.txt"
+            replacement = repo / "replacement.txt"
+            source.write_bytes(b"trusted\n")
+            replacement.write_bytes(b"changed\n")
+            original_open = self.helper["open_windows_snapshot_file"]
+
+            def replace_then_open(path: Path) -> io.BufferedReader:
+                replacement.replace(source)
+                return original_open(path)
+
+            with (
+                mock.patch.dict(
+                    self.helper["copy_worktree_file"].__globals__,
+                    {"open_windows_snapshot_file": replace_then_open},
+                ),
+                self.assertRaisesRegex(SystemExit, "file changed while opening"),
+            ):
+                self.helper["copy_worktree_file"](
+                    repo,
+                    Path(snapshot_dir),
+                    "review.txt",
+                )
+
+            self.assertFalse((Path(snapshot_dir) / "review.txt").exists())
+
     def test_worktree_snapshot_ignores_access_time_changes_caused_by_read(self) -> None:
         with (
             tempfile.TemporaryDirectory() as tempdir,

--- a/skills/autoreview/tests/test_autoreview_hardening.py
+++ b/skills/autoreview/tests/test_autoreview_hardening.py
@@ -638,7 +638,8 @@ class AutoreviewHardeningTests(unittest.TestCase):
                         expected_content,
                     )
 
-    def test_snapshot_stat_signature_ignores_access_time_but_retains_change_time(
+    @unittest.skipIf(os.name == "nt", "Windows uses an exclusive snapshot handle")
+    def test_posix_snapshot_stat_signature_ignores_access_time_but_retains_change_time(
         self,
     ) -> None:
         before = mock.Mock(
@@ -669,10 +670,36 @@ class AutoreviewHardeningTests(unittest.TestCase):
             st_ctime_ns=31,
         )
 
-        signature = self.helper["snapshot_stat_signature"]
+        signature = self.helper["posix_snapshot_stat_signature"]
 
         self.assertEqual(signature(before), signature(after_read))
         self.assertNotEqual(signature(before), signature(after_mutation))
+
+    @unittest.skipUnless(os.name == "nt", "Windows handle sharing is required")
+    def test_windows_snapshot_reader_denies_a_same_size_writer(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            source = Path(tempdir) / "review.txt"
+            original = b"review\n"
+            source.write_bytes(original)
+            writer_result: dict[str, OSError | None] = {"error": None}
+
+            with self.helper["open_windows_snapshot_file"](source) as reader:
+                def write_same_size_content() -> None:
+                    try:
+                        with source.open("r+b", buffering=0) as writer:
+                            writer.write(b"changed\n")
+                            writer.flush()
+                            os.fsync(writer.fileno())
+                    except OSError as exc:
+                        writer_result["error"] = exc
+
+                writer = threading.Thread(target=write_same_size_content)
+                writer.start()
+                writer.join(timeout=5)
+                self.assertFalse(writer.is_alive(), "writer did not complete")
+
+                self.assertIsInstance(writer_result["error"], PermissionError)
+                self.assertEqual(reader.read(), original)
 
     def test_worktree_snapshot_ignores_access_time_changes_caused_by_read(self) -> None:
         with (

--- a/skills/autoreview/tests/test_autoreview_hardening.py
+++ b/skills/autoreview/tests/test_autoreview_hardening.py
@@ -638,6 +638,42 @@ class AutoreviewHardeningTests(unittest.TestCase):
                         expected_content,
                     )
 
+    def test_snapshot_stat_signature_ignores_access_time_but_retains_change_time(
+        self,
+    ) -> None:
+        before = mock.Mock(
+            st_dev=1,
+            st_ino=2,
+            st_mode=stat.S_IFREG,
+            st_size=4,
+            st_atime_ns=10,
+            st_mtime_ns=20,
+            st_ctime_ns=30,
+        )
+        after_read = mock.Mock(
+            st_dev=1,
+            st_ino=2,
+            st_mode=stat.S_IFREG,
+            st_size=4,
+            st_atime_ns=11,
+            st_mtime_ns=20,
+            st_ctime_ns=30,
+        )
+        after_mutation = mock.Mock(
+            st_dev=1,
+            st_ino=2,
+            st_mode=stat.S_IFREG,
+            st_size=4,
+            st_atime_ns=11,
+            st_mtime_ns=20,
+            st_ctime_ns=31,
+        )
+
+        signature = self.helper["snapshot_stat_signature"]
+
+        self.assertEqual(signature(before), signature(after_read))
+        self.assertNotEqual(signature(before), signature(after_mutation))
+
     def test_worktree_snapshot_ignores_access_time_changes_caused_by_read(self) -> None:
         with (
             tempfile.TemporaryDirectory() as tempdir,

--- a/skills/autoreview/tests/test_autoreview_hardening.py
+++ b/skills/autoreview/tests/test_autoreview_hardening.py
@@ -153,6 +153,7 @@ class AutoreviewHardeningTests(unittest.TestCase):
                 )
                 self.assertEqual(command[3], "--since-commit")
                 self.assertEqual(command[5:7], ["--branch", "HEAD"])
+                self.assertEqual(command[2], "file://.")
                 self.assertEqual(
                     command[7:],
                     [
@@ -163,10 +164,7 @@ class AutoreviewHardeningTests(unittest.TestCase):
                         "--fail-on-scan-errors",
                     ],
                 )
-                scan_path = command[2].removeprefix("file://")
-                if os.name == "nt":
-                    scan_path = scan_path.lstrip("/")
-                scan_repo = Path(scan_path)
+                scan_repo = cwd
                 commits = git(
                     scan_repo,
                     "log",
@@ -639,6 +637,35 @@ class AutoreviewHardeningTests(unittest.TestCase):
                         git(scan_repo, "show", f"{commits[2]}:{expected_path}"),
                         expected_content,
                     )
+
+    def test_worktree_snapshot_ignores_access_time_changes_caused_by_read(self) -> None:
+        with (
+            tempfile.TemporaryDirectory() as tempdir,
+            tempfile.TemporaryDirectory() as snapshot_dir,
+        ):
+            repo = Path(tempdir)
+            source = repo / "review.txt"
+            source.write_text("review\n", encoding="utf-8")
+            source_stat = source.stat()
+            os.utime(
+                source,
+                ns=(
+                    source_stat.st_atime_ns - 3_000_000_000,
+                    source_stat.st_mtime_ns,
+                ),
+            )
+
+            copied = self.helper["copy_worktree_file"](
+                repo,
+                Path(snapshot_dir),
+                "review.txt",
+            )
+
+            self.assertTrue(copied)
+            self.assertEqual(
+                (Path(snapshot_dir) / "review.txt").read_text(encoding="utf-8"),
+                "review\n",
+            )
 
     def test_trufflehog_findings_and_errors_do_not_leak_scanner_output(self) -> None:
         for returncode, expected in (
@@ -4260,10 +4287,8 @@ class AutoreviewHardeningTests(unittest.TestCase):
             ) -> subprocess.CompletedProcess[str]:
                 if command[0] != "/trusted/trufflehog":
                     return original_run(command, cwd, **_kwargs)
-                scan_path = command[2].removeprefix("file://")
-                if os.name == "nt":
-                    scan_path = scan_path.lstrip("/")
-                scan_repo = Path(scan_path)
+                self.assertEqual(command[2], "file://.")
+                scan_repo = cwd
                 commits = git(
                     scan_repo,
                     "log",


### PR DESCRIPTION
﻿?## Summary

- Fix snapshot mutation detection so reading files during a scan does not produce false positives from access-time (`atime`) updates.
- Preserve the mutation guard's change-time signal: one shared signature now retains device, inode, mode, size, modification time, and `st_ctime_ns` in both descriptor and Windows fallback paths while excluding only access time.
- Fix TruffleHog preflight input on Windows by running from the temporary snapshot repository with `file://.`, avoiding duplicated absolute Windows file URIs.
- Add a regression test that distinguishes harmless access-time changes from change-time mutations.

## Windows behavior proof

The [redacted Windows transcript](https://gist.github.com/r-wa/50f6cd22a29becdca9a284a66e4a4255) is bound to pushed commit `fbdb4fac0b3ec22fab05885dceafa5d43313693f` and tree `2f37cc25a43e216f5181cd9a1b41eab173cc120a`.

It records an actual TruffleHog 3.96.0 commit-mode preflight on native Windows (`Windows-10-10.0.26200-SP0` as reported by Python) using Python 3.11.9. The candidate invokes the real scanner from the temporary snapshot repository with `file://.` and completes with `trufflehog: clean`; no scanner mock is involved.

## Verification

- `python scripts/validate-skills`: validated 7 skills.
- `python -m unittest skills/autoreview/scripts/autoreview_test.py skills.autoreview.tests.test_autoreview_hardening`: 307 passed, 10 platform skips.
- Focused access-time/change-time regressions: 2 passed.
- `python skills/autoreview/scripts/autoreview --mode commit --commit fbdb4fac0b3ec22fab05885dceafa5d43313693f`: clean, one 4,691-byte review pass, no accepted/actionable findings, overall confidence 0.99.
- Real TruffleHog 3.96.0 Windows preflight: clean.

## Native Windows final-head evidence

Verified head: `0515825a8b2bdc4541473d5c816ba958a938958f`

The Windows fallback now compares the pre-open `lstat()` identity with `fstat()` from the exclusive handle before reading. An atomic replacement between those operations fails closed with `file changed while opening`; the snapshot destination is not created. The existing same-size-writer denial and access-time-only read controls remain green.

<details>
<summary>Redacted native-Windows final-head transcript</summary>

```text
PS> git rev-parse HEAD
0515825a8b2bdc4541473d5c816ba958a938958f

PS> python skills/autoreview/tests/test_autoreview_hardening.py -k replaced_before_windows_open -v
test_worktree_snapshot_rejects_file_replaced_before_windows_open (...) ... ok

----------------------------------------------------------------------
Ran 1 test in 0.113s

OK

PS> python skills/autoreview/scripts/autoreview --mode branch --base upstream/main --engine codex --max-priority P1
autoreview target: branch
branch: fix/windows-autoreview-snapshot-scan
engine: codex
model: gpt-5.6-sol
thinking: high
ref: upstream/main
trufflehog: clean (4.1s)
bundle: 12173 bytes; review passes: 1
autoreview clean: no accepted/actionable findings reported
overall: patch is correct (0.86)
No P0 or P1 defect is demonstrated by the bundle.
```

</details>

Additional exact-tree gates:

- Native Windows full hardening suite: 293 tests passed, 14 platform-specific skips.
- `python scripts/validate-skills`: validated 7 skills.
- POSIX signature control passed under WSL.
- `python -m py_compile skills/autoreview/scripts/autoreview` and `git diff --check` passed.
