### PR TITLE
fix(autoreview): enforce safe engine env in opencode isolation self-test

### DIFF
--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -902,14 +902,6 @@ def run(
     return result
 
 
-def subprocess_env(extra: dict[str, str] | None) -> dict[str, str] | None:
-    if not extra:
-        return None
-    merged = os.environ.copy()
-    merged.update(extra)
-    return merged
-
-
 def safe_git_env(repo: Path) -> dict[str, str]:
     platform_keys = ("COMSPEC", "PATHEXT", "SYSTEMROOT", "TEMP", "TMP", "TMPDIR", "WINDIR")
     env = {
@@ -11903,13 +11895,25 @@ def self_test_opencode_real_project_isolation(args: argparse.Namespace) -> None:
         (repo / ".opencode" / "skills" / "hostile" / "SKILL.md").write_text(
             "---\nname: hostile\ndescription: hostile\n---\nHOSTILE_SENTINEL_DOT_OPENCODE_SKILL\n"
         )
-        baseline = run([opencode_bin, "debug", "config", "--pure"], repo, check=False)
+        baseline_env = safe_engine_env(
+            repo,
+            [Path(opencode_bin).parent],
+            engine="opencode",
+        )
+        baseline = run(
+            [opencode_bin, "debug", "config", "--pure"],
+            repo,
+            check=False,
+            env=baseline_env,
+        )
         baseline_text = f"{baseline.stdout}\n{baseline.stderr}"
         if baseline.returncode != 0:
             raise SystemExit(f"opencode real isolation self-test failed: baseline debug config failed\n{baseline_text[:1000]}")
         if "HOSTILE_SENTINEL_DOT_OPENCODE_AGENT" not in baseline_text or "nonexistent-hostile-model" not in baseline_text:
             raise SystemExit("opencode real isolation self-test failed: hostile project config did not load in baseline")
 
+        isolated_env = dict(baseline_env)
+        isolated_env.update(opencode_review_env(False))
         isolated = subprocess.run(
             [opencode_bin, "debug", "config", "--pure"],
             cwd=repo,
@@ -11918,7 +11922,7 @@ def self_test_opencode_real_project_isolation(args: argparse.Namespace) -> None:
             errors=SUBPROCESS_TEXT_ERRORS,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
-            env=subprocess_env(opencode_review_env(False)),
+            env=isolated_env,
         )
         isolated_text = f"{isolated.stdout}\n{isolated.stderr}"
         if isolated.returncode != 0:

--- a/skills/autoreview/tests/test_autoreview_hardening.py
+++ b/skills/autoreview/tests/test_autoreview_hardening.py
@@ -6450,6 +6450,27 @@ class AutoreviewHardeningTests(unittest.TestCase):
             os.environ.clear()
             os.environ.update(old)
 
+    def test_opencode_isolation_self_test_does_not_forward_unrelated_secret(self) -> None:
+        self_test = self.helper["self_test_opencode_real_project_isolation"]
+        with tempfile.TemporaryDirectory() as tempdir:
+            fake = Path(tempdir) / "opencode"
+            fake.write_text(
+                "#!/usr/bin/env python3\n"
+                "import os, sys\n"
+                "if 'UNRELATED_CREDENTIAL_SENTINEL' in os.environ:\n"
+                "    raise SystemExit(86)\n"
+                "if os.environ.get('OPENCODE_DISABLE_PROJECT_CONFIG') == '1':\n"
+                "    print('{}')\n"
+                "else:\n"
+                "    print('HOSTILE_SENTINEL_DOT_OPENCODE_AGENT nonexistent-hostile-model')\n"
+            )
+            fake.chmod(0o755)
+            with mock.patch.dict(
+                os.environ,
+                {"UNRELATED_CREDENTIAL_SENTINEL": realistic_secret_value()},
+            ):
+                self_test(argparse.Namespace(opencode_bin=str(fake)))
+
     def test_codex_isolation_restricts_tool_environment(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:
             root = Path(tempdir)


### PR DESCRIPTION
## TL;DR

The OpenCode real-project-isolation self-test builds its subprocess environments from the full parent `os.environ` instead of the `safe_engine_env` allowlist that every real engine invocation uses. So the self-test can pass while forwarding credentials and other host state the actual isolation contract strips. This makes both the baseline and isolated calls go through `safe_engine_env`, and adds a regression test that an unrelated secret in the parent environment does not reach the child.

## What Problem This Solves

The self-test claimed to prove isolation but exercised a weaker environment path than production review runs, so a regression in env confinement would not have been caught.

## Why This Change Was Made

I noticed the gap while auditing the isolation self-tests in my fork. The fix reuses the existing `safe_engine_env` pattern already used by the codex path, and deletes `subprocess_env`, which this change leaves with no callers.

## User Impact

`--self-test` now proves the same environment boundary the real OpenCode invocation enforces. No behavior change outside the self-test.

## Evidence

- `skills/autoreview/scripts/autoreview --self-test` → all ok, including `opencode isolation self-test: ok`
- `python3 -m unittest discover -s skills/autoreview/tests` → Ran 290 tests, OK (1 skipped), including the new `test_opencode_isolation_self_test_does_not_forward_unrelated_secret`
- `scripts/validate-skills` → validated 8 skills

## After-fix live behavior proof (real OpenCode 1.18.11)

The changed real-project isolation self-test, run explicitly on this branch against a real OpenCode installation (not the fake-executable unit fixtures):

```
$ opencode --version
1.18.11
$ skills/autoreview/scripts/autoreview --self-test-opencode-real-project-isolation
autoreview opencode real project isolation self-test: ok
$ echo $?
0
```

This exercises the exact code path this PR changes: the baseline call now proves the hostile project config loads under the sanitized `safe_engine_env`, and the isolated call proves it does not — both against the real CLI.
