### PR TITLE
test(autoreview): keep path fixture content neutral

### DIFF
--- a/skills/autoreview/scripts/autoreview_test.py
+++ b/skills/autoreview/scripts/autoreview_test.py
@@ -533,7 +533,7 @@ class AutoreviewCompatibilityTests(unittest.TestCase):
 
         with tempfile.TemporaryDirectory(prefix="autoreview-codex-workspace-test.") as tmpdir:
             repo = Path(tmpdir)
-            (repo / ".env").write_text("OPENAI_API_KEY=ignored-secret\n")
+            (repo / ".env").write_text("ignored environment fixture\n")
             with mock.patch.dict(
                 os.environ,
                 {"CODEX_HOME": ""},


### PR DESCRIPTION
## TL;DR

A workspace-path test writes `OPENAI_API_KEY=ignored-secret` into its `.env` fixture. The fixture only needs the file to exist; giving it credential-shaped content makes secret scanners (and human reviewers grepping for leaks) stop on a false positive. This replaces it with inert text. Two lines.

## What Problem This Solves

Credential-shaped strings in fixtures generate secret-scanner noise in a repo whose main artifact is itself a secret-scanning review tool.

## Why This Change Was Made

I hit this fixture as a scanner false-positive in my fork; the test asserts filesystem behavior, not env parsing, so the content is free to be neutral.

## User Impact

None at runtime; one less spurious match for anyone scanning the tree.

## Evidence

- `python3 -m unittest discover -s skills/autoreview/tests` and `autoreview_test.py` suite → 289 tests, OK (1 skipped)
- `--self-test` all ok; `scripts/validate-skills` → validated 8 skills