### PR TITLE
docs(agent-transcript): skip automatic exports for hosted sessions

### DIFF
--- a/skills/agent-transcript/SKILL.md
+++ b/skills/agent-transcript/SKILL.md
@@ -1,11 +1,17 @@
 ---
 name: agent-transcript
-description: "GitHub PR/issue agent transcripts: redact, preview, and insert safely."
+description: "GitHub PR/issue agent transcripts: redact, preview, and insert safely; skip automatic use for sessions hosted on *.openclaw.ai."
 ---
 
 # Agent Transcript
 
-Best-effort local-only provenance for OpenClaw PR/issue bodies. Use during agent-created GitHub PR or issue workflows before creating/updating the body.
+Best-effort local-only provenance for OpenClaw PR/issue bodies. Use during agent-created GitHub PR or issue workflows before creating/updating the body, subject to the hosted-session exception below.
+
+## Hosted-session exception
+
+- When the current session's hosting URL has a hostname matching `*.openclaw.ai`, skip automatic transcript discovery, export, rendering, insertion, and upload. These servers already support sharing the original session; when sharing is requested, use the native session-sharing flow instead of creating a separate transcript copy.
+- Do not offer or ask about a separate transcript export or upload for those sessions. Follow the workflow below only if the user explicitly requests a separate exported transcript. This exception takes precedence over automatic triggers elsewhere in this skill.
+- Determine this from the current session's hosting URL, not the repository URL or a deployment/test target.
 
 ## Contract
 


### PR DESCRIPTION
## What Problem This Solves

The agent-transcript skill starts transcript discovery during agent-created PR and issue workflows, including sessions hosted on `*.openclaw.ai`. Those servers already support sharing the original session, so offering a separate transcript copy is redundant.

## Why This Change Was Made

Add a hosted-session exception before the normal contract and workflow, and surface the exception in the skill description and entry instruction. The exception takes precedence over automatic triggers in the skill and is determined from the current session's hosting URL—not a repository URL or a deployment/test target.

## User Impact

For sessions hosted on `*.openclaw.ai`, skip automatic transcript discovery, export, rendering, insertion, and upload without offering or asking about a separate copy. When sharing is requested, prefer the native session-sharing flow.

An explicit request for a separate exported transcript still permits the existing workflow, with its local-only, redaction, preview, and approval requirements unchanged. Local sessions merely working on an `*.openclaw.ai` deployment do not qualify for the exception.

## Evidence

- `scripts/validate-skills`: passed; validated all 8 skills using the repository-pinned Python dependency in an isolated virtual environment.
- `git diff --check`: passed.
- Codex autoreview of the uncommitted patch: clean, no P0 findings.
- Manual instruction review covered hosted sessions, local sessions targeting a hosted deployment, explicit separate-export requests, and request-gated native sharing.
- Instruction-only change: one Markdown file, +8/-2 lines. Production code and tests: +0/-0. No runtime helpers, authentication, configuration, or persistence behavior changed.
- No live transcript was exported, uploaded, or shared for validation.
