### PR TITLE
fix(ci): restrict validation workflow permissions

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
## Summary

- restrict the validation workflow token to read-only repository contents
- resolve CodeQL alert #1 (`actions/missing-workflow-permissions`)

## Validation

- `.venv/bin/python scripts/validate-skills`
- `.venv/bin/python scripts/validate-skills.test.py`
- parsed `.github/workflows/validate.yml` with PyYAML and verified `permissions.contents == read`
- `git diff --check`

## Security

- no secrets, personal paths, private hosts, or account identifiers added
