### PR TITLE
test(autoreview): treat zombie descendants as terminated

### DIFF
--- a/skills/autoreview/tests/test_autoreview_hardening.py
+++ b/skills/autoreview/tests/test_autoreview_hardening.py
@@ -231,6 +231,21 @@ def init_repo(tempdir: Path) -> Path:
     return repo
 
 
+def posix_process_is_running(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    result = subprocess.run(
+        ["ps", "-o", "stat=", "-p", str(pid)],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    state = result.stdout.strip()
+    return result.returncode == 0 and bool(state) and not state.startswith("Z")
+
+
 def installed_java() -> str | None:
     java = shutil.which("java")
     if java is None:
@@ -4446,8 +4461,10 @@ Path(__file__).with_name("scan.json").write_text(json.dumps({
         self.assertIn("streaming-reviewer engine timed out after 0.5s", result.stderr)
         self.assertLess(elapsed, 5)
         child_pid = int(result.stdout.splitlines()[0])
-        with self.assertRaises(ProcessLookupError):
-            os.kill(child_pid, 0)
+        deadline = time.monotonic() + 1
+        while posix_process_is_running(child_pid) and time.monotonic() < deadline:
+            time.sleep(0.01)
+        self.assertFalse(posix_process_is_running(child_pid))
 
     @unittest.skipUnless(os.name == "posix", "detached process groups require POSIX")
     def test_deadline_bounds_drain_when_descendant_retains_pipe(self) -> None:


### PR DESCRIPTION
## Summary

- treat a reaped zombie descendant as terminated in the POSIX streaming-deadline regression test
- poll for a bounded second so the assertion observes process execution state instead of relying only on PID existence
- remove the earlier complete-pack scanner changes from this branch because the same boundary fix landed with stronger integrated coverage in #202

## Why

`os.kill(pid, 0)` succeeds for a zombie process. The previous assertion could therefore fail after the descendant had stopped executing but before the operating system finished reaping its process table entry.

The focused helper still checks PID existence first, then uses the POSIX process state to distinguish a live process from a zombie. Production timeout behavior is unchanged; this PR only makes its regression test match the state it intends to prove.

## Evidence

- focused streaming-deadline regression: 10 consecutive passes
- complete hardening suite: 188 passed, 1 platform skip
- `uv run --with PyYAML==6.0.3 python scripts/validate-skills`: validated 8 skills
- Python compilation: passed
- `git diff --check`: passed
- canonical Autoreview through P2: patch correct, no accepted/actionable findings

The former scanner-boundary portion is already present on current `main` through #202, including complete-input scanning and integrated partition/evidence coverage.
