### PR TITLE
fix(beam): accept readable share URLs

### DIFF
--- a/skills/beam/README.md
+++ b/skills/beam/README.md
@@ -70,6 +70,16 @@ node "$BEAM_SKILL_DIR/scripts/beam" publish \
   --thread-id "$CODEX_THREAD_ID"
 ```
 
+On success, Beam prints the endpoint-derived Control UI URL in its short share
+form, for example:
+
+```text
+Beamed session: https://gateway.example.com/beam/0123456789ab
+```
+
+A Gateway mounted below a base path returns that same base path, such as
+`https://gateway.example.com/openclaw/beam/0123456789ab`.
+
 Explicit transcript:
 
 ```sh
@@ -138,6 +148,11 @@ Gateway HTTP authentication. Uploads require `operator.write` or
 catalog, so a separate Gateway remains the isolation boundary between teams.
 
 The catalog has no continue, archive, terminal, tool, or node capability.
+
+For rollout compatibility, the helper also accepts the current server's exact
+`/chat/<agent>?catalog=beam&host=gateway&thread=<full-beam-id>` URL. This is a
+narrow transition path: the obsolete `?session=catalog:...` beta URL remains
+rejected.
 
 OpenClaw plugin documentation:
 https://docs.openclaw.ai/plugins/beam

--- a/skills/beam/SKILL.md
+++ b/skills/beam/SKILL.md
@@ -61,7 +61,9 @@ node "$BEAM_SKILL_DIR/scripts/beam" publish --endpoint "$BEAM_ENDPOINT" --dry-ru
 
 `--dry-run` prints the sanitized payload locally and performs no network request.
 
-On success, return only the Beam URL and a short disclosure summary: source harness, shared message count, whether older entries were truncated, and whether the beam is complete.
+On success, return only the Beam URL and a short disclosure summary: source harness, shared message count, whether older entries were truncated, and whether the beam is complete. The URL uses the endpoint-derived Control UI base path followed by `/beam/<12-character lowercase hex prefix>`, for example `https://gateway.example.com/beam/0123456789ab`.
+
+During rollout, the helper also accepts the current server's exact `/chat/<agent>?catalog=beam&host=gateway&thread=<full-beam-id>` response. It still rejects the obsolete `?session=catalog:...` beta form.
 
 ## Live Hooks
 

--- a/skills/beam/scripts/beam
+++ b/skills/beam/scripts/beam
@@ -247,12 +247,52 @@ function isLoopbackUrl(url) {
   return ["localhost", "127.0.0.1", "[::1]"].includes(url.hostname);
 }
 
-function expectedChatPath(endpoint) {
+function expectedControlUiBasePath(endpoint) {
   const suffix = "/api/v1/beam/sessions";
-  const basePath = endpoint.pathname.endsWith(suffix)
+  return endpoint.pathname.endsWith(suffix)
     ? endpoint.pathname.slice(0, -suffix.length)
     : "";
-  return `${basePath}/chat`;
+}
+
+function isSafeReceiverUrl(resultUrl, endpoint) {
+  return (
+    ["http:", "https:"].includes(resultUrl.protocol) &&
+    resultUrl.origin === endpoint.origin &&
+    !resultUrl.hash &&
+    !resultUrl.username &&
+    !resultUrl.password
+  );
+}
+
+function isPrettyBeamUrl(resultUrl, endpoint, beamId) {
+  const pathPrefix = `${expectedControlUiBasePath(endpoint)}/beam/`;
+  const returnedId = resultUrl.pathname.startsWith(pathPrefix)
+    ? resultUrl.pathname.slice(pathPrefix.length)
+    : "";
+  return (
+    /^[0-9a-f]{32}$/u.test(beamId) &&
+    /^[0-9a-f]{12,32}$/u.test(returnedId) &&
+    beamId.startsWith(returnedId) &&
+    resultUrl.searchParams.size === 0
+  );
+}
+
+function isCanonicalCatalogUrl(resultUrl, endpoint, beamId) {
+  const pathPrefix = `${expectedControlUiBasePath(endpoint)}/chat/`;
+  const agentId = resultUrl.pathname.startsWith(pathPrefix)
+    ? resultUrl.pathname.slice(pathPrefix.length)
+    : "";
+  const entries = [...resultUrl.searchParams.entries()];
+  return (
+    /^[a-z0-9_][a-z0-9_-]{0,63}$/u.test(agentId) &&
+    entries.length === 3 &&
+    resultUrl.searchParams.getAll("catalog").length === 1 &&
+    resultUrl.searchParams.get("catalog") === "beam" &&
+    resultUrl.searchParams.getAll("host").length === 1 &&
+    resultUrl.searchParams.get("host") === "gateway" &&
+    resultUrl.searchParams.getAll("thread").length === 1 &&
+    resultUrl.searchParams.get("thread") === beamId
+  );
 }
 
 function endpointUrl(options) {
@@ -350,18 +390,10 @@ async function publish(payload, options) {
       throw new Error("Beam receiver returned an unsafe session URL");
     }
     const resultUrl = new URL(printableUrl, url);
-    const expectedSession = `catalog:beam:gateway:${payload.beamId}`;
-    const entries = [...resultUrl.searchParams.entries()];
     if (
-      !["http:", "https:"].includes(resultUrl.protocol) ||
-      resultUrl.origin !== url.origin ||
-      resultUrl.pathname !== expectedChatPath(url) ||
-      resultUrl.hash ||
-      resultUrl.username ||
-      resultUrl.password ||
-      entries.length !== 1 ||
-      entries[0]?.[0] !== "session" ||
-      resultUrl.searchParams.get("session") !== expectedSession
+      !isSafeReceiverUrl(resultUrl, url) ||
+      (!isPrettyBeamUrl(resultUrl, url, payload.beamId) &&
+        !isCanonicalCatalogUrl(resultUrl, url, payload.beamId))
     ) {
       throw new Error("Beam receiver returned an unsafe session URL");
     }

--- a/skills/beam/scripts/beam.test.mjs
+++ b/skills/beam/scripts/beam.test.mjs
@@ -43,6 +43,28 @@ function run(args, options = {}) {
   });
 }
 
