### PR TITLE
ci: update setup actions to v7

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -14,10 +14,10 @@ jobs:
         os: [ubuntu-latest, windows-latest]
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: '22'
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@v7
         with:
           python-version: '3.x'
       - name: Install Python dependencies


### PR DESCRIPTION
## Summary

- update `actions/setup-node` from v6 to v7
- update `actions/setup-python` from v6 to v7

## Dependency audit

- PyYAML 6.0.3: current
- actions/checkout v7: current major (latest release v7.0.1)
- actions/setup-node: v7.0.0 is latest stable
- actions/setup-python: v7.0.0 is latest stable
- actions/create-github-app-token v3.2.0 pinned SHA: current

Both v7 setup-action releases are compatible with the inputs used here. Local actionlint, skill validation, Python compilation, diff checks, and Autoreview passed. The PR workflow itself is the live Ubuntu/Windows proof.

Public-model identifier audit: PASS; this workflow-only diff contains no model identifier.
