### PR TITLE
fix(autoreview): batch complete evidence within prompt limits

### DIFF
--- a/skills/autoreview/SKILL.md
+++ b/skills/autoreview/SKILL.md
@@ -171,8 +171,10 @@ with `--base`.
 
 ## Oversized Bundles
 
-The helper validates the complete patch before partitioning it and scans each
-exact outgoing review pack before sending it. A safe bundle that fits
+The helper validates the complete patch before partitioning it. For partitioned
+reviews it scans the complete frozen input first, so credentials cannot evade
+detection by crossing a chunk boundary. It also scans each exact outgoing review
+pack before sending it. A safe bundle that fits
 the aggregate prompt limit remains one integrated review pass. Larger bundles
 are split at bundle sections and file boundaries where possible; an oversized
 single-file block is split at line boundaries with repeated file/hunk context
@@ -180,15 +182,20 @@ and an absolute new- or old-file line offset. Untracked snapshots use
 injection-safe source-line records so continuation passes retain reportable
 locations. A single physical diff line split across passes also retains its
 original addition, deletion, or context marker.
-Every original bundle byte appears exactly once across the pass sequence, and
-all validated reports are merged before required-finding and exit-status checks.
+Prompt instructions remain whole in every pass. Large datasets are grouped from
+their validated file records, never by reparsing headings inside evidence.
+Individual oversized datasets split at lines or UTF-8 boundaries with their
+original path and byte offset. Each evidence batch is paired with the complete
+change bundle: every original change byte appears exactly once per evidence
+batch, and every evidence byte is retained. All validated reports are merged
+before required-finding and exit-status checks.
 There is no fixed pass-count ceiling: the complete frozen input determines the
 finite pass sequence. The helper prints its size and pass count before running
 passes serially. Each pass retains the same prompt-size limit, secret scan, and
 reviewer isolation; a failed pass aborts without publishing a partial verdict.
 
-Chunking makes large-diff review usable, but it cannot give one model call every
-cross-file implementation detail. For architecture-heavy changes, still prefer
+Evidence batches can multiply the pass count. Chunking cannot give one model
+call every cross-file implementation detail. For architecture-heavy changes, still prefer
 a coherent branch or PR shape whose semantic decision surface fits one pass.
 Removing verified non-authoritative generated noise remains useful, but never
 drop lockfiles, generated clients, policies, manifests, schemas, or other

--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -167,6 +167,12 @@ class ReviewChunk(NamedTuple):
     context: str = ""
 
 
+class ReviewDataset(NamedTuple):
+    path: str
+    content: str
+    byte_offset: int = 0
+
+
 DEFAULT_ENGINE_PATHS = ("/usr/local/bin", "/usr/bin", "/bin")
 # Keep this explicit: suffix matching leaks unrelated process credentials such
 # as package-registry and telemetry tokens into reviewer subprocesses.
@@ -2666,14 +2672,60 @@ def load_extra_prompt(args: argparse.Namespace, repo: Path) -> tuple[str, bool]:
     return "\n\n".join(chunks), input_truncated
 
 
-def load_datasets(args: argparse.Namespace, repo: Path) -> tuple[str, bool]:
-    chunks: list[str] = []
+def load_datasets(args: argparse.Namespace, repo: Path) -> tuple[list[ReviewDataset], bool]:
+    chunks: list[ReviewDataset] = []
     input_truncated = False
     for spec in args.dataset or []:
         path, content, truncated = validate_evidence_file(repo, spec, "--dataset")
         input_truncated = input_truncated or truncated
