### PR TITLE
fix(autoreview): redaction hardening (PEM gaps, bounded fallback scanning)

### DIFF
--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -6925,6 +6925,50 @@ def redact_unbalanced_private_key_hunks(section: str) -> tuple[str, set[str]]:
     lines = literal_lf_lines(section)
     redacted = list(lines)
     secret_fragments: set[str] = set()
+    combined_diff = section.startswith(("diff --cc ", "diff --combined "))
+    has_private_key_marker = (
+        PRIVATE_KEY_BEGIN_PATTERN.search(section) is not None
+        or PRIVATE_KEY_END_PATTERN.search(section) is not None
+    )
+    if combined_diff and has_private_key_marker:
+        in_hunk = False
+        prefix_columns = 1
+        for line in lines:
+            body = line.rstrip("\r\n")
+            header = re.match(r"^(@{2,})", body)
+            if header is not None:
+                in_hunk = True
+                prefix_columns = len(header.group(1)) - 1
+                continue
+            prefix = body[:prefix_columns]
+            if (
+                not in_hunk
+                or len(prefix) != prefix_columns
+                or not set(prefix) <= {"+", "-", " "}
+            ):
+                continue
+            content = body[prefix_columns:]
+            marker_spans = [
+                match.span()
+                for pattern in (
+                    PRIVATE_KEY_BEGIN_PATTERN,
+                    PRIVATE_KEY_END_PATTERN,
+                )
+                for match in pattern.finditer(content)
+            ]
+            for start, end in explicit_private_key_body_spans(
+                content,
+                in_pem=True,
+            ):
+                if any(
+                    marker_start < end and start < marker_end
+                    for marker_start, marker_end in marker_spans
+                ):
+                    continue
+                fragment = normalized_private_key_fragment(content, start, end)
+                if fragment.casefold() not in SECRET_PLACEHOLDER_VALUES:
+                    secret_fragments.add(fragment)
+        return REVIEW_SECURITY_REDACTION + "\n", secret_fragments
     section_old_text, section_new_text = unified_diff_contents(section)
     old_depth = private_key_initial_depth(section_old_text)
     new_depth = private_key_initial_depth(section_new_text)
@@ -8450,7 +8494,9 @@ def review_bundle_units(bundle: str) -> list[str]:
     units: list[str] = []
     current: list[str] = []
     for line in literal_lf_lines(bundle):
-        boundary = line.startswith("diff --git ") or line in section_boundaries
+        boundary = line.startswith(
+            ("diff --git ", "diff --cc ", "diff --combined ")
+        ) or line in section_boundaries
         if boundary and current:
             units.append("".join(current))
             current = []

--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -2064,38 +2064,77 @@ def raw_repo_path_has_symlink_component(repo: Path, rel_path: Path) -> bool:
     return False
 
 
-def fallback_expression(text: str, *, typescript: bool = False) -> str:
+def fallback_expression_end(
+    text: str,
+    start: int = 0,
+    *,
+    allow_multiline: bool = True,
+    diff_match_start: int | None = None,
+    end_limit: int | None = None,
+    operand_already_started: bool = False,
+    typescript: bool = False,
+) -> int:
+    scan_limit = len(text) if end_limit is None else min(len(text), end_limit)
+    line_start = bounded_line_start(text, start) + 1
+    prefix_end = start if diff_match_start is None else diff_match_start
+    diff_prefix = re.fullmatch(
+        r"(?P<prefix>[+-]{1,8})[ \t]*",
+        text[line_start:prefix_end],
+    )
+    diff_prefix_columns = (
+        len(diff_prefix.group("prefix")) if diff_prefix is not None else 0
+    )
     operator_keywords = (
         r"|as(?![\w$])|satisfies(?![\w$])" if typescript else ""
     )
-    operator = re.match(
-        r"\s*(?:\|\||&&|\?\?|[=<>!~:+\-*/%&|^?.,]"
+    operator = re.compile(
+        r"[ \t]*(?:\|\||&&|\?\?|[=<>!~:+\-*/%&|^?.,]"
         r"|and\b|else\b|if\b|in(?![\w$])|instanceof(?![\w$])"
         r"|is\b|not\b|or\b"
         r"|unless\b"
         + operator_keywords
         + r")",
-        text,
-    )
-    cursor = operator.end() if operator is not None else 0
+    ).match(text, start, scan_limit)
+    cursor = operator.end() if operator is not None else start
     stack: list[str] = []
-    operand_started = False
+    operand_started = operand_already_started and operator is None
+    expression_started = operand_already_started or operator is not None
     quote: str | None = None
     escaped = False
     line_comment = False
     block_comment = False
     pairs = {"(": ")", "[": "]", "{": "}"}
-    while cursor < len(text):
+    while cursor < scan_limit:
+        if text.startswith(DIFF_HUNK_CONTENT_BOUNDARY, cursor):
+            break
         char = text[cursor]
