### PR TITLE
fix(autoreview): preserve scope-filtered review conclusions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Preserve exact outgoing autoreview scan bytes on Windows instead of translating line endings.
 - Fix autoreview credential-source inclusion and scope-filtered results, preserving provider verdicts and rejected findings while documenting complete PR-plus-dirty review.
 - Honor explicit review bases in local Autoreview runs, preserving complete staged and unstaged changes without re-reviewing unchanged upstream files.
 - Update the validation workflow to Node.js 26.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fix autoreview credential-source inclusion and scope-filtered results, preserving provider verdicts and rejected findings while documenting complete PR-plus-dirty review.
 - Honor explicit review bases in local Autoreview runs, preserving complete staged and unstaged changes without re-reviewing unchanged upstream files.
 - Update the validation workflow to Node.js 26.
 - Fix autoreview scans with root-owned TruffleHog installations by disabling scanner self-updates while preserving credential detection and fail-closed behavior.

--- a/skills/autoreview/SKILL.md
+++ b/skills/autoreview/SKILL.md
@@ -13,7 +13,7 @@ Do not invoke Autoreview automatically before a commit, push, PR, merge, deploy,
 
 ## Contract
 
-- Default output is P0 only: report issues worth blocking the current change
+- Default accepted findings are P0 only: report issues worth blocking the current change
   because they materially break the normal flow, outcome, or safety boundary.
   Use `--max-priority P1`, `P2`, or `P3` only when the caller explicitly asks
   for a wider review.
@@ -38,7 +38,7 @@ Do not invoke Autoreview automatically before a commit, push, PR, merge, deploy,
 - If the blamed PR was merged by `clawsweeper[bot]` or another automation, identify the human trigger when practical. Check timeline/comments first; if rate-limited, use gitcrawl/cache or public PR HTML. Look for maintainer commands such as `@clawsweeper automerge`, `/landpr`, or labels/status comments that armed automerge. Report `automerge triggered by @login`; if not found, say trigger unknown.
 - Do not invoke built-in `codex review`, nested reviewers, or review panels from inside the review. The helper builds one validated bundle, calls the selected engine once for normal inputs or once per complete bounded chunk for oversized inputs, validates the structured results, and stops.
 - Stop as soon as the helper exits 0 with no accepted/actionable findings. Do not run an extra review just to get a nicer "clean" line, a second opinion, or clearer closeout wording.
-- Treat the helper's successful exit plus absence of actionable findings as the clean review result, even if the underlying Codex CLI output is terse.
+- Treat `scoped-clean` with exit 0 as clean only for the selected Git target and requested priority. `filtered` is not a correctness certificate; `incomplete` requires resolving the scope mismatch or missing required finding before claiming clean.
 - If rejecting a finding as intentional/not worth fixing, add a brief inline code comment only when it explains a real invariant or ownership decision that future reviewers should know.
 - If `gh`/Gitcrawl reports `database disk image is malformed`, run `gitcrawl doctor --json` once to let the portable cache repair before retrying review; do not bypass the shim unless repair fails and freshness requires live GitHub.
 - If Gitcrawl reports a portable manifest mismatch, source/runtime DB health error, or stale portable-store checkout, run `gitcrawl doctor --json` and inspect `source_db_health`, `runtime_db_health`, and `portable_store_status` before falling back to live GitHub.
@@ -110,18 +110,17 @@ $AUTOREVIEW_HARNESS = Join-Path $AgentsHome "skills\autoreview\scripts\test-revi
 
 ## Pick Target
 
-Dirty local work:
+Dirty local work relative to HEAD:
 
 ```bash
 "$AUTOREVIEW" --mode local
 ```
 
-Use this only when the patch is actually unstaged/staged/untracked in the
-current checkout. `--mode uncommitted` is accepted as an alias for `--mode local`.
-For committed, pushed, or PR work, point the helper at the commit
-or branch diff instead; do not force dirty modes just
-because the helper docs mention dirty work first. A clean local review
-only proves there is no local patch.
+Without `--base`, this reviews HEAD-to-index, index-to-working-tree, and validated
+untracked files only. `--mode auto` selects the same HEAD-based scope when dirty;
+it does not include the committed PR merely because the checkout is on a PR
+branch. `--mode uncommitted` is an alias for `--mode local`. A clean local checkout
+without an explicit base has no local patch to review.
 
 To review a dirty candidate against an explicit base, including a resolved merge
 that has not been committed:
@@ -139,13 +138,29 @@ staged base. Git status remains relative to HEAD and does not define review scop
 Without `--base`, local mode retains its usual HEAD-to-index behavior; it never
 infers a base from an in-progress merge.
 
-Branch/PR work:
+Committed-only branch/PR work:
 
 ```bash
 "$AUTOREVIEW" --mode branch --base origin/main
 ```
 
