### PR TITLE
test(autoreview): keep deleted Swift status literals reviewable

### DIFF
--- a/skills/autoreview/tests/fixtures/swift-benign-status-literals.swift
+++ b/skills/autoreview/tests/fixtures/swift-benign-status-literals.swift
@@ -1,0 +1,32 @@
+import SwiftUI
+
+// Benign status-string switch distilled from a real menu view. The
+// "ok-token" case is a heartbeat status literal, not a credential; a
+// deleted file containing it must stay reviewable without redaction.
+struct HeartbeatStatusView: View {
+    let store: HeartbeatStore
+
+    var heartbeatStatus: (label: String, color: Color) {
+        if let evt = store.lastEvent {
+            let ageText = age(from: Date(timeIntervalSince1970: evt.ts / 1000))
+            switch evt.status {
+            case "sent":
+                return ("Last heartbeat sent · \(ageText)", .blue)
+            case "ok-empty", "ok-token":
+                return ("Heartbeat ok · \(ageText)", .green)
+            case "skipped":
+                return ("Heartbeat skipped · \(ageText)", .secondary)
+            case "failed":
+                return ("Heartbeat failed · \(ageText)", .red)
+            default:
+                return ("Heartbeat · \(ageText)", .secondary)
+            }
+        }
+        return ("No heartbeat yet", .secondary)
+    }
+
+    var body: some View {
+        Label(heartbeatStatus.label, systemImage: "waveform.path.ecg")
+            .foregroundStyle(heartbeatStatus.color)
+    }
+}

--- a/skills/autoreview/tests/test_autoreview_hardening.py
+++ b/skills/autoreview/tests/test_autoreview_hardening.py
@@ -1317,6 +1317,57 @@ class AutoreviewHardeningTests(unittest.TestCase):
         ):
             self.assertIn(reference, validated)
 
+    def test_review_bundle_preserves_deleted_swift_status_literals(self) -> None:
+        # Regression: a deleted Swift file with status-string cases like
+        # `case "ok-empty", "ok-token":` next to value returns is not a
+        # credential. The retired heuristic scanner flagged the "ok-token"
+        # key shape as secret-like even after value redaction, so the whole
+        # deletion became unreviewable; the bundle must stay byte-identical.
+        source = (FIXTURES / "swift-benign-status-literals.swift").read_text(
+            encoding="utf-8"
+        )
+        patch = (
+            "diff --git a/apps/macos/MenuContentView.swift "
+            "b/apps/macos/MenuContentView.swift\n"
+            "deleted file mode 100644\n"
+            "--- a/apps/macos/MenuContentView.swift\n"
+            "+++ /dev/null\n"
+            f"@@ -1,{len(source.splitlines())} +0,0 @@\n"
+            + "".join(f"-{line}\n" for line in source.splitlines())
+        )
+
+        self.assertEqual(
+            self.helper["validate_review_patch"](
+                "branch diff",
+                ["apps/macos/MenuContentView.swift"],
+                patch,
+            ),
+            patch,
+        )
+
+    @unittest.skipUnless(
+        shutil.which("trufflehog"), "TruffleHog binary not installed"
+    )
+    def test_outgoing_pack_scan_accepts_deleted_swift_status_literals(self) -> None:
+        # Live-scanner companion to the regression above: TruffleHog must not
+        # flag the benign "ok-token" status literal in a deleted-file bundle.
+        source = (FIXTURES / "swift-benign-status-literals.swift").read_text(
+            encoding="utf-8"
+        )
+        prompt = (
+            "# Change Bundle\n"
+            "diff --git a/apps/macos/MenuContentView.swift "
+            "b/apps/macos/MenuContentView.swift\n"
+            "deleted file mode 100644\n"
+            "--- a/apps/macos/MenuContentView.swift\n"
+            "+++ /dev/null\n"
+            f"@@ -1,{len(source.splitlines())} +0,0 @@\n"
+            + "".join(f"-{line}\n" for line in source.splitlines())
+        )
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo = init_repo(Path(tempdir))
+            self.helper["scan_outgoing_review_pack"](repo, prompt)
+
     def test_review_bundle_preserves_typescript_config_paths(self) -> None:
         source = (FIXTURES / "typescript-benign-config-path-references.ts").read_text(
             encoding="utf-8"


### PR DESCRIPTION
## What

Regression fixture + tests pinning that a deleted Swift file containing benign status-string cases like `case "ok-empty", "ok-token":` next to value returns stays reviewable.

## Why

The retired heuristic secret scanner (pre-TruffleHog, up to the parent of ca100e6) refused any branch diff deleting such a file: `secret_text_risk` flagged the `"ok-token"` key shape, and the deletion-only redaction pass could never clear it — even after value redaction the post-redaction risk re-check still fired, so `refuse_secret_like_review_patch` killed the whole review. Reproduced in openclaw/openclaw with `apps/macos/Sources/OpenClaw/MenuContentView.swift`; minimal trigger is the `case` line plus a tuple return beneath it.

The TruffleHog replacement already fixed this class; this PR pins it so a future heuristic reintroduction can't regress.

## Evidence

- New bundle test fails on the pre-TruffleHog script (`ca100e6^`) with the exact historical refusal: `refusing to include a known secret-like value in branch diff`.
- On current main: `validate_review_patch` returns the deletion bundle byte-identical, and a live TruffleHog pack scan accepts it (test skips when the binary is absent).
- Full suite green: `python -m unittest skills/autoreview/scripts/autoreview_test.py skills.autoreview.tests.test_autoreview_hardening` exits 0.
- Codex autoreview of this branch diff: clean, no findings.
