### PR TITLE
chore(deps): update validation runtime to Node.js 26

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v7
         with:
-          node-version: '22'
+          node-version: '26'
       - uses: actions/setup-python@v7
         with:
           python-version: '3.x'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,4 +2,5 @@
 
 ## Unreleased
 
+- Update the validation workflow to Node.js 26.
 - Fix autoreview scans with root-owned TruffleHog installations by disabling scanner self-updates while preserving credential detection and fail-closed behavior.


### PR DESCRIPTION
The validation workflow still ran its JavaScript and TypeScript checks on Node.js 22. Update it to Node.js 26, the current release line, and record the change under Unreleased. The existing Ubuntu/Windows matrix and test commands stay unchanged. No application code or runtime compatibility requirement changes.

Dependency audit: PyYAML 6.0.3 is already current. The existing actions/checkout v7, actions/setup-node v7, actions/setup-python v7, and actions/create-github-app-token v3.2.0 references are current; the app-token commit pin was verified against its release tag. There are no package manifests or lockfiles for npm, Go, Rust, or Swift. Held upgrades: none. Superseded Dependabot/Renovate PRs: none.

All three baseline workflows were green: [validate](https://github.com/openclaw/agent-skills/actions/runs/33143780006), [Push on main](https://github.com/openclaw/agent-skills/actions/runs/33143779849), and [ClawSweeper Dispatch](https://github.com/openclaw/agent-skills/actions/runs/33143715954).

Local proof on macOS arm64 with Node.js 26.8.1 and Python 3.14.7:

- Installed requirements-dev.txt and passed pip check; validated all 8 skills.
- Passed shell syntax, Python compilation, and all 3 Node syntax checks.
- Repository script tests: 6 installer tests and 9 validator tests passed.
- Autoreview tests: 193 total, 192 passed and 1 platform skip.
- Node tests: 85 passed, 0 failed or skipped.
- Five CLI smoke checks passed: installer, autoreview, agent-transcript, beam, and session-viewer.
- Required Codex autoreview completed with no accepted/actionable findings; git diff --check passed.

The Node.js 26.8.1 archive was downloaded from nodejs.org and verified against its published SHA-256 checksum. The PR's existing Linux and Windows jobs provide hosted-platform confirmation.
