### PR TITLE
Add HOL Guard runtime safety skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ repo. See [VISION.md](VISION.md) for catalog boundaries and admission principles
   proof.
 - `handoff`: path-free prompt handoff workflow for delegating a task to another
   agent.
+- `hol-guard`: fail-closed local runtime protection for supported coding-agent
+  harnesses using the pinned HOL Guard CLI.
 - `readme-standard`: house README structure, badge row, tone, and verification
   gates for steipete/openclaw repos.
 - `session-viewer`: local searchable HTML viewer for agent session JSONL.

--- a/skills.sh.json
+++ b/skills.sh.json
@@ -8,6 +8,11 @@
       "skills": ["autoreview", "behavior-validator", "crabbox"]
     },
     {
+      "title": "Runtime Safety",
+      "description": "Skills for protecting local agent runtimes before tool execution.",
+      "skills": ["hol-guard"]
+    },
+    {
       "title": "Handoff",
       "description": "Skills for sharing context across agents, PRs, and issues.",
       "skills": ["handoff", "agent-transcript"]

--- a/skills/hol-guard/SKILL.md
+++ b/skills/hol-guard/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: hol-guard
+description: "Protect supported local coding-agent harnesses with HOL Guard before mutation-bearing tool use."
+---
+
+# HOL Guard
+
+Use HOL Guard as the local runtime boundary before a supported coding agent performs mutation-bearing tool work. Keep repository review, client permissions, provider authorization, sandboxing, and remote safeguards authoritative.
+
+## Setup
+
+Probe the real CLI:
+
+```sh
+hol-guard --version
+```
+
+If it is unavailable and runtime setup is in scope, install the isolated CLI:
+
+```sh
+pipx install hol-guard
+```
+
+If installation is not authorized or `pipx` is unavailable, stop and report the missing runtime rather than weakening the boundary.
+
+Resolve support and the exact harness identifier from HOL Guard itself:
+
+```sh
+hol-guard detect --json
+```
+
+Use only a supported identifier returned by `detect`. Do not maintain a separate alias list.
+
+## Protect the harness
+
+Run the Guard-owned setup and protected launch flow:
+
+```sh
+hol-guard bootstrap
+hol-guard install <detected-harness>
+hol-guard run <detected-harness> --dry-run
+hol-guard run <detected-harness>
+hol-guard doctor <detected-harness> --json
+hol-guard status
+```
+
+Treat an unprotected fallback as failure. If the dry run, protected launch, doctor, or status cannot prove the expected protection state, stop mutation-bearing tool work and report the failing command. Do not retry by launching the agent directly.
+
+## Approvals and evidence
+
+When Guard blocks or queues work, inspect the actual request before deciding what to do:
+
+```sh
+hol-guard approvals
+hol-guard approvals open
+hol-guard receipts
+```
+
+Approve or deny only through Guard-owned commands after reviewing the risk reason and requested scope. Do not bypass a Guard decision by editing harness configuration manually.
+
+For troubleshooting or evidence, prefer:
+
+```sh
+hol-guard doctor <detected-harness> --json
+hol-guard diff <detected-harness>
+hol-guard receipts
+hol-guard events
+```
+
+Report the command that ran, what Guard found, what remains blocked or risky, and the evidence available. Never claim protection or approval without Guard output proving it.
+
+## Boundary
+
+HOL Guard protects the local supported-agent runtime. It does not replace repository policy, code review, operating-system isolation, application authorization, provider-side access controls, or any remote service's own safety checks.

--- a/skills/hol-guard/SKILL.md
+++ b/skills/hol-guard/SKILL.md
@@ -15,13 +15,14 @@ Probe the real CLI:
 hol-guard --version
 ```
 
-If it is unavailable and runtime setup is in scope, install the isolated CLI:
+If it is unavailable and runtime setup is in scope, install the vetted release pin used by this skill:
 
 ```sh
-pipx install hol-guard
+uv tool install "hol-guard[cisco]==2.2.128"
+hol-guard --version
 ```
 
-If installation is not authorized or `pipx` is unavailable, stop and report the missing runtime rather than weakening the boundary.
+The pin is the official Hashgraph Online `v2.2.128` release and PyPI `hol-guard` distribution. Require the version check to report `2.2.128`; do not replace the pin with `latest`, a branch URL, or an unversioned package. If installation is not authorized or `uv` is unavailable, stop and report the missing runtime rather than weakening the boundary.
 
 Resolve support and the exact harness identifier from HOL Guard itself:
 


### PR DESCRIPTION
## Summary

Adds a small reusable `hol-guard` skill for protecting supported local coding-agent runtimes before mutation-bearing tool work.

The skill uses the actual HOL Guard runtime rather than generic security guidance:

- probes the real CLI and, only when setup is in scope, installs the exact reviewed stable pin `hol-guard[cisco]==2.2.128` via `uv tool install`
- ties that pin to the official Hashgraph Online `v2.2.128` release and rejects `latest`, branch URLs, and unversioned packages
- resolves the exact supported harness identifier from `hol-guard detect --json`
- uses the Guard-owned `bootstrap -> install -> dry-run -> protected launch -> doctor/status` flow
- fails closed instead of falling back to an unprotected agent session
- preserves repository policy, client/provider permissions, review, sandboxing, and remote safeguards as separate authoritative boundaries
- adds `hol-guard` to the repository's `skills.sh` Runtime Safety discovery grouping

This is intentionally a shared cross-agent runtime workflow, rather than OpenClaw product-specific policy, matching the repository's `AGENTS.md` and `VISION.md` admission boundary.

## Review-requested distribution and runtime proof

Addressed the P1 review finding in commit `6c08bf2c5634be9c4600252ac38aa26de0a2aaab`.

The skill now uses the exact stable package pin documented by the official HOL Guard release: https://github.com/hashgraph-online/hol-guard/releases/tag/v2.2.128

I then exercised the pinned package from a clean isolated home against a real supported Codex CLI (`codex-cli 0.150.1`). The output below is intentionally reduced to the behavior fields relevant to this PR; no credentials, private endpoints, or host-specific absolute paths are included.

### Exact package and harness

```text
hol-guard 2.2.128
codex-cli 0.150.1
```

### Detection

`hol-guard detect --json` reported:

```json
{
  "harness": "codex",
  "installed": true,
  "command_available": true,
  "warnings": []
}
```

### Guard install

`hol-guard install codex --json` completed successfully and reported an active managed install with native hooks enabled and a valid managed hook manifest. The installation emitted SHA-256 artifact proof for the managed Codex config and Guard launcher.

### Protected launch

To prove the non-dry protected launch path without starting an interactive coding session, I launched the real Codex binary through Guard with the harmless `--version` argument:

```sh
hol-guard run codex --json --arg=--version
```

Relevant result:

```json
{
  "harness": "codex",
  "blocked": false,
  "launched": true,
  "return_code": 0,
  "dry_run": false
}
```

The wrapped process returned `codex-cli 0.150.1`.

### Doctor and status

`hol-guard doctor codex --json` reported:

```json
{
  "harness": "codex",
  "installed": true,
  "setup_status": "active",
  "command_available": true,
  "native_hook_state": {
    "managed_pre_tool_hook_installed": true,
    "managed_permission_request_hook_installed": true,
    "managed_hook_installed": true,
    "shell_enforcement_boundary": "codex-native-hooks",
    "shell_protection_active": true,
    "protection_active": true,
    "integrity_status": "valid",
    "manifest_package_version": "2.2.128"
  },
  "warnings": []
}
```

`hol-guard status --json` then reported one managed harness, recommended harness `codex`, and zero pending approvals.

### Denied mutation before tool I/O

After the 12:29 PM ET ClawSweeper re-review asked for a real denied-path proof, I repeated the setup with the same `hol-guard 2.2.128` and `codex-cli 0.150.1` in a disposable isolated home. `hol-guard install codex --json` completed with `native_hooks: true`; `hol-guard doctor codex --json` then reported `setup_status: "active"`, `managed_pre_tool_hook_installed: true`, `shell_enforcement_boundary: "codex-native-hooks"`, `shell_protection_active: true`, `protection_active: true`, `integrity_status: "valid"`, and manifest package version `2.2.128`.

I then exercised the exact installed Codex `PreToolUse` callback from the managed `~/.codex/config.toml` against a destructive Bash action aimed only at a disposable proof directory. Before invoking the hook, `$PROOF_DIR/sentinel.txt` existed.

Redacted hook input:

```json
{
  "hook_event_name": "PreToolUse",
  "event": "PreToolUse",
  "tool_name": "Bash",
  "tool_input": {
    "command": "rm -rf $PROOF_DIR"
  },
  "cwd": "$WORKSPACE",
  "session_id": "hol-guard-openclaw-proof"
}
```

The installed native hook returned successfully with:

```json
{
  "hookSpecificOutput": {
    "hookEventName": "PreToolUse",
    "permissionDecision": "deny",
    "permissionDecisionReason": "HOL Guard flagged this request: Requests a sensitive native tool action: destructive shell command. HOL Guard blocked this action with a terminal policy decision. Browser approval cannot override it."
  }
}
```

The hook process returned `0`, and `$PROOF_DIR/sentinel.txt` still existed immediately afterward. The destructive Bash command was never executed; the only executable path exercised was the managed Codex `PreToolUse` callback itself. This demonstrates the fail-closed decision at the native pre-tool boundary before the protected tool can perform its final effect.

This proof directly exercises the exact native callback installed for a real supported Codex 0.150.1 harness. It is intentionally a hook-boundary proof rather than a model-generated tool turn, so it does not depend on provider credentials and does not claim model behavior beyond the installed Codex hook contract.

## Repository validation after the repair

Re-ran the repository's current validation/test contract against repaired head `6c08bf2c5634be9c4600252ac38aa26de0a2aaab`:

- `python scripts/validate-skills` -> `validated 9 skills`
- `python scripts/install-skills.test.py` -> 6 tests passed
- `python scripts/validate-skills.test.py` -> 9 tests passed
- `python -m unittest skills/autoreview/scripts/autoreview_test.py skills.autoreview.tests.test_autoreview_hardening` -> 190 tests passed, 1 skipped
- current GitHub `dispatch` check -> success

No generated/vendor downstream snapshots were edited.