-        next_char = text[cursor + 1] if cursor + 1 < len(text) else ""
+        next_char = text[cursor + 1] if cursor + 1 < scan_limit else ""
         if line_comment:
             if char in "\r\n\u2028\u2029":
                 line_comment = False
                 if (
+                    diff_prefix_columns
+                    and raw_diff_continuation_start(
+                        text,
+                        cursor,
+                        diff_prefix_columns,
+                    )
+                    is None
+                ):
+                    break
+                if (
+                    not stack
+                    and not allow_multiline
+                    and (operand_started or not expression_started)
+                ):
+                    break
+                if (
                     operand_started
                     and not stack
-                    and not javascript_continues_after_line_terminator(
-                        text[cursor + 1 :],
+                    and not javascript_expression_continues_after_line(
+                        text,
+                        cursor,
+                        diff_prefix_columns=diff_prefix_columns,
                         typescript=typescript,
                     )
                 ):
@@ -2120,7 +2159,9 @@ def fallback_expression(text: str, *, typescript: bool = False) -> str:
             continue
         regex_end = javascript_regex_literal_end(text, cursor)
         if regex_end is not None:
-            cursor = regex_end
+            expression_started = True
+            operand_started = True
+            cursor = min(regex_end, scan_limit)
             continue
         if char == "/" and next_char == "/":
             line_comment = True
@@ -2137,11 +2178,13 @@ def fallback_expression(text: str, *, typescript: bool = False) -> str:
         if char in {'"', "'", "`"}:
             quote = char
             operand_started = True
+            expression_started = True
             cursor += 1
             continue
         if char in pairs:
             stack.append(pairs[char])
             operand_started = True
+            expression_started = True
             cursor += 1
             continue
         if stack and char == stack[-1]:
@@ -2150,15 +2193,34 @@ def fallback_expression(text: str, *, typescript: bool = False) -> str:
             continue
         if not stack and char in ",;)]}":
             break
-        if char in "\r\n\u2028\u2029" and operand_started and not stack:
-            if not javascript_continues_after_line_terminator(
-                text[cursor + 1 :],
-                typescript=typescript,
+        if (
+            char in "\r\n\u2028\u2029"
+            and diff_prefix_columns
+            and raw_diff_continuation_start(
+                text,
+                cursor,
+                diff_prefix_columns,
+            )
+            is None
+        ):
+            break
+        if char in "\r\n\u2028\u2029" and not stack:
+            if (
+                not allow_multiline
+                and (operand_started or not expression_started)
+            ) or (
+                operand_started
+                and not javascript_expression_continues_after_line(
+                    text,
+                    cursor,
+                    diff_prefix_columns=diff_prefix_columns,
+                    typescript=typescript,
+                )
             ):
                 break
         if not stack and (char.isalpha() or char in "_$"):
             word_end = cursor + 1
-            while word_end < len(text) and (
+            while word_end < scan_limit and (
                 text[word_end].isalnum() or text[word_end] in "_$"
             ):
                 word_end += 1
@@ -2167,14 +2229,89 @@ def fallback_expression(text: str, *, typescript: bool = False) -> str:
             if typescript:
                 word_operators.update({"as", "satisfies"})
             operand_started = word not in word_operators
+            expression_started = True
             cursor = word_end
             continue
         if not stack and char in "=<>!~:+-*/%&|^?.":
             operand_started = False
+            expression_started = True
         elif not char.isspace():
             operand_started = True
+            expression_started = True
         cursor += 1
-    return text[:cursor]
+    return min(cursor, scan_limit)
+
+
+def raw_diff_prefix_columns(text: str, position: int) -> int:
+    line_start = bounded_line_start(text, position) + 1
+    match = re.fullmatch(
+        r"(?P<prefix>[+-]{1,8})[ \t]*",
+        text[line_start:position],
+    )
+    return len(match.group("prefix")) if match is not None else 0
+
+
+def enclosing_string_content_end(
+    text: str,
+    context: tuple[str, int] | None,
+) -> int | None:
+    if context is None:
+        return None
+    quote, quote_start = context
+    end = quoted_string_end(text, quote, quote_start)
+    return None if end is None else end - len(quote)
+
+
+def fallback_expression(text: str, *, typescript: bool = False) -> str:
+    return text[:fallback_expression_end(text, typescript=typescript)]
+
+
+def javascript_expression_continues_after_line(
+    text: str,
+    line_end: int,
+    *,
+    diff_prefix_columns: int,
+    typescript: bool,
+) -> bool:
+    if diff_prefix_columns:
+        continuation_start = raw_diff_continuation_start(
+            text,
+            line_end,
+            diff_prefix_columns,
+        )
+        if continuation_start is None:
+            return False
+        return javascript_continues_after_line_terminator_at(
+            text,
+            continuation_start,
+            typescript=typescript,
+        )
+    next_start = line_end
+    while next_start < len(text) and text[next_start] in "\r\n\u2028\u2029":
+        next_start += 1
+    return not safe_javascript_reference_suffix(
+        text,
+        line_end,
+        typescript=typescript,
+    ) and javascript_continues_after_line_terminator_at(
+        text,
+        next_start,
+        typescript=typescript,
+    )
+
+
+def raw_diff_continuation_start(
+    text: str,
+    line_end: int,
+    prefix_columns: int,
+) -> int | None:
+    next_start = line_end
+    while next_start < len(text) and text[next_start] in "\r\n\u2028\u2029":
+        next_start += 1
+    prefix = text[next_start : next_start + prefix_columns]
+    if len(prefix) != prefix_columns or not set(prefix) <= {"+", "-", " "}:
+        return None
+    return next_start + prefix_columns
 
 
 def javascript_continues_after_line_terminator(
@@ -2182,20 +2319,34 @@ def javascript_continues_after_line_terminator(
     *,
     typescript: bool = False,
 ) -> bool:
-    suffix = text.lstrip()
-    if suffix.startswith(("++", "--", "~")) or (
-        suffix.startswith("!") and not suffix.startswith("!=")
+    return javascript_continues_after_line_terminator_at(
+        text,
+        0,
+        typescript=typescript,
+    )
+
+
+def javascript_continues_after_line_terminator_at(
+    text: str,
+    start: int,
+    *,
+    typescript: bool = False,
+) -> bool:
+    cursor = start
+    while cursor < len(text) and text[cursor].isspace():
+        cursor += 1
+    if text.startswith(("++", "--", "~"), cursor) or (
+        text.startswith("!", cursor) and not text.startswith("!=", cursor)
     ):
         return False
     type_operators = (
         r"|as(?![\w$])|satisfies(?![\w$])" if typescript else ""
     )
-    return re.match(
+    return re.compile(
         r"(?:[=<>!:+\-*/%&|^?.,([`]|in(?![\w$])|instanceof(?![\w$])"
         + type_operators
         + r")",
-        suffix,
-    ) is not None
+    ).match(text, cursor) is not None
 
 
 def top_level_fallback_suffix(
@@ -5856,38 +6007,52 @@ def assignment_fallback_literal_spans(
     text: str,
     match: re.Match[str],
     *,
+    expression_limit: int | None = None,
     javascript_dialect: str | None = None,
 ) -> list[tuple[int, int]]:
-    line_end_candidates = [
-        position
-        for position in (
-            text.find("\n", match.end()),
-            text.find("\r", match.end()),
-        )
-        if position >= 0
-    ]
-    line_end = min(line_end_candidates, default=len(text))
-    expression_end = line_end
-    if (
-        javascript_dialect is not None
-        and line_end < len(text)
-        and not safe_javascript_reference_suffix(
-            text,
-            line_end,
-            typescript=javascript_dialect == "typescript",
-        )
-    ):
-        continued = fallback_expression(
-            text[line_end:],
-            typescript=javascript_dialect == "typescript",
-        )
-        expression_end = line_end + len(continued)
     fallback_start = match.end()
+    diff_prefix_columns = raw_diff_prefix_columns(text, match.start())
+    adjusted_diff_continuation = False
+    if diff_prefix_columns:
+        cursor = fallback_start
+        while cursor < len(text) and text[cursor] in " \t":
+            cursor += 1
+        if cursor < len(text) and text[cursor] in "\r\n\u2028\u2029":
+            while cursor < len(text) and text[cursor] in "\r\n\u2028\u2029":
+                cursor += 1
+            prefix = text[cursor : cursor + diff_prefix_columns]
+            if (
+                len(prefix) != diff_prefix_columns
+                or not set(prefix) <= {"+", "-", " "}
+            ):
+                return []
+            continuation_start = cursor + diff_prefix_columns
+            if not javascript_continues_after_line_terminator_at(
+                text,
+                continuation_start,
+                typescript=javascript_dialect == "typescript",
+            ):
+                return []
+            fallback_start = continuation_start
+            adjusted_diff_continuation = True
+    expression_end = fallback_expression_end(
+        text,
+        fallback_start,
+        allow_multiline=javascript_dialect is not None,
+        diff_match_start=(None if adjusted_diff_continuation else match.start()),
+        end_limit=expression_limit,
+        operand_already_started=True,
+        typescript=javascript_dialect == "typescript",
+    )
     if match.group("call_value") is not None:
-        whitespace = re.match(r"[ \t]*", text[fallback_start:expression_end])
+        whitespace = re.compile(r"[ \t]*").match(
+            text,
+            fallback_start,
+            expression_end,
+        )
         assert whitespace is not None
-        call_start = fallback_start + whitespace.end()
-        if call_start < line_end and text[call_start] == "(":
+        call_start = whitespace.end()
+        if call_start < expression_end and text[call_start] == "(":
             depth = 0
             quote: str | None = None
             escaped = False
@@ -5919,32 +6084,6 @@ def assignment_fallback_literal_spans(
     if operator_span is None:
         return []
     expression_start = operator_span[1]
-    depth = 0
-    quote: str | None = None
-    escaped = False
-    cursor = expression_start
-    while cursor < line_end:
-        char = text[cursor]
-        if quote is not None:
-            if escaped:
-                escaped = False
-            elif char == "\\":
-                escaped = True
-            elif char == quote:
-                quote = None
-        elif char in {'"', "'", "`"}:
-            quote = char
-        elif char in "([{":
-            depth += 1
-        elif char in ")]}":
-            if depth == 0:
-                expression_end = cursor
-                break
-            depth -= 1
-        elif depth == 0 and char in ";,":
-            expression_end = cursor
-            break
-        cursor += 1
     return top_level_fallback_value_spans(
         text,
         expression_start,
@@ -5957,18 +6096,18 @@ def assignment_prefix_fallback_literal_spans(
     text: str,
     match: re.Match[str],
     *,
+    expression_limit: int | None = None,
     javascript_dialect: str | None = None,
 ) -> list[tuple[int, int]]:
-    suffix = text[match.end() :]
-    fallback = top_level_fallback_suffix(suffix)
-    if fallback is None:
-        return []
-    fallback_start = match.end() + len(suffix) - len(fallback)
-    expression = fallback_expression(
-        fallback,
+    fallback_start = match.end()
+    expression_end = fallback_expression_end(
+        text,
+        fallback_start,
+        allow_multiline=javascript_dialect is not None,
+        diff_match_start=match.start(),
+        end_limit=expression_limit,
         typescript=javascript_dialect == "typescript",
     )
-    expression_end = fallback_start + len(expression)
     operator_span = top_level_fallback_operator_span(
         text,
         fallback_start,
@@ -6150,6 +6289,7 @@ def review_call_literal_spans(
     text: str,
     match: re.Match[str],
     *,
+    expression_limit: int | None = None,
     javascript_dialect: str | None = None,
 ) -> list[tuple[int, int]]:
     whitespace = re.match(r"[ \t]*", text[match.end() :])
@@ -6158,9 +6298,13 @@ def review_call_literal_spans(
     if call_start >= len(text) or text[call_start] != "(":
         return []
     call_end = balanced_delimiter_end(text, call_start, "(", ")")
-    if call_end is None or not secret_text_risk(
-        text[match.start() : call_end],
-        javascript_dialect=javascript_dialect,
+    if (
+        call_end is None
+        or (expression_limit is not None and call_end > expression_limit)
+        or not secret_text_risk(
+            text[match.start() : call_end],
+            javascript_dialect=javascript_dialect,
+        )
     ):
         return []
     candidates = sorted(
@@ -6232,6 +6376,12 @@ def review_repeatable_secret_spans(
     javascript_dialect: str | None = None,
 ) -> list[tuple[int, int]]:
     boolean_declarations = tuple(SECRET_BOOLEAN_DECLARATION_PATTERN.finditer(text))
+    prefix_matches = tuple(SECRET_ASSIGNMENT_PREFIX_PATTERN.finditer(text))
+    assignment_matches = tuple(SECRET_ASSIGNMENT_PATTERN.finditer(text))
+    assignment_contexts = string_contexts_at(
+        text,
+        {match.start() for match in prefix_matches + assignment_matches},
+    )
     boolean_declaration_positions = {
         match.start("boolean_key") for match in boolean_declarations
     }
@@ -6246,17 +6396,25 @@ def review_repeatable_secret_spans(
     ]
     spans.extend(
         span
-        for match in SECRET_ASSIGNMENT_PREFIX_PATTERN.finditer(text)
+        for match in prefix_matches
         if match.start() not in boolean_declaration_positions
         for span in assignment_prefix_fallback_literal_spans(
             text,
             match,
+            expression_limit=enclosing_string_content_end(
+                text,
+                assignment_contexts.get(match.start()),
+            ),
             javascript_dialect=javascript_dialect,
         )
     )
-    for match in SECRET_ASSIGNMENT_PATTERN.finditer(text):
+    for match in assignment_matches:
         if match.start() in boolean_declaration_positions:
             continue
+        expression_limit = enclosing_string_content_end(
+            text,
+            assignment_contexts.get(match.start()),
+        )
         selected_name = next(
             (
                 name
@@ -6284,6 +6442,7 @@ def review_repeatable_secret_spans(
             assignment_fallback_literal_spans(
                 text,
                 match,
+                expression_limit=expression_limit,
                 javascript_dialect=javascript_dialect,
             )
             if selected_name in {"reference_value", "call_value", "bare_value"}
@@ -6297,6 +6456,7 @@ def review_repeatable_secret_spans(
                 review_call_literal_spans(
                     text,
                     match,
+                    expression_limit=expression_limit,
                     javascript_dialect=javascript_dialect,
                 )
             )
@@ -6330,6 +6490,12 @@ def review_secret_value_spans(
     javascript_dialect: str | None = None,
 ) -> list[tuple[int, int]]:
     boolean_declarations = tuple(SECRET_BOOLEAN_DECLARATION_PATTERN.finditer(text))
+    prefix_matches = tuple(SECRET_ASSIGNMENT_PREFIX_PATTERN.finditer(text))
+    assignment_matches = tuple(SECRET_ASSIGNMENT_PATTERN.finditer(text))
+    assignment_contexts = string_contexts_at(
+        text,
+        {match.start() for match in prefix_matches + assignment_matches},
+    )
     boolean_declaration_positions = {
         match.start("boolean_key") for match in boolean_declarations
     }
@@ -6344,17 +6510,25 @@ def review_secret_value_spans(
     ]
     spans.extend(
         span
-        for match in SECRET_ASSIGNMENT_PREFIX_PATTERN.finditer(text)
+        for match in prefix_matches
         if match.start() not in boolean_declaration_positions
         for span in assignment_prefix_fallback_literal_spans(
             text,
             match,
+            expression_limit=enclosing_string_content_end(
+                text,
+                assignment_contexts.get(match.start()),
+            ),
             javascript_dialect=javascript_dialect,
         )
     )
-    for match in SECRET_ASSIGNMENT_PATTERN.finditer(text):
+    for match in assignment_matches:
         if match.start() in boolean_declaration_positions:
             continue
+        expression_limit = enclosing_string_content_end(
+            text,
+            assignment_contexts.get(match.start()),
+        )
         for name in (
             "double_value",
             "single_value",
@@ -6374,6 +6548,7 @@ def review_secret_value_spans(
                     assignment_fallback_literal_spans(
                         text,
                         match,
+                        expression_limit=expression_limit,
                         javascript_dialect=javascript_dialect,
                     )
                     if name in {"reference_value", "call_value", "bare_value"}
@@ -6387,6 +6562,7 @@ def review_secret_value_spans(
                         review_call_literal_spans(
                             text,
                             match,
+                            expression_limit=expression_limit,
                             javascript_dialect=javascript_dialect,
                         )
                     )
@@ -7014,46 +7190,50 @@ def redact_unbalanced_private_key_hunks(section: str) -> tuple[str, set[str]]:
             continue
         ambiguous_changed_lines: set[int] = set()
         redact_ambiguous_hunk = False
-        for position, (_, prefix, content, _) in enumerate(hunk_lines):
-            if not (
-                PRIVATE_KEY_BEGIN_PATTERN.search(content)
-                or PRIVATE_KEY_END_PATTERN.search(content)
-            ):
+        sides = [diff_prefix_side(prefix) for _, prefix, _, _ in hunk_lines]
+        marker_lines = [
+            PRIVATE_KEY_BEGIN_PATTERN.search(content) is not None
+            or PRIVATE_KEY_END_PATTERN.search(content) is not None
+            for _, _, content, _ in hunk_lines
+        ]
+        runs: list[tuple[str, int, int, bool]] = []
+        run_start = 0
+        while run_start < len(hunk_lines):
+            side = sides[run_start]
+            run_end = run_start + 1
+            while run_end < len(hunk_lines) and sides[run_end] == side:
+                run_end += 1
+            runs.append(
+                (
+                    side,
+                    run_start,
+                    run_end,
+                    any(marker_lines[run_start:run_end]),
+                )
+            )
+            run_start = run_end
+        for run_index, (side, run_start, run_end, has_marker) in enumerate(runs):
+            if not has_marker:
                 continue
-            side = diff_prefix_side(prefix)
             if side == "":
                 redact_ambiguous_hunk = True
                 break
             if side not in {"+", "-"}:
                 continue
             opposite = "+" if side == "-" else "-"
-            run_start = position
-            while (
-                run_start > 0
-                and diff_prefix_side(hunk_lines[run_start - 1][1]) == side
-            ):
-                run_start -= 1
-            run_end = position
-            while (
-                run_end + 1 < len(hunk_lines)
-                and diff_prefix_side(hunk_lines[run_end + 1][1]) == side
-            ):
-                run_end += 1
-            for neighbor in (run_start - 1, run_end + 1):
-                opposite_run: list[int] = []
-                while (
-                    0 <= neighbor < len(hunk_lines)
-                    and diff_prefix_side(hunk_lines[neighbor][1]) == opposite
-                ):
-                    opposite_run.append(neighbor)
-                    neighbor += -1 if neighbor < run_start else 1
-                if not any(
-                    PRIVATE_KEY_BEGIN_PATTERN.search(hunk_lines[item][2])
-                    or PRIVATE_KEY_END_PATTERN.search(hunk_lines[item][2])
-                    for item in opposite_run
-                ):
+            for neighbor_run in (run_index - 1, run_index + 1):
+                if not 0 <= neighbor_run < len(runs):
+                    continue
+                (
+                    neighbor_side,
+                    neighbor_start,
+                    neighbor_end,
+                    neighbor_has_marker,
+                ) = runs[neighbor_run]
+                if neighbor_side == opposite and not neighbor_has_marker:
                     ambiguous_changed_lines.update(
-                        hunk_lines[item][0] for item in opposite_run
+                        hunk_lines[item][0]
+                        for item in range(neighbor_start, neighbor_end)
                     )
         if redact_ambiguous_hunk:
             for line_index, prefix, content, ending in hunk_lines:

--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -6933,7 +6933,7 @@ def redact_unbalanced_private_key_hunks(section: str) -> tuple[str, set[str]]:
     if combined_diff and has_private_key_marker:
         in_hunk = False
         prefix_columns = 1
-        for line in lines:
+        for line_index, line in enumerate(lines):
             body = line.rstrip("\r\n")
             header = re.match(r"^(@{2,})", body)
             if header is not None:
@@ -6956,10 +6956,11 @@ def redact_unbalanced_private_key_hunks(section: str) -> tuple[str, set[str]]:
                 )
                 for match in pattern.finditer(content)
             ]
-            for start, end in explicit_private_key_body_spans(
+            body_spans = explicit_private_key_body_spans(
                 content,
                 in_pem=True,
-            ):
+            )
+            for start, end in body_spans:
                 if any(
                     marker_start < end and start < marker_end
                     for marker_start, marker_end in marker_spans
@@ -6968,7 +6969,12 @@ def redact_unbalanced_private_key_hunks(section: str) -> tuple[str, set[str]]:
                 fragment = normalized_private_key_fragment(content, start, end)
                 if fragment.casefold() not in SECRET_PLACEHOLDER_VALUES:
                     secret_fragments.add(fragment)
-        return REVIEW_SECURITY_REDACTION + "\n", secret_fragments
+            redacted[line_index] = (
+                f"{prefix}"
+                f"{redact_review_spans(content, marker_spans + body_spans)}"
+                f"{line[len(body):]}"
+            )
+        return "".join(redacted), secret_fragments
     section_old_text, section_new_text = unified_diff_contents(section)
     old_depth = private_key_initial_depth(section_old_text)
     new_depth = private_key_initial_depth(section_new_text)
@@ -7116,7 +7122,7 @@ def redact_unbalanced_private_key_hunks(section: str) -> tuple[str, set[str]]:
                     and fragment.casefold() not in SECRET_PLACEHOLDER_VALUES
                 )
                 redacted[line_index] = (
-                    f"{prefix}{REVIEW_SECRET_REDACTION}{ending}"
+                    f"{prefix}{redact_review_spans(content, candidate_spans)}{ending}"
                 )
                 continue
             spans: list[tuple[int, int]] = []

--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -5953,6 +5953,37 @@ def assignment_fallback_literal_spans(
     )
 
 
+def assignment_prefix_fallback_literal_spans(
+    text: str,
+    match: re.Match[str],
+    *,
+    javascript_dialect: str | None = None,
+) -> list[tuple[int, int]]:
+    suffix = text[match.end() :]
+    fallback = top_level_fallback_suffix(suffix)
+    if fallback is None:
+        return []
+    fallback_start = match.end() + len(suffix) - len(fallback)
+    expression = fallback_expression(
+        fallback,
+        typescript=javascript_dialect == "typescript",
+    )
+    expression_end = fallback_start + len(expression)
+    operator_span = top_level_fallback_operator_span(
+        text,
+        fallback_start,
+        expression_end,
+    )
+    if operator_span is None:
+        return []
+    return top_level_fallback_value_spans(
+        text,
+        operator_span[1],
+        expression_end,
+        include_nested=True,
+    )
+
+
 def top_level_fallback_operator_span(
     text: str,
     start: int,
@@ -6075,7 +6106,10 @@ def top_level_fallback_value_spans(
                         include_nested
                         and value.casefold() not in SECRET_PLACEHOLDER_VALUES
                         and len(value) >= 7
-                        and any(character.isdigit() for character in value)
+                        and (
+                            len(value) >= 12
+                            or any(character.isdigit() for character in value)
+                        )
                         and not any(
                             pattern.fullmatch(value)
                             for pattern in QUOTED_SECRET_REFERENCE_PATTERNS
@@ -6210,6 +6244,16 @@ def review_repeatable_secret_spans(
             javascript_dialect=javascript_dialect,
         )
     ]
+    spans.extend(
+        span
+        for match in SECRET_ASSIGNMENT_PREFIX_PATTERN.finditer(text)
+        if match.start() not in boolean_declaration_positions
+        for span in assignment_prefix_fallback_literal_spans(
+            text,
+            match,
+            javascript_dialect=javascript_dialect,
+        )
+    )
     for match in SECRET_ASSIGNMENT_PATTERN.finditer(text):
         if match.start() in boolean_declaration_positions:
             continue
@@ -6298,6 +6342,16 @@ def review_secret_value_spans(
             javascript_dialect=javascript_dialect,
         )
     ]
+    spans.extend(
+        span
+        for match in SECRET_ASSIGNMENT_PREFIX_PATTERN.finditer(text)
+        if match.start() not in boolean_declaration_positions
+        for span in assignment_prefix_fallback_literal_spans(
+            text,
+            match,
+            javascript_dialect=javascript_dialect,
+        )
+    )
     for match in SECRET_ASSIGNMENT_PATTERN.finditer(text):
         if match.start() in boolean_declaration_positions:
             continue
@@ -6853,11 +6907,27 @@ def tolerant_pem_line_spans(text: str, depth: int) -> tuple[list[tuple[int, int]
     return spans, depth
 
 
+def diff_prefix_side(prefix: str) -> str:
+    """Return the semantic side for a unified or combined-diff prefix."""
+    has_addition = "+" in prefix
+    has_removal = "-" in prefix
+    if has_addition and not has_removal:
+        return "+"
+    if has_removal and not has_addition:
+        return "-"
+    if not has_addition and not has_removal:
+        return " "
+    return ""
+
+
 def redact_unbalanced_private_key_hunks(section: str) -> tuple[str, set[str]]:
     """Redact inherited truncated PEM material while retaining changed code."""
     lines = literal_lf_lines(section)
     redacted = list(lines)
     secret_fragments: set[str] = set()
+    section_old_text, section_new_text = unified_diff_contents(section)
+    old_depth = private_key_initial_depth(section_old_text)
+    new_depth = private_key_initial_depth(section_new_text)
     index = 0
     while index < len(lines):
         header = lines[index]
@@ -6871,9 +6941,7 @@ def redact_unbalanced_private_key_hunks(section: str) -> tuple[str, set[str]]:
         prefix_columns = len(prefix_match.group(1)) - 1
         old_content: list[str] = []
         new_content: list[str] = []
-        raw_content: list[str] = []
         hunk_lines: list[tuple[int, str, str, str]] = []
-        has_changed_marker = False
         for line_index in range(index + 1, hunk_end):
             line = lines[line_index]
             body = line.rstrip("\r\n")
@@ -6883,32 +6951,138 @@ def redact_unbalanced_private_key_hunks(section: str) -> tuple[str, set[str]]:
                 continue
             content = body[prefix_columns:]
             hunk_lines.append((line_index, prefix, content, ending))
-            raw_content.append(content)
-            if set(prefix) != {" "} and (
-                PRIVATE_KEY_BEGIN_PATTERN.search(content) is not None
-                or PRIVATE_KEY_END_PATTERN.search(content) is not None
-            ):
-                has_changed_marker = True
             if set(prefix) == {" "} or "-" in prefix:
                 old_content.append(content)
             if set(prefix) == {" "} or "+" in prefix:
                 new_content.append(content)
         old_text = "\n".join(old_content)
         new_text = "\n".join(new_content)
-        raw_text = "\n".join(raw_content)
         old_balanced = private_key_markers_balanced(old_text)
         new_balanced = private_key_markers_balanced(new_text)
-        raw_balanced = private_key_markers_balanced(raw_text)
-        if old_balanced and new_balanced and raw_balanced:
+        if old_balanced and new_balanced and old_depth == 0 and new_depth == 0:
             index = hunk_end
             continue
-        if has_changed_marker:
+        ambiguous_changed_lines: set[int] = set()
+        redact_ambiguous_hunk = False
+        for position, (_, prefix, content, _) in enumerate(hunk_lines):
+            if not (
+                PRIVATE_KEY_BEGIN_PATTERN.search(content)
+                or PRIVATE_KEY_END_PATTERN.search(content)
+            ):
+                continue
+            side = diff_prefix_side(prefix)
+            if side == "":
+                redact_ambiguous_hunk = True
+                break
+            if side not in {"+", "-"}:
+                continue
+            opposite = "+" if side == "-" else "-"
+            run_start = position
+            while (
+                run_start > 0
+                and diff_prefix_side(hunk_lines[run_start - 1][1]) == side
+            ):
+                run_start -= 1
+            run_end = position
+            while (
+                run_end + 1 < len(hunk_lines)
+                and diff_prefix_side(hunk_lines[run_end + 1][1]) == side
+            ):
+                run_end += 1
+            for neighbor in (run_start - 1, run_end + 1):
+                opposite_run: list[int] = []
+                while (
+                    0 <= neighbor < len(hunk_lines)
+                    and diff_prefix_side(hunk_lines[neighbor][1]) == opposite
+                ):
+                    opposite_run.append(neighbor)
+                    neighbor += -1 if neighbor < run_start else 1
+                if not any(
+                    PRIVATE_KEY_BEGIN_PATTERN.search(hunk_lines[item][2])
+                    or PRIVATE_KEY_END_PATTERN.search(hunk_lines[item][2])
+                    for item in opposite_run
+                ):
+                    ambiguous_changed_lines.update(
+                        hunk_lines[item][0] for item in opposite_run
+                    )
+        if redact_ambiguous_hunk:
+            for line_index, prefix, content, ending in hunk_lines:
+                spans: list[tuple[int, int]] = []
+                if old_depth > 0 or new_depth > 0:
+                    spans.extend(
+                        explicit_private_key_body_spans(
+                            content,
+                            in_pem=True,
+                        )
+                    )
+                if set(prefix) == {" "} or "-" in prefix:
+                    old_spans, old_depth = tolerant_pem_line_spans(
+                        content,
+                        old_depth,
+                    )
+                    spans.extend(old_spans)
+                if set(prefix) == {" "} or "+" in prefix:
+                    new_spans, new_depth = tolerant_pem_line_spans(
+                        content,
+                        new_depth,
+                    )
+                    spans.extend(new_spans)
+                marker_spans = {
+                    match.span()
+                    for pattern in (
+                        PRIVATE_KEY_BEGIN_PATTERN,
+                        PRIVATE_KEY_END_PATTERN,
+                    )
+                    for match in pattern.finditer(content)
+                }
+                secret_fragments.update(
+                    fragment
+                    for start, end in spans
+                    if (start, end) not in marker_spans
+                    and (
+                        fragment := normalized_private_key_fragment(
+                            content,
+                            start,
+                            end,
+                        )
+                    )
+                    and fragment.casefold() not in SECRET_PLACEHOLDER_VALUES
+                )
+                redacted[line_index] = (
+                    f"{prefix}{REVIEW_SECURITY_REDACTION}{ending}"
+                )
             index = hunk_end
             continue
-        old_depth = private_key_initial_depth(old_text)
-        new_depth = private_key_initial_depth(new_text)
         for line_index, prefix, content, ending in hunk_lines:
+            if line_index in ambiguous_changed_lines:
+                candidate_spans = explicit_private_key_body_spans(
+                    content,
+                    in_pem=True,
+                )
+                secret_fragments.update(
+                    fragment
+                    for start, end in candidate_spans
+                    if (
+                        fragment := normalized_private_key_fragment(
+                            content,
+                            start,
+                            end,
+                        )
+                    )
+                    and fragment.casefold() not in SECRET_PLACEHOLDER_VALUES
+                )
+                redacted[line_index] = (
+                    f"{prefix}{REVIEW_SECRET_REDACTION}{ending}"
+                )
+                continue
             spans: list[tuple[int, int]] = []
+            if (old_depth > 0 or new_depth > 0) and set(prefix) != {" "}:
+                spans.extend(
+                    explicit_private_key_body_spans(
+                        content,
+                        in_pem=True,
+                    )
+                )
             if set(prefix) == {" "} or "-" in prefix:
                 old_spans, old_depth = tolerant_pem_line_spans(content, old_depth)
                 spans.extend(old_spans)
@@ -7468,7 +7642,7 @@ def validate_review_patch(
     redacted_units: list[str] = []
     known_secret_fragments: set[str] = set()
     for unit in units:
-        if unit.startswith("diff --git "):
+        if unit.startswith(("diff --git ", "diff --cc ", "diff --combined ")):
             try:
                 unit, fragments = redact_unbalanced_private_key_hunks(unit)
                 known_secret_fragments.update(fragments)

--- a/skills/autoreview/tests/test_autoreview_hardening.py
+++ b/skills/autoreview/tests/test_autoreview_hardening.py
@@ -4122,7 +4122,7 @@ class AutoreviewHardeningTests(unittest.TestCase):
         self.assertNotIn(PRIVATE_KEY_BEGIN_TEXT, redacted)
         self.assertIn("+runDangerousOperation();", redacted)
 
-    def test_review_patch_redacts_ambiguous_combined_diff_hunk_only(self) -> None:
+    def test_review_patch_omits_ambiguous_combined_diff_section_only(self) -> None:
         replacement = "MIIEowIBAAKCAQEAcombined0123456789ABCDEF"
         patch = (
             "diff --cc fixture.test.ts\n"
@@ -4136,17 +4136,23 @@ class AutoreviewHardeningTests(unittest.TestCase):
             "@@@ -20,1 -20,1 +20,1 @@@\n"
             "--const timeout = 0;\n"
             "++runDangerousOperation();\n"
+            "diff --git a/safe.ts b/safe.ts\n"
+            "--- a/safe.ts\n"
+            "+++ b/safe.ts\n"
+            "@@ -0,0 +1 @@\n"
+            "+runSafeReviewOperation();\n"
         )
 
         redacted = self.helper["validate_review_patch"](
             "local unstaged diff",
-            ["fixture.test.ts"],
+            ["fixture.test.ts", "safe.ts"],
             patch,
         )
 
         self.assertNotIn(replacement, redacted)
         self.assertNotIn("END PRIVATE KEY", redacted)
-        self.assertIn("++runDangerousOperation();", redacted)
+        self.assertNotIn("++runDangerousOperation();", redacted)
+        self.assertIn("+runSafeReviewOperation();", redacted)
 
     def test_review_patch_carries_ambiguous_combined_diff_state(self) -> None:
         body = "MIIEowIBAAKCAQEAcombinedbody0123456789ABCDEF"
@@ -4161,17 +4167,23 @@ class AutoreviewHardeningTests(unittest.TestCase):
             "@@@ -10,1 -10,1 +10,2 @@@\n"
             f'++const body = "{body}";\n'
             "++runDangerousOperation();\n"
+            "diff --git a/safe.ts b/safe.ts\n"
+            "--- a/safe.ts\n"
+            "+++ b/safe.ts\n"
+            "@@ -0,0 +1 @@\n"
+            "+runSafeReviewOperation();\n"
         )
 
         redacted = self.helper["validate_review_patch"](
             "local unstaged diff",
-            ["fixture.test.ts"],
+            ["fixture.test.ts", "safe.ts"],
             patch,
         )
 
         self.assertNotIn(body, redacted)
         self.assertNotIn(PRIVATE_KEY_BEGIN_TEXT, redacted)
-        self.assertIn("++runDangerousOperation();", redacted)
+        self.assertNotIn("++runDangerousOperation();", redacted)
+        self.assertIn("+runSafeReviewOperation();", redacted)
 
     def test_review_patch_redacts_repeated_ambiguous_combined_fragment(self) -> None:
         body = "MIIEowIBAAKCAQEArepeatedbody0123456789ABCDEF"
@@ -4189,15 +4201,26 @@ class AutoreviewHardeningTests(unittest.TestCase):
             + 'PRIVATE KEY-----";\n'
             "@@@ -20,1 -20,1 +20,1 @@@\n"
             f'++log("{body}");\n'
+            "diff --git a/runtime.ts b/runtime.ts\n"
+            "--- a/runtime.ts\n"
+            "+++ b/runtime.ts\n"
+            "@@ -0,0 +1 @@\n"
+            f'+log("{body}");\n'
+            "diff --git a/safe.ts b/safe.ts\n"
+            "--- a/safe.ts\n"
+            "+++ b/safe.ts\n"
+            "@@ -0,0 +1 @@\n"
+            "+runSafeReviewOperation();\n"
         )
 
         redacted = self.helper["validate_review_patch"](
             "local unstaged diff",
-            ["fixture.test.ts"],
+            ["fixture.test.ts", "runtime.ts", "safe.ts"],
             patch,
         )
 
         self.assertNotIn(body, redacted)
+        self.assertIn("+runSafeReviewOperation();", redacted)
 
     def test_review_patch_skips_no_newline_metadata_when_pairing(self) -> None:
         replacement = "MIIEowIBAAKCAQEAnewline0123456789ABCDEF"

--- a/skills/autoreview/tests/test_autoreview_hardening.py
+++ b/skills/autoreview/tests/test_autoreview_hardening.py
@@ -4094,6 +4094,31 @@ class AutoreviewHardeningTests(unittest.TestCase):
 
         self.assertNotIn(replacement, redacted)
         self.assertNotIn(PRIVATE_KEY_BEGIN_TEXT, redacted)
+        self.assertIn("+const replacementLabel =", redacted)
+        self.assertIn("+runDangerousOperation();", redacted)
+
+    def test_review_patch_preserves_nonsecret_private_key_replacement(self) -> None:
+        patch = (
+            "diff --git a/fixture.test.ts b/fixture.test.ts\n"
+            "--- a/fixture.test.ts\n"
+            "+++ b/fixture.test.ts\n"
+            "@@ -1 +1 @@\n"
+            '-const begin = "-----BEGIN '
+            + 'PRIVATE KEY-----";\n'
+            "+sendCredentials();\n"
+            "@@ -20 +20 @@\n"
+            "-const timeout = 0;\n"
+            "+runDangerousOperation();\n"
+        )
+
+        redacted = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["fixture.test.ts"],
+            patch,
+        )
+
+        self.assertNotIn(PRIVATE_KEY_BEGIN_TEXT, redacted)
+        self.assertIn("+sendCredentials();", redacted)
         self.assertIn("+runDangerousOperation();", redacted)
 
     def test_review_patch_carries_private_key_state_across_hunks(self) -> None:
@@ -4122,7 +4147,7 @@ class AutoreviewHardeningTests(unittest.TestCase):
         self.assertNotIn(PRIVATE_KEY_BEGIN_TEXT, redacted)
         self.assertIn("+runDangerousOperation();", redacted)
 
-    def test_review_patch_omits_ambiguous_combined_diff_section_only(self) -> None:
+    def test_review_patch_redacts_ambiguous_combined_diff_spans(self) -> None:
         replacement = "MIIEowIBAAKCAQEAcombined0123456789ABCDEF"
         patch = (
             "diff --cc fixture.test.ts\n"
@@ -4151,7 +4176,7 @@ class AutoreviewHardeningTests(unittest.TestCase):
 
         self.assertNotIn(replacement, redacted)
         self.assertNotIn("END PRIVATE KEY", redacted)
-        self.assertNotIn("++runDangerousOperation();", redacted)
+        self.assertIn("++runDangerousOperation();", redacted)
         self.assertIn("+runSafeReviewOperation();", redacted)
 
     def test_review_patch_carries_ambiguous_combined_diff_state(self) -> None:
@@ -4182,7 +4207,7 @@ class AutoreviewHardeningTests(unittest.TestCase):
 
         self.assertNotIn(body, redacted)
         self.assertNotIn(PRIVATE_KEY_BEGIN_TEXT, redacted)
-        self.assertNotIn("++runDangerousOperation();", redacted)
+        self.assertIn("++runDangerousOperation();", redacted)
         self.assertIn("+runSafeReviewOperation();", redacted)
 
     def test_review_patch_redacts_repeated_ambiguous_combined_fragment(self) -> None:

--- a/skills/autoreview/tests/test_autoreview_hardening.py
+++ b/skills/autoreview/tests/test_autoreview_hardening.py
@@ -4274,6 +4274,32 @@ class AutoreviewHardeningTests(unittest.TestCase):
         self.assertNotIn("END PRIVATE KEY", redacted)
         self.assertIn("+runDangerousOperation();", redacted)
 
+    def test_private_key_marker_run_scan_is_bounded(self) -> None:
+        marker = "-----BEGIN " + "PRIVATE KEY-----"
+        count = 1_000
+        patch = (
+            "diff --git a/fixture.test.ts b/fixture.test.ts\n"
+            "--- a/fixture.test.ts\n"
+            "+++ b/fixture.test.ts\n"
+            f"@@ -1,{count} +1,{count} @@\n"
+            + "".join(
+                f'-const marker{index} = "{marker}";\n'
+                for index in range(count)
+            )
+            + "".join(
+                "+sendCredentials();\n" for _ in range(count)
+            )
+        )
+
+        started = time.monotonic()
+        redacted, _ = self.helper["redact_unbalanced_private_key_hunks"](
+            patch
+        )
+
+        self.assertLess(time.monotonic() - started, 5.0)
+        self.assertEqual(redacted.count("+sendCredentials();"), count)
+        self.assertNotIn(marker, redacted)
+
     def test_review_patch_redacts_net_new_unmatched_private_key_marker(self) -> None:
         patch = (
             "diff --git a/fixture.test.ts b/fixture.test.ts\n"
@@ -4880,6 +4906,31 @@ class AutoreviewHardeningTests(unittest.TestCase):
         self.assertIn('choose("redacted")', redacted)
         self.assertIn('log("redacted")', redacted)
 
+    def test_review_patch_redacts_multiline_arrow_fallback_literal(self) -> None:
+        secret = "fallback-secret-123"
+        patch = (
+            "diff --git a/runtime.ts b/runtime.ts\n"
+            "--- a/runtime.ts\n"
+            "+++ b/runtime.ts\n"
+            "@@ -0,0 +1,6 @@\n"
+            "+password = (() => {\n"
+            "+  const value = source;\n"
+            "+  return value;\n"
+            f'+}})() || "{secret}";\n'
+            f'+log("{secret}");\n'
+            "+runDangerousOperation();\n"
+        )
+
+        redacted = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["runtime.ts"],
+            patch,
+        )
+
+        self.assertNotIn(secret, redacted)
+        self.assertIn('+log("redacted");', redacted)
+        self.assertIn("+runDangerousOperation();", redacted)
+
     def test_review_patch_omits_ambiguous_changed_line_before_repeated_value(
         self,
     ) -> None:
@@ -4944,6 +4995,182 @@ class AutoreviewHardeningTests(unittest.TestCase):
 
         self.assertIn(self.helper["REVIEW_SECRET_REDACTION"], redacted)
         self.assertIn('+log("long-status-label");', redacted)
+
+    def test_assignment_prefix_fallback_scan_is_bounded(self) -> None:
+        for separator in ("\n", ""):
+            with self.subTest(separator=repr(separator)):
+                content = separator.join(
+                    f"password = value_{index};" for index in range(5_000)
+                )
+
+                started = time.monotonic()
+                spans = self.helper["review_repeatable_secret_spans"](content)
+
+                self.assertLess(time.monotonic() - started, 5.0)
+                self.assertEqual(spans, [])
+
+    def test_assignment_prefix_scan_stops_at_raw_diff_line_boundary(self) -> None:
+        content = (
+            "+password = cachedPassword\n"
+            '+role = suppliedRole || "admin";\n'
+        )
+
+        spans = self.helper["review_repeatable_secret_spans"](
+            content,
+            javascript_dialect="typescript",
+        )
+
+        self.assertNotIn("admin", {content[start:end] for start, end in spans})
+
+    def test_assignment_prefix_scan_continues_after_trailing_operator(self) -> None:
+        content = (
+            "+password = supplied ||\n"
+            '+  "real-secret";\n'
+        )
+
+        spans = self.helper["review_repeatable_secret_spans"](
+            content,
+            javascript_dialect="typescript",
+        )
+
+        self.assertIn(
+            "real-secret",
+            {content[start:end] for start, end in spans},
+        )
+        prefix_match = next(
+            self.helper["SECRET_ASSIGNMENT_PREFIX_PATTERN"].finditer(content)
+        )
+        assignment_match = next(
+            self.helper["SECRET_ASSIGNMENT_PATTERN"].finditer(content)
+        )
+        for collector, match in (
+            ("assignment_prefix_fallback_literal_spans", prefix_match),
+            ("assignment_fallback_literal_spans", assignment_match),
+        ):
+            with self.subTest(collector=collector):
+                collected = self.helper[collector](
+                    content,
+                    match,
+                    javascript_dialect="typescript",
+                )
+                self.assertIn(
+                    "real-secret",
+                    {content[start:end] for start, end in collected},
+                )
+
+    def test_assignment_prefix_scan_accepts_raw_diff_context_line(self) -> None:
+        content = (
+            "+password = newSource\n"
+            '  || "real-secret";\n'
+        )
+
+        spans = self.helper["review_repeatable_secret_spans"](
+            content,
+            javascript_dialect="typescript",
+        )
+
+        self.assertIn(
+            "real-secret",
+            {content[start:end] for start, end in spans},
+        )
+
+    def test_generic_assignment_scan_stops_at_next_diff_line(self) -> None:
+        content = (
+            "+password = source or fallback\n"
+            '+(grant_role("admin"))\n'
+        )
+
+        spans = self.helper["review_repeatable_secret_spans"](content)
+
+        self.assertNotIn(
+            "admin",
+            {content[start:end] for start, end in spans},
+        )
+
+    def test_generic_literal_scan_stops_at_next_diff_line(self) -> None:
+        content = (
+            '+password = "foo"\n'
+            '+grant_role("admin")\n'
+        )
+
+        spans = self.helper["review_repeatable_secret_spans"](content)
+
+        self.assertNotIn(
+            "admin",
+            {content[start:end] for start, end in spans},
+        )
+
+    def test_generic_assignment_scan_continues_after_fallback_operator(self) -> None:
+        content = (
+            '+password = ENV["PASSWORD"] ||\n'
+            '+  "production-secret"\n'
+        )
+
+        spans = self.helper["review_repeatable_secret_spans"](content)
+
+        self.assertIn(
+            "production-secret",
+            {content[start:end] for start, end in spans},
+        )
+
+    def test_assignment_scan_bounds_encoded_source_fixture(self) -> None:
+        content = "'password = source || \"production-secret\";'"
+
+        spans = self.helper["review_repeatable_secret_spans"](content)
+
+        self.assertIn(
+            "production-secret",
+            {content[start:end] for start, end in spans},
+        )
+
+    def test_assignment_scan_redacts_command_payload_fallback(self) -> None:
+        content = 'run("password = ENV.PASSWORD || \'tenant-default\'")'
+
+        spans = self.helper["review_repeatable_secret_spans"](content)
+
+        self.assertIn(
+            "tenant-default",
+            {content[start:end] for start, end in spans},
+        )
+
+    def test_assignment_scan_redacts_serialized_string_payload(self) -> None:
+        secret = realistic_secret_value()
+        content = f"const body = '{{\"password\":\"{secret}\"}}'"
+
+        spans = self.helper["review_repeatable_secret_spans"](content)
+
+        self.assertIn(secret, {content[start:end] for start, end in spans})
+
+    def test_reference_scan_stops_before_independent_statement(self) -> None:
+        content = (
+            "password = process.env.PASSWORD\n"
+            'value || "public"\n'
+        )
+
+        spans = self.helper["review_repeatable_secret_spans"](
+            content,
+            javascript_dialect="typescript",
+        )
+
+        self.assertNotIn(
+            "public",
+            {content[start:end] for start, end in spans},
+        )
+
+    def test_assignment_scan_stops_at_hunk_boundary_with_open_call(self) -> None:
+        boundary = self.helper["DIFF_HUNK_CONTENT_BOUNDARY"]
+        content = (
+            "password = choose(\n"
+            f"{boundary}\n"
+            'grant_role("admin"))\n'
+        )
+
+        spans = self.helper["review_repeatable_secret_spans"](content)
+
+        self.assertNotIn(
+            "admin",
+            {content[start:end] for start, end in spans},
+        )
 
     def test_review_patch_ignores_fallback_literals_inside_comments(self) -> None:
         patch = (

--- a/skills/autoreview/tests/test_autoreview_hardening.py
+++ b/skills/autoreview/tests/test_autoreview_hardening.py
@@ -3886,7 +3886,7 @@ class AutoreviewHardeningTests(unittest.TestCase):
         self.assertNotIn("AB12cd34EF56", redacted)
         self.assertNotIn(PRIVATE_KEY_BEGIN_TEXT, redacted)
 
-    def test_review_patch_omits_added_unmatched_private_key_begin(self) -> None:
+    def test_review_patch_redacts_added_unmatched_private_key_begin(self) -> None:
         patch = (
             "diff --git a/fixture.txt b/fixture.txt\n"
             "--- a/fixture.txt\n"
@@ -3903,11 +3903,9 @@ class AutoreviewHardeningTests(unittest.TestCase):
             ["fixture.txt"],
             patch,
         )
-        self.assertEqual(
-            redacted,
-            self.helper["REVIEW_SECURITY_REDACTION"] + "\n",
-        )
         self.assertNotIn(PRIVATE_KEY_BEGIN_TEXT, redacted)
+        self.assertNotIn("MIIEowIBAAKCAQEAunmatched0123456789ABCDEF", redacted)
+        self.assertIn("+runDangerousOperation();", redacted)
 
     def test_review_patch_redacts_truncated_inherited_private_key_context(self) -> None:
         patch = (
@@ -3994,7 +3992,7 @@ class AutoreviewHardeningTests(unittest.TestCase):
         self.assertIn('const label = "visible";', redacted)
         self.assertIn("+const timeout = 30_000;", redacted)
 
-    def test_review_patch_omits_truncated_private_key_marker_replacement(self) -> None:
+    def test_review_patch_redacts_truncated_private_key_marker_replacement(self) -> None:
         patch = (
             "diff --git a/fixture.test.ts b/fixture.test.ts\n"
             "--- a/fixture.test.ts\n"
@@ -4016,13 +4014,12 @@ class AutoreviewHardeningTests(unittest.TestCase):
             ["fixture.test.ts"],
             patch,
         )
-        self.assertEqual(
-            redacted,
-            self.helper["REVIEW_SECURITY_REDACTION"] + "\n",
-        )
         self.assertNotIn(PRIVATE_KEY_BEGIN_TEXT, redacted)
+        self.assertNotIn("AB12cd34EF56", redacted)
+        self.assertIn("expect(key).toBeDefined();", redacted)
+        self.assertIn("+const timeout = 30_000;", redacted)
 
-    def test_review_patch_omits_removed_private_key_end_marker(self) -> None:
+    def test_review_patch_redacts_removed_private_key_end_marker(self) -> None:
         replacement = "AB12cd34EF56gh78"
         patch = (
             "diff --git a/fixture.test.ts b/fixture.test.ts\n"
@@ -4043,13 +4040,11 @@ class AutoreviewHardeningTests(unittest.TestCase):
             ["fixture.test.ts"],
             patch,
         )
-        self.assertEqual(
-            redacted,
-            self.helper["REVIEW_SECURITY_REDACTION"] + "\n",
-        )
         self.assertNotIn(replacement, redacted)
+        self.assertNotIn("END PRIVATE KEY", redacted)
+        self.assertIn("+const timeout = 30_000;", redacted)
 
-    def test_review_patch_omits_removed_private_key_begin_marker(self) -> None:
+    def test_review_patch_redacts_removed_private_key_begin_marker(self) -> None:
         replacement = "AB12cd34EF56gh78"
         patch = (
             "diff --git a/fixture.test.ts b/fixture.test.ts\n"
@@ -4070,13 +4065,168 @@ class AutoreviewHardeningTests(unittest.TestCase):
             ["fixture.test.ts"],
             patch,
         )
-        self.assertEqual(
-            redacted,
-            self.helper["REVIEW_SECURITY_REDACTION"] + "\n",
-        )
         self.assertNotIn(replacement, redacted)
+        self.assertNotIn(PRIVATE_KEY_BEGIN_TEXT, redacted)
+        self.assertIn("+const timeout = 30_000;", redacted)
 
-    def test_review_patch_omits_net_new_unmatched_private_key_marker(self) -> None:
+    def test_review_patch_redacts_multiline_private_key_replacement(self) -> None:
+        replacement = "MIIEowIBAAKCAQEAreplacement0123456789ABCDEF"
+        patch = (
+            "diff --git a/fixture.test.ts b/fixture.test.ts\n"
+            "--- a/fixture.test.ts\n"
+            "+++ b/fixture.test.ts\n"
+            "@@ -1,2 +1,2 @@\n"
+            '-const begin = "-----BEGIN '
+            + 'PRIVATE KEY-----";\n'
+            '-const oldBody = "ZX90yu12WV34";\n'
+            f'+const replacement = "{replacement}";\n'
+            '+const replacementLabel = "visible later";\n'
+            "@@ -20 +20 @@\n"
+            "-const timeout = 0;\n"
+            "+runDangerousOperation();\n"
+        )
+
+        redacted = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["fixture.test.ts"],
+            patch,
+        )
+
+        self.assertNotIn(replacement, redacted)
+        self.assertNotIn(PRIVATE_KEY_BEGIN_TEXT, redacted)
+        self.assertIn("+runDangerousOperation();", redacted)
+
+    def test_review_patch_carries_private_key_state_across_hunks(self) -> None:
+        replacement = "MIIEowIBAAKCAQEAcrosshunk0123456789ABCDEF"
+        patch = (
+            "diff --git a/fixture.test.ts b/fixture.test.ts\n"
+            "--- a/fixture.test.ts\n"
+            "+++ b/fixture.test.ts\n"
+            "@@ -1 +1 @@\n"
+            '-const begin = "-----BEGIN '
+            + 'PRIVATE KEY-----";\n'
+            '+const begin = "removed";\n'
+            "@@ -20 +20,2 @@\n"
+            '-const oldBody = "ZX90yu12WV34";\n'
+            f'+const replacement = "{replacement}";\n'
+            "+runDangerousOperation();\n"
+        )
+
+        redacted = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["fixture.test.ts"],
+            patch,
+        )
+
+        self.assertNotIn(replacement, redacted)
+        self.assertNotIn(PRIVATE_KEY_BEGIN_TEXT, redacted)
+        self.assertIn("+runDangerousOperation();", redacted)
+
+    def test_review_patch_redacts_ambiguous_combined_diff_hunk_only(self) -> None:
+        replacement = "MIIEowIBAAKCAQEAcombined0123456789ABCDEF"
+        patch = (
+            "diff --cc fixture.test.ts\n"
+            "index 1111111,2222222..3333333\n"
+            "--- a/fixture.test.ts\n"
+            "+++ b/fixture.test.ts\n"
+            "@@@ -1,2 -1,2 +1,2 @@@\n"
+            '-+const end = "-----END '
+            + 'PRIVATE KEY-----";\n'
+            f'++const replacement = "{replacement}";\n'
+            "@@@ -20,1 -20,1 +20,1 @@@\n"
+            "--const timeout = 0;\n"
+            "++runDangerousOperation();\n"
+        )
+
+        redacted = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["fixture.test.ts"],
+            patch,
+        )
+
+        self.assertNotIn(replacement, redacted)
+        self.assertNotIn("END PRIVATE KEY", redacted)
+        self.assertIn("++runDangerousOperation();", redacted)
+
+    def test_review_patch_carries_ambiguous_combined_diff_state(self) -> None:
+        body = "MIIEowIBAAKCAQEAcombinedbody0123456789ABCDEF"
+        patch = (
+            "diff --cc fixture.test.ts\n"
+            "index 1111111,2222222..3333333\n"
+            "--- a/fixture.test.ts\n"
+            "+++ b/fixture.test.ts\n"
+            "@@@ -1,1 -1,1 +1,1 @@@\n"
+            '-+const begin = "-----BEGIN '
+            + 'PRIVATE KEY-----";\n'
+            "@@@ -10,1 -10,1 +10,2 @@@\n"
+            f'++const body = "{body}";\n'
+            "++runDangerousOperation();\n"
+        )
+
+        redacted = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["fixture.test.ts"],
+            patch,
+        )
+
+        self.assertNotIn(body, redacted)
+        self.assertNotIn(PRIVATE_KEY_BEGIN_TEXT, redacted)
+        self.assertIn("++runDangerousOperation();", redacted)
+
+    def test_review_patch_redacts_repeated_ambiguous_combined_fragment(self) -> None:
+        body = "MIIEowIBAAKCAQEArepeatedbody0123456789ABCDEF"
+        patch = (
+            "diff --cc fixture.test.ts\n"
+            "index 1111111,2222222..3333333\n"
+            "--- a/fixture.test.ts\n"
+            "+++ b/fixture.test.ts\n"
+            "@@@ -1,2 -1,2 +1,2 @@@\n"
+            '-+const key = "-----BEGIN '
+            + 'PRIVATE KEY-----";\n'
+            f'-+const body = "{body}";\n'
+            "@@@ -10,1 -10,1 +10,1 @@@\n"
+            '-+const end = "-----END '
+            + 'PRIVATE KEY-----";\n'
+            "@@@ -20,1 -20,1 +20,1 @@@\n"
+            f'++log("{body}");\n'
+        )
+
+        redacted = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["fixture.test.ts"],
+            patch,
+        )
+
+        self.assertNotIn(body, redacted)
+
+    def test_review_patch_skips_no_newline_metadata_when_pairing(self) -> None:
+        replacement = "MIIEowIBAAKCAQEAnewline0123456789ABCDEF"
+        patch = (
+            "diff --git a/fixture.test.ts b/fixture.test.ts\n"
+            "--- a/fixture.test.ts\n"
+            "+++ b/fixture.test.ts\n"
+            "@@ -1 +1 @@\n"
+            '-const end = "-----END '
+            + 'PRIVATE KEY-----";\n'
+            "\\ No newline at end of file\n"
+            f'+const replacement = "{replacement}";\n'
+            "\\ No newline at end of file\n"
+            "@@ -20 +20 @@\n"
+            "-const timeout = 0;\n"
+            "+runDangerousOperation();\n"
+        )
+
+        redacted = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["fixture.test.ts"],
+            patch,
+        )
+
+        self.assertNotIn(replacement, redacted)
+        self.assertNotIn("END PRIVATE KEY", redacted)
+        self.assertIn("+runDangerousOperation();", redacted)
+
+    def test_review_patch_redacts_net_new_unmatched_private_key_marker(self) -> None:
         patch = (
             "diff --git a/fixture.test.ts b/fixture.test.ts\n"
             "--- a/fixture.test.ts\n"
@@ -4095,11 +4245,28 @@ class AutoreviewHardeningTests(unittest.TestCase):
             ["fixture.test.ts"],
             patch,
         )
-        self.assertEqual(
-            redacted,
-            self.helper["REVIEW_SECURITY_REDACTION"] + "\n",
-        )
         self.assertNotIn(PRIVATE_KEY_BEGIN_TEXT, redacted)
+        self.assertIn("@@ -1 +1,2 @@", redacted)
+
+    def test_review_patch_redacts_changed_unmatched_private_key_end_marker(self) -> None:
+        patch = (
+            "diff --git a/fixture.test.ts b/fixture.test.ts\n"
+            "--- a/fixture.test.ts\n"
+            "+++ b/fixture.test.ts\n"
+            "@@ -0,0 +1,2 @@\n"
+            "+const end = \"-----END "
+            + "PRIVATE KEY-----\";\n"
+            "+runDangerousOperation();\n"
+        )
+
+        redacted = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["fixture.test.ts"],
+            patch,
+        )
+
+        self.assertNotIn("END PRIVATE KEY", redacted)
+        self.assertIn("+runDangerousOperation();", redacted)
 
     def test_review_patch_redacts_before_unmatched_private_key_end(self) -> None:
         patch = (
@@ -4139,11 +4306,8 @@ class AutoreviewHardeningTests(unittest.TestCase):
             ["fixture.txt"],
             patch,
         )
-        self.assertEqual(
-            redacted,
-            self.helper["REVIEW_SECURITY_REDACTION"] + "\n",
-        )
         self.assertNotIn(PRIVATE_KEY_BEGIN_TEXT, redacted)
+        self.assertNotIn("CDef3456GHij7890", redacted)
 
     def test_review_patch_redacts_secret_like_hunk_header_section(self) -> None:
         fixture_value = realistic_secret_value()
@@ -4668,6 +4832,29 @@ class AutoreviewHardeningTests(unittest.TestCase):
         self.assertIn('choose("redacted")', redacted)
         self.assertIn('log("redacted")', redacted)
 
+    def test_review_patch_omits_ambiguous_changed_line_before_repeated_value(
+        self,
+    ) -> None:
+        secret = "correct-horse-battery-staple"
+        patch = (
+            "diff --git a/runtime.ts b/runtime.ts\n"
+            "--- a/runtime.ts\n"
+            "+++ b/runtime.ts\n"
+            "@@ -0,0 +1,2 @@\n"
+            f'+password = env || choose("{secret}");\n'
+            f'+log("{secret}");\n'
+        )
+
+        redacted = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["runtime.ts"],
+            patch,
+        )
+
+        self.assertNotIn(secret, redacted)
+        self.assertIn('choose("redacted")', redacted)
+        self.assertIn('log("redacted")', redacted)
+
     def test_review_patch_preserves_repeated_nested_noncredential_literals(self) -> None:
         short_secret = "hunter2"
         patch = (
@@ -4675,7 +4862,7 @@ class AutoreviewHardeningTests(unittest.TestCase):
             "--- a/runtime.ts\n"
             "+++ b/runtime.ts\n"
             "@@ -0,0 +1,3 @@\n"
-            f'+password = derive(input, "application/json") || choose("application/json", "{short_secret}");\n'
+            f'+password = derive(input, "application/json") || choose("{short_secret}");\n'
             '+log("application/json");\n'
             f'+log("{short_secret}");\n'
         )
@@ -4689,6 +4876,26 @@ class AutoreviewHardeningTests(unittest.TestCase):
         self.assertNotIn(short_secret, redacted)
         self.assertIn(self.helper["REVIEW_SECRET_REDACTION"], redacted)
         self.assertIn('log("application/json")', redacted)
+        self.assertIn('log("redacted")', redacted)
+
+    def test_review_patch_preserves_boolean_fallback_literals(self) -> None:
+        patch = (
+            "diff --git a/runtime.ts b/runtime.ts\n"
+            "--- a/runtime.ts\n"
+            "+++ b/runtime.ts\n"
+            "@@ -0,0 +1,2 @@\n"
+            '+const password: boolean = enabled || choose("long-status-label");\n'
+            '+log("long-status-label");\n'
+        )
+
+        redacted = self.helper["validate_review_patch"](
+            "local unstaged diff",
+            ["runtime.ts"],
+            patch,
+        )
+
+        self.assertIn(self.helper["REVIEW_SECRET_REDACTION"], redacted)
+        self.assertIn('+log("long-status-label");', redacted)
 
     def test_review_patch_ignores_fallback_literals_inside_comments(self) -> None:
         patch = (


### PR DESCRIPTION
## Summary

Four local autoreview redaction-hardening commits from 2026-07-19, pushed for review/merge:

- `0deabd9` fix(autoreview): close residual redaction gaps
- `7327be9` fix(autoreview): isolate combined PEM diffs
- `8de3d2f` fix(autoreview): preserve reviewable PEM context
- `d8fd963` fix(autoreview): bound fallback scanning

They add PEM/private-key hunk redaction gap fixes and bounded fallback literal scanning, with ~500 lines of hardening tests.

## Merge status

**This branch conflicts with main.** Since these commits were written, main landed a rewrite of the same redaction machinery (#154 redact deleted-file secrets, #156 fail closed on scanner recursion, #160 ignore TypeScript type annotations, plus #163's kimi engine rework). Upstream deleted `redact_unbalanced_private_key_hunks`, `tolerant_pem_line_spans`, `unified_diff_metadata`, and `review_hunk_header_secret_fragments`, which the first commit here modifies — a modify/delete conflict that needs a deliberate semantic merge, checking which gaps the upstream rewrite already covers.

## Testing

- Not yet run against current main (pre-merge state is the 2026-07-19 tree).