-Optional review context is first-class. Prompt files and datasets must be repo-relative so review bundles cannot pull arbitrary host files:
+Branch mode reviews `BASE...HEAD` (merge-base-to-HEAD); staged, unstaged, and
+untracked changes are excluded even in a dirty checkout. To review the **complete
+PR candidate including dirty rewrites**, pin the PR merge base and use local mode:
+
+```bash
+pr_base=$(gh pr view --json baseRefName --jq .baseRefName)
+merge_base=$(git merge-base HEAD "origin/$pr_base")
+"$AUTOREVIEW" --mode local --base "$merge_base"
+```
+
+The remote base must already be available and current locally; the helper does
+not fetch. The pinned merge base avoids including unrelated upstream changes.
+Add `--max-priority P2` when the caller requests P2 findings. An explicit `--base`
+also applies when auto selects local, but explicit local mode avoids changing
+targets when the checkout becomes clean.
+
+Optional review context is first-class. Prompt files and datasets must be repo-relative so review bundles cannot pull arbitrary host files. Context never expands the selected Git target, even if it contains a complete candidate diff or asks to review the whole PR. Finding membership is checked by changed file, not individual hunk:
 
 ```bash
 "$AUTOREVIEW" --mode branch --base origin/main --prompt-file review-notes.md --dataset evidence.json
@@ -333,7 +348,7 @@ The helper:
 - resolves bare `git`, `gh`, reviewer, and PowerShell shell commands from absolute `PATH` entries only, never from the reviewed checkout; explicit `--*-bin` paths are interpreted from the reviewed repository root when relative and accepted only when both the supplied path and resolved target stay outside the reviewed repository
 - use `--mode commit --commit <ref>` for already-committed work, especially clean `main` after landing
 - validates complete Git patches, scans every outgoing review pack, reviews them in one pass up to the aggregate prompt limit, and automatically uses complete bounded passes above it
-- should be left in `--mode auto` or forced to `--mode branch` for PR/branch work; do not force `--mode local` after committing
+- uses branch mode for committed-only PR work, or explicit local mode with a pinned merge base for a complete PR plus dirty candidate
 - writes only to stdout unless `--output`, `--json-output`, or live streamed engine stderr is set
 - supports `--dry-run` (validates bundle construction, reviewer CLI resolution, and local isolation startup with version/help probes without contacting a provider; exits nonzero if any check fails), an opt-in per-reviewer wall-clock bound via `--engine-timeout-seconds`, `--prompt`, repo-relative `--prompt-file`, repo-relative `--dataset`, `--no-tools`, `--no-web-search`, repeatable Codex-only safe model/response tuning with `--codex-config key=value`, Codex-only `--codex-speed fast|flex|default`, and commit refs
 - supports `--stream-engine-output` or `AUTOREVIEW_STREAM_ENGINE_OUTPUT=1` for live engine text while preserving structured validation; Codex and Claude hide tool/file event details, emit compact activity summaries, and report usage at turn completion
@@ -345,8 +360,39 @@ The helper:
 - runs Pi `v0.79.0+` from neutral temporary directories with `--no-approve`, `--no-session`, disabled Pi context/resource loading, and `--no-tools` because its built-in read tools are not repository-confined
 - runs Kimi Code CLI `v0.30.0+` from an empty temporary workspace with a staged `KIMI_CODE_HOME`, sanitized config, an empty `--skills-dir`, and a no-tools/no-subagents Markdown `--agent-file`
 - prints `review still running: <engine> elapsed=<seconds>s pid=<pid>` to stderr at long-running intervals while waiting for the selected review engine, unless streamed output or compact Codex activity has been visible recently
-- prints `autoreview clean: no accepted/actionable findings reported` when the selected review command exits 0
-- exits nonzero when accepted/actionable findings are present
+- prints `autoreview scoped-clean` only when no findings were rejected or filtered and the provider returned a correct verdict
+- exits nonzero for accepted findings, a provider's incorrect verdict, or an incomplete result
+
+## Result handling
+
+Filtering never rewrites provider correctness, explanation, or confidence.
+`findings` contains accepted findings at the requested priority; local JSON and
+text results retain `scope_rejected_findings` and `priority_filtered_findings`
+separately. Any scope rejection makes `review_status` `incomplete` and exits 2,
+including when other findings remain or `--expect-findings` is set. Resolve the
+target mismatch explicitly; do not infer a broader target from prompt prose.
+
+With no scope rejection, status is `findings` for accepted findings, `filtered`
+when only lower-priority findings remain, `incorrect` for an incorrect verdict
+without findings, or `scoped-clean` otherwise. Exit 1 means accepted findings or
+an incorrect provider verdict; even a priority-filtered incorrect verdict stays
+nonzero. Exit 0 for a filtered correct verdict does not certify correctness.
+`--expect-findings` accepts retained findings for harness checks, never scope
+rejections. `--require-finding` checks only accepted findings after both filters
+across every pass; missing text is retained in `missing_required_findings` and
+exits 2 after writing results.
+
+Chunked results retain each provider report under `pass_reports`, print each
+provider explanation, and use the minimum pass confidence rather than promoting
+confidence from another pass. Provider JSON remains strictly validated before
+the helper adds local audit metadata. All engines use this same result path.
+
+The exact source filename `CredentialFile.swift` is allowed for untracked and
+evidence inputs only outside sensitive parent paths, matching its existing
+tracked-source treatment. This is not a general source-extension exemption:
+credential stores, credential directories, `.env`, PEM, and key files retain
+their exclusions. TruffleHog still scans the exact outgoing pack, including
+source content, deleted lines, prompts, and datasets, before every provider call.
 
 ## Final Report
 

--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -1611,7 +1611,7 @@ def scan_outgoing_review_pack(repo: Path, prompt: str) -> None:
         dir=safe_temp_root(repo),
     ) as tempdir:
         pack_path = Path(tempdir) / "review-pack.txt"
-        pack_path.write_text(prompt, encoding="utf-8")
+        pack_path.write_bytes(prompt.encode("utf-8"))
         pack_path.chmod(0o600)
         result = run(
             [

--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -1804,9 +1804,20 @@ def sensitive_repo_path_risk(rel: str) -> str | None:
         any(pattern.search(normalized) for pattern in SENSITIVE_NAME_PATTERNS)
         and not design_token_artifact_path(path, SENSITIVE_NAME_PATTERNS)
         and not github_workflow_path(path)
+        and not credential_source_path(path)
     ):
         return "sensitive filename"
     return None
+
+
+def credential_source_path(path: Path) -> bool:
+    # A named source type, not an extension-wide exemption for credential data.
+    # Parent names still use the strict untracked/evidence policy.
+    return path.name == "CredentialFile.swift" and not any(
+        pattern.search(part)
+        for part in path.parts[:-1]
+        for pattern in SENSITIVE_NAME_PATTERNS
+    )
 
 
 def token_credential_store_path(normalized: str) -> bool:
@@ -2603,7 +2614,6 @@ def review_paths(repo: Path, target: str, target_ref: str | None, commit_ref: st
         staged_base = ("--end-of-options", target_ref) if target_ref is not None else ()
         names.update(git_path_list(repo, "diff", *SAFE_DIFF_FLAGS, "--name-only", "--cached", "-z", *staged_base))
         names.update(git_path_list(repo, "diff", *SAFE_DIFF_FLAGS, "--name-only", "-z"))
-        names.update(safe_untracked_files(repo))
     elif target == "branch":
         assert target_ref
         target_ref = validate_git_ref(repo, target_ref, "base")
@@ -2632,6 +2642,9 @@ def review_paths(repo: Path, target: str, target_ref: str | None, commit_ref: st
                 commit_ref,
             )
         )
+    names.difference_update(tracked_sensitive_paths(list(names)))
+    if target == "local":
+        names.update(safe_untracked_files(repo))
     return names
 
 
@@ -2684,6 +2697,8 @@ def review_scope_policy() -> str:
           redesign request.
         - Report a finding only when this diff introduces or exposes a concrete
           defect that must be fixed before this target can land.
+        - Prompt text and datasets are context only. They do not expand the
+          selected Git target or make unchanged files part of the reviewed diff.
         - If the best fix requires a new protocol, config, storage, public API,
           release process, migration, owner-boundary move, or canonical contract,
           say that directly in the finding and keep the finding tied to the
@@ -5218,7 +5233,6 @@ def _validate_report(
         raise SystemExit("review JSON overall_explanation is too long")
     if not number_in_range(report.get("overall_confidence")):
         raise SystemExit("review JSON overall_confidence must be numeric")
-    finding_text = ""
     kept_findings: list[dict[str, Any]] = []
     ignored_findings: list[tuple[int, dict[str, Any], str, int]] = []
     for index, finding in enumerate(report["findings"]):
@@ -5273,12 +5287,11 @@ def _validate_report(
             ignored_findings.append((index, finding, rel, line))
             continue
         kept_findings.append(finding)
-        finding_text += "\n" + json.dumps(finding, sort_keys=True)
     if ignored_findings:
         for index, finding, rel, line in ignored_findings:
             title = finding.get("title", "<untitled>")
             print(
-                "autoreview ignored out-of-scope finding "
+                "autoreview rejected out-of-scope finding "
                 f"{index}: {display_escape(title, 140)} "
                 f"({display_escape(rel, 500)}:{line})",
                 file=sys.stderr,
@@ -5292,15 +5305,24 @@ def _validate_report(
                 file=sys.stderr,
             )
         report["findings"] = kept_findings
-        if not kept_findings and report["overall_correctness"] == "patch is incorrect":
-            note = f"Ignored {len(ignored_findings)} out-of-scope finding(s) outside the reviewed change."
-            explanation = report["overall_explanation"].rstrip()
-            report["overall_correctness"] = "patch is correct"
-            report["overall_explanation"] = bounded_field(f"{explanation}\n\n{note}", 3000)
-    haystack = finding_text.lower()
-    for needle in required:
-        if needle.lower() not in haystack:
-            raise SystemExit(f"required finding text not found: {needle}")
+        report["scope_rejected_findings"] = [finding for _, finding, _, _ in ignored_findings]
+    require_findings(report, required)
+
+
+def missing_required_findings(report: dict[str, Any], required: list[str]) -> list[str]:
+    # Check accepted findings before merge deduplication or display truncation.
+    reports = [entry["report"] for entry in report.get("pass_reports", [])] or [report]
+    haystack = "\n".join(
+        json.dumps(finding, sort_keys=True)
+        for source in reports
+        for finding in source["findings"]
+    ).lower()
+    return [needle for needle in required if needle.lower() not in haystack]
+
+
+def require_findings(report: dict[str, Any], required: list[str]) -> None:
+    for needle in missing_required_findings(report, required):
+        raise SystemExit(f"required finding text not found: {needle}")
 
 
 def validate_report(
@@ -5331,30 +5353,47 @@ def filter_findings_by_priority(
         for finding in original
         if order[finding["priority"]] <= limit
     ]
-    removed = len(original) - len(kept)
+    removed = [finding for finding in original if order[finding["priority"]] > limit]
     if not removed:
         return
     report["findings"] = kept
-    if not kept and report["overall_correctness"] == "patch is incorrect":
-        report["overall_correctness"] = "patch is correct"
-    note = (
-        f"Omitted {removed} finding(s) below the requested "
-        f"{max_priority} priority threshold."
-    )
-    report["overall_explanation"] = bounded_field(
-        report["overall_explanation"].rstrip() + "\n\n" + note,
-        3000,
-    )
+    report.setdefault("priority_filtered_findings", []).extend(removed)
 
 
 def number_in_range(value: Any) -> bool:
     return isinstance(value, (int, float)) and not isinstance(value, bool) and 0 <= value <= 1
 
 
+def review_status(report: dict[str, Any]) -> str:
+    if report.get("scope_rejected_findings") or report.get("missing_required_findings"):
+        return "incomplete"
+    if report["findings"]:
+        return "findings"
+    if report.get("priority_filtered_findings"):
+        return "filtered"
+    if report["overall_correctness"] == "patch is incorrect":
+        return "incorrect"
+    return "scoped-clean"
+
+
+def print_findings(findings: list[dict[str, Any]]) -> None:
+    for finding in findings:
+        loc = finding["code_location"]
+        print(f"[{finding['priority']}] {display_escape(finding['title'], 140)}")
+        print(f"{display_escape(loc['file_path'], 500)}:{loc['line']}")
+        print(display_escape(finding["body"], 2000, multiline=True))
+        print()
+
+
 def print_report(report: dict[str, Any], *, label: str = "autoreview") -> None:
     findings = report["findings"]
     display_label = display_escape(label, 200)
-    if findings:
+    status = review_status(report)
+    if status == "incomplete":
+        print(f"{display_label} incomplete: selected scope could not be certified")
+    elif status == "filtered":
+        print(f"{display_label} filtered: no findings at the requested priority; not a correctness certificate")
+    elif findings:
         print(f"{display_label} findings: {len(findings)}")
     elif report["overall_correctness"] == "patch is incorrect":
         print(
@@ -5363,20 +5402,26 @@ def print_report(report: dict[str, Any], *, label: str = "autoreview") -> None:
         )
     else:
         print(
-            f"{display_label} clean: "
-            "no accepted/actionable findings reported"
+            f"{display_label} scoped-clean: "
+            "no accepted/actionable findings in the selected Git scope and priority"
         )
-    for finding in findings:
-        loc = finding["code_location"]
-        print(
-            f"[{finding['priority']}] "
-            f"{display_escape(finding['title'], 140)}"
-        )
-        print(f"{display_escape(loc['file_path'], 500)}:{loc['line']}")
-        print(display_escape(finding["body"], 2000, multiline=True))
-        print()
+    print_findings(findings)
+    for key, description in (
+        ("scope_rejected_findings", "Rejected out-of-scope findings (retained for audit)"),
+        ("priority_filtered_findings", "Findings below the requested priority (retained for audit)"),
+    ):
+        if report.get(key):
+            print(f"{description}: {len(report[key])}")
+            print_findings(report[key])
+    for needle in report.get("missing_required_findings", []):
+        print(f"required finding text not found: {display_escape(needle, 2000)}")
     print(f"overall: {report['overall_correctness']} ({report['overall_confidence']})")
     print(display_escape(report["overall_explanation"], 3000, multiline=True))
+    for entry in report.get("pass_reports", []):
+        provider = entry["report"]
+        print(f"{display_escape(entry['label'], 200)} overall: "
+              f"{provider['overall_correctness']} ({provider['overall_confidence']})")
+        print(display_escape(provider["overall_explanation"], 3000, multiline=True))
 
 
 def positive_float(value: str) -> float:
@@ -5443,7 +5488,7 @@ def parse_args() -> argparse.Namespace:
         "--max-priority",
         choices=["P0", "P1", "P2", "P3"],
         default=os.environ.get("AUTOREVIEW_MAX_PRIORITY", "P0"),
-        help="Widest finding priority to report. Default: P0.",
+        help="Widest finding priority to accept. Default: P0; lower priorities remain in audit output.",
     )
     parser.add_argument("--output", help="Write human output to a file as well as stdout.")
     parser.add_argument("--json-output", help="Write validated structured review JSON.")
@@ -5848,8 +5893,9 @@ def run_reviewer(
     scan_outgoing_review_pack(repo, prompt)
     raw = run_engine(args, repo, prompt)
     report = extract_json(raw)
-    validate_report(report, repo, changed_paths, required)
+    validate_report(report, repo, changed_paths, [])
     filter_findings_by_priority(report, args.max_priority)
+    require_findings(report, required)
     return report
 
 
@@ -5879,15 +5925,21 @@ def merge_chunk_reports(reports: list[tuple[str, dict[str, Any]]]) -> dict[str, 
         chunk_report["overall_correctness"] == "patch is incorrect"
         for _, chunk_report in reports
     )
-    return {
+    report = {
         "findings": findings,
         "overall_correctness": "patch is incorrect" if incorrect else "patch is correct",
-        "overall_explanation": bounded_field(f"Chunked review complete. {summary}.", 3000),
-        "overall_confidence": max(
+        "overall_explanation": bounded_field(f"Review passes returned. {summary}. See preserved pass reports for provider conclusions.", 3000),
+        "overall_confidence": min(
             (chunk_report["overall_confidence"] for _, chunk_report in reports),
             default=0.5,
         ),
+        "pass_reports": [{"label": label, "report": copy.deepcopy(chunk_report)} for label, chunk_report in reports],
     }
+    for field in ("scope_rejected_findings", "priority_filtered_findings"):
+        retained = [copy.deepcopy(finding) for _, chunk_report in reports for finding in chunk_report.get(field, [])]
+        if retained:
+            report[field] = retained
+    return report
 
 
 def run_review_passes(
@@ -5905,13 +5957,12 @@ def run_review_passes(
                 f"review pass: {index}/{len(prompts)} "
                 f"({utf8_size(prompt)} prompt bytes)"
             )
-        required = args.require_finding if len(prompts) == 1 else []
         chunk_report = run_reviewer(
             reviewers[0],
             repo,
             prompt,
             changed_paths,
-            required,
+            [],
             input_truncated,
         )
         chunk_reports.append((f"chunk {index}/{len(prompts)}", chunk_report))
@@ -6046,7 +6097,10 @@ def main_impl() -> int:
         report = chunk_reports[0][1]
     else:
         report = merge_chunk_reports(chunk_reports)
-        validate_report(report, repo, changed_paths, args.require_finding)
+    missing = missing_required_findings(report, args.require_finding)
+    if missing:
+        report["missing_required_findings"] = missing
+    report["review_status"] = review_status(report)
     label = "autoreview"
     if len(chunk_reports) > 1:
         label += " chunked"
@@ -6081,6 +6135,8 @@ def main_impl() -> int:
 
     has_findings = bool(report["findings"])
     overall_incorrect = report["overall_correctness"] == "patch is incorrect"
+    if report["review_status"] == "incomplete":
+        return 2
     if args.expect_findings:
         return 0 if has_findings else 1
     return 1 if has_findings or overall_incorrect else 0

--- a/skills/autoreview/scripts/autoreview_test.py
+++ b/skills/autoreview/scripts/autoreview_test.py
@@ -5,6 +5,7 @@ import argparse
 import contextlib
 import copy
 import importlib.util
+import io
 import json
 import os
 import runpy
@@ -110,12 +111,79 @@ class AutoreviewPriorityTests(unittest.TestCase):
             args = AUTOREVIEW.parse_args()
         self.assertEqual(args.max_priority, "P0")
 
-    def test_priority_filter_omits_lower_findings_and_cleans_verdict(self) -> None:
+    def test_priority_filter_preserves_lower_findings_and_provider_verdict(self) -> None:
         report = copy.deepcopy(DRAFT_REPORT)
         AUTOREVIEW.filter_findings_by_priority(report, "P0")
         self.assertEqual(report["findings"], [])
-        self.assertEqual(report["overall_correctness"], "patch is correct")
-        self.assertIn("below the requested P0", report["overall_explanation"])
+        self.assertEqual(report["priority_filtered_findings"], DRAFT_REPORT["findings"])
+        for key in ("overall_correctness", "overall_explanation", "overall_confidence"):
+            self.assertEqual(report[key], DRAFT_REPORT[key])
+
+
+class AutoreviewResultScopeTests(unittest.TestCase):
+    def test_scope_rejection_preserves_provider_conclusion_and_audit(self) -> None:
+        report = copy.deepcopy(DRAFT_REPORT)
+        with contextlib.redirect_stderr(io.StringIO()):
+            AUTOREVIEW.validate_report(report, Path.cwd(), {"changed.js"}, [])
+        self.assertEqual(report["findings"], [])
+        for key in ("overall_correctness", "overall_explanation", "overall_confidence"):
+            self.assertEqual(report[key], DRAFT_REPORT[key])
+        self.assertEqual(report["scope_rejected_findings"], DRAFT_REPORT["findings"])
+        output = io.StringIO()
+        with contextlib.redirect_stdout(output):
+            AUTOREVIEW.print_report(report)
+        self.assertIn("incomplete", output.getvalue())
+        self.assertIn("Draft finding", output.getvalue())
+        self.assertIn("draft.js:1", output.getvalue())
+        self.assertNotIn("clean:", output.getvalue())
+
+    def test_chunk_merge_keeps_rejections_explanations_and_conservative_confidence(self) -> None:
+        rejected = copy.deepcopy(DRAFT_REPORT)
+        with contextlib.redirect_stderr(io.StringIO()):
+            AUTOREVIEW.validate_report(rejected, Path.cwd(), {"changed.js"}, [])
+        reports = [("chunk 1/2", copy.deepcopy(FINAL_REPORT)), ("chunk 2/2", rejected)]
+        merged = AUTOREVIEW.merge_chunk_reports(reports)
+        self.assertEqual(merged["overall_correctness"], "patch is incorrect")
+        self.assertEqual(merged["overall_confidence"], 0.2)
+        self.assertEqual(len(merged["scope_rejected_findings"]), 1)
+        self.assertEqual(merged["pass_reports"][1]["report"], rejected)
+        output = io.StringIO()
+        with contextlib.redirect_stdout(output):
+            AUTOREVIEW.print_report(merged)
+        self.assertIn("draft", output.getvalue())
+        self.assertIn("incomplete", output.getvalue())
+        self.assertNotIn("clean:", output.getvalue())
+
+    def test_required_finding_must_survive_priority_filter_for_every_pass_count(self) -> None:
+        args = argparse.Namespace(engine="codex", max_priority="P0", require_finding=["Draft finding"])
+        for count in (1, 2):
+            with self.subTest(count=count), mock.patch.object(
+                AUTOREVIEW, "scan_outgoing_review_pack"
+            ), mock.patch.object(AUTOREVIEW, "run_engine", return_value=json.dumps(DRAFT_REPORT)):
+                reports = AUTOREVIEW.run_review_passes(
+                    args, [args], Path.cwd(), ["pack"] * count, {"draft.js"}, False
+                )
+            report = reports[0][1] if count == 1 else AUTOREVIEW.merge_chunk_reports(reports)
+            self.assertEqual(
+                AUTOREVIEW.missing_required_findings(report, args.require_finding), ["Draft finding"]
+            )
+            self.assertEqual(report["overall_correctness"], "patch is incorrect")
+            self.assertTrue(report["priority_filtered_findings"])
+
+    def test_provider_cannot_supply_local_audit_metadata(self) -> None:
+        for key in ("scope_rejected_findings", "priority_filtered_findings", "pass_reports", "review_status"):
+            report = copy.deepcopy(FINAL_REPORT)
+            report[key] = []
+            with self.subTest(key=key), self.assertRaisesRegex(SystemExit, "unexpected top-level"):
+                AUTOREVIEW.validate_report(report, Path.cwd(), set(), [])
+
+    def test_required_finding_survives_merge_deduplication_and_body_prefix(self) -> None:
+        first = copy.deepcopy(DRAFT_REPORT)
+        second = copy.deepcopy(DRAFT_REPORT)
+        second["findings"][0]["body"] = "x" * 1980 + " required tail"
+        merged = AUTOREVIEW.merge_chunk_reports([("chunk 1/2", first), ("chunk 2/2", second)])
+        self.assertEqual(len(merged["findings"]), 1)
+        self.assertEqual(AUTOREVIEW.missing_required_findings(merged, ["required tail"]), [])
 
 
 def amp_test_stream(

--- a/skills/autoreview/tests/test_autoreview_hardening.py
+++ b/skills/autoreview/tests/test_autoreview_hardening.py
@@ -617,7 +617,7 @@ Path(__file__).with_name("scan.json").write_text(json.dumps({
                     self.assertIn(safe, self.helper["review_paths"](repo, "local", None, "HEAD"))
                     for label in ("--dataset", "--prompt-file"):
                         _, content, truncated = self.helper["validate_evidence_file"](repo, safe, label)
-                        self.assertEqual(content, source.read_text())
+                        self.assertEqual(content, source.read_bytes().decode("utf-8"))
                         self.assertFalse(truncated)
 
             blocked = (
@@ -640,6 +640,8 @@ Path(__file__).with_name("scan.json").write_text(json.dumps({
         with tempfile.TemporaryDirectory() as tempdir:
             root = Path(tempdir)
             repo = init_repo(root)
+            # Match the helper's raw Git policy so CRLF fixtures stay committed-only.
+            git(repo, "config", "core.autocrlf", "false")
             (repo / "runtime.txt").write_text("old runtime\n", encoding="utf-8")
             (repo / "context.md").write_text("Full candidate context: integration contract broken.\n", encoding="utf-8")
             git(repo, "add", ".")
@@ -650,6 +652,7 @@ Path(__file__).with_name("scan.json").write_text(json.dumps({
             test_file.write_text("// synthetic integration fixture\n" * 27 + "func testLive() { preconditionFailure() }\n", encoding="utf-8")
             git(repo, "add", e2e)
             git(repo, "commit", "-q", "-m", "original candidate")
+            self.assertEqual(git(repo, "status", "--porcelain"), "")
             for rel in (source, untracked):
                 path = repo / rel
                 path.parent.mkdir(parents=True)
@@ -709,7 +712,7 @@ Path(__file__).with_name("scan.json").write_text(json.dumps({
                         rejected = result.get("scope_rejected_findings", [])
                         self.assertEqual(len(rejected), 2 - len(accepted))
                         self.assertEqual(scans, sends)
-                        self.assertIn("# Dataset: " + e2e, sends[0])
+                        self.assertIn("# Dataset: " + str(Path(e2e)), sends[0])
                         self.assertNotIn("OMIT_STAGED_STORE", sends[0])
                         self.assertNotIn("OMIT_UNTRACKED_ENV", sends[0])
                         if mode == "local" and ref:
@@ -812,7 +815,7 @@ Path(__file__).with_name("scan.json").write_text(json.dumps({
 
                 def scanner(command, _repo, **_kwargs):
                     outgoing = Path(command[2])
-                    self.assertEqual(outgoing.read_text(encoding="utf-8"), pack)
+                    self.assertEqual(outgoing.read_bytes(), pack.encode("utf-8"))
                     if os.name != "nt":
                         self.assertEqual(stat.S_IMODE(outgoing.stat().st_mode), 0o600)
                     self.assertIn("--results=verified,unknown", command)

--- a/skills/autoreview/tests/test_autoreview_hardening.py
+++ b/skills/autoreview/tests/test_autoreview_hardening.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import argparse
 import contextlib
+import copy
 import io
 import json
 import os
@@ -597,6 +598,247 @@ Path(__file__).with_name("scan.json").write_text(json.dumps({
             for ref, error in (("--help", "unsafe"), ("HEAD:source.txt", "unsafe"), ("", "unsafe"), ("missing-base", "unknown")):
                 with self.subTest(ref=ref), self.assertRaisesRegex(SystemExit, f"{error} base ref"):
                     self.helper["choose_target"](repo, "local", ref)
+
+    def test_credential_source_filename_is_safe_but_stores_remain_blocked(self) -> None:
+        safe = "Sources/Configuration/CredentialFile.swift"
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo = init_repo(Path(tempdir))
+            git(repo, "commit", "-q", "--allow-empty", "-m", "base")
+            source = repo / safe
+            source.parent.mkdir(parents=True)
+            source.write_text("struct CredentialFile { let version = 1 }\n", encoding="utf-8")
+            for staged in (False, True):
+                if staged:
+                    git(repo, "add", safe)
+                with self.subTest(staged=staged):
+                    bundle, truncated = self.helper["local_bundle"](repo)
+                    self.assertFalse(truncated)
+                    self.assertIn("struct CredentialFile", bundle)
+                    self.assertIn(safe, self.helper["review_paths"](repo, "local", None, "HEAD"))
+                    for label in ("--dataset", "--prompt-file"):
+                        _, content, truncated = self.helper["validate_evidence_file"](repo, safe, label)
+                        self.assertEqual(content, source.read_text())
+                        self.assertFalse(truncated)
+
+            blocked = (
+                "credentials.json", "config/prod-credentials.json", "credentials/store.json",
+                "tokens/session.dat", ".env", ".env.local", "config/client.pem", "config/client.key",
+                ".ssh/id_ed25519", "Sources/credentials/CredentialFile.swift",
+                "Sources/backup-secrets/CredentialFile.swift", ".env/CredentialFile.swift",
+                "Sources/CredentialFile.swift.key", "Sources/credentials.swift",
+            )
+            for rel in blocked:
+                with self.subTest(blocked=rel):
+                    self.assertIsNotNone(self.helper["sensitive_repo_path_risk"](rel))
+                    with self.assertRaisesRegex(SystemExit, "sensitive|unsafe"):
+                        self.helper["validate_evidence_file"](repo, rel, "--dataset")
+
+    def test_complete_candidate_scope_and_local_results_remain_honest(self) -> None:
+        source = "Sources/Configuration/CredentialFile.swift"
+        untracked = "Runtime/Configuration/CredentialFile.swift"
+        e2e = "Tests/Integration/EndToEndTests.swift"
+        with tempfile.TemporaryDirectory() as tempdir:
+            root = Path(tempdir)
+            repo = init_repo(root)
+            (repo / "runtime.txt").write_text("old runtime\n", encoding="utf-8")
+            (repo / "context.md").write_text("Full candidate context: integration contract broken.\n", encoding="utf-8")
+            git(repo, "add", ".")
+            git(repo, "commit", "-q", "-m", "base")
+            base = git(repo, "rev-parse", "HEAD").strip()
+            test_file = repo / e2e
+            test_file.parent.mkdir(parents=True)
+            test_file.write_text("// synthetic integration fixture\n" * 27 + "func testLive() { preconditionFailure() }\n", encoding="utf-8")
+            git(repo, "add", e2e)
+            git(repo, "commit", "-q", "-m", "original candidate")
+            for rel in (source, untracked):
+                path = repo / rel
+                path.parent.mkdir(parents=True)
+                path.write_text("struct CredentialFile { let version = 2 }\n", encoding="utf-8")
+            (repo / "credentials.json").write_text('{"fixture": "OMIT_STAGED_STORE"}\n', encoding="utf-8")
+            git(repo, "add", source, "credentials.json")
+            (repo / "runtime.txt").write_text("unstaged runtime\n", encoding="utf-8")
+            (repo / ".env").write_text("OMIT_UNTRACKED_ENV\n", encoding="utf-8")
+            findings = [{
+                "title": title, "body": body, "priority": "P2", "confidence": 0.8,
+                "category": "bug", "code_location": {"file_path": rel, "line": line},
+            } for title, body, rel, line in (
+                ("Preserve source contract", "The public API contract is broken.", source, 1),
+                ("Keep integration runnable", "The live E2E fails unconditionally.", e2e, 28),
+            )]
+            provider_report = {
+                "findings": findings, "overall_correctness": "patch is incorrect",
+                "overall_explanation": "The public API contract is broken and live E2E fails unconditionally.",
+                "overall_confidence": 0.73,
+            }
+            cases = (
+                ("local", None, {source}, 2),
+                ("auto", None, {source}, 2),
+                ("branch", base, {e2e}, 2),
+                ("local", base, {source, e2e}, 1),
+            )
+            for engine in ("codex", "claude", "amp", "pi", "kimi"):
+                for mode, ref, accepted, expected_exit in cases:
+                    with self.subTest(engine=engine, mode=mode, ref=bool(ref)):
+                        scans, sends = [], []
+
+                        def run_engine(_args, _repo, prompt):
+                            sends.append(prompt)
+                            return json.dumps(provider_report)
+
+                        argv = [str(SCRIPT), "--engine", engine, "--mode", mode, "--max-priority", "P2",
+                                "--dataset", e2e, "--prompt-file", "context.md", "--prompt", "Review the complete candidate.",
+                                "--output", str(root / "result.txt"), "--json-output", str(root / "result.json")]
+                        if ref:
+                            argv.extend(["--base", ref])
+                        output = io.StringIO()
+                        with mock.patch.dict(self.helper["main_impl"].__globals__, {
+                            "repo_root": lambda: repo, "run_engine": run_engine,
+                            "scan_outgoing_review_pack": lambda _repo, prompt: scans.append(prompt),
+                        }), mock.patch.object(sys, "argv", argv), contextlib.redirect_stdout(output), contextlib.redirect_stderr(io.StringIO()):
+                            self.assertEqual(self.helper["main_impl"](), expected_exit)
+                        result = json.loads((root / "result.json").read_text())
+                        self.assertEqual({f["code_location"]["file_path"] for f in result["findings"]}, accepted)
+                        for key in ("overall_correctness", "overall_explanation", "overall_confidence"):
+                            self.assertEqual(result[key], provider_report[key])
+                        self.assertEqual(result["review_status"], "incomplete" if expected_exit == 2 else "findings")
+                        text = (root / "result.txt").read_text()
+                        self.assertIn(text, output.getvalue())
+                        self.assertIn("Keep integration runnable", text)
+                        self.assertIn("Preserve source contract", text)
+                        self.assertNotIn("clean:", text)
+                        rejected = result.get("scope_rejected_findings", [])
+                        self.assertEqual(len(rejected), 2 - len(accepted))
+                        self.assertEqual(scans, sends)
+                        self.assertIn("# Dataset: " + e2e, sends[0])
+                        self.assertNotIn("OMIT_STAGED_STORE", sends[0])
+                        self.assertNotIn("OMIT_UNTRACKED_ENV", sends[0])
+                        if mode == "local" and ref:
+                            self.assertIn(f"# Staged Diff\nbase: {base}", sends[0])
+                            for marker in ("+func testLive", "+struct CredentialFile", "-old runtime", "+unstaged runtime", f'path: "{untracked}"'):
+                                self.assertIn(marker, sends[0])
+            for target, ref in (("local", None), ("local", base), ("branch", base)):
+                paths = self.helper["review_paths"](repo, target, ref, "HEAD")
+                self.assertNotIn("credentials.json", paths)
+                self.assertNotIn(".env", paths)
+                if target == "local":
+                    self.assertIn(untracked, paths)
+
+    def test_single_and_chunked_result_status_exit_and_required_checks(self) -> None:
+        finding = {
+            "title": "Synthetic defect", "body": "Keep this finding auditable.",
+            "priority": "P2", "confidence": 0.7, "category": "bug",
+            "code_location": {"file_path": "source.txt", "line": 1},
+        }
+        cases = (
+            # location, provider verdict, priority, required, expect, status, exit
+            (None, "patch is correct", "P2", [], False, "scoped-clean", 0),
+            (None, "patch is incorrect", "P2", [], False, "incorrect", 1),
+            ("source.txt", "patch is incorrect", "P2", [], False, "findings", 1),
+            ("source.txt", "patch is incorrect", "P2", ["Synthetic defect"], True, "findings", 0),
+            ("source.txt", "patch is incorrect", "P0", [], False, "filtered", 1),
+            ("source.txt", "patch is correct", "P0", [], False, "filtered", 0),
+            ("source.txt", "patch is incorrect", "P0", ["Synthetic defect"], True, "incomplete", 2),
+            ("elsewhere.txt", "patch is incorrect", "P2", [], False, "incomplete", 2),
+            ("elsewhere.txt", "patch is correct", "P0", [], True, "incomplete", 2),
+            ("elsewhere.txt", "patch is incorrect", "P2", ["Synthetic defect"], False, "incomplete", 2),
+        )
+        with tempfile.TemporaryDirectory() as tempdir:
+            root = Path(tempdir)
+            repo = init_repo(root)
+            git(repo, "commit", "-q", "--allow-empty", "-m", "base")
+            (repo / "source.txt").write_text("changed\n", encoding="utf-8")
+            for count in (1, 2):
+                for rel, verdict, priority, required, expect, expected_status, exit_code in cases:
+                    with self.subTest(count=count, rel=rel, verdict=verdict, priority=priority, required=required, expect=expect):
+                        issue = copy.deepcopy(finding)
+                        issue["code_location"]["file_path"] = rel
+                        provider = {
+                            "findings": [issue] if rel else [], "overall_correctness": verdict,
+                            "overall_explanation": "Synthetic provider explanation.", "overall_confidence": 0.61,
+                        }
+                        argv = [str(SCRIPT), "--engine", "codex", "--mode", "local", "--max-priority", priority,
+                                "--output", str(root / "result.txt"), "--json-output", str(root / "result.json")]
+                        for needle in required:
+                            argv.extend(["--require-finding", needle])
+                        if expect:
+                            argv.append("--expect-findings")
+                        with mock.patch.dict(self.helper["main_impl"].__globals__, {
+                            "repo_root": lambda: repo,
+                            "build_review_prompts": lambda *_args: ["synthetic pack"] * count,
+                            "scan_outgoing_review_pack": lambda *_args: None,
+                            "run_engine": lambda *_args: json.dumps(provider),
+                        }), mock.patch.object(sys, "argv", argv), contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(io.StringIO()):
+                            self.assertEqual(self.helper["main_impl"](), exit_code)
+                        result = json.loads((root / "result.json").read_text())
+                        text = (root / "result.txt").read_text()
+                        self.assertEqual(result["review_status"], expected_status)
+                        self.assertEqual(result["overall_correctness"], verdict)
+                        self.assertEqual(result["overall_confidence"], 0.61)
+                        self.assertIn(provider["overall_explanation"], text)
+                        self.assertEqual("scoped-clean:" in text, expected_status == "scoped-clean")
+                        if rel:
+                            self.assertIn("Keep this finding auditable.", text)
+                        if expected_status == "incomplete":
+                            self.assertIn("incomplete:", text)
+                        if required and expected_status == "incomplete":
+                            self.assertEqual(result["missing_required_findings"], required)
+
+    def test_credential_source_exception_still_scans_every_outgoing_input(self) -> None:
+        source = "Sources/Configuration/CredentialFile.swift"
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo = init_repo(Path(tempdir))
+            path = repo / source
+            path.parent.mkdir(parents=True)
+            path.write_text("// DELETED_SCAN_MARKER\n", encoding="utf-8")
+            git(repo, "add", source)
+            git(repo, "commit", "-q", "-m", "base")
+            path.write_text("// STAGED_SCAN_MARKER\n", encoding="utf-8")
+            git(repo, "add", source)
+            untracked = repo / "Runtime/CredentialFile.swift"
+            untracked.parent.mkdir()
+            untracked.write_text("// UNTRACKED_SCAN_MARKER\n", encoding="utf-8")
+            extra, _ = self.helper["load_extra_prompt"](argparse.Namespace(
+                prompt=["PROMPT_SCAN_MARKER"], prompt_file=[source]
+            ), repo)
+            datasets, _ = self.helper["load_datasets"](argparse.Namespace(dataset=[str(untracked.relative_to(repo))]), repo)
+            bundle, _ = self.helper["local_bundle"](repo)
+            pack = self.helper["build_prompt"](repo, "local", None, bundle, extra, datasets)
+            provider = mock.Mock(return_value=json.dumps({
+                "findings": [], "overall_correctness": "patch is correct",
+                "overall_explanation": "Synthetic review.", "overall_confidence": 0.8,
+            }))
+            for marker in (None, "DELETED_SCAN_MARKER", "STAGED_SCAN_MARKER", "UNTRACKED_SCAN_MARKER", "PROMPT_SCAN_MARKER"):
+                events = []
+
+                def scanner(command, _repo, **_kwargs):
+                    outgoing = Path(command[2])
+                    self.assertEqual(outgoing.read_text(encoding="utf-8"), pack)
+                    if os.name != "nt":
+                        self.assertEqual(stat.S_IMODE(outgoing.stat().st_mode), 0o600)
+                    self.assertIn("--results=verified,unknown", command)
+                    self.assertIn("--no-update", command)
+                    for token in ("-// DELETED_SCAN_MARKER", "+// STAGED_SCAN_MARKER", "UNTRACKED_SCAN_MARKER", "PROMPT_SCAN_MARKER", "# Dataset:", "# Prompt file:"):
+                        self.assertIn(token, pack)
+                    events.append("scan")
+                    if marker:
+                        line = next(i for i, text in enumerate(pack.splitlines(), 1) if marker in text)
+                        detected = {"SourceMetadata": {"Data": {"Filesystem": {"file": str(outgoing), "line": line}}}}
+                        return subprocess.CompletedProcess(command, self.helper["TRUFFLEHOG_FINDINGS_EXIT_CODE"], json.dumps(detected), "")
+                    return subprocess.CompletedProcess(command, 0, "", "")
+
+                provider.reset_mock()
+                with self.subTest(marker=marker), mock.patch.dict(self.helper["run_reviewer"].__globals__, {
+                    "find_command": lambda *_args: "/trusted/trufflehog", "run": scanner, "run_engine": provider,
+                }):
+                    args = argparse.Namespace(engine="codex", max_priority="P2")
+                    if marker:
+                        with self.assertRaisesRegex(SystemExit, "refusing to send review pack"):
+                            self.helper["run_reviewer"](args, repo, pack, {source}, [])
+                        provider.assert_not_called()
+                    else:
+                        self.helper["run_reviewer"](args, repo, pack, {source}, [])
+                        provider.assert_called_once_with(args, repo, pack)
+                    self.assertEqual(events, ["scan"])
 
     def test_tracked_binary_changes_are_blocked_in_all_modes(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:
@@ -1204,9 +1446,7 @@ Path(__file__).with_name("scan.json").write_text(json.dumps({
                             args, [args], repo, prompts, {"source.txt"}, False
                         )
                         report = self.helper["merge_chunk_reports"](reports)
-                        self.helper["validate_report"](
-                            report, repo, {"source.txt"}, args.require_finding
-                        )
+                        self.helper["require_findings"](report, args.require_finding)
                         self.assertEqual(report["overall_correctness"], "patch is incorrect")
                         self.assertEqual(
                             [item["title"] for item in report["findings"]], [finding["title"]]
@@ -3585,7 +3825,8 @@ Path(__file__).with_name("scan.json").write_text(json.dumps({
                 Path(tempdir),
                 label="streaming-reviewer",
                 heartbeat_seconds=0.01,
-                max_runtime_seconds=0.05,
+                # Allow interpreter startup before exercising continuous output.
+                max_runtime_seconds=0.5,
                 stream_output=True,
                 stream_display=lambda _name, _line: None,
             )
@@ -3593,7 +3834,7 @@ Path(__file__).with_name("scan.json").write_text(json.dumps({
 
         self.assertEqual(result.returncode, 124, result.stderr)
         self.assertIn("tick", result.stdout)
-        self.assertIn("streaming-reviewer engine timed out after 0.05s", result.stderr)
+        self.assertIn("streaming-reviewer engine timed out after 0.5s", result.stderr)
         self.assertLess(elapsed, 5)
         child_pid = int(result.stdout.splitlines()[0])
         with self.assertRaises(ProcessLookupError):
@@ -3627,7 +3868,8 @@ Path(__file__).with_name("scan.json").write_text(json.dumps({
                             Path(tempdir),
                             label="retained-pipe-reviewer",
                             heartbeat_seconds=0.01,
-                            max_runtime_seconds=0.05,
+                            # Let the child publish its PID before the deadline.
+                            max_runtime_seconds=0.5,
                             stream_output=stream_output,
                             stream_display=lambda _name, _line: None,
                         )
@@ -3641,7 +3883,7 @@ Path(__file__).with_name("scan.json").write_text(json.dumps({
 
                 self.assertEqual(result.returncode, 124, result.stderr)
                 self.assertIn("retained-pipe-reviewer engine timed out", result.stderr)
-                self.assertLess(time.monotonic() - started, 1)
+                self.assertLess(time.monotonic() - started, 2)
 
     def test_large_repo_relative_evidence_file_is_rejected(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:

--- a/skills/autoreview/tests/test_autoreview_hardening.py
+++ b/skills/autoreview/tests/test_autoreview_hardening.py
@@ -255,7 +255,7 @@ class AutoreviewHardeningTests(unittest.TestCase):
         self.helper = load_helper()
 
     def test_outgoing_pack_scan_disables_installed_scanner_updates(self) -> None:
-        prompt = "harmless review pack\n"
+        prompt = "harmless review pack\npreserved CRLF\r\nfinal line\r"
         with tempfile.TemporaryDirectory() as tempdir:
             root = Path(tempdir)
             repo = root / "repo"
@@ -279,7 +279,7 @@ assert set(args[2:]) == {
 pack = Path(args[1])
 Path(__file__).with_name("scan.json").write_text(json.dumps({
     "pack": str(pack),
-    "prompt": pack.read_text(encoding="utf-8"),
+    "prompt": pack.read_bytes().decode("utf-8"),
 }))
 ''',
             )
@@ -312,7 +312,7 @@ Path(__file__).with_name("scan.json").write_text(json.dumps({
                 **_kwargs: object,
             ) -> subprocess.CompletedProcess[str]:
                 self.assertEqual(command[1], "filesystem")
-                self.assertEqual(Path(command[2]).read_text(encoding="utf-8"), prompt)
+                self.assertEqual(Path(command[2]).read_bytes(), prompt.encode("utf-8"))
                 self.assertIn("-const apiKey", prompt)
                 return subprocess.CompletedProcess(command, 0, "", "")
 


### PR DESCRIPTION
## Summary

Fix a false-clean result when a reviewer reports defects outside the selected Git scope. The helper previously discarded those findings and could rewrite an incorrect verdict to correct while retaining an explanation describing broken behavior.

- Preserve provider verdicts, explanations, and confidence; retain scope-rejected and priority-filtered findings in structured and human-readable results. Scope rejection now reports `incomplete` and exits 2.
- Preserve per-pass reports when merging chunked reviews instead of discarding explanations or promoting confidence from another pass.
- Allow the exact source filename `CredentialFile.swift` for untracked/evidence inputs outside sensitive parent paths. Credential-store exclusions, mandatory TruffleHog scanning, and reviewer isolation remain intact.
- Document complete PR-plus-dirty review using explicit local mode with a pinned PR merge base. Prompt text and datasets never expand Git scope.
- Preserve exact outgoing scan-pack bytes on Windows by writing UTF-8 bytes rather than translating line endings in text mode.
- Add synthetic regressions for staged/untracked source, credential-file exclusions, mixed committed and dirty candidates, and JSON/text/exit behavior across all five engine selections.

## Validation

- [Hosted validation for final head `6823271`](https://github.com/openclaw/agent-skills/actions/runs/33198398836): complete Ubuntu/Windows suites and repository validation.
- Full macOS autoreview suite for the initial scope repair: 203 passed, one Linux-specific raw-filename test skipped. Final scanner/source/scope corrections: five affected tests passed locally.
- Reproduced the original false-clean behavior against the pre-change helper and verified the corrected incomplete result.
- CRLF emulation reproduced seven failing pre-fix fixture subtests, then passed after the portability correction. Windows text-writer emulation separately proved that the old scan file changed prompt bytes and the corrected writer preserves them exactly.
- Skill metadata validation, Python compilation, and diff formatting checks passed.
- Independent isolated Codex review through P2 of the final complete committed-plus-dirty candidate: no actionable, scope-rejected, or priority-filtered findings.

Two initial CI attempts exposed Windows-specific problems: first fixture newline/native-path assumptions, then a genuine scan-file newline translation bug revealed by the stronger byte assertion. Both are fixed without skipping the tests or weakening scanner checks. Two existing macOS subprocess tests also received test-only startup allowances; production deadlines are unchanged.

The result-label and exit-code transition is intentional and documented. The bundled smoke harness propagates nonzero helper exits. No raw review logs, incident artifacts, private runtime identifiers, or sensitive data are included.
