### PR TITLE
fix(autoreview): make OpenCode isolation test portable

### DIFF
--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -11872,7 +11872,7 @@ def self_test_opencode_real_project_isolation(args: argparse.Namespace) -> None:
         (repo / "opencode.json").write_text(
             json.dumps(
                 {
-                    "model": "zai/nonexistent-hostile-model",
+                    "model": "HOSTILE_MODEL_SELECTION_SENTINEL",
                     "instructions": ["HOSTILE.md"],
                     "command": {"hostile": {"template": "HOSTILE_SENTINEL_OPENCODE_COMMAND"}},
                     "mcp": {
@@ -11908,7 +11908,10 @@ def self_test_opencode_real_project_isolation(args: argparse.Namespace) -> None:
         baseline_text = f"{baseline.stdout}\n{baseline.stderr}"
         if baseline.returncode != 0:
             raise SystemExit(f"opencode real isolation self-test failed: baseline debug config failed\n{baseline_text[:1000]}")
-        if "HOSTILE_SENTINEL_DOT_OPENCODE_AGENT" not in baseline_text or "nonexistent-hostile-model" not in baseline_text:
+        if (
+            "HOSTILE_SENTINEL_DOT_OPENCODE_AGENT" not in baseline_text
+            or "HOSTILE_MODEL_SELECTION_SENTINEL" not in baseline_text
+        ):
             raise SystemExit("opencode real isolation self-test failed: hostile project config did not load in baseline")
 
         isolated_env = dict(baseline_env)
@@ -11928,7 +11931,7 @@ def self_test_opencode_real_project_isolation(args: argparse.Namespace) -> None:
             raise SystemExit(f"opencode real isolation self-test failed: isolated debug config failed\n{isolated_text[:1000]}")
         hostile_needles = [
             "HOSTILE_SENTINEL",
-            "nonexistent-hostile-model",
+            "HOSTILE_MODEL_SELECTION_SENTINEL",
             "HOSTILE.md",
         ]
         leaked = [needle for needle in hostile_needles if needle in isolated_text]

--- a/skills/autoreview/tests/test_autoreview_hardening.py
+++ b/skills/autoreview/tests/test_autoreview_hardening.py
@@ -6452,17 +6452,29 @@ class AutoreviewHardeningTests(unittest.TestCase):
     def test_opencode_isolation_self_test_does_not_forward_unrelated_secret(self) -> None:
         self_test = self.helper["self_test_opencode_real_project_isolation"]
         with tempfile.TemporaryDirectory() as tempdir:
-            fake = Path(tempdir) / "opencode"
-            fake.write_text(
-                "#!/usr/bin/env python3\n"
-                "import os, sys\n"
-                "if 'UNRELATED_CREDENTIAL_SENTINEL' in os.environ:\n"
-                "    raise SystemExit(86)\n"
-                "if os.environ.get('OPENCODE_DISABLE_PROJECT_CONFIG') == '1':\n"
-                "    print('{}')\n"
-                "else:\n"
-                "    print('HOSTILE_SENTINEL_DOT_OPENCODE_AGENT nonexistent-hostile-model')\n"
-            )
+            if os.name == "nt":
+                fake = Path(tempdir) / "opencode.cmd"
+                fake.write_text(
+                    "@echo off\r\n"
+                    "if defined UNRELATED_CREDENTIAL_SENTINEL exit /b 86\r\n"
+                    'if "%OPENCODE_DISABLE_PROJECT_CONFIG%"=="1" (\r\n'
+                    "  echo {}\r\n"
+                    ") else (\r\n"
+                    "  echo HOSTILE_SENTINEL_DOT_OPENCODE_AGENT HOSTILE_MODEL_SELECTION_SENTINEL\r\n"
+                    ")\r\n"
+                )
+            else:
+                fake = Path(tempdir) / "opencode"
+                fake.write_text(
+                    "#!/usr/bin/env python3\n"
+                    "import os\n"
+                    "if 'UNRELATED_CREDENTIAL_SENTINEL' in os.environ:\n"
+                    "    raise SystemExit(86)\n"
+                    "if os.environ.get('OPENCODE_DISABLE_PROJECT_CONFIG') == '1':\n"
+                    "    print('{}')\n"
+                    "else:\n"
+                    "    print('HOSTILE_SENTINEL_DOT_OPENCODE_AGENT HOSTILE_MODEL_SELECTION_SENTINEL')\n"
+                )
             fake.chmod(0o755)
             with mock.patch.dict(
                 os.environ,


### PR DESCRIPTION
## Summary

- use a native `.cmd` fake OpenCode executable for the isolation self-test on Windows
- retain the existing Python shebang fixture on POSIX
- replace the provider-shaped fake model value with an explicit selection sentinel

## Root cause

PR #167 added an extensionless shebang fixture. Native Windows passes that path to `CreateProcess`, which rejects it with WinError 193 before the environment-isolation assertion can run.

## Proof

- focused isolation regression: pass on macOS
- full local gate: 330 Python tests (1 platform skip), 81 Node tests, all validators/self-tests/syntax checks
- real OpenCode 1.18.15 isolation self-test: pass
- Autoreview: no accepted/actionable findings, confidence 0.99
- native Windows reproduction on AWS Crabbox run `run_09cc04d85c2b`: exact pre-fix failure captured; PR CI provides the post-fix Windows proof

Public-model identifier audit: PASS. The patch removes a synthetic provider-shaped value from public fixtures/logs.
