### PR TITLE
fix(transcript): bound JSONL file reads before parse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Bound agent-transcript JSONL reads to 8 MiB (head and tail) before parse, so render, preview, append-body, and html do not load multi-hundred-megabyte session files into memory.
 - Show Autoreview preparation progress, reuse captured bundle membership, and guard explicit evidence against content and path changes while preserving full-tree integrity checks.
 - Verify raw Git parents in Autoreview commit bundles, preserving true roots and refusing unsupported attribution from shallow boundaries, grafts, or misleading metadata.
 - Partition oversized Autoreview evidence without dropping change context, keeping complete-input and per-pass credential scans within existing engine limits.

--- a/skills/agent-transcript/SKILL.md
+++ b/skills/agent-transcript/SKILL.md
@@ -46,6 +46,8 @@ skills/agent-transcript/scripts/agent-transcript find \
 
 `find` scans the newest 400 matching local JSONL logs by default across Codex, Claude, Pi, and OpenClaw agent sessions. Use `--max-files N` for a wider local search.
 
+`render`, `preview`, `append-body`, and `html` read at most 8 MiB of each session file (head and tail, `--max-read-bytes`) before JSONL parse, matching the sibling beam transcript bound.
+
 In a downstream repo that syncs shared skills under `.agents/skills`, replace
 `skills/agent-transcript` with `.agents/skills/agent-transcript`.
 

--- a/skills/agent-transcript/scripts/agent-transcript
+++ b/skills/agent-transcript/scripts/agent-transcript
@@ -9,15 +9,16 @@ const MARKER_START = "<!-- agent-transcript:start -->";
 const MARKER_END = "<!-- agent-transcript:end -->";
 const DEFAULT_MAX_CHARS = 50000;
 const DEFAULT_ENTRY_MAX_CHARS = 6000;
+const MAX_TRANSCRIPT_BYTES = 8 * 1024 * 1024;
 
 function usage() {
   console.log(`Usage:
   agent-transcript find --query TEXT [--cwd PATH] [--since-days N] [--max-files N] [--root PATH...]
-  agent-transcript render --session FILE [--app-server] [--thread-id ID] [--out FILE] [--max-chars N] [--entry-max-chars N] [--title TEXT] [--url URL]
+  agent-transcript render --session FILE [--app-server] [--thread-id ID] [--out FILE] [--max-chars N] [--entry-max-chars N] [--max-read-bytes N] [--title TEXT] [--url URL]
   agent-transcript render-thread --thread-id ID [--out FILE] [--max-chars N] [--entry-max-chars N] [--title TEXT] [--url URL]
-  agent-transcript preview --session FILE [--app-server] [--thread-id ID] [--out FILE] [--max-chars N] [--entry-max-chars N] [--title TEXT] [--url URL]
-  agent-transcript append-body --body FILE --session FILE [--app-server] [--thread-id ID] [--out FILE] [--max-chars N] [--entry-max-chars N]
-  agent-transcript html --prs FILE [--out FILE] [--since-days N] [--min-score N] [--root PATH...] [--exclude-session FILE...]
+  agent-transcript preview --session FILE [--app-server] [--thread-id ID] [--out FILE] [--max-chars N] [--entry-max-chars N] [--max-read-bytes N] [--title TEXT] [--url URL]
+  agent-transcript append-body --body FILE --session FILE [--app-server] [--thread-id ID] [--out FILE] [--max-chars N] [--entry-max-chars N] [--max-read-bytes N]
+  agent-transcript html --prs FILE [--out FILE] [--since-days N] [--min-score N] [--max-read-bytes N] [--root PATH...] [--exclude-session FILE...]
 
 Local-only. No network calls.`);
 }
@@ -134,8 +135,17 @@ function walkJsonl(root, sinceMs, out = []) {
   return out;
 }
 
