### PR TITLE
fix(session-viewer): avoid Windows shell opener

### DIFF
--- a/skills/session-viewer/scripts/open-browser.ts
+++ b/skills/session-viewer/scripts/open-browser.ts
@@ -1,0 +1,17 @@
+export type OpenBrowserCommand = {
+  args: string[];
+  executable: string;
+};
+
+export function resolveOpenBrowserCommand(
+  platform: NodeJS.Platform,
+  filePath: string,
+): OpenBrowserCommand {
+  if (platform === "darwin") {
+    return { executable: "open", args: [filePath] };
+  }
+  if (platform === "win32") {
+    return { executable: "explorer.exe", args: [filePath] };
+  }
+  return { executable: "xdg-open", args: [filePath] };
+}

--- a/skills/session-viewer/scripts/session-viewer.test.ts
+++ b/skills/session-viewer/scripts/session-viewer.test.ts
@@ -7,6 +7,7 @@ import test from "node:test";
 import { promisify } from "node:util";
 import { parseSessionDocument } from "./core/detect.ts";
 import { parseJsonl } from "./core/jsonl.ts";
+import { resolveOpenBrowserCommand } from "./open-browser.ts";
 
 const execFileAsync = promisify(execFile);
 
@@ -14,6 +15,20 @@ function parse(text: string) {
   const { records } = parseJsonl(text);
   return parseSessionDocument(records, "fixture.jsonl");
 }
+
+test("opens hostile Windows paths without a command shell", () => {
+  for (const filePath of [
+    "C:\\Reports\\session & calc.exe.html",
+    "C:\\Reports\\session | whoami.html",
+    "C:\\Reports\\%COMSPEC%.html",
+    "C:\\Reports\\session ^& echo injected.html",
+  ]) {
+    assert.deepEqual(resolveOpenBrowserCommand("win32", filePath), {
+      executable: "explorer.exe",
+      args: [filePath],
+    });
+  }
+});
 
 test("parses Codex rollout tool calls and outputs", () => {
   const doc = parse(

--- a/skills/session-viewer/scripts/session-viewer.ts
+++ b/skills/session-viewer/scripts/session-viewer.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { parseSessionDocument } from "./core/detect.ts";
 import { parseJsonl } from "./core/jsonl.ts";
 import { buildSessionViewerHtml } from "./html.ts";
+import { resolveOpenBrowserCommand } from "./open-browser.ts";
 
 type Options = {
   blank: boolean;
@@ -80,15 +81,8 @@ function defaultOutputPath(inputPath: string | undefined, blank: boolean): strin
 }
 
 async function openBrowser(filePath: string): Promise<void> {
-  if (process.platform === "darwin") {
-    spawn("open", [filePath], { detached: true, stdio: "ignore" }).unref();
-    return;
-  }
-  if (process.platform === "win32") {
-    spawn("cmd", ["/c", "start", "", filePath], { detached: true, stdio: "ignore" }).unref();
-    return;
-  }
-  spawn("xdg-open", [filePath], { detached: true, stdio: "ignore" }).unref();
+  const command = resolveOpenBrowserCommand(process.platform, filePath);
+  spawn(command.executable, command.args, { detached: true, stdio: "ignore" }).unref();
 }
 
 async function main(): Promise<void> {


### PR DESCRIPTION
## Summary

- remove the Windows `cmd /c start` shell boundary from the session viewer opener
- launch `explorer.exe` directly with the output path as one argv element
- add hostile-path regression coverage for Windows command metacharacters
- resolve CodeQL alert #5 (`js/shell-command-injection-from-environment`)

## Root cause

The Windows opener passed a path derived from CLI input through `cmd.exe`. Shell metacharacters in that path could be interpreted as commands instead of remaining file-path data.

The platform command selector now owns the executable/argv contract. macOS and Linux retain their existing direct launchers; Windows uses the same direct-executable pattern.

Production delta: +20/-9 lines. The positive delta isolates the security boundary in a pure helper so hostile-path behavior is directly testable.

## Validation

- `node --test skills/agent-transcript/scripts/agent-transcript.test.mjs skills/session-viewer/scripts/session-viewer.test.ts` (35 passed)
- `node --check skills/session-viewer/scripts/open-browser.ts`
- `node --check skills/session-viewer/scripts/session-viewer.ts`
- `python scripts/validate-skills` (8 skills)
- `python scripts/validate-skills.test.py` (9 passed)
- `git diff --check`

## Security

- the output path is never passed to a command shell
- no secrets, personal paths, private hosts, or account identifiers added
