### PR TITLE
fix(transcript): cap session tree walk during find and html

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fail closed when agent-transcript `find` or `html` walks more than 20,000 session files, instead of hanging on unbounded recursive discovery.
 - Partition oversized Autoreview evidence without dropping change context, keeping complete-input and per-pass credential scans within existing engine limits.
 - Preserve exact outgoing autoreview scan bytes on Windows instead of translating line endings.
 - Fix autoreview credential-source inclusion and scope-filtered results, preserving provider verdicts and rejected findings while documenting complete PR-plus-dirty review.

--- a/skills/agent-transcript/SKILL.md
+++ b/skills/agent-transcript/SKILL.md
@@ -44,7 +44,7 @@ skills/agent-transcript/scripts/agent-transcript find \
   --since-days 14
 ```
 
-`find` scans the newest 400 matching local JSONL logs by default across Codex, Claude, Pi, and OpenClaw agent sessions. Use `--max-files N` for a wider local search.
+`find` scans the newest 400 matching local JSONL logs by default across Codex, Claude, Pi, and OpenClaw agent sessions. Use `--max-files N` for a wider local search. Discovery walks at most 20,000 JSONL files (`--max-discovery-files`) and fails closed if a session tree is larger.
 
 In a downstream repo that syncs shared skills under `.agents/skills`, replace
 `skills/agent-transcript` with `.agents/skills/agent-transcript`.

--- a/skills/agent-transcript/scripts/agent-transcript
+++ b/skills/agent-transcript/scripts/agent-transcript
@@ -9,15 +9,16 @@ const MARKER_START = "<!-- agent-transcript:start -->";
 const MARKER_END = "<!-- agent-transcript:end -->";
 const DEFAULT_MAX_CHARS = 50000;
 const DEFAULT_ENTRY_MAX_CHARS = 6000;
+const MAX_DISCOVERY_FILES = 20_000;
 
 function usage() {
   console.log(`Usage:
-  agent-transcript find --query TEXT [--cwd PATH] [--since-days N] [--max-files N] [--root PATH...]
+  agent-transcript find --query TEXT [--cwd PATH] [--since-days N] [--max-files N] [--max-discovery-files N] [--root PATH...]
   agent-transcript render --session FILE [--app-server] [--thread-id ID] [--out FILE] [--max-chars N] [--entry-max-chars N] [--title TEXT] [--url URL]
   agent-transcript render-thread --thread-id ID [--out FILE] [--max-chars N] [--entry-max-chars N] [--title TEXT] [--url URL]
   agent-transcript preview --session FILE [--app-server] [--thread-id ID] [--out FILE] [--max-chars N] [--entry-max-chars N] [--title TEXT] [--url URL]
   agent-transcript append-body --body FILE --session FILE [--app-server] [--thread-id ID] [--out FILE] [--max-chars N] [--entry-max-chars N]