-function readJsonl(file, maxLines = 12000) {
-  const text = fs.readFileSync(file, "utf8");
+function transcriptReadLimit(options = {}) {
+  const value = options.maxReadBytes ?? options["max-read-bytes"] ?? MAX_TRANSCRIPT_BYTES;
+  const maxBytes = Number(value);
+  if (!Number.isFinite(maxBytes) || maxBytes < 1) {
+    throw new Error("--max-read-bytes must be a positive number");
+  }
+  return maxBytes;
+}
+
+function readJsonl(file, maxLines = 12000, maxBytes = MAX_TRANSCRIPT_BYTES) {
+  const text = readBoundedText(file, maxBytes);
   const lines = text.split(/\n+/).filter(Boolean).slice(0, maxLines);
   const rows = [];
   for (const line of lines) {
@@ -407,7 +417,7 @@ function expandCompactedReplacementItems(row) {
 }
 
 function renderSession(file, options = {}) {
-  const rows = readJsonl(file);
+  const rows = readJsonl(file, 12000, transcriptReadLimit(options));
   const agent = detectAgent(file, rows);
   const stats = {
     agent,

--- a/skills/agent-transcript/scripts/agent-transcript.test.mjs
+++ b/skills/agent-transcript/scripts/agent-transcript.test.mjs
@@ -142,3 +142,46 @@ test("find labels explicit roots under trailing-slash CLAUDE_CONFIG_DIR as Claud
   assert.equal(matches[0].file, session);
   assert.equal(matches[0].agent, "claude");
 });
+
+function oversizedSession(dir) {
+  const session = path.join(dir, "session.jsonl");
+  const pad = JSON.stringify({
+    type: "user",
+    message: { role: "user", content: `pad-${"x".repeat(80)}` },
+  });
+  const lines = [
+    JSON.stringify({ type: "user", message: { role: "user", content: "HEAD_READ_BOUND_MARKER" } }),
+    ...Array.from({ length: 40 }, () => pad),
+    JSON.stringify({ type: "user", message: { role: "user", content: "MIDDLE_READ_BOUND_MARKER" } }),
+    ...Array.from({ length: 40 }, () => pad),
+    JSON.stringify({ type: "user", message: { role: "user", content: "TAIL_READ_BOUND_MARKER" } }),
+  ];
+  fs.writeFileSync(session, `${lines.join("\n")}\n`);
+  return session;
+}
+
+test("render bounds oversized JSONL reads before parse", () => {
+  const dir = tempDir();
+  const session = oversizedSession(dir);
+
+  const output = run(["render", "--session", session, "--max-read-bytes", "400"]);
+  assert.match(output, /HEAD_READ_BOUND_MARKER/);
+  assert.match(output, /TAIL_READ_BOUND_MARKER/);
+  assert.doesNotMatch(output, /MIDDLE_READ_BOUND_MARKER/);
+});
+
+test("html bounds oversized JSONL reads before parse", () => {
+  const dir = tempDir();
+  const home = tempDir();
+  oversizedSession(dir);
+  const prs = path.join(dir, "prs.json");
+  fs.writeFileSync(prs, JSON.stringify([{ title: "HEAD_READ_BOUND_MARKER", url: "https://example.com/pr/1" }]));
+
+  const output = run(
+    ["html", "--prs", prs, "--root", dir, "--since-days", "1", "--min-score", "1", "--max-read-bytes", "400"],
+    { env: { ...process.env, HOME: home } },
+  );
+  assert.match(output, /HEAD_READ_BOUND_MARKER/);
+  assert.match(output, /TAIL_READ_BOUND_MARKER/);
+  assert.doesNotMatch(output, /MIDDLE_READ_BOUND_MARKER/);
+});


### PR DESCRIPTION
## What Problem This Solves

`agent-transcript render`, `preview`, `append-body`, and `html` parse session JSONL with `readFileSync` of the entire file, then keep at most 12,000 lines. The line cap does not limit memory. `html` can pick a multi-hundred-megabyte local session after discovery and OOM during parse.

This matches the sibling beam reader: cap the file read at 8 MiB (head and tail) before JSON.parse.

## Evidence

Unfixed `render` on an 11,353-byte session ignored `--max-read-bytes 400` and kept the middle marker (exit 0). The patched script reads only the head and tail windows and omits the middle marker. `html` shows the same before/after. A session under the default 8 MiB cap still renders in full.

## Real behavior proof

- **Behavior or issue addressed:** Session JSONL parse loaded the whole file into memory. A large local session could OOM `render`, `preview`, `append-body`, and `html` before the 12,000-line slice ran.
- **Real environment tested:** macOS 15 (Darwin 25.6.0 arm64), Node v26.7.0, worktree `/tmp/oc-pr-agent-skills-F003` at branch `fix/f003-transcript-read-bound`. Isolated 11,353-byte JSONL fixture under `/tmp/agent-skills-F003-tree.4yzqhE`.
- **Exact steps or command run after this patch:**

  ```bash
  git show upstream/main:skills/agent-transcript/scripts/agent-transcript > /tmp/agent-skills-F003-old-transcript
  node /tmp/agent-skills-F003-old-transcript render --session "$TREE/session.jsonl" --max-read-bytes 400
  node skills/agent-transcript/scripts/agent-transcript render --session "$TREE/session.jsonl" --max-read-bytes 400
  node /tmp/agent-skills-F003-old-transcript html --prs "$TREE/prs.json" --root "$TREE" --since-days 1 --min-score 1 --max-read-bytes 400
  node skills/agent-transcript/scripts/agent-transcript html --prs "$TREE/prs.json" --root "$TREE" --since-days 1 --min-score 1 --max-read-bytes 400
  node skills/agent-transcript/scripts/agent-transcript render --session "$TREE/small.jsonl"
  ```

- **Evidence after fix:** terminal output from the unfixed script versus the patched script:

  ```console
  $ wc -c "$TREE/session.jsonl"
  11353 /tmp/agent-skills-F003-tree.4yzqhE/session.jsonl

  $ node /tmp/agent-skills-F003-old-transcript render --session "$TREE/session.jsonl" --max-read-bytes 400
  stats: {"agent":"agent","entries":4,"user":4}
  [user]
  HEAD_READ_BOUND_MARKER
  [user]
  MIDDLE_READ_BOUND_MARKER
  [user]
  TAIL_READ_BOUND_MARKER
  unfixed_render_exit=0

  $ node skills/agent-transcript/scripts/agent-transcript render --session "$TREE/session.jsonl" --max-read-bytes 400
  stats: {"agent":"agent","entries":2,"user":2}
  [user]
  HEAD_READ_BOUND_MARKER
  [user]
  TAIL_READ_BOUND_MARKER
  patched_render_exit=0

  $ node /tmp/agent-skills-F003-old-transcript html --prs "$TREE/prs.json" --root "$TREE" --since-days 1 --min-score 1 --max-read-bytes 400
  MIDDLE_READ_BOUND_MARKER
  TAIL_READ_BOUND_MARKER
  unfixed_html_exit=0

  $ node skills/agent-transcript/scripts/agent-transcript html --prs "$TREE/prs.json" --root "$TREE" --since-days 1 --min-score 1 --max-read-bytes 400
  TAIL_READ_BOUND_MARKER
  patched_html_exit=0

  $ node skills/agent-transcript/scripts/agent-transcript render --session "$TREE/small.jsonl"
  [user]
  small-file-live-marker
  ```

- **Observed result after fix:** The unfixed reader still loaded every JSONL line and kept the middle marker. The patched reader used the existing head-and-tail bound and dropped the omitted middle. A small session under the default 8 MiB cap still rendered in full.
- **What was not tested:** A full 8 MiB-plus session on disk. Windows path encoding. Codex app-server `render-thread`, which does not read a local JSONL file.

## Summary

`readJsonl` now reads through `readBoundedText` with an 8 MiB default (`--max-read-bytes`), the same cap as `skills/beam/scripts/beam-session.js` (`MAX_TRANSCRIPT_BYTES = 8 * 1024 * 1024`). `render`, `preview`, `append-body`, and `html` share that bound. The 12,000-line slice still applies after the bounded read.

The unbounded `readFileSync` has been present since the skill landed in [`7d7427a`](https://github.com/openclaw/agent-skills/commit/7d7427a) (2026-05-25).

Related:
- Sibling bound: `skills/beam/scripts/beam-session.js`
- [beam session sharing #152](https://github.com/openclaw/agent-skills/pull/152)
- Walk-cap sibling: [#204](https://github.com/openclaw/agent-skills/pull/204)
