### PR TITLE
fix: honor explicit bases in local autoreview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,5 +2,6 @@
 
 ## Unreleased
 
+- Honor explicit review bases in local Autoreview runs, preserving complete staged and unstaged changes without re-reviewing unchanged upstream files.
 - Update the validation workflow to Node.js 26.
 - Fix autoreview scans with root-owned TruffleHog installations by disabling scanner self-updates while preserving credential detection and fail-closed behavior.

--- a/skills/autoreview/SKILL.md
+++ b/skills/autoreview/SKILL.md
@@ -123,6 +123,22 @@ or branch diff instead; do not force dirty modes just
 because the helper docs mention dirty work first. A clean local review
 only proves there is no local patch.
 
+To review a dirty candidate against an explicit base, including a resolved merge
+that has not been committed:
+
+```bash
+"$AUTOREVIEW" --mode local --base origin/main
+```
+
+The helper pins that base to a commit at target selection. It reviews base-to-index
+changes and index-to-working-tree changes separately, plus validated untracked
+files. Only files identical across the base, index, and working tree are outside
+the change bundle; staged changes later undone remain included. Actual binary
+or submodule changes still refuse review. The bundle labels its pinned
+staged base. Git status remains relative to HEAD and does not define review scope.
+Without `--base`, local mode retains its usual HEAD-to-index behavior; it never
+infers a base from an in-progress merge.
+
 Branch/PR work:
 
 ```bash

--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -1380,7 +1380,8 @@ def choose_target(repo: Path, mode: str, base_ref: str | None) -> tuple[str, str
     mode = "local" if mode == "uncommitted" else mode
     branch = current_branch(repo)
     if mode == "local" or (mode == "auto" and is_dirty(repo)):
-        return "local", None
+        # Pin an explicit base once; later queries must not follow a moving branch.
+        return "local", validate_git_ref(repo, base_ref, "base", pin=True) if base_ref is not None else None
     if mode == "commit":
         return "commit", None
     if mode == "branch" or (mode == "auto" and branch != "main"):
@@ -1466,7 +1467,7 @@ def first_executable_candidate(path: Path, *, reject_root: Path | None = None) -
     return None
 
 
-def validate_git_ref(repo: Path, ref: str, label: str) -> str:
+def validate_git_ref(repo: Path, ref: str, label: str, *, pin: bool = False) -> str:
     if not ref or ref.startswith("-") or ":" in ref or "\0" in ref or any(char.isspace() for char in ref):
         raise SystemExit(f"unsafe {label} ref: {ref}")
     result = git(
@@ -1480,7 +1481,7 @@ def validate_git_ref(repo: Path, ref: str, label: str) -> str:
     )
     if not result:
         raise SystemExit(f"unknown {label} ref: {ref}")
-    return ref
+    return result.strip() if pin else ref
 
 
 TRUFFLEHOG_INSTALL_URL = "https://github.com/trufflesecurity/trufflehog#installation"
@@ -2190,12 +2191,15 @@ def local_status(repo: Path, untracked: list[str], *, redact: bool = False) -> s
     return "\n".join(lines)
 
 
-def local_bundle(repo: Path) -> tuple[str, bool]:
-    staged_patch = git(repo, "diff", *SAFE_DIFF_FLAGS, "--cached", "--patch")
+def local_bundle(repo: Path, base_ref: str | None = None) -> tuple[str, bool]:
+    if base_ref is not None:
+        base_ref = validate_git_ref(repo, base_ref, "base", pin=True)
+    staged_base = ("--end-of-options", base_ref) if base_ref is not None else ()
+    staged_patch = git(repo, "diff", *SAFE_DIFF_FLAGS, "--cached", "--patch", *staged_base)
     unstaged_patch = git(repo, "diff", *SAFE_DIFF_FLAGS, "--patch")
     require_no_binary_diff(
         "local staged diff",
-        git(repo, "diff", *SAFE_DIFF_FLAGS, "--cached", "--numstat", "-z"),
+        git(repo, "diff", *SAFE_DIFF_FLAGS, "--cached", "--numstat", "-z", *staged_base),
     )
     require_no_binary_diff(
         "local unstaged diff",
@@ -2203,7 +2207,7 @@ def local_bundle(repo: Path) -> tuple[str, bool]:
     )
     require_no_gitlink_diff(
         "local staged diff",
-        git(repo, "diff", *SAFE_DIFF_FLAGS, "--cached", "--raw", "-z"),
+        git(repo, "diff", *SAFE_DIFF_FLAGS, "--cached", "--raw", "-z", *staged_base),
     )
     require_no_gitlink_diff(
         "local unstaged diff",
@@ -2216,6 +2220,7 @@ def local_bundle(repo: Path) -> tuple[str, bool]:
         "--name-only",
         "--cached",
         "-z",
+        *staged_base,
     )
     unstaged_paths = git_path_list(
         repo,
@@ -2247,11 +2252,11 @@ def local_bundle(repo: Path) -> tuple[str, bool]:
             untracked,
             redact=bool(omitted_tracked or omitted_untracked),
         ),
-        "# Staged Diff",
+        "# Staged Diff" if base_ref is None else f"# Staged Diff\nbase: {base_ref}",
         (
             REVIEW_SECURITY_OMISSION
             if tracked_sensitive_paths(staged_paths)
-            else git(repo, "diff", *SAFE_DIFF_FLAGS, "--cached", "--stat")
+            else git(repo, "diff", *SAFE_DIFF_FLAGS, "--cached", "--stat", *staged_base)
         ),
         staged_patch,
         "# Unstaged Diff",
@@ -2593,7 +2598,10 @@ def commit_bundle(repo: Path, commit_ref: str) -> tuple[str, bool]:
 def review_paths(repo: Path, target: str, target_ref: str | None, commit_ref: str) -> set[str]:
     names: set[str] = set()
     if target == "local":
-        names.update(git_path_list(repo, "diff", *SAFE_DIFF_FLAGS, "--name-only", "--cached", "-z"))
+        if target_ref is not None:
+            target_ref = validate_git_ref(repo, target_ref, "base", pin=True)
+        staged_base = ("--end-of-options", target_ref) if target_ref is not None else ()
+        names.update(git_path_list(repo, "diff", *SAFE_DIFF_FLAGS, "--name-only", "--cached", "-z", *staged_base))
         names.update(git_path_list(repo, "diff", *SAFE_DIFF_FLAGS, "--name-only", "-z"))
         names.update(safe_untracked_files(repo))
     elif target == "branch":
@@ -5384,7 +5392,7 @@ def positive_float(value: str) -> float:
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Bundle-driven AI code review.")
     parser.add_argument("--mode", choices=["auto", "local", "uncommitted", "branch", "commit"], default="auto")
-    parser.add_argument("--base")
+    parser.add_argument("--base", help="Branch base, or explicit commit to compare with the index in local mode.")
     parser.add_argument("--commit", default="HEAD")
     parser.add_argument("--engine", choices=ENGINE_CHOICES, default=os.environ.get("AUTOREVIEW_ENGINE", "codex"))
     parser.add_argument(
@@ -5745,7 +5753,7 @@ def dry_run_preflight(
     bundle_ok = True
     try:
         if target == "local":
-            bundle, bundle_truncated = local_bundle(repo)
+            bundle, bundle_truncated = local_bundle(repo, target_ref)
         elif target == "branch":
             assert target_ref
             bundle, bundle_truncated = branch_bundle(repo, target_ref)
@@ -5998,7 +6006,7 @@ def main_impl() -> int:
 
     review_source_snapshot = source_tree_snapshot(repo)
     if target == "local":
-        bundle, bundle_truncated = local_bundle(repo)
+        bundle, bundle_truncated = local_bundle(repo, target_ref)
     elif target == "branch":
         assert target_ref
         bundle, bundle_truncated = branch_bundle(repo, target_ref)

--- a/skills/autoreview/tests/test_autoreview_hardening.py
+++ b/skills/autoreview/tests/test_autoreview_hardening.py
@@ -484,6 +484,118 @@ Path(__file__).with_name("scan.json").write_text(json.dumps({
             self.assertFalse(truncated)
             self.assertEqual(reads, 1)
 
+    def test_local_base_reviews_resolved_merge_without_upstream_binary(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo = init_repo(Path(tempdir))
+            source = repo / "source.txt"
+            source.write_text("common\nretained line\n", encoding="utf-8")
+            git(repo, "add", "source.txt")
+            git(repo, "commit", "-q", "-m", "base")
+            common = git(repo, "rev-parse", "HEAD").strip()
+            git(repo, "checkout", "-q", "-b", "incoming")
+            (repo / "proof.png").write_bytes(b"\x89PNG\r\n\0upstream-proof")
+            source.write_text("upstream\nretained line\n", encoding="utf-8")
+            git(repo, "add", "source.txt", "proof.png")
+            git(repo, "commit", "-q", "-m", "upstream")
+            incoming = git(repo, "rev-parse", "HEAD").strip()
+            git(repo, "checkout", "-q", "-b", "task", common)
+            source.write_text("task\nretained line\n", encoding="utf-8")
+            (repo / "committed.txt").write_text("committed task change\n", encoding="utf-8")
+            git(repo, "add", "source.txt", "committed.txt")
+            git(repo, "commit", "-q", "-m", "task")
+            with self.assertRaises(subprocess.CalledProcessError):
+                git(repo, "merge", "--no-ff", "--no-commit", "incoming")
+            self.assertEqual(git(repo, "rev-parse", "MERGE_HEAD").strip(), incoming)
+            source.write_text("resolved staged task\n", encoding="utf-8")
+            git(repo, "add", "source.txt")
+            self.assertEqual(git(repo, "diff", "--name-only", "--diff-filter=U").strip(), "")
+            source.write_text("resolved staged task\nretained line\nunstaged task\n", encoding="utf-8")
+            (repo / "notes.md").write_text("untracked task note\n", encoding="utf-8")
+            staged = git(repo, "diff", "--no-ext-diff", "--no-textconv", "--no-renames", "--cached", incoming)
+            unstaged = git(repo, "diff", "--no-ext-diff", "--no-textconv", "--no-renames")
+            scanned: list[str] = []
+            sent: list[str] = []
+            report = {
+                "findings": [{
+                    "title": "Task change finding",
+                    "body": "The committed task change remains in the selected review scope.",
+                    "priority": "P0",
+                    "confidence": 0.99,
+                    "category": "bug",
+                    "code_location": {"file_path": "committed.txt", "line": 1},
+                }],
+                "overall_correctness": "patch is incorrect",
+                "overall_explanation": "Task change finding.",
+                "overall_confidence": 0.99,
+            }
+
+            def run_engine(_args, _repo, prompt):
+                sent.append(prompt)
+                return json.dumps(report)
+
+            main = self.helper["main_impl"]
+            with mock.patch.dict(main.__globals__, {
+                "repo_root": lambda: repo,
+                "scan_outgoing_review_pack": lambda _repo, prompt: scanned.append(prompt),
+                "run_engine": run_engine,
+                "resolve_engine_binary": lambda _reviewer, _repo: (True, None),
+            }):
+                for dry_run in (False, True):
+                    argv = [str(SCRIPT), "--engine", "codex", "--mode", "local", "--base", "incoming"]
+                    if dry_run:
+                        argv.append("--dry-run")
+                    with mock.patch.object(sys, "argv", argv), contextlib.redirect_stdout(io.StringIO()):
+                        self.assertEqual(main(), 0 if dry_run else 1)
+
+            self.assertEqual(len(sent), 1)
+            self.assertEqual(scanned, [sent[0], sent[0]])
+            self.assertIn(f"# Staged Diff\nbase: {incoming}", sent[0])
+            self.assertIn(staged.rstrip(), sent[0])
+            self.assertIn(unstaged.rstrip(), sent[0])
+            self.assertIn("-retained line", sent[0])
+            self.assertIn("+retained line", sent[0])
+            self.assertIn('path: "notes.md"', sent[0])
+            self.assertIn("untracked task note", sent[0])
+            self.assertNotIn("diff --git a/proof.png", sent[0])
+            self.assertEqual(
+                self.helper["review_paths"](repo, "local", incoming, "HEAD"),
+                {"source.txt", "committed.txt", "notes.md"},
+            )
+            for mode in ("local", "uncommitted", "auto"):
+                self.assertEqual(self.helper["choose_target"](repo, mode, "incoming"), ("local", incoming))
+            self.assertEqual(self.helper["choose_target"](repo, "local", None), ("local", None))
+            with self.assertRaisesRegex(SystemExit, "refusing binary changes"):
+                self.helper["local_bundle"](repo)
+
+    def test_local_base_pins_named_ref_and_rejects_invalid_refs(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo = init_repo(Path(tempdir))
+            (repo / "source.txt").write_text("base\n", encoding="utf-8")
+            git(repo, "add", "source.txt")
+            git(repo, "commit", "-q", "-m", "base")
+            base = git(repo, "rev-parse", "HEAD").strip()
+            git(repo, "branch", "review-base")
+            (repo / "committed.txt").write_text("committed task change\n", encoding="utf-8")
+            git(repo, "add", "committed.txt")
+            git(repo, "commit", "-q", "-m", "task")
+            (repo / "source.txt").write_text("staged task change\n", encoding="utf-8")
+            git(repo, "add", "source.txt")
+            target, pinned = self.helper["choose_target"](repo, "local", "review-base")
+            self.assertEqual((target, pinned), ("local", base))
+            snapshot = self.helper["source_tree_snapshot"](repo)
+            git(repo, "update-ref", "refs/heads/review-base", "HEAD")
+            self.assertEqual(self.helper["source_tree_snapshot"](repo), snapshot)
+            bundle, truncated = self.helper["local_bundle"](repo, pinned)
+            self.assertFalse(truncated)
+            self.assertIn("+committed task change", bundle)
+            self.assertEqual(
+                self.helper["review_paths"](repo, target, pinned, "HEAD"),
+                {"source.txt", "committed.txt"},
+            )
+            for ref, error in (("--help", "unsafe"), ("HEAD:source.txt", "unsafe"), ("", "unsafe"), ("missing-base", "unknown")):
+                with self.subTest(ref=ref), self.assertRaisesRegex(SystemExit, f"{error} base ref"):
+                    self.helper["choose_target"](repo, "local", ref)
+
     def test_tracked_binary_changes_are_blocked_in_all_modes(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:
             repo = init_repo(Path(tempdir))
@@ -494,9 +606,12 @@ Path(__file__).with_name("scan.json").write_text(json.dumps({
             base = git(repo, "rev-parse", "HEAD").strip()
 
             binary.write_bytes(b"\0changed")
-            git(repo, "add", "artifact.bin")
-            with self.assertRaisesRegex(SystemExit, "refusing binary changes"):
-                self.helper["local_bundle"](repo)
+            for staged in (False, True):
+                if staged:
+                    git(repo, "add", "artifact.bin")
+                for local_base in (None, base):
+                    with self.subTest(staged=staged, base=local_base), self.assertRaisesRegex(SystemExit, "refusing binary changes"):
+                        self.helper["local_bundle"](repo, local_base)
 
             git(repo, "commit", "-q", "-m", "binary change")
             with self.assertRaisesRegex(SystemExit, "refusing binary changes"):
@@ -520,8 +635,9 @@ Path(__file__).with_name("scan.json").write_text(json.dumps({
                 "--cacheinfo",
                 f"160000,{base},vendor/dependency",
             )
-            with self.assertRaisesRegex(SystemExit, "gitlink/submodule changes"):
-                self.helper["local_bundle"](repo)
+            for local_base in (None, base):
+                with self.subTest(base=local_base), self.assertRaisesRegex(SystemExit, "gitlink/submodule changes"):
+                    self.helper["local_bundle"](repo, local_base)
 
             git(repo, "commit", "-q", "-m", "add gitlink")
             with self.assertRaisesRegex(SystemExit, "gitlink/submodule changes"):

--- a/skills/autoreview/tests/test_autoreview_hardening.py
+++ b/skills/autoreview/tests/test_autoreview_hardening.py
@@ -511,8 +511,10 @@ Path(__file__).with_name("scan.json").write_text(json.dumps({
             self.assertEqual(git(repo, "diff", "--name-only", "--diff-filter=U").strip(), "")
             source.write_text("resolved staged task\nretained line\nunstaged task\n", encoding="utf-8")
             (repo / "notes.md").write_text("untracked task note\n", encoding="utf-8")
-            staged = git(repo, "diff", "--no-ext-diff", "--no-textconv", "--no-renames", "--cached", incoming)
-            unstaged = git(repo, "diff", "--no-ext-diff", "--no-textconv", "--no-renames")
+            # Review reads ignore host Git settings, including Windows autocrlf.
+            # Expected patches must use the same protected Git policy.
+            staged = self.helper["git"](repo, "diff", *self.helper["SAFE_DIFF_FLAGS"], "--cached", incoming)
+            unstaged = self.helper["git"](repo, "diff", *self.helper["SAFE_DIFF_FLAGS"])
             scanned: list[str] = []
             sent: list[str] = []
             report = {


### PR DESCRIPTION
Autoreview accepted `--base` in local mode but silently ignored it. During a resolved, uncommitted merge, that compared the index with the old branch HEAD and rejected unchanged binary proof assets from incoming main.

This makes the existing explicit base work in local, uncommitted, and dirty auto mode. The selected commit is pinned once and used consistently for the staged patch, binary/submodule guards, statistics, and allowed finding paths. Unstaged changes and validated untracked files remain separate; a staged deletion later restored in the working tree still reaches the scanner. Without an explicit base, behavior is unchanged. There is no automatic merge-base inference or binary omission.

The regression constructs a real conflicted merge, resolves it, then calls the normal CLI entry point. It fails before the fix with the unchanged PNG refusal and passes afterward. Normal and dry-run paths produce the same complete review pack; a finding in an already committed task file remains valid. Additional controls cover a moving named base, unsafe or missing refs, and actual staged/unstaged binary and submodule changes. The four focused tests pass.

Skill validation and the complete Python suite pass (195 tests, one expected skip). The complete dirty Gateway candidate also passes the real explicit-base dry run, including credential scanning and CLI isolation preflight. Independent Codex review completed with no actionable findings. Runtime helper delta is +21/-13 (+8); the added lines carry the explicit base through existing owners. Prompt limits, complete chunk coverage, credential scanning, provider isolation, and report validation are unchanged.

The first Windows CI run caught a test expectation that inherited host Git newline conversion. The production reader already ignores host Git configuration. The test now uses that existing protected Git reader for its expected patches, without changing any full-content assertions. A local CRLF/host-autocrlf reproduction fails before this test fix and passes afterward; all four focused cases and its independent review pass. The updated Windows CI run remains the final platform check.
