### PR TITLE
fix(autoreview): report preparation and protect evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Show Autoreview preparation progress, reuse captured bundle membership, and guard explicit evidence against content and path changes while preserving full-tree integrity checks.
 - Partition oversized Autoreview evidence without dropping change context, keeping complete-input and per-pass credential scans within existing engine limits.
 - Preserve exact outgoing autoreview scan bytes on Windows instead of translating line endings.
 - Fix autoreview credential-source inclusion and scope-filtered results, preserving provider verdicts and rejected findings while documenting complete PR-plus-dirty review.

--- a/skills/autoreview/SKILL.md
+++ b/skills/autoreview/SKILL.md
@@ -209,6 +209,22 @@ finite pass sequence. The helper prints its size and pass count before running
 passes serially. Each pass retains the same prompt-size limit, secret scan, and
 reviewer isolation; a failed pass aborts without publishing a partial verdict.
 
+Preparation prints immediate phase updates and periodic elapsed time to stderr,
+with file/byte counts during hashing and no filenames or contents. These updates
+are separate from provider heartbeats and do not count against engine deadlines.
+Bundle construction captures finding membership alongside validated text; normal
+and dry runs reuse that record without reopening untracked files for membership.
+
+Dry runs reuse capture and scanning without whole-tree integrity sweeps. Real
+reviews retain full fresh tree hashing before bundle construction, before review,
+and before publication, including unrelated tracked files, nonignored untracked files, index
+state, and initialized submodules. Explicit prompt files and datasets also retain
+their own frozen bytes and raw path identities, regardless of Git ignore status
+or finding scope. They are revalidated before sending each pass and before
+publication; content changes, replacements, and leaf or ancestor symlink swaps
+refuse stale results. These endpoint checks are not atomic filesystem snapshots
+and cannot guarantee detection of transient changes restored between checks.
+
 Evidence batches can multiply the pass count. Chunking cannot give one model
 call every cross-file implementation detail. For architecture-heavy changes, still prefer
 a coherent branch or PR shape whose semantic decision surface fits one pass.
@@ -356,7 +372,7 @@ The helper:
 - use `--mode commit --commit <ref>` for already-committed work, especially clean `main` after landing
 - validates complete Git patches, scans every outgoing review pack, reviews them in one pass up to the aggregate prompt limit, and automatically uses complete bounded passes above it
 - uses branch mode for committed-only PR work, or explicit local mode with a pinned merge base for a complete PR plus dirty candidate
-- writes only to stdout unless `--output`, `--json-output`, or live streamed engine stderr is set
+- writes reports to stdout and optionally to `--output` or `--json-output` files; preparation progress and provider heartbeats use stderr
 - supports `--dry-run` (validates bundle construction, reviewer CLI resolution, and local isolation startup with version/help probes without contacting a provider; exits nonzero if any check fails), an opt-in per-reviewer wall-clock bound via `--engine-timeout-seconds`, `--prompt`, repo-relative `--prompt-file`, repo-relative `--dataset`, `--no-tools`, `--no-web-search`, repeatable Codex-only safe model/response tuning with `--codex-config key=value`, Codex-only `--codex-speed fast|flex|default`, and commit refs
 - supports `--stream-engine-output` or `AUTOREVIEW_STREAM_ENGINE_OUTPUT=1` for live engine text while preserving structured validation; Codex and Claude hide tool/file event details, emit compact activity summaries, and report usage at turn completion
 - supports per-engine `--model`, `--thinking`, and Claude `--fallback-model`

--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -173,6 +173,78 @@ class ReviewDataset(NamedTuple):
     byte_offset: int = 0
 
 
+class CapturedBundle(NamedTuple):
+    text: str
+    truncated: bool
+    paths: set[str]
+
+
+class EvidenceFile(NamedTuple):
+    raw_path: str
+    label: str
+    path: Path
+    content: str
+    truncated: bool
+    topology: tuple[tuple[int, int, int], ...]
+
+
+class EvidenceInputs(NamedTuple):
+    prompt: str
+    datasets: list[ReviewDataset]
+    truncated: bool
+    files: list[EvidenceFile]
+
+
+class PreparationProgress:
+    """Own a quiet, path-free ticker only while preparing or verifying inputs."""
+
+    def __init__(self, phase: str):
+        self.phase = phase
+        self.started = time.monotonic()
+        self.last_report = self.started
+        self.files = 0
+        self.bytes = 0
+        self.lock = threading.Lock()
+        self.stopped = threading.Event()
+        self.thread = threading.Thread(target=self._run, name="autoreview-preparation")
+
+    def __enter__(self):
+        print(f"preparation: {self.phase}", file=sys.stderr, flush=True)
+        try:
+            self.thread.start()
+        except BaseException:
+            self.stopped.set()
+            if self.thread.ident is not None:
+                self.thread.join()
+            raise
+        return self
+
+    def __exit__(self, *_exc):
+        self.stopped.set()
+        self.thread.join()
+
+    def advance(self, *, files: int = 0, bytes: int = 0) -> None:
+        with self.lock:
+            self.files += files
+            self.bytes += bytes
+
+    def _report(self) -> None:
+        now = time.monotonic()
+        if now - self.last_report < 15:
+            return
+        with self.lock:
+            counts = f"files={self.files} bytes={self.bytes}"
+        print(
+            f"preparation: {self.phase} elapsed={int(now - self.started)}s {counts}",
+            file=sys.stderr, flush=True,
+        )
+        self.last_report = now
+
+    def _run(self) -> None:
+        while not self.stopped.wait(15):
+            self._report()
+
+
 DEFAULT_ENGINE_PATHS = ("/usr/local/bin", "/usr/bin", "/bin")
 # Keep this explicit: suffix matching leaks unrelated process credentials such
 # as package-registry and telemetry tokens into reviewer subprocesses.
@@ -2190,15 +2262,6 @@ def collect_untracked_file_snapshots(
     return included, omitted
 
 
-def safe_untracked_file_snapshots(repo: Path) -> list[tuple[str, str, bool]]:
-    snapshots, _omitted = collect_untracked_file_snapshots(repo)
-    return snapshots
-
-
-def safe_untracked_files(repo: Path) -> list[str]:
-    return [rel for rel, _content, _truncated in safe_untracked_file_snapshots(repo)]
-
-
 def local_status(repo: Path, untracked: list[str], *, redact: bool = False) -> str:
     if redact:
         return REVIEW_SECURITY_OMISSION
@@ -2208,7 +2271,7 @@ def local_status(repo: Path, untracked: list[str], *, redact: bool = False) -> s
     return "\n".join(lines)
 
 
-def local_bundle(repo: Path, base_ref: str | None = None) -> tuple[str, bool]:
+def local_bundle(repo: Path, base_ref: str | None = None) -> CapturedBundle:
     if base_ref is not None:
         base_ref = validate_git_ref(repo, base_ref, "base", pin=True)
     staged_base = ("--end-of-options", base_ref) if base_ref is not None else ()
@@ -2307,10 +2370,13 @@ def local_bundle(repo: Path, base_ref: str | None = None) -> tuple[str, bool]:
                     for line_number, record in enumerate(records, start=1)
                 )
             )
-    return "\n\n".join(parts), input_truncated
+    paths = (set(staged_paths) - staged_blocked_paths) | (set(unstaged_paths) - unstaged_blocked_paths)
+    return CapturedBundle("\n\n".join(parts), input_truncated, paths | set(untracked))
 
 
-def source_file_fingerprint(path: Path) -> tuple[str, int, int, str]:
+def source_file_fingerprint(
+    path: Path, progress: PreparationProgress | None = None,
+) -> tuple[str, int, int, str]:
     try:
         before = os.stat(path, follow_symlinks=False)
     except FileNotFoundError:
@@ -2364,6 +2430,8 @@ def source_file_fingerprint(path: Path) -> tuple[str, int, int, str]:
             raise OSError("file changed while opening")
         while chunk := os.read(descriptor, 1024 * 1024):
             digest.update(chunk)