-        chunks.append(f"# Dataset: {path.relative_to(repo.resolve())}\n{content}")
-    return "\n\n".join(chunks), input_truncated
+        chunks.append(ReviewDataset(str(path.relative_to(repo.resolve())), content))
+    return chunks, input_truncated
+
+
+def render_datasets(datasets: list[ReviewDataset]) -> str:
+    return "\n\n".join(
+        f"# Dataset: {dataset.path}\n"
+        f"[Dataset byte offset: {dataset.byte_offset}]\n{dataset.content}"
+        for dataset in datasets
+    )
+
+
+def split_review_datasets(
+    datasets: list[ReviewDataset],
+    limit: int,
+) -> list[list[ReviewDataset]]:
+    batches: list[list[ReviewDataset]] = []
+    pending: list[ReviewDataset] = []
+    for dataset in datasets:
+        # Keep loader-owned paths separate from evidence text: source may itself
+        # contain headings that look like dataset boundaries.
+        overhead = utf8_size(render_datasets(
+            [ReviewDataset(dataset.path, "", utf8_size(dataset.content))]
+        ))
+        content_limit = limit - overhead
+        if content_limit < 4:
+            raise SystemExit("dataset path leaves too little room for evidence content")
+        fragments: list[str] = []
+        lines: list[str] = []
+        size = 0
+        for line in literal_lf_lines(dataset.content):
+            if size + utf8_size(line) > content_limit and lines:
+                fragments.append("".join(lines))
+                lines, size = [], 0
+            pieces = split_utf8_fragment(line, content_limit)
+            fragments.extend(pieces[:-1])
+            lines.append(pieces[-1])
+            size += utf8_size(pieces[-1])
+        fragments.append("".join(lines))
+        offset = 0
+        for fragment in fragments:
+            part = ReviewDataset(dataset.path, fragment, offset)
+            if pending and utf8_size(render_datasets([*pending, part])) > limit:
+                batches.append(pending)
+                pending = []
+            pending.append(part)
+            offset += utf8_size(fragment)
+    return [*batches, pending] if pending else [[]]
 
 
 def review_scope_policy() -> str:
@@ -3048,7 +3100,7 @@ def split_review_bundle(bundle: str, limit: int) -> list[ReviewChunk]:
 
 
 def render_review_prompt(
-    repo: Path,
+    branch: str,
     target: str,
     target_ref: str | None,
     chunk: ReviewChunk,
@@ -3057,7 +3109,6 @@ def render_review_prompt(
     chunk_position: tuple[int, int] | None = None,
 ) -> str:
     target_line = f"{target} {target_ref}" if target_ref else target
-    branch = current_branch(repo)
     scope_policy = review_scope_policy()
     chunk_policy = ""
     if chunk_position:
@@ -3106,45 +3157,25 @@ def render_review_prompt(
 
         {chunk_policy}
 
-        {extra_prompt}
-
-        {datasets}
-
-        # Change Bundle
         """
     ).strip()
-    return instructions + "\n" + chunk.content
-
-
-def build_prompt(repo: Path, target: str, target_ref: str | None, bundle: str, extra_prompt: str, datasets: str) -> str:
-    prompt = render_review_prompt(
-        repo,
-        target,
-        target_ref,
-        ReviewChunk(bundle),
-        extra_prompt,
-        datasets,
+    return (
+        instructions + "\n\n" + extra_prompt + "\n\n" + datasets
+        + "\n\n# Change Bundle\n" + chunk.content
     )
-    prompt_bytes = len(prompt.encode("utf-8"))
-    if prompt_bytes > MAX_REVIEW_PROMPT_BYTES:
-        raise SystemExit(
-            f"review input is {prompt_bytes} bytes, exceeding the {MAX_REVIEW_PROMPT_BYTES}-byte aggregate limit; "
-            "reduce the change, prompt files, or datasets"
-        )
-    return prompt
 
 
-def build_review_prompts(
-    repo: Path,
+def build_change_review_prompts(
+    branch: str,
     target: str,
     target_ref: str | None,
     bundle: str,
     extra_prompt: str,
     datasets: str,
     max_prompt_bytes: int = MAX_REVIEW_PROMPT_BYTES,
-) -> list[str]:
+) -> list[str] | None:
     full_prompt = render_review_prompt(
-        repo,
+        branch,
         target,
         target_ref,
         ReviewChunk(bundle),
@@ -3155,7 +3186,7 @@ def build_review_prompts(
         return [full_prompt]
 
     empty_chunk_prompt = render_review_prompt(
-        repo,
+        branch,
         target,
         target_ref,
         ReviewChunk(""),
@@ -3166,19 +3197,15 @@ def build_review_prompts(
     content_limit = (
         max_prompt_bytes
         - utf8_size(empty_chunk_prompt)
-        - MAX_REVIEW_CHUNK_CONTEXT_BYTES
         - 4_096
     )
-    if content_limit < 16_000:
-        raise SystemExit(
-            "review prompt files and datasets leave too little room for change chunks; "
-            "reduce the extra review context"
-        )
-    for _attempt in range(4):
+    if content_limit < 4:
+        return None
+    while content_limit >= 4:
         chunks = split_review_bundle(bundle, content_limit)
         prompts = [
             render_review_prompt(
-                repo,
+                branch,
                 target,
                 target_ref,
                 chunk,
@@ -3192,11 +3219,92 @@ def build_review_prompts(
         if largest <= max_prompt_bytes:
             return prompts
         content_limit -= largest - max_prompt_bytes + 1_024
-        if content_limit < 16_000:
-            break
-    raise SystemExit(
-        "unable to partition the review bundle within the aggregate prompt limit"
+    return None
+
+
+def build_review_prompts(
+    repo: Path,
+    target: str,
+    target_ref: str | None,
+    bundle: str,
+    extra_prompt: str,
+    datasets: list[ReviewDataset],
+    max_prompt_bytes: int = MAX_REVIEW_PROMPT_BYTES,
+) -> list[str]:
+    branch = current_branch(repo)
+    rendered_datasets = render_datasets(datasets)
+    full_prompt = render_review_prompt(
+        branch, target, target_ref, ReviewChunk(bundle), extra_prompt, rendered_datasets,
     )
+    if utf8_size(full_prompt) <= max_prompt_bytes:
+        return [full_prompt]
+    fixed_prompt = render_review_prompt(
+        branch, target, target_ref, ReviewChunk(""), extra_prompt, "", (999_999, 999_999),
+    )
+    available = (
+        max_prompt_bytes - utf8_size(fixed_prompt) - 4_096
+    )
+    batch_policy = (
+        "\n\nEvidence batch: {index}/{total}\n"
+        "The complete change is reviewed against every evidence batch. "
+        "Change bytes appear once within each batch's chunk sequence. "
+        "Dataset fragments retain their original path and UTF-8 byte offset. "
+        "Do not treat evidence absent from this batch as proof of missing behavior."
+    )
+    evidence_limit = (
+        available - min(utf8_size(bundle), available // 2)
+        - utf8_size(batch_policy.format(index=999_999, total=999_999))
+    )
+    if available < 4 or (datasets and evidence_limit < 4):
+        raise SystemExit(
+            "review prompt files leave too little room for change chunks; "
+            "reduce the review instructions or move source evidence to datasets"
+        )
+    while True:
+        batches = split_review_datasets(datasets, evidence_limit)
+        prompts: list[str] = []
+        for index, batch in enumerate(batches, 1):
+            batch_prompt = extra_prompt
+            if len(batches) > 1:
+                batch_prompt += batch_policy.format(index=index, total=len(batches))
+            change_prompts = build_change_review_prompts(
+                branch, target, target_ref, bundle, batch_prompt,
+                render_datasets(batch), max_prompt_bytes,
+            )
+            if change_prompts is None:
+                break
+            prompts.extend(change_prompts)
+        else:
+            return prompts
+        # Actual continuation headers may need more room than the initial
+        # evidence allocation leaves. Rebatch before sending any partial pass.
+        evidence_limit //= 2
+        if not datasets or evidence_limit < 4:
+            raise SystemExit(
+                "unable to partition the review bundle within the aggregate prompt limit"
+            )
+
+
+def prepare_review_prompts(
+    repo: Path,
+    target: str,
+    target_ref: str | None,
+    bundle: str,
+    extra_prompt: str,
+    datasets: list[ReviewDataset],
+    max_prompt_bytes: int,
+) -> list[str]:
+    prompts = build_review_prompts(
+        repo, target, target_ref, bundle, extra_prompt, datasets, max_prompt_bytes,
+    )
+    if len(prompts) > 1:
+        # A credential can span a partition boundary. Scan the complete frozen
+        # input before any send, in addition to each exact outgoing pack.
+        scan_outgoing_review_pack(repo, render_review_prompt(
+            current_branch(repo), target, target_ref, ReviewChunk(bundle),
+            extra_prompt, render_datasets(datasets),
+        ))
+    return prompts
 
 
 def write_json_temp(data: dict[str, Any], temp_root: Path) -> Path:
@@ -5774,7 +5882,7 @@ def dry_run_preflight(
         print(f"bundle: FAILED ({exc})")
 
     extra_prompt = ""
-    datasets = ""
+    datasets: list[ReviewDataset] = []
     prompt_truncated = False
     datasets_truncated = False
     inputs_ok = True
@@ -5803,7 +5911,7 @@ def dry_run_preflight(
             if reviewers:
                 ensure_reviewer_input_complete(reviewers[0], input_truncated)
             threshold_extra_prompt = apply_finding_threshold_prompt(args, extra_prompt)
-            prompts = build_review_prompts(
+            prompts = prepare_review_prompts(
                 repo,
                 target,
                 target_ref,
@@ -6018,7 +6126,8 @@ def main_impl() -> int:
     datasets, datasets_truncated = load_datasets(args, repo)
     input_truncated = bundle_truncated or prompt_truncated or datasets_truncated
     max_prompt_bytes = max_prompt_bytes_for_reviewers(reviewers)
-    prompts = build_review_prompts(
+    ensure_reviewer_input_complete(reviewer, input_truncated)
+    prompts = prepare_review_prompts(
         repo,
         target,
         target_ref,

--- a/skills/autoreview/tests/test_autoreview_hardening.py
+++ b/skills/autoreview/tests/test_autoreview_hardening.py
@@ -175,6 +175,30 @@ def load_helper() -> dict[str, object]:
     return runpy.run_path(str(SCRIPT), run_name="autoreview_under_test")
 
 
+@contextlib.contextmanager
+def deadline_after_reviewer_ready(helper, ready: Path):
+    deadline_type = helper["EngineRuntimeDeadline"]
+
+    class ReadyDeadline(deadline_type):
+        def __init__(self, label, seconds):
+            super().__init__(label, seconds)
+            self.expires_at = time.monotonic() + 5
+            self.ready_seen = False
+
+        def expired(self):
+            if not self.ready_seen and ready.exists():
+                self.ready_seen = True
+                self.expires_at = time.monotonic() + self.max_runtime_seconds
+            return super().expired()
+
+    # These fixtures test termination/draining after startup. The separate
+    # silent-reviewer case covers an unconditional deadline from process launch.
+    with mock.patch.dict(
+        helper["run_with_heartbeat"].__globals__, {"EngineRuntimeDeadline": ReadyDeadline}
+    ):
+        yield
+
+
 def git(repo: Path, *args: str) -> str:
     env = os.environ.copy()
     env.update(
@@ -1085,7 +1109,7 @@ Path(__file__).with_name("scan.json").write_text(json.dumps({
                 "HEAD",
                 "# Commit Diff\n" + "safe review content\n" * 18_000,
                 "",
-                "",
+                [],
             )
 
         self.assertEqual(len(prompts), 1)
@@ -1099,7 +1123,7 @@ Path(__file__).with_name("scan.json").write_text(json.dumps({
                         f"+review line {index}: \U0001f99e\n" for index in range(line_count)
                     )
                     prompts = self.helper["build_review_prompts"](
-                        repo, "commit", "HEAD", bundle, "", ""
+                        repo, "commit", "HEAD", bundle, "", []
                     )
 
                     self.assertGreaterEqual(len(prompts), minimum_passes)
@@ -1114,8 +1138,6 @@ Path(__file__).with_name("scan.json").write_text(json.dumps({
                         self.assertIn(f"Oversized review bundle chunk: {index}/{len(prompts)}", prompt)
 
     def test_kimi_prompt_budget_partitions_before_argv_limits(self) -> None:
-        if os.name == "nt":
-            self.skipTest("the 30 KiB Windows argv budget cannot fit the chunk-context reservation")
         with tempfile.TemporaryDirectory() as tempdir:
             repo = init_repo(Path(tempdir))
             prompts = self.helper["build_review_prompts"](
@@ -1124,11 +1146,11 @@ Path(__file__).with_name("scan.json").write_text(json.dumps({
                 "HEAD",
                 "# Commit Diff\n" + "safe review content\n" * 35_000,
                 "",
-                "",
+                [],
                 self.helper["KIMI_MAX_PROMPT_BYTES"],
             )
 
-        self.assertGreater(len(prompts), 8)
+        self.assertGreater(len(prompts), 1)
         self.assertTrue(
             all(
                 len(prompt.encode("utf-8")) <= self.helper["KIMI_MAX_PROMPT_BYTES"]
@@ -1136,20 +1158,150 @@ Path(__file__).with_name("scan.json").write_text(json.dumps({
             )
         )
 
+    def test_large_datasets_review_every_change_against_all_evidence(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo = init_repo(Path(tempdir))
+            paths = []
+            expected_lines = []
+            for index in range(5):
+                path = f"evidence-{index}.txt"
+                lines = [
+                    f"evidence-{index}-{line}: \U0001f99e{'x' * 70}"
+                    for line in range(1_400)
+                ]
+                expected_lines.extend(lines)
+                (repo / path).write_text("\n".join(lines) + "\n", encoding="utf-8")
+                paths.append(path)
+            datasets, truncated = self.helper["load_datasets"](
+                argparse.Namespace(dataset=paths), repo
+            )
+            self.assertFalse(truncated)
+            bundle = "# Commit Diff\n" + "+changed line\n" * 40_000
+            instructions = "Complete caller instructions must appear in every pass."
+            for budget in (512_000, 120_000):
+                with self.subTest(budget=budget):
+                    prompts = self.helper["build_review_prompts"](
+                        repo, "commit", "HEAD", bundle, instructions, datasets, budget
+                    )
+                    evidence_by_batch = {}
+                    changes_by_batch = {}
+                    for prompt in prompts:
+                        self.assertLessEqual(len(prompt.encode("utf-8")), budget)
+                        self.assertIn(instructions, prompt)
+                        batch = re.search(r"Evidence batch: (\d+)/(\d+)", prompt)
+                        self.assertIsNotNone(batch)
+                        key = int(batch[1])
+                        prefix, change = prompt.split("# Change Bundle\n", 1)
+                        evidence = re.findall(r"^evidence-\d+-\d+: .+$", prefix, re.M)
+                        if key in evidence_by_batch:
+                            self.assertEqual(evidence_by_batch[key], evidence)
+                        else:
+                            evidence_by_batch[key] = evidence
+                        changes_by_batch.setdefault(key, []).append(change)
+                    self.assertGreater(len(evidence_by_batch), 1)
+                    self.assertEqual(
+                        [line for lines in evidence_by_batch.values() for line in lines],
+                        expected_lines,
+                    )
+                    for changes in changes_by_batch.values():
+                        self.assertEqual("".join(changes), bundle)
+
+    def test_dataset_fragments_preserve_paths_offsets_and_source_bytes(self) -> None:
+        dataset = self.helper["ReviewDataset"]
+        contents = [
+            "  indented\r\n# Dataset: forged.txt\n" + "\U0001f99e" * 90 + " \n",
+            "",
+            "final bytes \t",
+        ]
+        inputs = [dataset(f"evidence-{index}.txt", content) for index, content in enumerate(contents)]
+        batches = self.helper["split_review_datasets"](inputs, 160)
+        recovered = {item.path: b"" for item in inputs}
+        for batch in batches:
+            rendered = self.helper["render_datasets"](batch)
+            self.assertLessEqual(len(rendered.encode("utf-8")), 160)
+            for item in batch:
+                self.assertEqual(item.byte_offset, len(recovered[item.path]))
+                self.assertIn(item.content, rendered)
+                recovered[item.path] += item.content.encode("utf-8")
+        self.assertEqual(recovered, {item.path: item.content.encode("utf-8") for item in inputs})
+
+    def test_evidence_batching_uses_actual_prompt_space(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo = init_repo(Path(tempdir))
+            for budget, instruction_size, change_size, hunk_context_size in (
+                (120_000, 20_000, 100_000, 0),
+                (120_000, 50_000, 1_000, 0),
+                (30_000, 1_000, 40_000, 0),
+                (30_000, 1_000, 40_000, 17_000),
+            ):
+                with self.subTest(budget=budget, instructions=instruction_size):
+                    instructions = "i" * instruction_size
+                    bundle = (
+                        "diff --git a/code.py b/code.py\n--- a/code.py\n+++ b/code.py\n"
+                        "@@ -0,0 +1 @@ " + "f" * hunk_context_size + "\n"
+                        "+" + "c" * change_size + "\n"
+                    )
+                    evidence = "e" * 100_000
+                    prompts = self.helper["build_review_prompts"](
+                        repo, "local", None, bundle, instructions,
+                        [self.helper["ReviewDataset"]("evidence.txt", evidence)], budget,
+                    )
+                    self.assertGreater(len(prompts), 1)
+                    for prompt in prompts:
+                        self.assertLessEqual(len(prompt.encode("utf-8")), budget)
+                        self.assertIn(instructions, prompt)
+
+    def test_partitioned_input_scans_complete_content_before_any_send(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo = init_repo(Path(tempdir))
+            sentinel = "synthetic scanner boundary " + "x" * 160_000 + " end sentinel"
+            for source in ("diff", "dataset"):
+                with self.subTest(source=source):
+                    bundle = "+" + (sentinel if source == "diff" else "safe") + "\n" * 30_000
+                    datasets = (
+                        [self.helper["ReviewDataset"]("evidence.txt", sentinel)]
+                        if source == "dataset" else []
+                    )
+                    prompts = self.helper["build_review_prompts"](
+                        repo, "local", None, bundle, "", datasets, 120_000
+                    )
+                    self.assertGreater(len(prompts), 1)
+                    self.assertFalse(any(sentinel in prompt for prompt in prompts))
+                    scanned = []
+
+                    def scan(_repo, prompt):
+                        scanned.append(prompt)
+                        if sentinel in prompt:
+                            raise SystemExit("complete input scanner rejection")
+
+                    with mock.patch.dict(
+                        self.helper["prepare_review_prompts"].__globals__,
+                        {"scan_outgoing_review_pack": scan},
+                    ), self.assertRaisesRegex(SystemExit, "complete input scanner rejection"):
+                        self.helper["prepare_review_prompts"](
+                            repo, "local", None, bundle, "", datasets, 120_000
+                        )
+                    self.assertEqual(len(scanned), 1)
+                    self.assertIn(sentinel, scanned[0])
+
     def test_review_prompt_preserves_bundle_ending_whitespace(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:
             repo = init_repo(Path(tempdir))
             bundle = "# Commit Diff\n+Markdown hard break  \n+\n"
+            instructions = "  Keep all instructions. \t\n"
+            evidence = "  source indentation\r\n  ending whitespace \t"
             prompt = self.helper["render_review_prompt"](
-                repo,
+                self.helper["current_branch"](repo),
                 "commit",
                 "HEAD",
                 self.helper["ReviewChunk"](bundle),
-                "",
-                "",
+                instructions,
+                evidence,
             )
 
         self.assertTrue(prompt.endswith(bundle))
+        self.assertIn(instructions, prompt)
+        self.assertIn(evidence, prompt)
 
     def test_many_review_passes_preserve_late_findings_and_fail_closed(self) -> None:
         args = argparse.Namespace(
@@ -2054,10 +2206,10 @@ Path(__file__).with_name("scan.json").write_text(json.dumps({
             self.assertIn("# Prompt file: review.md", prompt)
             self.assertFalse(truncated)
 
-    def test_build_prompt_omits_absolute_repo_path_and_caps_aggregate_input(self) -> None:
+    def test_review_prompts_omit_absolute_repo_path_and_keep_instructions_whole(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:
             repo = init_repo(Path(tempdir))
-            prompt = self.helper["build_prompt"](repo, "local", None, "diff", "", "")
+            prompt, = self.helper["build_review_prompts"](repo, "local", None, "diff", "", [])
 
             self.assertIn(
                 "Review sandbox: . (intentionally contains no reviewed repository files)",
@@ -2069,14 +2221,14 @@ Path(__file__).with_name("scan.json").write_text(json.dumps({
                 prompt,
             )
             self.assertNotIn(str(repo), prompt)
-            with self.assertRaisesRegex(SystemExit, "aggregate limit"):
-                self.helper["build_prompt"](
+            with self.assertRaisesRegex(SystemExit, "too little room"):
+                self.helper["build_review_prompts"](
                     repo,
                     "local",
                     None,
+                    "diff",
                     "x" * self.helper["MAX_REVIEW_PROMPT_BYTES"],
-                    "",
-                    "",
+                    [],
                 )
 
     def test_read_text_truncates_without_scanning_tail(self) -> None:
@@ -3567,21 +3719,24 @@ Path(__file__).with_name("scan.json").write_text(json.dumps({
     @unittest.skipUnless(os.name == "posix", "process groups require POSIX")
     def test_streaming_deadline_kills_sigterm_resistant_continuous_output(self) -> None:
         child = (
-            "import signal,time; "
+            "import signal,sys,time; from pathlib import Path; "
             "signal.signal(signal.SIGTERM, signal.SIG_IGN); "
+            "Path(sys.argv[1]).touch(); "
             "time.sleep(60)"
         )
         script = (
             "import signal,subprocess,sys,time; "
             "signal.signal(signal.SIGTERM, signal.SIG_IGN); "
-            f"child=subprocess.Popen([sys.executable, '-c', {child!r}]); "
+            f"child=subprocess.Popen([sys.executable, '-c', {child!r}, sys.argv[1]]); "
             "print(child.pid, flush=True); "
             "\nwhile True: print('tick', flush=True); time.sleep(0.005)"
         )
         started = time.monotonic()
-        with tempfile.TemporaryDirectory() as tempdir:
+        with tempfile.TemporaryDirectory() as tempdir, deadline_after_reviewer_ready(
+            self.helper, Path(tempdir) / "ready",
+        ):
             result = self.helper["run_with_heartbeat"](
-                [sys.executable, "-c", script],
+                [sys.executable, "-c", script, str(Path(tempdir) / "ready")],
                 Path(tempdir),
                 label="streaming-reviewer",
                 heartbeat_seconds=0.01,
@@ -3603,16 +3758,18 @@ Path(__file__).with_name("scan.json").write_text(json.dumps({
     def test_deadline_bounds_drain_when_descendant_retains_pipe(self) -> None:
         child = "import time; time.sleep(60)"
         script = (
-            "import subprocess,sys; "
+            "import subprocess,sys; from pathlib import Path; "
             f"child=subprocess.Popen([sys.executable, '-c', {child!r}], start_new_session=True); "
-            "print(child.pid, flush=True)"
+            "print(child.pid, flush=True); Path(sys.argv[1]).touch()"
         )
         for stream_output in (False, True):
             with self.subTest(stream_output=stream_output):
                 child_pid: int | None = None
                 started = time.monotonic()
                 try:
-                    with tempfile.TemporaryDirectory() as tempdir, mock.patch.dict(
+                    with tempfile.TemporaryDirectory() as tempdir, deadline_after_reviewer_ready(
+                        self.helper, Path(tempdir) / "ready",
+                    ), mock.patch.dict(
                         self.helper["EngineRuntimeDeadline"].terminate.__globals__,
                         {
                             "_TIMED_OUT_STREAM_DRAIN_SECONDS": 0.05,
@@ -3623,7 +3780,7 @@ Path(__file__).with_name("scan.json").write_text(json.dumps({
                         },
                     ):
                         result = self.helper["run_with_heartbeat"](
-                            [sys.executable, "-c", script],
+                            [sys.executable, "-c", script, str(Path(tempdir) / "ready")],
                             Path(tempdir),
                             label="retained-pipe-reviewer",
                             heartbeat_seconds=0.01,

--- a/skills/autoreview/tests/test_autoreview_hardening.py
+++ b/skills/autoreview/tests/test_autoreview_hardening.py
@@ -1170,7 +1170,7 @@ Path(__file__).with_name("scan.json").write_text(json.dumps({
                     for line in range(1_400)
                 ]
                 expected_lines.extend(lines)
-                (repo / path).write_text("\n".join(lines) + "\n", encoding="utf-8")
+                (repo / path).write_bytes(("\n".join(lines) + "\n").encode("utf-8"))
                 paths.append(path)
             datasets, truncated = self.helper["load_datasets"](
                 argparse.Namespace(dataset=paths), repo


### PR DESCRIPTION
Autoreview split large diffs but repeated every dataset in each pass. Once source evidence exceeded the per-pass budget, a safe complete review was rejected before reaching the engine.

Keep validated dataset paths and content as records, partition evidence with UTF-8 offsets, and review the complete change against every evidence batch. Preserve complete instructions in every pass. Measure rendered prompt sizes, including continuation headers, and reduce evidence allocation when needed instead of reserving an unconditional 64 KB or requiring 16 KB change chunks. Resolve the branch once while preparing the pass sequence.

Scan the complete frozen input before any partitioned send so credentials cannot cross an unseen chunk boundary. Keep every exact outgoing-pack scan, engine isolation, binary/truncated-input refusal, and all-pass report validation. Remove the unused single-prompt builder. The two existing process-termination fixtures now wait for child readiness before arming their test deadlines; production timeouts are unchanged.

Validation:

- Regression failed before the repair at both 512 KB and 120 KB budgets; complete evidence/change coverage passes afterward.
- Instruction-heavy inputs, 30 KB budgets, long continuation headers, UTF-8/whitespace/path preservation, and scanner boundary failures are covered.
- Python 3.14: the integrated 208-test suite passed with one platform skip (140.004 seconds); six installer tests, nine validator tests, skill validation, compilation, shell syntax, and whitespace checks passed.
- The previously rejected full OpenClaw review input passed the real scanner and reviewer preflight without changing its candidate diff.
- Fresh live Codex Autoreview of the integrated candidate completed both bounded passes with no accepted/actionable P0 findings (`scoped-clean`). Two unchanged credential-shaped proxy fixtures were excluded from optional source context after the scanner correctly refused them; the entire change diff and production owners were reviewed.

Tooling delta: +109 lines; tests: +157; documentation: +7. The added tooling owns evidence records, complete-input scanning, and two-dimensional prompt partitioning. No new dependencies, flags, or larger engine limits. Evidence batches can increase review cost, and a single pass still cannot see evidence from every other batch.

Terminal proof (selected actual stdout; private model routing identifiers omitted, no prompt or reviewer transcript):

Formerly rejected complete Gateway input

```text
review prompt files and datasets leave too little room for change chunks; reduce the extra review context
```

Same Gateway candidate, scanner and engine preflight

```text
bundle: constructible
inputs: OK
prompt: OK
engine check: codex [model omitted] thinking=high OK
```

Live two-pass Codex review of the repair

```text
bundle: 32116 bytes; review passes: 2
review pass: 1/2 (424994 prompt bytes)
review pass: 2/2 (192870 prompt bytes)
autoreview chunked scoped-clean: no accepted/actionable findings in the selected Git scope and priority
```

Live result (provider pass reports preserved):

```json
{
  "findings": [],
  "overall_correctness": "patch is correct",
  "overall_explanation": "Review passes returned. chunk 1/2: 0 finding(s), chunk 2/2: 0 finding(s). See preserved pass reports for provider conclusions.",
  "overall_confidence": 0.96,
  "pass_reports": [
    {
      "label": "chunk 1/2",
      "report": {
        "findings": [],
        "overall_correctness": "patch is correct",
        "overall_explanation": "No actionable P0 defects were identified in the supplied change bundle. Evidence batching retains pre-send scanning, reviewer isolation, and complete-result merging.",
        "overall_confidence": 0.96
      }
    },
    {
      "label": "chunk 2/2",
      "report": {
        "findings": [],
        "overall_correctness": "patch is correct",
        "overall_explanation": "No actionable P0 defects were identified in the supplied change bundle. This verdict is limited to the requested P0 threshold.",
        "overall_confidence": 0.97
      }
    }
  ],
  "review_status": "scoped-clean"
}
```

CI follow-through: the first Windows run exposed fixture newline conversion, not lost review bytes. Explicit UTF-8 fixture writes fixed it without relaxing assertions. A second run then exposed a newly merged main-branch test calling the removed single-prompt builder; integrating current main and migrating that caller to `build_review_prompts` resolved it while retaining the current scanner and result-audit contracts. No CI gate was bypassed.

Exact-head validation is green for `06dfb759a3ff72f07a3dceb886f11aafe43a2b28`: [Linux and Windows validate](https://github.com/openclaw/agent-skills/actions/runs/33199973361), [CodeQL](https://github.com/openclaw/agent-skills/actions/runs/33199967666). The fresh two-pass review covered the complete candidate diff against `a3847edbd0000e0223336f7277eb8e5a1ce73d7e`; the diff remained unchanged during tests and review.