+async function beamReceiverEndpoint(t, urlForPayload, basePath = "") {
+  const server = http.createServer((request, response) => {
+    let body = "";
+    request.setEncoding("utf8");
+    request.on("data", (chunk) => {
+      body += chunk;
+    });
+    request.on("end", () => {
+      const payload = JSON.parse(body);
+      response.writeHead(200, {
+        "content-type": "application/json",
+        connection: "close",
+      });
+      response.end(JSON.stringify({ ok: true, url: urlForPayload(payload, request) }));
+    });
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  t.after(() => server.close());
+  const address = server.address();
+  return `http://127.0.0.1:${address.port}${basePath}/api/v1/beam/sessions`;
+}
+
 function claudeSession() {
   const dir = tempDir();
   const session = path.join(dir, "11111111-2222-4333-8444-555555555555.jsonl");
@@ -900,9 +922,13 @@ test("publish sends Cloudflare Access auth and normalized session JSON", async (
     });
     request.on("end", () => {
       const received = JSON.parse(requestBody);
-      const sessionKey = encodeURIComponent(`catalog:beam:gateway:${received.beamId}`);
       response.writeHead(200, { "content-type": "application/json" });
-      response.end(JSON.stringify({ ok: true, url: `/chat?session=${sessionKey}` }));
+      response.end(
+        JSON.stringify({
+          ok: true,
+          url: `/beam/${received.beamId.slice(0, 12)}`,
+        }),
+      );
     });
   });
   await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
@@ -916,7 +942,10 @@ test("publish sends Cloudflare Access auth and normalized session JSON", async (
   );
 
   assert.equal(result.code, 0, result.stderr);
-  assert.match(result.stdout, new RegExp(`http://127\\.0\\.0\\.1:${address.port}/chat\\?session=`));
+  assert.match(
+    result.stdout,
+    new RegExp(`http://127\\.0\\.0\\.1:${address.port}/beam/[a-f0-9]{12}`),
+  );
   assert.equal(accessToken, "test-access-token");
   const payload = JSON.parse(requestBody);
   assert.equal(payload.version, 1);
@@ -1015,66 +1044,157 @@ test("publish rejects receiver URLs containing reflected credentials", async (t)
 
 test("publish accepts the endpoint-derived Control UI base path", async (t) => {
   const session = claudeSession();
-  let body = "";
-  const server = http.createServer((request, response) => {
-    request.setEncoding("utf8");
-    request.on("data", (chunk) => {
-      body += chunk;
-    });
-    request.on("end", () => {
-      const payload = JSON.parse(body);
-      const key = encodeURIComponent(`catalog:beam:gateway:${payload.beamId}`);
-      response.writeHead(200, { "content-type": "application/json" });
-      response.end(JSON.stringify({ ok: true, url: `/openclaw/chat?session=${key}` }));
-    });
-  });
-  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
-  t.after(() => server.close());
-  const address = server.address();
+  const endpoint = await beamReceiverEndpoint(
+    t,
+    (payload) => `/openclaw/beam/${payload.beamId.slice(0, 12)}`,
+    "/openclaw",
+  );
   const result = await run([
     "publish",
     "--endpoint",
-    `http://127.0.0.1:${address.port}/openclaw/api/v1/beam/sessions`,
+    endpoint,
     "--session",
     session,
   ]);
 
   assert.equal(result.code, 0, result.stderr);
-  assert.match(result.stdout, /\/openclaw\/chat\?session=/);
+  assert.match(result.stdout, /\/openclaw\/beam\/[a-f0-9]{12}/);
 });
 
-test("publish rejects duplicate session parameters and receiver-controlled chat prefixes", async (t) => {
+test("publish accepts a full-id pretty URL for collision fallback", async (t) => {
   const session = claudeSession();
-  for (const mode of ["duplicate", "prefix"]) {
-    let body = "";
-    const server = http.createServer((request, response) => {
-      request.setEncoding("utf8");
-      request.on("data", (chunk) => {
-        body += chunk;
-      });
-      request.on("end", () => {
-        const payload = JSON.parse(body);
-        const key = encodeURIComponent(`catalog:beam:gateway:${payload.beamId}`);
-        const url =
-          mode === "duplicate"
-            ? `/chat?session=${key}&session=extra`
-            : `/secret-prefix/chat?session=${key}`;
-        response.writeHead(200, { "content-type": "application/json" });
-        response.end(JSON.stringify({ ok: true, url }));
-      });
-    });
-    await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
-    t.after(() => server.close());
-    const address = server.address();
+  const endpoint = await beamReceiverEndpoint(t, (payload) => `/beam/${payload.beamId}`);
+  const result = await run([
+    "publish",
+    "--endpoint",
+    endpoint,
+    "--session",
+    session,
+  ]);
+
+  assert.equal(result.code, 0, result.stderr);
+  assert.match(result.stdout, /\/beam\/[a-f0-9]{32}/);
+});
+
+test("publish accepts the current canonical catalog URL during rollout", async (t) => {
+  const session = claudeSession();
+  const endpoint = await beamReceiverEndpoint(
+    t,
+    (payload) =>
+      `/chat/roboclaw?catalog=beam&host=gateway&thread=${payload.beamId}`,
+  );
+  const result = await run([
+    "publish",
+    "--endpoint",
+    endpoint,
+    "--session",
+    session,
+  ]);
+
+  assert.equal(result.code, 0, result.stderr);
+  assert.match(
+    result.stdout,
+    /\/chat\/roboclaw\?catalog=beam&host=gateway&thread=[a-f0-9]{32}/,
+  );
+});
+
+test("publish rejects malformed pretty Beam URLs", async (t) => {
+  const session = claudeSession();
+  let makeUrl;
+  const endpoint = await beamReceiverEndpoint(t, (payload, request) =>
+    makeUrl(payload, request),
+  );
+  const cases = [
+    ["short id", ({ beamId }) => `/beam/${beamId.slice(0, 11)}`],
+    ["uppercase id", ({ beamId }) => `/beam/${beamId.slice(0, 12).toUpperCase()}`],
+    ["nonhex id", ({ beamId }) => `/beam/${beamId.slice(0, 11)}g`],
+    ["long id", ({ beamId }) => `/beam/${beamId}0`],
+    [
+      "wrong prefix",
+      ({ beamId }) => `/beam/${beamId[0] === "0" ? "1" : "0"}${beamId.slice(1, 12)}`,
+    ],
+    ["extra segment", ({ beamId }) => `/beam/${beamId.slice(0, 12)}/extra`],
+    ["query", ({ beamId }) => `/beam/${beamId.slice(0, 12)}?view=debug`],
+    [
+      "duplicate query",
+      ({ beamId }) => `/beam/${beamId.slice(0, 12)}?thread=${beamId}&thread=${beamId}`,
+    ],
+    ["wrong base path", ({ beamId }) => `/secret-prefix/beam/${beamId.slice(0, 12)}`],
+    ["foreign origin", ({ beamId }) => `https://example.test/beam/${beamId.slice(0, 12)}`],
+    [
+      "credentials",
+      ({ beamId }, request) =>
+        `http://user@${request.headers.host}/beam/${beamId.slice(0, 12)}`,
+    ],
+    ["hash", ({ beamId }) => `/beam/${beamId.slice(0, 12)}#fragment`],
+    ["control", ({ beamId }) => `/beam/${beamId.slice(0, 12)}\n`],
+    ["non-http", ({ beamId }) => `ftp://example.test/beam/${beamId.slice(0, 12)}`],
+  ];
+
+  for (const [label, urlFactory] of cases) {
+    makeUrl = urlFactory;
     const result = await run([
       "publish",
       "--endpoint",
-      `http://127.0.0.1:${address.port}/api/v1/beam/sessions`,
+      endpoint,
       "--session",
       session,
     ]);
-    assert.equal(result.code, 1);
-    assert.match(result.stderr, /unsafe session URL/);
+    assert.equal(result.code, 1, label);
+    assert.match(result.stderr, /unsafe session URL/, label);
+  }
+});
+
+test("publish rejects malformed rollout catalog URLs", async (t) => {
+  const session = claudeSession();
+  let makeUrl;
+  const endpoint = await beamReceiverEndpoint(t, (payload) => makeUrl(payload));
+  const canonical = (beamId) =>
+    `/chat/roboclaw?catalog=beam&host=gateway&thread=${beamId}`;
+  const cases = [
+    ["duplicate thread", ({ beamId }) => `${canonical(beamId)}&thread=extra`],
+    ["extra query", ({ beamId }) => `${canonical(beamId)}&view=debug`],
+    ["wrong base path", ({ beamId }) => `/secret-prefix${canonical(beamId)}`],
+    [
+      "missing agent",
+      ({ beamId }) => `/chat?catalog=beam&host=gateway&thread=${beamId}`,
+    ],
+    [
+      "extra segment",
+      ({ beamId }) =>
+        `/chat/roboclaw/extra?catalog=beam&host=gateway&thread=${beamId}`,
+    ],
+    [
+      "legacy beta session",
+      ({ beamId }) =>
+        `/chat?session=${encodeURIComponent(`catalog:beam:gateway:${beamId}`)}`,
+    ],
+    [
+      "wrong catalog",
+      ({ beamId }) => `/chat/roboclaw?catalog=other&host=gateway&thread=${beamId}`,
+    ],
+    [
+      "wrong host",
+      ({ beamId }) => `/chat/roboclaw?catalog=beam&host=other&thread=${beamId}`,
+    ],
+    ["wrong thread", () => "/chat/roboclaw?catalog=beam&host=gateway&thread=other"],
+    [
+      "invalid agent",
+      ({ beamId }) => `/chat/Bad.Agent?catalog=beam&host=gateway&thread=${beamId}`,
+    ],
+  ];
+
+  for (const [label, urlFactory] of cases) {
+    makeUrl = urlFactory;
+    const result = await run([
+      "publish",
+      "--endpoint",
+      endpoint,
+      "--session",
+      session,
+    ]);
+    assert.equal(result.code, 1, label);
+    assert.match(result.stderr, /unsafe session URL/, label);
   }
 });
 


### PR DESCRIPTION
## Summary

Update the standalone Beam publisher for readable OpenClaw share URLs.

The helper now strictly accepts same-origin `/beam/<12-32 lowercase hex prefix>` responses when the prefix belongs to the uploaded Beam id. It keeps a narrow rollout bridge for the current OpenClaw catalog URL shape and continues to reject the obsolete beta `?session=catalog:...` form.

## Context

Companion OpenClaw change: https://github.com/openclaw/openclaw/pull/125755

Feature issue: https://github.com/openclaw/openclaw/issues/125752

## Safety

- Same endpoint origin and HTTP(S) only.
- No credentials, fragments, control characters, query parameters on pretty URLs, extra path segments, or unrelated prefixes.
- Pretty ids must be 12-32 lowercase hexadecimal characters and an exact prefix of the uploaded 32-character Beam id.
- The rollout catalog URL retains exact path, agent-id, query-key, host, catalog, and full-thread validation.
- Redirects remain disabled and tokens are never printed.

## Validation

- Complete repository workflow: passed locally on macOS.
- Beam suite: 50 tests passed after rebase.
- Skill validation: 8 skills validated.
- Autoreview: clean; no accepted/actionable findings.
- `git diff --check`: passed.

Production LOC: +46/-14 | Tests: +166/-46 | Docs: +18/-1.
