### PR TITLE
fix(autoreview): remove --no-update flag rejected by TruffleHog 3.91.x

### DIFF
--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -2540,7 +2540,6 @@ def run_trufflehog_preflight(
                 base_commit,
                 "--branch",
                 "HEAD",
-                "--no-update",
                 "--no-color",
                 # Match TruffleHog's pre-commit mode. Unverified heuristic
                 # candidates are excluded to avoid restoring false positives.

--- a/skills/autoreview/tests/test_autoreview_hardening.py
+++ b/skills/autoreview/tests/test_autoreview_hardening.py
@@ -156,7 +156,6 @@ class AutoreviewHardeningTests(unittest.TestCase):
                 self.assertEqual(
                     command[7:],
                     [
-                        "--no-update",
                         "--no-color",
                         "--results=verified,unknown",
                         "--fail",


### PR DESCRIPTION
## TL;DR

TruffleHog 3.91.x removed the `--no-update` flag, so autoreview's secret-scan preflight now fails before any review starts for anyone on a current TruffleHog install. This removes the flag from the scan invocation and the matching test expectation. Two deleted lines.

## What Problem This Solves

On TruffleHog 3.91.x the preflight exits with an unknown-flag error, which blocks every review in a repo that has secrets scanning available.

## Why This Change Was Made

The flag no longer exists upstream in TruffleHog, so passing it can never work. I run this fix in my fork and reviews scan normally again.

## User Impact

Reviews work on current TruffleHog releases. On older TruffleHog versions the self-update check re-enables, which costs a version check at scan time and nothing else.

## Evidence

- `skills/autoreview/scripts/autoreview --self-test` → all self-tests ok
- `python3 -m unittest discover -s skills/autoreview/tests` → Ran 289 tests, OK (1 skipped)
- `scripts/validate-skills` → validated 8 skills

## After-fix live behavior proof (real TruffleHog 3.96.0)

Run on this branch against a real dirty checkout, with a deliberately fake review engine so only the scan matters (redacted paths):

```
$ trufflehog --version
trufflehog 3.96.0
$ autoreview --mode local --engine codex --codex-bin .../fake-codex-quick
autoreview target: local
...
trufflehog: clean (3.3s)
bundle: 150 bytes; review passes: 1
```

The secret-scan preflight completes successfully on a current TruffleHog (3.96.0, i.e. post-3.91.x where `--no-update` no longer exists). Before this fix the same invocation dies in the preflight with TruffleHog's unknown-flag error before any scan runs. (The `unexpected JSON shape` failure after the scan line is the intentionally-fake engine, unrelated to the scan.)