-  agent-transcript html --prs FILE [--out FILE] [--since-days N] [--min-score N] [--root PATH...] [--exclude-session FILE...]
+  agent-transcript html --prs FILE [--out FILE] [--since-days N] [--min-score N] [--max-discovery-files N] [--root PATH...] [--exclude-session FILE...]
 
 Local-only. No network calls.`);
 }
@@ -115,22 +116,75 @@ function defaultRoots() {
   ];
 }
 
-function walkJsonl(root, sinceMs, out = []) {
+function discoveryLimit(options = {}) {
+  const value = options.maxDiscoveryFiles ?? options["max-discovery-files"] ?? MAX_DISCOVERY_FILES;
+  const maxFiles = Number(value);
+  if (!Number.isFinite(maxFiles) || maxFiles < 1) {
+    throw new Error("--max-discovery-files must be a positive number");
+  }
+  return maxFiles;
+}
+
+function walkJsonl(root, sinceMs, out, state) {
   if (!root || !fs.existsSync(root)) return out;
-  const stat = fs.statSync(root);
-  if (stat.isFile()) {
-    if (root.endsWith(".jsonl") && stat.mtimeMs >= sinceMs) out.push(root);
+  if (state.files >= state.maxFiles) {
+    state.exhausted = true;
     return out;
   }
-  for (const entry of fs.readdirSync(root, { withFileTypes: true })) {
+  let stat;
+  try {
+    stat = fs.statSync(root);
+  } catch {
+    return out;
+  }
+  if (stat.isFile()) {
+    if (root.endsWith(".jsonl")) {
+      state.files++;
+      if (stat.mtimeMs >= sinceMs) out.push(root);
+    }
+    return out;
+  }
+  let entries;
+  try {
+    entries = fs.readdirSync(root, { withFileTypes: true });
+  } catch {
+    return out;
+  }
+  for (const entry of entries) {
+    if (state.files >= state.maxFiles) {
+      state.exhausted = true;
+      break;
+    }
     if (entry.name === "node_modules" || entry.name === ".git") continue;
     const file = path.join(root, entry.name);
-    if (entry.isDirectory()) walkJsonl(file, sinceMs, out);
-    else if (entry.isFile() && entry.name.endsWith(".jsonl")) {
+    if (entry.isDirectory()) {
+      walkJsonl(file, sinceMs, out, state);
+      continue;
+    }
+    if (!entry.isFile() || !entry.name.endsWith(".jsonl")) continue;
+    state.files++;
+    try {
       const entryStat = fs.statSync(file);
       if (entryStat.mtimeMs >= sinceMs) out.push(file);
+    } catch {
+      // File disappeared during discovery.
     }
   }
+  return out;
+}
+
+function discoverSessionFiles(roots, sinceMs, options = {}) {
+  const state = {
+    files: 0,
+    exhausted: false,
+    maxFiles: discoveryLimit(options),
+  };
+  const out = [];
+  for (const root of roots) {
+    walkJsonl(root, sinceMs, out, state);
+    if (state.exhausted) break;
+  }
+  if (state.exhausted) throw new Error("session discovery exceeded its file limit");
   return out;
 }
 
@@ -722,7 +776,7 @@ function recentFiles(files, maxFiles) {
 }
 
 function candidateFiles(roots, terms, sinceMs, options = {}) {
-  return recentFiles(roots.flatMap((root) => walkJsonl(root, sinceMs)), Number(options["max-files"] || 400));
+  return recentFiles(discoverSessionFiles(roots, sinceMs, options), Number(options["max-files"] || 400));
 }
 
 function findSessions(options) {
@@ -749,8 +803,7 @@ function sessionScanRecords(options) {
   const sinceMs = Date.now() - sinceDays * 24 * 60 * 60 * 1000;
   const roots = asArray(options.root).length ? asArray(options.root) : defaultRoots();
   const excluded = new Set(asArray(options["exclude-session"]).map((file) => path.resolve(file)));
-  return roots
-    .flatMap((root) => walkJsonl(root, sinceMs))
+  return discoverSessionFiles(roots, sinceMs, options)
     .filter((file) => !excluded.has(path.resolve(file)))
     .map((file) => sessionScanRecord(file, Number(options["scan-bytes"] || 90000)));
 }

--- a/skills/agent-transcript/scripts/agent-transcript.test.mjs
+++ b/skills/agent-transcript/scripts/agent-transcript.test.mjs
@@ -142,3 +142,62 @@ test("find labels explicit roots under trailing-slash CLAUDE_CONFIG_DIR as Claud
   assert.equal(matches[0].file, session);
   assert.equal(matches[0].agent, "claude");
 });
+
+test("find fails closed when session discovery exceeds the walk cap", () => {
+  const dir = tempDir();
+  const home = tempDir();
+  writeJsonl(path.join(dir, "a.jsonl"), [
+    { type: "user", message: { role: "user", content: "walk-cap-find-marker" } },
+  ]);
+  writeJsonl(path.join(dir, "b.jsonl"), [
+    { type: "user", message: { role: "user", content: "walk-cap-find-marker" } },
+  ]);
+
+  assert.throws(
+    () =>
+      run(
+        [
+          "find",
+          "--query",
+          "walk-cap-find-marker",
+          "--root",
+          dir,
+          "--since-days",
+          "1",
+          "--max-files",
+          "20",
+          "--max-discovery-files",
+          "1",
+        ],
+        { env: { ...process.env, HOME: home } },
+      ),
+    (error) => {
+      assert.match(String(error.stderr || ""), /session discovery exceeded its file limit/);
+      return true;
+    },
+  );
+});
+
+test("html fails closed when session discovery exceeds the walk cap", () => {
+  const dir = tempDir();
+  const home = tempDir();
+  writeJsonl(path.join(dir, "a.jsonl"), [
+    { type: "user", message: { role: "user", content: "walk-cap-html-marker" } },
+  ]);
+  writeJsonl(path.join(dir, "b.jsonl"), [
+    { type: "user", message: { role: "user", content: "walk-cap-html-marker" } },
+  ]);
+  const prs = path.join(dir, "prs.json");
+  fs.writeFileSync(prs, JSON.stringify([{ title: "walk-cap-html-marker", url: "https://example.com/pr/1" }]));
+
+  assert.throws(
+    () =>
+      run(["html", "--prs", prs, "--root", dir, "--since-days", "1", "--max-discovery-files", "1"], {
+        env: { ...process.env, HOME: home },
+      }),
+    (error) => {
+      assert.match(String(error.stderr || ""), /session discovery exceeded its file limit/);
+      return true;
+    },
+  );
+});


### PR DESCRIPTION
## What Problem This Solves

`agent-transcript find` and `agent-transcript html` recursively walk session trees with `readdirSync` and no file cap. `--max-files` only slices after that walk finishes, so a large Codex, Claude, Pi, or OpenClaw session tree hangs discovery before any newest-N scan. `html` had no file cap at all.

This matches the sibling beam session walker: count JSONL files during the walk, stop at the cap, and fail closed instead of returning a partial tree.

## Evidence

Unfixed `find` on a 3-file tree ignored `--max-discovery-files 1` and returned all three sessions (exit 0). The patched script stops during the walk and exits 1 with `session discovery exceeded its file limit`. The same before/after holds for `html`. A tree that fits the cap still finds all three sessions.

## Real behavior proof

- **Behavior or issue addressed:** Recursive session discovery for `find` and `html` had no walk cap, so a large local session tree could hang before `--max-files` sliced the result.
- **Real environment tested:** macOS 15 (Darwin 25.6.0 arm64), Node v26.7.0, worktree `/tmp/oc-pr-agent-skills-F002` at branch `fix/f002-transcript-walk-cap`. Isolated `HOME` and a 3-file JSONL tree under `/tmp/agent-skills-F002-tree.DGQlUP`.
- **Exact steps or command run after this patch:**

  ```bash
  git show upstream/main:skills/agent-transcript/scripts/agent-transcript > /tmp/agent-skills-F002-old-transcript
  printf '%s\n' '{"type":"user","message":{"role":"user","content":"walk-cap-live-marker"}}' > "$TREE/a.jsonl"
  printf '%s\n' '{"type":"user","message":{"role":"user","content":"walk-cap-live-marker"}}' > "$TREE/b.jsonl"
  printf '%s\n' '{"type":"user","message":{"role":"user","content":"walk-cap-live-marker"}}' > "$TREE/c.jsonl"
  node /tmp/agent-skills-F002-old-transcript find --query walk-cap-live-marker --root "$TREE" --since-days 1 --max-files 20 --max-discovery-files 1
  node skills/agent-transcript/scripts/agent-transcript find --query walk-cap-live-marker --root "$TREE" --since-days 1 --max-files 20 --max-discovery-files 1
  node skills/agent-transcript/scripts/agent-transcript find --query walk-cap-live-marker --root "$TREE" --since-days 1 --max-files 20 --max-discovery-files 20
  node /tmp/agent-skills-F002-old-transcript html --prs "$TREE/prs.json" --root "$TREE" --since-days 1 --max-discovery-files 1
  node skills/agent-transcript/scripts/agent-transcript html --prs "$TREE/prs.json" --root "$TREE" --since-days 1 --max-discovery-files 1
  ```

- **Evidence after fix:** terminal output from the unfixed script versus the patched script:

  ```console
  $ node /tmp/agent-skills-F002-old-transcript find --query walk-cap-live-marker --root "$TREE" --since-days 1 --max-files 20 --max-discovery-files 1
  [
    { "file": "/tmp/agent-skills-F002-tree.DGQlUP/c.jsonl", "score": 6 },
    { "file": "/tmp/agent-skills-F002-tree.DGQlUP/b.jsonl", "score": 6 },
    { "file": "/tmp/agent-skills-F002-tree.DGQlUP/a.jsonl", "score": 6 }
  ]
  unfixed_find_exit=0

  $ node skills/agent-transcript/scripts/agent-transcript find --query walk-cap-live-marker --root "$TREE" --since-days 1 --max-files 20 --max-discovery-files 1
  session discovery exceeded its file limit
  patched_find_capped_exit=1

  $ node skills/agent-transcript/scripts/agent-transcript find --query walk-cap-live-marker --root "$TREE" --since-days 1 --max-files 20 --max-discovery-files 20
  [
    { "file": "/tmp/agent-skills-F002-tree.DGQlUP/c.jsonl", "score": 6 },
    { "file": "/tmp/agent-skills-F002-tree.DGQlUP/b.jsonl", "score": 6 },
    { "file": "/tmp/agent-skills-F002-tree.DGQlUP/a.jsonl", "score": 6 }
  ]

  $ node /tmp/agent-skills-F002-old-transcript html --prs "$TREE/prs.json" --root "$TREE" --since-days 1 --max-discovery-files 1
  unfixed_html_exit=0

  $ node skills/agent-transcript/scripts/agent-transcript html --prs "$TREE/prs.json" --root "$TREE" --since-days 1 --max-discovery-files 1
  session discovery exceeded its file limit
  patched_html_capped_exit=1
  ```

- **Observed result after fix:** The unfixed walker still enumerated every JSONL file and returned matches. The patched walker stopped inside `walkJsonl` and failed closed for both `find` and `html`. A tree under the cap still returned the three matching sessions.
- **What was not tested:** A full 20,000-file default-cap tree on disk. Windows readdir order. `render`, `preview`, and `append-body`, which take an explicit `--session` and do not walk.

## Summary

`walkJsonl` now shares a discovery state (`maxFiles`, default 20,000) across roots, counts every JSONL file it visits, and throws `session discovery exceeded its file limit` when the cap is hit. `find` still applies `--max-files` as the newest-N scan budget after a complete bounded walk. `html` uses the same walk cap.

This follows `skills/beam/scripts/beam-session.js` (`MAX_DISCOVERY_FILES = 20_000`). The unbounded walk has been present since the skill landed in `7d7427a` (2026-05-25).

Related:
- Sibling cap: `skills/beam/scripts/beam-session.js`
- [beam session sharing #152](https://github.com/openclaw/agent-skills/pull/152)