+            if progress is not None:
+                progress.advance(bytes=len(chunk))
         after = os.fstat(descriptor)
         if (
             opened.st_dev,
@@ -2392,6 +2460,7 @@ def source_file_fingerprint(path: Path) -> tuple[str, int, int, str]:
 
 def source_tree_snapshot(
     repo: Path,
+    progress: PreparationProgress | None = None,
 ) -> tuple[
     str,
     str,
@@ -2448,22 +2517,25 @@ def source_tree_snapshot(
         "--exclude-standard",
         "-z",
     )
-    fingerprints = tuple(
-        (
+    fingerprints = []
+    for rel in sorted(set(tracked + untracked)):
+        fingerprints.append((
             rel,
-            source_tree_snapshot(repo / rel)
+            source_tree_snapshot(repo / rel, progress)
             if index_modes.get(rel) == "160000"
             and (repo / rel / ".git").exists()
-            else source_file_fingerprint(repo / rel),
-        )
-        for rel in sorted(set(tracked + untracked))
-    )
-    return head, index_entries, fingerprints
+            else source_file_fingerprint(repo / rel, progress),
+        ))
+        if progress is not None:
+            progress.advance(files=1)
+    return head, index_entries, tuple(fingerprints)
 
 
-def branch_bundle(repo: Path, base_ref: str) -> tuple[str, bool]:
-    base_ref = validate_git_ref(repo, base_ref, "base")
-    diff_range = f"{base_ref}...HEAD"
+def branch_bundle(repo: Path, base_ref: str) -> CapturedBundle:
+    base_label = base_ref
+    base_ref = validate_git_ref(repo, base_ref, "base", pin=True)
+    head_ref = validate_git_ref(repo, "HEAD", "commit", pin=True)
+    diff_range = f"{base_ref}...{head_ref}"
     branch_patch = git(
         repo,
         "diff",
@@ -2511,10 +2583,10 @@ def branch_bundle(repo: Path, base_ref: str) -> tuple[str, bool]:
         branch_paths,
         branch_patch,
     )
-    return "\n\n".join(
+    return CapturedBundle("\n\n".join(
         [
             "# Branch Diff",
-            f"base: {base_ref}",
+            f"base: {base_label}",
             (
                 REVIEW_SECURITY_OMISSION
                 if omitted_tracked
@@ -2529,11 +2601,12 @@ def branch_bundle(repo: Path, base_ref: str) -> tuple[str, bool]:
             ),
             branch_patch,
         ]
-    ), False
+    ), False, set(branch_paths) - tracked_sensitive_paths(branch_paths))
 
 
-def commit_bundle(repo: Path, commit_ref: str) -> tuple[str, bool]:
-    commit_ref = validate_git_ref(repo, commit_ref, "commit")
+def commit_bundle(repo: Path, commit_ref: str) -> CapturedBundle:
+    commit_label = commit_ref
+    commit_ref = validate_git_ref(repo, commit_ref, "commit", pin=True)
     parents = git(repo, "rev-list", "--parents", "-n", "1", commit_ref).split()
     if len(parents) > 2:
         raise SystemExit(
@@ -2602,56 +2675,23 @@ def commit_bundle(repo: Path, commit_ref: str) -> tuple[str, bool]:
     )
     if omitted_tracked:
         commit_summary = REVIEW_SECURITY_OMISSION
-    return "\n\n".join(
+    return CapturedBundle("\n\n".join(
         [
             "# Commit Diff",
-            f"commit: {commit_ref}",
+            f"commit: {commit_label}",
             commit_summary,
             commit_patch,
         ]
-    ), False
+    ), False, set(commit_paths) - tracked_sensitive_paths(commit_paths))
 
 
-def review_paths(repo: Path, target: str, target_ref: str | None, commit_ref: str) -> set[str]:
-    names: set[str] = set()
+def build_bundle(repo: Path, target: str, target_ref: str | None, commit_ref: str) -> CapturedBundle:
     if target == "local":
-        if target_ref is not None:
-            target_ref = validate_git_ref(repo, target_ref, "base", pin=True)
-        staged_base = ("--end-of-options", target_ref) if target_ref is not None else ()
-        names.update(git_path_list(repo, "diff", *SAFE_DIFF_FLAGS, "--name-only", "--cached", "-z", *staged_base))
-        names.update(git_path_list(repo, "diff", *SAFE_DIFF_FLAGS, "--name-only", "-z"))
-    elif target == "branch":
+        return local_bundle(repo, target_ref)
+    if target == "branch":
         assert target_ref
-        target_ref = validate_git_ref(repo, target_ref, "base")
-        names.update(
-            git_path_list(
-                repo,
-                "diff",
-                *SAFE_DIFF_FLAGS,
-                "--name-only",
-                "-z",
-                "--end-of-options",
-                f"{target_ref}...HEAD",
-            )
-        )
-    else:
-        commit_ref = validate_git_ref(repo, commit_ref, "commit")
-        names.update(
-            git_path_list(
-                repo,
-                "show",
-                *SAFE_DIFF_FLAGS,
-                "--name-only",
-                "--format=",
-                "-z",
-                "--end-of-options",
-                commit_ref,
-            )
-        )
-    names.difference_update(tracked_sensitive_paths(list(names)))
-    if target == "local":
-        names.update(safe_untracked_files(repo))
-    return names
+        return branch_bundle(repo, target_ref)
+    return commit_bundle(repo, commit_ref)
 
 
 def validate_evidence_file(repo: Path, raw_path: str, label: str) -> tuple[Path, str, bool]:
@@ -2673,26 +2713,59 @@ def validate_evidence_file(repo: Path, raw_path: str, label: str) -> tuple[Path,
     return path, content, truncated
 
 
-def load_extra_prompt(args: argparse.Namespace, repo: Path) -> tuple[str, bool]:
-    chunks: list[str] = []
-    input_truncated = False
-    for value in args.prompt or []:
-        chunks.append(value)
-    for path in args.prompt_file or []:
-        resolved, content, truncated = validate_evidence_file(repo, path, "--prompt-file")
-        input_truncated = input_truncated or truncated
-        chunks.append(f"# Prompt file: {resolved.relative_to(repo.resolve())}\n{content}")
-    return "\n\n".join(chunks), input_truncated
+def evidence_topology(repo: Path, raw_path: str) -> tuple[tuple[int, int, int], ...]:
+    # Inspect the supplied path, not just its resolved leaf. Directory identity
+    # excludes mtime: unrelated siblings may change without changing this input.
+    current = repo.resolve()
+    identities = []
+    for part in Path(raw_path).parts:
+        current = current / part
+        try:
+            info = os.stat(current, follow_symlinks=False)
+        except OSError as exc:
+            raise SystemExit(f"evidence changed or became unreadable: {raw_path}") from exc
+        if stat.S_ISLNK(info.st_mode):
+            raise SystemExit("refusing symlinked evidence")
+        identities.append((info.st_dev, info.st_ino, info.st_mode))
+    return tuple(identities)
 
 
-def load_datasets(args: argparse.Namespace, repo: Path) -> tuple[list[ReviewDataset], bool]:
-    chunks: list[ReviewDataset] = []
-    input_truncated = False
-    for spec in args.dataset or []:
-        path, content, truncated = validate_evidence_file(repo, spec, "--dataset")
-        input_truncated = input_truncated or truncated
-        chunks.append(ReviewDataset(str(path.relative_to(repo.resolve())), content))
-    return chunks, input_truncated
+def capture_evidence_file(repo: Path, raw_path: str, label: str) -> EvidenceFile:
+    # Keep evidence's stricter role validation even for tracked source paths.
+    original = Path(raw_path)
+    if original.is_absolute() or ".." in original.parts or not original.parts:
+        raise SystemExit(f"{label} must be a repo-relative path: {raw_path}")
+    before = evidence_topology(repo, raw_path)
+    path, content, truncated = validate_evidence_file(repo, raw_path, label)
+    if evidence_topology(repo, raw_path) != before:
+        raise SystemExit("evidence changed while being captured")
+    return EvidenceFile(raw_path, label, path, content, truncated, before)
+
+
+def capture_evidence_inputs(args: argparse.Namespace, repo: Path) -> EvidenceInputs:
+    chunks = list(args.prompt or [])
+    datasets = []
+    files = []
+    for label, paths in (("--prompt-file", args.prompt_file), ("--dataset", args.dataset)):
+        for raw_path in paths or []:
+            record = capture_evidence_file(repo, raw_path, label)
+            files.append(record)
+            rel = str(record.path.relative_to(repo.resolve()))
+            if label == "--prompt-file":
+                chunks.append(f"# Prompt file: {rel}\n{record.content}")
+            else:
+                datasets.append(ReviewDataset(rel, record.content))
+    return EvidenceInputs("\n\n".join(chunks), datasets, any(f.truncated for f in files), files)
+
+
+def verify_evidence(repo: Path, files: list[EvidenceFile]) -> None:
+    for record in files:
+        try:
+            current = capture_evidence_file(repo, record.raw_path, record.label)
+        except SystemExit as exc:
+            raise SystemExit("evidence changed or became unsafe; rerun autoreview") from exc
+        if current != record:
+            raise SystemExit("evidence changed; rerun autoreview against the updated inputs")
 
 
 def render_datasets(datasets: list[ReviewDataset]) -> str:
@@ -5890,7 +5963,7 @@ def dry_run_preflight(
     contacting any review engine: that the review bundle can be built for
     the chosen target, that --prompt-file and --dataset inputs resolve
     and pass the same repo-relative/existence checks the real run applies
-    via load_extra_prompt/load_datasets, that the assembled prompt(s) pass
+    via capture_evidence_inputs, that the assembled prompt(s) pass
     the same aggregate-size/partition and truncation-refusal checks the
     real run applies via build_review_prompts/ensure_reviewer_input_complete
     and the same fail-closed TruffleHog scan of each exact outgoing prompt
@@ -5901,48 +5974,27 @@ def dry_run_preflight(
     process exit status: 0 when every check passes, 1 otherwise.
     """
     ok = True
-    bundle = ""
-    bundle_truncated = False
+    inputs_ok = True
+    evidence = EvidenceInputs("", [], False, [])
+    try:
+        with PreparationProgress("evidence selection"):
+            evidence = capture_evidence_inputs(args, repo)
+        print("inputs: OK", flush=True)
+    except (SystemExit, Exception) as exc:
+        ok = inputs_ok = False
+        print(f"inputs: FAILED ({exc})", flush=True)
+
+    captured = CapturedBundle("", False, set())
     bundle_ok = True
     try:
-        if target == "local":
-            bundle, bundle_truncated = local_bundle(repo, target_ref)
-        elif target == "branch":
-            assert target_ref
-            bundle, bundle_truncated = branch_bundle(repo, target_ref)
-        else:
-            bundle, bundle_truncated = commit_bundle(repo, args.commit)
-            # Mirror main()'s post-commit_bundle() assignment (see main() just
-            # after the commit_bundle() call above) so the prompt built below
-            # includes the commit reference the real run would include.
+        with PreparationProgress("bundle preparation"):
+            captured = build_bundle(repo, target, target_ref, args.commit)
+        if target == "commit":
             target_ref = args.commit
-        print("bundle: constructible")
-    except SystemExit as exc:
-        ok = False
-        bundle_ok = False
-        print(f"bundle: FAILED ({exc.code})")
-    except Exception as exc:
-        ok = False
-        bundle_ok = False
-        print(f"bundle: FAILED ({exc})")
-
-    extra_prompt = ""
-    datasets: list[ReviewDataset] = []
-    prompt_truncated = False
-    datasets_truncated = False
-    inputs_ok = True
-    try:
-        extra_prompt, prompt_truncated = load_extra_prompt(args, repo)
-        datasets, datasets_truncated = load_datasets(args, repo)
-        print("inputs: OK")
-    except SystemExit as exc:
-        ok = False
-        inputs_ok = False
-        print(f"inputs: FAILED ({exc.code})")
-    except Exception as exc:
-        ok = False
-        inputs_ok = False
-        print(f"inputs: FAILED ({exc})")
+        print("bundle: constructible", flush=True)
+    except (SystemExit, Exception) as exc:
+        ok = bundle_ok = False
+        print(f"bundle: FAILED ({exc})", flush=True)
 
     # The normal path (see main() below) does not stop at per-file
     # validation: it also assembles the final prompt(s) and enforces the
@@ -5952,22 +6004,20 @@ def dry_run_preflight(
     # inputs a real run rejects once combined.
     if bundle_ok and inputs_ok:
         try:
-            input_truncated = bundle_truncated or prompt_truncated or datasets_truncated
-            if reviewers:
-                ensure_reviewer_input_complete(reviewers[0], input_truncated)
-            threshold_extra_prompt = apply_finding_threshold_prompt(args, extra_prompt)
-            prompts = prepare_review_prompts(
-                repo,
-                target,
-                target_ref,
-                bundle,
-                threshold_extra_prompt,
-                datasets,
-                max_prompt_bytes_for_reviewers(reviewers),
-            )
-            for prompt in prompts:
-                scan_outgoing_review_pack(repo, prompt)
-            print("prompt: OK")
+            with PreparationProgress("bundle/evidence preparation and scan"):
+                input_truncated = captured.truncated or evidence.truncated
+                if reviewers:
+                    ensure_reviewer_input_complete(reviewers[0], input_truncated)
+                threshold_extra_prompt = apply_finding_threshold_prompt(args, evidence.prompt)
+                prompts = prepare_review_prompts(
+                    repo, target, target_ref, captured.text, threshold_extra_prompt,
+                    evidence.datasets, max_prompt_bytes_for_reviewers(reviewers),
+                )
+                for prompt in prompts:
+                    scan_outgoing_review_pack(repo, prompt)
+            with PreparationProgress("evidence verification"):
+                verify_evidence(repo, evidence.files)
+            print("prompt: OK", flush=True)
         except SystemExit as exc:
             ok = False
             print(f"prompt: FAILED ({exc.code})")
@@ -5978,7 +6028,8 @@ def dry_run_preflight(
         print("prompt: SKIPPED (bundle or inputs failed above)")
 
     for reviewer in reviewers:
-        available, reason = resolve_engine_binary(reviewer, repo)
+        with PreparationProgress("reviewer isolation preflight"):
+            available, reason = resolve_engine_binary(reviewer, repo)
         label = reviewer_label(reviewer)
         if available:
             print(f"engine check: {label} OK")
@@ -5996,9 +6047,12 @@ def run_reviewer(
     changed_paths: set[str],
     required: list[str],
     input_truncated: bool = False,
+    evidence: list[EvidenceFile] | None = None,
 ) -> dict[str, Any]:
     ensure_reviewer_input_complete(args, input_truncated)
-    scan_outgoing_review_pack(repo, prompt)
+    with PreparationProgress("outgoing pack scan and evidence verification"):
+        scan_outgoing_review_pack(repo, prompt)
+        verify_evidence(repo, evidence or [])
     raw = run_engine(args, repo, prompt)
     report = extract_json(raw)
     validate_report(report, repo, changed_paths, [])
@@ -6057,6 +6111,7 @@ def run_review_passes(
     prompts: list[str],
     changed_paths: set[str],
     input_truncated: bool,
+    evidence: list[EvidenceFile] | None = None,
 ) -> list[tuple[str, dict[str, Any]]]:
     chunk_reports: list[tuple[str, dict[str, Any]]] = []
     for index, prompt in enumerate(prompts, start=1):
@@ -6072,6 +6127,7 @@ def run_review_passes(
             changed_paths,
             [],
             input_truncated,
+            evidence,
         )
         chunk_reports.append((f"chunk {index}/{len(prompts)}", chunk_report))
     return chunk_reports
@@ -6135,72 +6191,68 @@ def main() -> int:
 def main_impl() -> int:
     args = parse_args()
     reviewers = reviewer_args(args)
-    repo = repo_root()
-    reject_repo_output_paths(args, repo)
-    target, target_ref = choose_target(repo, args.mode, args.base)
-    print(f"autoreview target: {target}")
-    print(f"branch: {current_branch(repo)}")
+    with PreparationProgress("target selection"):
+        repo = repo_root()
+        reject_repo_output_paths(args, repo)
+        target, target_ref = choose_target(repo, args.mode, args.base)
+        branch = current_branch(repo)
+    print(f"autoreview target: {target}", flush=True)
+    print(f"branch: {branch}", flush=True)
     reviewer = reviewers[0]
-    print(f"engine: {reviewer.engine}")
+    print(f"engine: {reviewer.engine}", flush=True)
     if reviewer.model:
-        print(f"model: {reviewer.model}")
+        print(f"model: {reviewer.model}", flush=True)
     if getattr(reviewer, "fallback_model", None):
-        print(f"fallback_model: {reviewer.fallback_model}")
+        print(f"fallback_model: {reviewer.fallback_model}", flush=True)
     if reviewer.thinking:
-        print(f"thinking: {reviewer.thinking}")
+        print(f"thinking: {reviewer.thinking}", flush=True)
     if reviewer.engine == "codex":
         config_keys = codex_config_keys(reviewer)
         if config_keys:
-            print(f"codex_config_keys: {', '.join(config_keys)}")
+            print(f"codex_config_keys: {', '.join(config_keys)}", flush=True)
         speed = codex_speed_override(reviewer)
         if speed:
-            print(f"codex_speed: {speed}")
-    print(f"tools: {'on' if reviewer.tools else 'off'}")
-    print(f"web_search: {'on' if args.web_search else 'off'}")
+            print(f"codex_speed: {speed}", flush=True)
+    print(f"tools: {'on' if reviewer.tools else 'off'}", flush=True)
+    print(f"web_search: {'on' if args.web_search else 'off'}", flush=True)
     display_ref = args.commit if target == "commit" else target_ref
     if display_ref:
-        print(f"ref: {display_ref}")
+        print(f"ref: {display_ref}", flush=True)
     if args.dry_run:
         return dry_run_preflight(args, reviewers, repo, target, target_ref)
 
-    review_source_snapshot = source_tree_snapshot(repo)
-    if target == "local":
-        bundle, bundle_truncated = local_bundle(repo, target_ref)
-    elif target == "branch":
-        assert target_ref
-        bundle, bundle_truncated = branch_bundle(repo, target_ref)
-    else:
-        bundle, bundle_truncated = commit_bundle(repo, args.commit)
-        target_ref = args.commit
-    extra_prompt, prompt_truncated = load_extra_prompt(args, repo)
-    extra_prompt = apply_finding_threshold_prompt(args, extra_prompt)
-    datasets, datasets_truncated = load_datasets(args, repo)
-    input_truncated = bundle_truncated or prompt_truncated or datasets_truncated
-    max_prompt_bytes = max_prompt_bytes_for_reviewers(reviewers)
-    ensure_reviewer_input_complete(reviewer, input_truncated)
-    prompts = prepare_review_prompts(
-        repo,
-        target,
-        target_ref,
-        bundle,
-        extra_prompt,
-        datasets,
-        max_prompt_bytes,
-    )
-    changed_paths = review_paths(repo, target, target_ref, args.commit)
-    print(f"bundle: {utf8_size(bundle)} bytes; review passes: {len(prompts)}")
-    if source_tree_snapshot(repo) != review_source_snapshot:
-        raise SystemExit(
-            "source changed while the review bundle was being created; "
-            "rerun autoreview against the updated tree"
+    with PreparationProgress("evidence selection"):
+        evidence = capture_evidence_inputs(args, repo)
+    with PreparationProgress("initial source snapshot") as progress:
+        review_source_snapshot = source_tree_snapshot(repo, progress)
+    with PreparationProgress("bundle/evidence preparation and scan"):
+        captured = build_bundle(repo, target, target_ref, args.commit)
+        if target == "commit":
+            target_ref = args.commit
+        extra_prompt = apply_finding_threshold_prompt(args, evidence.prompt)
+        input_truncated = captured.truncated or evidence.truncated
+        ensure_reviewer_input_complete(reviewer, input_truncated)
+        prompts = prepare_review_prompts(
+            repo, target, target_ref, captured.text, extra_prompt, evidence.datasets,
+            max_prompt_bytes_for_reviewers(reviewers),
         )
+    print(f"bundle: {utf8_size(captured.text)} bytes; review passes: {len(prompts)}", flush=True)
+    with PreparationProgress("pre-review verification") as progress:
+        current_snapshot = source_tree_snapshot(repo, progress)
+        verify_evidence(repo, evidence.files)
+        if current_snapshot != review_source_snapshot:
+            raise SystemExit(
+                "source changed while the review bundle was being created; "
+                "rerun autoreview against the updated tree"
+            )
     chunk_reports = run_review_passes(
         args,
         reviewers,
         repo,
         prompts,
-        changed_paths,
+        captured.paths,
         input_truncated,
+        evidence.files,
     )
     if len(chunk_reports) == 1:
         report = chunk_reports[0][1]
@@ -6214,13 +6266,16 @@ def main_impl() -> int:
     if len(chunk_reports) > 1:
         label += " chunked"
 
-    if source_tree_snapshot(repo) != review_source_snapshot:
-        print(
-            "source changed after the review bundle was created; "
-            "rerun autoreview against the updated tree",
-            file=sys.stderr,
-        )
-        return 1
+    with PreparationProgress("final source verification") as progress:
+        current_snapshot = source_tree_snapshot(repo, progress)
+        verify_evidence(repo, evidence.files)
+        if current_snapshot != review_source_snapshot:
+            print(
+                "source changed after the review bundle was created; "
+                "rerun autoreview against the updated tree",
+                file=sys.stderr,
+            )
+            return 1
 
     if args.json_output:
         atomic_write_text(

--- a/skills/autoreview/tests/test_autoreview_hardening.py
+++ b/skills/autoreview/tests/test_autoreview_hardening.py
@@ -278,6 +278,316 @@ class AutoreviewHardeningTests(unittest.TestCase):
     def setUp(self) -> None:
         self.helper = load_helper()
 
+    @contextlib.contextmanager
+    def preparation_fixture(self, *options):
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo = init_repo(Path(tempdir))
+            for index in range(24):
+                (repo / f"unchanged-{index}.txt").write_text("old\n")
+            (repo / "source.md").write_text("before\n")
+            (repo / ".gitignore").write_text("evidence/\n")
+            git(repo, "add", ".")
+            git(repo, "commit", "-qm", "fixture")
+            (repo / "source.md").write_text("after\n")
+            (repo / "evidence").mkdir()
+            (repo / "evidence/note.md").write_text("frozen evidence\r\n")
+            sends, scans = [], []
+            stdout, stderr = io.StringIO(), io.StringIO()
+
+            def engine(_args, _repo, prompt):
+                self.assertFalse(any(thread.name == "autoreview-preparation"
+                                     for thread in threading.enumerate()))
+                sends.append(prompt)
+                return json.dumps({
+                    "findings": [], "overall_correctness": "patch is correct",
+                    "overall_explanation": "fixture clean", "overall_confidence": 0.99,
+                })
+
+            with mock.patch.dict(self.helper["main_impl"].__globals__, {
+                "repo_root": lambda: repo,
+                "run_engine": engine,
+                "scan_outgoing_review_pack": lambda _repo, prompt: scans.append(prompt),
+                "resolve_engine_binary": lambda *_args: (True, None),
+            }), mock.patch.object(sys, "argv", [str(SCRIPT), "--mode", "local", *options]), \
+                    contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+                yield repo, sends, scans, stdout, stderr
+
+    def test_preparation_reuses_untracked_capture_and_keeps_three_full_snapshots(self):
+        for explicit in (False, True):
+            options = ("--dataset", "note.md") if explicit else ()
+            with self.subTest(explicit=explicit), self.preparation_fixture(*options) as (repo, sends, scans, _out, err):
+                (repo / "note.md").write_text("untracked evidence\n")
+                read = mock.Mock(wraps=self.helper["file_bundle_snapshot"])
+                fingerprint = mock.Mock(wraps=self.helper["source_file_fingerprint"])
+                with mock.patch.dict(self.helper["main_impl"].__globals__, {
+                    "file_bundle_snapshot": read, "source_file_fingerprint": fingerprint,
+                }):
+                    self.assertEqual(self.helper["main_impl"](), 0)
+                self.assertEqual(scans, sends)
+                # Explicit evidence has its own initial capture and three fresh
+                # checks; finding membership never adds another content read.
+                self.assertEqual(read.call_count, 5 if explicit else 1)
+                self.assertEqual(fingerprint.call_count, 3 * 27)
+                for index in range(24):
+                    self.assertEqual(sum(call.args[0] == repo / f"unchanged-{index}.txt"
+                                         for call in fingerprint.call_args_list), 3)
+                self.assertNotIn("note.md", err.getvalue())
+                self.assertNotIn("untracked evidence", err.getvalue())
+
+    def test_ignored_evidence_change_during_capture_refuses_send(self):
+        with self.preparation_fixture("--dataset", "evidence/note.md") as (repo, sends, *_):
+            original = self.helper["local_bundle"]
+
+            def build(*args, **kwargs):
+                captured = original(*args, **kwargs)
+                (repo / "evidence/note.md").write_text("changed evidence\n")
+                return captured
+
+            with mock.patch.dict(self.helper["main_impl"].__globals__, {"local_bundle": build}):
+                with self.assertRaisesRegex(SystemExit, "evidence changed"):
+                    self.helper["main_impl"]()
+            self.assertFalse(sends)
+
+    def test_preparation_progress_precedes_snapshot(self):
+        with self.preparation_fixture() as (_repo, sends, _scans, _out, err):
+            def snapshot(*_args, **_kwargs):
+                self.assertIn("preparation: initial source snapshot", err.getvalue())
+                self.assertFalse(sends)
+                raise KeyboardInterrupt
+
+            with mock.patch.dict(self.helper["main_impl"].__globals__, {"source_tree_snapshot": snapshot}):
+                with self.assertRaises(KeyboardInterrupt):
+                    self.helper["main_impl"]()
+
+    def test_dry_run_reuses_capture_without_whole_tree_snapshots(self):
+        with self.preparation_fixture("--dry-run", "--dataset", "evidence/note.md") as (_repo, sends, scans, *_):
+            snapshot = mock.Mock(side_effect=AssertionError("dry run must not sweep the checkout"))
+            with mock.patch.dict(self.helper["main_impl"].__globals__, {"source_tree_snapshot": snapshot}):
+                self.assertEqual(self.helper["main_impl"](), 0)
+            snapshot.assert_not_called()
+            self.assertTrue(scans)
+            self.assertFalse(sends)
+
+    def test_evidence_mutations_refuse_stale_publication_and_later_passes(self):
+        for tracked in (False, True):
+            for timing in ("construction", "scan", "review", "between passes"):
+                with self.subTest(tracked=tracked, timing=timing), self.preparation_fixture(
+                    "--prompt-file", "evidence/note.md", "--dataset", "evidence/note.md",
+                ) as (repo, sends, _scans, out, _err):
+                    evidence = repo / "evidence/note.md"
+                    if tracked:
+                        git(repo, "add", "-f", "evidence/note.md")
+                        git(repo, "commit", "-qm", "unchanged evidence")
+                    frozen = evidence.read_bytes()
+                    original_engine = self.helper["main_impl"].__globals__["run_engine"]
+                    original_build = self.helper["build_bundle"]
+                    output = repo.parent / "report.json"
+
+                    def mutate():
+                        info = evidence.stat()
+                        evidence.write_bytes(frozen.replace(b"frozen", b"edited"))
+                        os.utime(evidence, ns=(info.st_atime_ns, info.st_mtime_ns))
+
+                    def engine(*args):
+                        result = original_engine(*args)
+                        if timing in ("review", "between passes"):
+                            mutate()
+                        return result
+
+                    def build(*args):
+                        result = original_build(*args)
+                        if timing == "construction":
+                            mutate()
+                        return result
+
+                    patches = {"run_engine": engine, "build_bundle": build}
+                    if timing == "scan":
+                        patches["scan_outgoing_review_pack"] = lambda *_args: mutate()
+                    if timing == "between passes":
+                        original_prepare = self.helper["prepare_review_prompts"]
+                        patches["prepare_review_prompts"] = lambda *args: original_prepare(*args) * 2
+                    with mock.patch.dict(self.helper["main_impl"].__globals__, patches), \
+                            mock.patch.object(sys, "argv", [*sys.argv, "--json-output", str(output)]):
+                        with self.assertRaisesRegex(SystemExit, "evidence changed"):
+                            self.helper["main_impl"]()
+                    self.assertEqual(len(sends), int(timing in ("review", "between passes")))
+                    if sends:
+                        self.assertEqual(sends[0].count(frozen.decode()), 2)
+                    self.assertFalse(output.exists())
+                    self.assertNotIn("autoreview scoped-clean", out.getvalue())
+
+    def test_evidence_topology_changes_with_identical_bytes_refuse_send(self):
+        for change in ("delete", "replace", "leaf symlink", "ancestor symlink"):
+            if "symlink" in change and os.name == "nt":
+                continue
+            with self.subTest(change=change), self.preparation_fixture(
+                "--dataset", "evidence/tree/note.md",
+            ) as (repo, sends, *_):
+                evidence = repo / "evidence/tree/note.md"
+                evidence.parent.mkdir()
+                (repo / "evidence/note.md").rename(evidence)
+                snapshot = self.helper["source_tree_snapshot"](repo)
+                original = self.helper["build_bundle"]
+
+                def build(*args):
+                    result = original(*args)
+                    if change == "delete":
+                        evidence.unlink()
+                    elif change == "replace":
+                        replacement = repo.parent / "replacement.md"
+                        replacement.write_bytes(evidence.read_bytes())
+                        replacement.replace(evidence)
+                    elif change == "leaf symlink":
+                        evidence.rename(evidence.with_name("same.md"))
+                        evidence.symlink_to("same.md")
+                    else:
+                        evidence.parent.rename(evidence.parent.with_name("same-tree"))
+                        evidence.parent.symlink_to("same-tree", target_is_directory=True)
+                    # All mutations stay inside ignored evidence: the ordinary
+                    # whole-tree guard cannot account for this failure.
+                    self.assertEqual(self.helper["source_tree_snapshot"](repo), snapshot)
+                    return result
+
+                with mock.patch.dict(self.helper["main_impl"].__globals__, {"build_bundle": build}):
+                    with self.assertRaisesRegex(SystemExit, "evidence changed"):
+                        self.helper["main_impl"]()
+                self.assertFalse(sends)
+
+    def test_duplicate_evidence_keeps_exact_frozen_bytes_across_passes(self):
+        with self.preparation_fixture(
+            "--prompt-file", "evidence/note.md", "--dataset", "evidence/note.md",
+            "--dataset", "evidence/note.md",
+        ) as (repo, sends, scans, *_):
+            evidence = (repo / "evidence/note.md").read_bytes().decode()
+            original = self.helper["prepare_review_prompts"]
+            with mock.patch.dict(self.helper["main_impl"].__globals__, {
+                "prepare_review_prompts": lambda *args: original(*args) * 2,
+            }):
+                self.assertEqual(self.helper["main_impl"](), 0)
+            self.assertEqual(len(sends), 2)
+            self.assertEqual(scans, sends)
+            for prompt in sends:
+                self.assertEqual(prompt.count(evidence), 3)
+
+    def test_tracked_source_permission_never_authorizes_evidence(self):
+        with self.preparation_fixture("--dataset", "private/source.swift") as (repo, sends, *_):
+            source = repo / "private/source.swift"
+            source.parent.mkdir()
+            source.write_text("let safe = true\n")
+            git(repo, "add", "private/source.swift")
+            self.assertIn("private/source.swift", self.helper["local_bundle"](repo).paths)
+            with self.assertRaisesRegex(SystemExit, "sensitive --dataset"):
+                self.helper["main_impl"]()
+            self.assertFalse(sends)
+
+    def test_unrelated_same_size_restored_mtime_mutation_is_still_guarded(self):
+        for timing in ("construction", "review"):
+            with self.subTest(timing=timing), self.preparation_fixture() as (repo, sends, *_):
+                name = "build_bundle" if timing == "construction" else "run_engine"
+                original = self.helper["main_impl"].__globals__[name]
+
+                def mutate(*args):
+                    result = original(*args)
+                    source = repo / "unchanged-0.txt"
+                    info = source.stat()
+                    source.write_text("new\n")
+                    os.utime(source, ns=(info.st_atime_ns, info.st_mtime_ns))
+                    return result
+
+                with mock.patch.dict(self.helper["main_impl"].__globals__, {name: mutate}):
+                    if timing == "construction":
+                        with self.assertRaisesRegex(SystemExit, "source changed"):
+                            self.helper["main_impl"]()
+                        self.assertFalse(sends)
+                    else:
+                        self.assertEqual(self.helper["main_impl"](), 1)
+
+    def test_preparation_ticker_rate_limit_counts_and_cleanup(self):
+        progress_type = self.helper["PreparationProgress"]
+        clock = [100.0]
+        stderr = io.StringIO()
+        with mock.patch.object(time, "monotonic", side_effect=lambda: clock[0]), \
+                contextlib.redirect_stderr(stderr):
+            progress = progress_type("initial source snapshot")
+            progress.advance(files=3, bytes=45)
+            for now in (100, 114, 115, 115, 129, 130):
+                clock[0] = now
+                progress._report()
+        self.assertEqual(stderr.getvalue().splitlines(), [
+            "preparation: initial source snapshot elapsed=15s files=3 bytes=45",
+            "preparation: initial source snapshot elapsed=30s files=3 bytes=45",
+        ])
+        for error in (None, ValueError, KeyboardInterrupt, self.helper["EngineInterrupted"]):
+            with self.subTest(error=error), contextlib.redirect_stderr(io.StringIO()):
+                progress = progress_type("bundle preparation")
+                try:
+                    with progress:
+                        self.assertTrue(progress.thread.is_alive())
+                        if error:
+                            raise error(130)
+                except BaseException as exc:
+                    self.assertIsInstance(exc, error)
+                self.assertFalse(progress.thread.is_alive())
+                self.assertTrue(progress.stopped.is_set())
+
+    def test_hash_progress_advances_inside_large_file_without_path_output(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            source = Path(tempdir) / "do-not-print-this-name.txt"
+            source.write_bytes(b"x" * (2 * 1024 * 1024 + 1))
+            progress = self.helper["PreparationProgress"]("initial source snapshot")
+            original = os.read
+            counts = []
+
+            def read(*args):
+                counts.append(progress.bytes)
+                return original(*args)
+
+            with mock.patch.object(os, "read", side_effect=read):
+                self.helper["source_file_fingerprint"](source, progress)
+            self.assertEqual(counts, [0, 1024 * 1024, 2 * 1024 * 1024, source.stat().st_size])
+
+    def test_preparation_ticker_reports_while_caller_is_blocked(self):
+        stderr = io.StringIO()
+        progress = self.helper["PreparationProgress"]("bundle preparation")
+        progress.stopped = mock.Mock()
+        progress.stopped.wait.side_effect = [False, True]
+        with mock.patch.object(time, "monotonic", return_value=progress.started + 15), \
+                contextlib.redirect_stderr(stderr), mock.patch.object(stderr, "flush") as flush:
+            with progress:
+                progress.thread.join()
+            self.assertEqual(flush.call_count, 2)
+        self.assertEqual(progress.stopped.wait.call_args_list, [mock.call(15), mock.call(15)])
+        self.assertIn("elapsed=15s files=0 bytes=0", stderr.getvalue())
+        self.assertFalse(progress.thread.is_alive())
+
+    def test_bundle_ref_pinning_keeps_patch_and_membership_coherent(self):
+        for target in ("branch", "commit"):
+            with self.subTest(target=target), tempfile.TemporaryDirectory() as tempdir:
+                repo = init_repo(Path(tempdir))
+                (repo / "base.md").write_text("base\n")
+                git(repo, "add", ".")
+                git(repo, "commit", "-qm", "base")
+                base = git(repo, "rev-parse", "HEAD").strip()
+                git(repo, "branch", "moving-base")
+                (repo / "task.md").write_text("task change\n")
+                git(repo, "add", ".")
+                git(repo, "commit", "-qm", "task")
+                head = git(repo, "rev-parse", "HEAD").strip()
+                original = self.helper["git"]
+
+                def moving_git(repo, *args, **kwargs):
+                    result = original(repo, *args, **kwargs)
+                    if "--patch" in args:
+                        git(repo, "update-ref", "refs/heads/moving-base", head)
+                        git(repo, "update-ref", "HEAD", base)
+                    return result
+
+                with mock.patch.dict(self.helper["build_bundle"].__globals__, {"git": moving_git}):
+                    captured = self.helper["build_bundle"](repo, target, "moving-base", "HEAD")
+                self.assertEqual(captured.paths, {"task.md"})
+                self.assertIn("+task change", captured.text)
+                self.assertFalse(captured.truncated)
+
     def test_outgoing_pack_scan_disables_installed_scanner_updates(self) -> None:
         prompt = "harmless review pack\npreserved CRLF\r\nfinal line\r"
         with tempfile.TemporaryDirectory() as tempdir:
@@ -430,7 +740,7 @@ Path(__file__).with_name("scan.json").write_text(json.dumps({
             path.write_text("TOKEN=changed-placeholder\n", encoding="utf-8")
             git(repo, "add", path.name)
 
-            bundle, truncated = self.helper["local_bundle"](repo)
+            bundle, truncated, _paths = self.helper["local_bundle"](repo)
 
             self.assertIn(self.helper["REVIEW_SECURITY_OMISSION"], bundle)
             self.assertFalse(truncated)
@@ -449,7 +759,7 @@ Path(__file__).with_name("scan.json").write_text(json.dumps({
                 path.write_text("placeholder=true\n", encoding="utf-8")
                 (repo / "review.py").write_text("print('review me')\n", encoding="utf-8")
 
-                bundle, truncated = self.helper["local_bundle"](repo)
+                bundle, truncated, _paths = self.helper["local_bundle"](repo)
 
                 self.assertIn("# Review Input Omissions", bundle)
                 self.assertIn(self.helper["REVIEW_SECURITY_OMISSION"], bundle)
@@ -463,7 +773,7 @@ Path(__file__).with_name("scan.json").write_text(json.dumps({
             repo = init_repo(Path(tempdir))
             (repo / "image.bin").write_bytes(b"\x89PNG\r\n\0binary-content")
 
-            bundle, truncated = self.helper["local_bundle"](repo)
+            bundle, truncated, _paths = self.helper["local_bundle"](repo)
 
             self.assertIn(
                 '# Untracked File\npath: "image.bin"\n'
@@ -498,7 +808,7 @@ Path(__file__).with_name("scan.json").write_text(json.dumps({
                 self.helper["local_bundle"].__globals__,
                 {"read_prefix": read_once},
             ):
-                bundle, truncated = self.helper["local_bundle"](repo)
+                bundle, truncated, _paths = self.helper["local_bundle"](repo)
 
             expected_record = json.dumps("review me" + os.linesep)
             self.assertIn(
@@ -585,7 +895,7 @@ Path(__file__).with_name("scan.json").write_text(json.dumps({
             self.assertIn("untracked task note", sent[0])
             self.assertNotIn("diff --git a/proof.png", sent[0])
             self.assertEqual(
-                self.helper["review_paths"](repo, "local", incoming, "HEAD"),
+                self.helper["local_bundle"](repo, incoming).paths,
                 {"source.txt", "committed.txt", "notes.md"},
             )
             for mode in ("local", "uncommitted", "auto"):
@@ -612,11 +922,11 @@ Path(__file__).with_name("scan.json").write_text(json.dumps({
             snapshot = self.helper["source_tree_snapshot"](repo)
             git(repo, "update-ref", "refs/heads/review-base", "HEAD")
             self.assertEqual(self.helper["source_tree_snapshot"](repo), snapshot)
-            bundle, truncated = self.helper["local_bundle"](repo, pinned)
+            bundle, truncated, _paths = self.helper["local_bundle"](repo, pinned)
             self.assertFalse(truncated)
             self.assertIn("+committed task change", bundle)
             self.assertEqual(
-                self.helper["review_paths"](repo, target, pinned, "HEAD"),
+                self.helper["build_bundle"](repo, target, pinned, "HEAD").paths,
                 {"source.txt", "committed.txt"},
             )
             for ref, error in (("--help", "unsafe"), ("HEAD:source.txt", "unsafe"), ("", "unsafe"), ("missing-base", "unknown")):
@@ -635,10 +945,10 @@ Path(__file__).with_name("scan.json").write_text(json.dumps({
                 if staged:
                     git(repo, "add", safe)
                 with self.subTest(staged=staged):
-                    bundle, truncated = self.helper["local_bundle"](repo)
+                    bundle, truncated, _paths = self.helper["local_bundle"](repo)
                     self.assertFalse(truncated)
                     self.assertIn("struct CredentialFile", bundle)
-                    self.assertIn(safe, self.helper["review_paths"](repo, "local", None, "HEAD"))
+                    self.assertIn(safe, self.helper["local_bundle"](repo).paths)
                     for label in ("--dataset", "--prompt-file"):
                         _, content, truncated = self.helper["validate_evidence_file"](repo, safe, label)
                         self.assertEqual(content, source.read_bytes().decode("utf-8"))
@@ -744,7 +1054,7 @@ Path(__file__).with_name("scan.json").write_text(json.dumps({
                             for marker in ("+func testLive", "+struct CredentialFile", "-old runtime", "+unstaged runtime", f'path: "{untracked}"'):
                                 self.assertIn(marker, sends[0])
             for target, ref in (("local", None), ("local", base), ("branch", base)):
-                paths = self.helper["review_paths"](repo, target, ref, "HEAD")
+                paths = self.helper["build_bundle"](repo, target, ref, "HEAD").paths
                 self.assertNotIn("credentials.json", paths)
                 self.assertNotIn(".env", paths)
                 if target == "local":
@@ -824,11 +1134,12 @@ Path(__file__).with_name("scan.json").write_text(json.dumps({
             untracked = repo / "Runtime/CredentialFile.swift"
             untracked.parent.mkdir()
             untracked.write_text("// UNTRACKED_SCAN_MARKER\n", encoding="utf-8")
-            extra, _ = self.helper["load_extra_prompt"](argparse.Namespace(
-                prompt=["PROMPT_SCAN_MARKER"], prompt_file=[source]
+            evidence = self.helper["capture_evidence_inputs"](argparse.Namespace(
+                prompt=["PROMPT_SCAN_MARKER"], prompt_file=[source],
+                dataset=[str(untracked.relative_to(repo))],
             ), repo)
-            datasets, _ = self.helper["load_datasets"](argparse.Namespace(dataset=[str(untracked.relative_to(repo))]), repo)
-            bundle, _ = self.helper["local_bundle"](repo)
+            extra, datasets = evidence.prompt, evidence.datasets
+            bundle, _, _paths = self.helper["local_bundle"](repo)
             pack, = self.helper["build_review_prompts"](repo, "local", None, bundle, extra, datasets)
             provider = mock.Mock(return_value=json.dumps({
                 "findings": [], "overall_correctness": "patch is correct",
@@ -994,7 +1305,7 @@ Path(__file__).with_name("scan.json").write_text(json.dumps({
                 },
             ):
                 self.assertEqual(
-                    self.helper["safe_untracked_files"](repo),
+                    [rel for rel, _, _ in self.helper["collect_untracked_file_snapshots"](repo)[0]],
                     ["hostile-gitconfig", "visible.txt"],
                 )
 
@@ -1030,13 +1341,13 @@ Path(__file__).with_name("scan.json").write_text(json.dumps({
             untracked = repo / "untracked.txt"
             untracked.write_text(content, encoding="utf-8")
             with self.assertRaisesRegex(SystemExit, "file too large to scan safely"):
-                self.helper["safe_untracked_files"](repo)
+                [rel for rel, _, _ in self.helper["collect_untracked_file_snapshots"](repo)[0]]
 
             untracked.unlink()
             binary = repo / "binary.bin"
             binary.write_bytes(b"\0" + content.encode())
             self.assertEqual(
-                self.helper["safe_untracked_files"](repo),
+                [rel for rel, _, _ in self.helper["collect_untracked_file_snapshots"](repo)[0]],
                 ["binary.bin"],
             )
 
@@ -1417,10 +1728,11 @@ Path(__file__).with_name("scan.json").write_text(json.dumps({
                 expected_lines.extend(lines)
                 (repo / path).write_bytes(("\n".join(lines) + "\n").encode("utf-8"))
                 paths.append(path)
-            datasets, truncated = self.helper["load_datasets"](
-                argparse.Namespace(dataset=paths), repo
+            evidence = self.helper["capture_evidence_inputs"](
+                argparse.Namespace(prompt=[], prompt_file=[], dataset=paths), repo
             )
-            self.assertFalse(truncated)
+            datasets = evidence.datasets
+            self.assertFalse(evidence.truncated)
             bundle = "# Commit Diff\n" + "+changed line\n" * 40_000
             instructions = "Complete caller instructions must appear in every pass."
             for budget in (512_000, 120_000):
@@ -1680,7 +1992,7 @@ Path(__file__).with_name("scan.json").write_text(json.dumps({
             (repo / ".env").write_text("placeholder=true\n", encoding="utf-8")
             (repo / "base.txt").write_text("base\nreview me\n", encoding="utf-8")
             git(repo, "add", ".env", "base.txt")
-            local, local_truncated = self.helper["local_bundle"](repo)
+            local, local_truncated, _paths = self.helper["local_bundle"](repo)
             self.assertIn(self.helper["REVIEW_SECURITY_OMISSION"], local)
             self.assertNotIn(".env", local)
             self.assertNotIn("placeholder=true", local)
@@ -1688,7 +2000,7 @@ Path(__file__).with_name("scan.json").write_text(json.dumps({
             self.assertFalse(local_truncated)
 
             git(repo, "commit", "-q", "-m", "sensitive path")
-            for bundle, truncated in (
+            for bundle, truncated, paths in (
                 self.helper["branch_bundle"](repo, base),
                 self.helper["commit_bundle"](repo, "HEAD"),
             ):
@@ -1709,16 +2021,16 @@ Path(__file__).with_name("scan.json").write_text(json.dumps({
             workflow = repo / ".github" / "workflows" / "secret-scan.yml"
             workflow.parent.mkdir(parents=True)
             workflow.write_text("name: Secret scan\n", encoding="utf-8")
-            untracked_bundle, _ = self.helper["local_bundle"](repo)
+            untracked_bundle, _, _paths = self.helper["local_bundle"](repo)
             self.assertIn("secret-scan.yml", untracked_bundle)
 
             git(repo, "add", str(workflow.relative_to(repo)))
-            tracked_bundle, _ = self.helper["local_bundle"](repo)
+            tracked_bundle, _, _paths = self.helper["local_bundle"](repo)
             self.assertIn("secret-scan.yml", tracked_bundle)
 
             git(repo, "commit", "-q", "-m", "add secret scanner")
-            branch_bundle, _ = self.helper["branch_bundle"](repo, base)
-            commit_bundle, _ = self.helper["commit_bundle"](repo, "HEAD")
+            branch_bundle, _, _paths = self.helper["branch_bundle"](repo, base)
+            commit_bundle, _, _paths = self.helper["commit_bundle"](repo, "HEAD")
             self.assertIn("secret-scan.yml", branch_bundle)
             self.assertIn("secret-scan.yml", commit_bundle)
 
@@ -1786,7 +2098,7 @@ Path(__file__).with_name("scan.json").write_text(json.dumps({
             path.parent.mkdir()
             path.write_text(source, encoding="utf-8")
 
-            bundle, truncated = self.helper["local_bundle"](repo)
+            bundle, truncated, _paths = self.helper["local_bundle"](repo)
 
             self.assertIn("ordinary-hardcoded-value-12345", bundle)
             self.assertFalse(truncated)
@@ -2087,7 +2399,7 @@ Path(__file__).with_name("scan.json").write_text(json.dumps({
             git(repo, "add", "-u")
             git(repo, "commit", "-q", "-m", "delete template")
 
-            bundle, truncated = self.helper["branch_bundle"](repo, base)
+            bundle, truncated, _paths = self.helper["branch_bundle"](repo, base)
 
             self.assertIn("deleted file mode 100644", bundle)
             self.assertIn("------BEGIN [A-Z ]+-----", bundle)
@@ -2256,7 +2568,7 @@ Path(__file__).with_name("scan.json").write_text(json.dumps({
 
             path.write_text('const request = { token: String() };\n', encoding="utf-8")
 
-            bundle, truncated = self.helper["local_bundle"](repo)
+            bundle, truncated, _paths = self.helper["local_bundle"](repo)
 
             self.assertIn('-const request = { token: "test-token" };', bundle)
             self.assertFalse(truncated)
@@ -2442,12 +2754,12 @@ Path(__file__).with_name("scan.json").write_text(json.dumps({
         with tempfile.TemporaryDirectory() as tempdir:
             repo = init_repo(Path(tempdir))
             (repo / "review.md").write_text("review context\n", encoding="utf-8")
-            args = argparse.Namespace(prompt=[], prompt_file=["review.md"])
+            args = argparse.Namespace(prompt=[], prompt_file=["review.md"], dataset=[])
 
-            prompt, truncated = self.helper["load_extra_prompt"](args, repo)
+            evidence = self.helper["capture_evidence_inputs"](args, repo)
 
-            self.assertIn("# Prompt file: review.md", prompt)
-            self.assertFalse(truncated)
+            self.assertIn("# Prompt file: review.md", evidence.prompt)
+            self.assertFalse(evidence.truncated)
 
     def test_review_prompts_omit_absolute_repo_path_and_keep_instructions_whole(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:
@@ -4668,15 +4980,8 @@ os.execv(target, [str(target), *sys.argv[1:]])
             self.assertIn("bundle: FAILED", result.stdout)
 
     def test_dry_run_commit_mode_passes_commit_ref_to_prompt_construction(self) -> None:
-        # choose_target() always returns target_ref=None for commit mode
-        # (see choose_target()); main() derives the real ref by assigning
-        # target_ref = args.commit right after commit_bundle() (see main(),
-        # just below its commit_bundle() call) before build_review_prompts()
-        # runs. dry_run_preflight() must mirror that same assignment so the
-        # prompt it validates matches the one a real run would build,
-        # instead of validating a prompt with the ref omitted (and
-        # potentially under the real byte budget only because of that
-        # omission).
+        # Both paths must retain the commit label in the assembled prompt,
+        # including its bytes in the aggregate prompt budget.
         with tempfile.TemporaryDirectory() as tempdir:
             root = Path(tempdir)
             repo = init_repo(root)
@@ -5170,7 +5475,7 @@ os.execv(target, [str(target), *sys.argv[1:]])
 
     @unittest.skipIf(os.name == "nt", "the fake executable is POSIX-only")
     def test_dry_run_flag_exits_nonzero_when_prompt_unpartitionable(self) -> None:
-        # The real run does not stop at load_extra_prompt()'s per-file
+        # The real run does not stop at capture_evidence_inputs()'s per-file
         # checks: main() also builds the final prompt(s) via
         # build_review_prompts() and rejects context that cannot fit the
         # aggregate prompt budget even after partitioning (see
@@ -5230,7 +5535,7 @@ os.execv(target, [str(target), *sys.argv[1:]])
 
     @unittest.skipIf(os.name == "nt", "the fake executable is POSIX-only")
     def test_dry_run_flag_exits_nonzero_when_prompt_file_missing(self) -> None:
-        # The real run loads --prompt-file via load_extra_prompt() before
+        # The real run loads --prompt-file via capture_evidence_inputs() before
         # ever contacting an engine (see main_impl just after
         # dry_run_preflight returns); --dry-run must reuse that same
         # validation instead of reporting readiness for an input that
@@ -5319,9 +5624,8 @@ os.execv(target, [str(target), *sys.argv[1:]])
 
     @unittest.skipIf(os.name == "nt", "the fake executable is POSIX-only")
     def test_dry_run_flag_exits_nonzero_when_dataset_missing(self) -> None:
-        # load_datasets() shares validate_evidence_file() with
-        # load_extra_prompt(); confirm --dataset gets the same pre-engine
-        # existence check as --prompt-file.
+        # Both evidence roles use capture_evidence_inputs(); confirm datasets
+        # get the same pre-engine existence check as prompt files.
         with tempfile.TemporaryDirectory() as tempdir:
             root = Path(tempdir)
             repo = init_repo(root)


### PR DESCRIPTION
## Summary

Autoreview could remain silent while preparing a small review in a large checkout. Bundle construction also reopened validated untracked files just to rediscover finding membership, and explicit ignored prompt/dataset files were outside the source mutation checks.

Capture bundle text, completeness, and finding membership together, so normal and dry runs reuse authoritative input records. Pin branch/commit references during construction. Add immediate, flushed preparation phases and periodic elapsed/file/byte progress on stderr, with the ticker stopped before provider execution and on error or interruption.

Explicit evidence now retains its validated bytes and raw path identities independently of Git ignore status or finding scope. Fresh checks reject content changes, replacement, deletion, and leaf/ancestor symlink swaps before sending a pass or publishing a result. Credential-path restrictions, complete-input and exact outgoing-pack TruffleHog scans, and reviewer isolation remain in place.

The three fresh whole-checkout snapshots remain intact, including unrelated files, binary tails, index state, and initialized submodules. This removes duplicate preparation work and fixes visibility; it does not replace content hashing with a metadata cache or claim to eliminate checkout-sized I/O. Dry-run keeps its lighter preflight without gaining whole-tree sweeps. No OpenClaw files, downstream skill copies, or test routing are changed.

## Validation

The final Python suite ran 221 tests successfully with one skip. All 85 Node tests passed on Node.js 26.5.1; the 15 repository script tests, eight skill validations, compilation/syntax checks, and diff checks also passed. Regression coverage includes capture read counts, ignored and unchanged evidence races, duplicate evidence, topology changes, retained full-tree mutation checks, and preparation ticker cleanup. The new read-count, evidence, and initial-progress regressions failed against the original helper for their intended reasons.

Codex autoreview returned scoped-clean at the default P0 threshold using the unchanged helper from the base commit. An optional full-helper context attachment was refused by the existing size limit before any provider call; the completed review used the complete change bundle without that attachment. No limits or enforcement were relaxed.
