### PR TITLE
fix(beam): accept named transcript share URLs

### DIFF
--- a/skills/beam/README.md
+++ b/skills/beam/README.md
@@ -74,18 +74,25 @@ On success, Beam prints the endpoint-derived Control UI URL in its short share
 form, for example:
 
 ```text
-Beamed session: https://gateway.example.com/beam/0123456789ab
+Beamed session: https://gateway.example.com/beam/fix-upload-flow-0123456789ab
 ```
 
 A Gateway mounted below a base path returns that same base path, such as
-`https://gateway.example.com/openclaw/beam/0123456789ab`.
+`https://gateway.example.com/openclaw/beam/fix-upload-flow-0123456789ab`.
+
+The Gateway builds the optional title slug from the redacted `--title` value or
+the first shared user message. It contains up to 48 lowercase alphanumeric
+characters and hyphens. The final 12–32 lowercase hex characters identify the
+session independently of its title, so earlier named links still work after a
+rename. Bare `/beam/<id-prefix>` links remain accepted.
 
 Explicit transcript:
 
 ```sh
 node "$BEAM_SKILL_DIR/scripts/beam" publish \
   --endpoint "$BEAM_ENDPOINT" \
-  --session /path/to/session.jsonl
+  --session /path/to/session.jsonl \
+  --title "Fix upload flow"
 ```
 
 Inspect the exact sanitized payload without networking:

--- a/skills/beam/SKILL.md
+++ b/skills/beam/SKILL.md
@@ -55,15 +55,16 @@ Useful options:
 ```bash
 node "$BEAM_SKILL_DIR/scripts/beam" publish --endpoint "$BEAM_ENDPOINT" --session /path/to/session.jsonl
 node "$BEAM_SKILL_DIR/scripts/beam" publish --endpoint "$BEAM_ENDPOINT" --thread-id "$CODEX_THREAD_ID"
+node "$BEAM_SKILL_DIR/scripts/beam" publish --endpoint "$BEAM_ENDPOINT" --title "Fix upload flow"
 node "$BEAM_SKILL_DIR/scripts/beam" publish --endpoint "$BEAM_ENDPOINT" --complete
 node "$BEAM_SKILL_DIR/scripts/beam" publish --endpoint "$BEAM_ENDPOINT" --dry-run
 ```
 
 `--dry-run` prints the sanitized payload locally and performs no network request.
 
-On success, return only the Beam URL and a short disclosure summary: source harness, shared message count, whether older entries were truncated, and whether the beam is complete. The URL uses the endpoint-derived Control UI base path followed by `/beam/<12-character lowercase hex prefix>`, for example `https://gateway.example.com/beam/0123456789ab`.
+On success, return only the Beam URL and a short disclosure summary: source harness, shared message count, whether older entries were truncated, and whether the beam is complete. The URL uses the endpoint-derived Control UI base path followed by `/beam/<title-slug>-<id-prefix>`, for example `https://gateway.example.com/beam/fix-upload-flow-0123456789ab`. The title comes from `--title` or the first shared user message. The stable ID suffix identifies the session; links with an earlier title remain valid.
 
-During rollout, the helper also accepts the current server's exact `/chat/<agent>?catalog=beam&host=gateway&thread=<full-beam-id>` response. It still rejects the obsolete `?session=catalog:...` beta form.
+The helper also accepts bare `/beam/<id-prefix>` links and, during rollout, the current server's exact `/chat/<agent>?catalog=beam&host=gateway&thread=<full-beam-id>` response. It still rejects the obsolete `?session=catalog:...` beta form.
 
 ## Live Hooks
 

--- a/skills/beam/scripts/beam
+++ b/skills/beam/scripts/beam
@@ -266,13 +266,15 @@ function isSafeReceiverUrl(resultUrl, endpoint) {
 
 function isPrettyBeamUrl(resultUrl, endpoint, beamId) {
   const pathPrefix = `${expectedControlUiBasePath(endpoint)}/beam/`;
-  const returnedId = resultUrl.pathname.startsWith(pathPrefix)
+  const returnedPath = resultUrl.pathname.startsWith(pathPrefix)
     ? resultUrl.pathname.slice(pathPrefix.length)
     : "";
+  const match = /^(?:([a-z0-9]+(?:-[a-z0-9]+)*)-)?([0-9a-f]{12,32})$/u.exec(returnedPath);
   return (
     /^[0-9a-f]{32}$/u.test(beamId) &&
-    /^[0-9a-f]{12,32}$/u.test(returnedId) &&
-    beamId.startsWith(returnedId) &&
+    match !== null &&
+    (match[1]?.length ?? 0) <= 48 &&
+    beamId.startsWith(match[2]) &&
     resultUrl.searchParams.size === 0
   );
 }

--- a/skills/beam/scripts/beam.test.mjs
+++ b/skills/beam/scripts/beam.test.mjs
@@ -1042,38 +1042,39 @@ test("publish rejects receiver URLs containing reflected credentials", async (t)
   assert.doesNotMatch(`${result.stdout}\n${result.stderr}`, /test-access-token/);
 });
 
-test("publish accepts the endpoint-derived Control UI base path", async (t) => {
+test("publish accepts bare and named Beam URLs below the endpoint-derived base path", async (t) => {
   const session = claudeSession();
+  let makePath;
+  let returnedPath;
   const endpoint = await beamReceiverEndpoint(
     t,
-    (payload) => `/openclaw/beam/${payload.beamId.slice(0, 12)}`,
+    ({ beamId }) => (returnedPath = `/openclaw/beam/${makePath(beamId)}`),
     "/openclaw",
   );
-  const result = await run([
-    "publish",
-    "--endpoint",
-    endpoint,
-    "--session",
-    session,
-  ]);
+  const cases = [
+    ["bare prefix", (beamId) => beamId.slice(0, 12)],
+    ["bare full id", (beamId) => beamId],
+    ["current title", (beamId) => `current-session-title-${beamId.slice(0, 12)}`],
+    ["stale title", (beamId) => `previous-title-${beamId.slice(0, 12)}`],
+    ["named full id", (beamId) => `collision-fallback-${beamId}`],
+    ["maximum title length", (beamId) => `${"a".repeat(48)}-${beamId.slice(0, 12)}`],
+  ];
 
-  assert.equal(result.code, 0, result.stderr);
-  assert.match(result.stdout, /\/openclaw\/beam\/[a-f0-9]{12}/);
-});
+  for (const [label, pathFactory] of cases) {
+    makePath = pathFactory;
+    const result = await run([
+      "publish",
+      "--endpoint",
+      endpoint,
+      "--session",
+      session,
+      "--title",
+      "Current session title",
+    ]);
 
-test("publish accepts a full-id pretty URL for collision fallback", async (t) => {
-  const session = claudeSession();
-  const endpoint = await beamReceiverEndpoint(t, (payload) => `/beam/${payload.beamId}`);
-  const result = await run([
-    "publish",
-    "--endpoint",
-    endpoint,
-    "--session",
-    session,
-  ]);
-
-  assert.equal(result.code, 0, result.stderr);
-  assert.match(result.stdout, /\/beam\/[a-f0-9]{32}/);
+    assert.equal(result.code, 0, `${label}: ${result.stderr}`);
+    assert.ok(result.stdout.includes(returnedPath), label);
+  }
 });
 
 test("publish accepts the current canonical catalog URL during rollout", async (t) => {
@@ -1109,9 +1110,24 @@ test("publish rejects malformed pretty Beam URLs", async (t) => {
     ["uppercase id", ({ beamId }) => `/beam/${beamId.slice(0, 12).toUpperCase()}`],
     ["nonhex id", ({ beamId }) => `/beam/${beamId.slice(0, 11)}g`],
     ["long id", ({ beamId }) => `/beam/${beamId}0`],
+    ["uppercase title", ({ beamId }) => `/beam/Current-title-${beamId.slice(0, 12)}`],
+    ["long title", ({ beamId }) => `/beam/${"a".repeat(49)}-${beamId.slice(0, 12)}`],
+    ["empty title", ({ beamId }) => `/beam/-${beamId.slice(0, 12)}`],
+    ["title with empty word", ({ beamId }) => `/beam/current--title-${beamId.slice(0, 12)}`],
+    ["title with trailing hyphen", ({ beamId }) => `/beam/current-title--${beamId.slice(0, 12)}`],
+    ["title with punctuation", ({ beamId }) => `/beam/current_title-${beamId.slice(0, 12)}`],
+    ["encoded title", ({ beamId }) => `/beam/current%2ftitle-${beamId.slice(0, 12)}`],
+    ["named short id", ({ beamId }) => `/beam/current-title-${beamId.slice(0, 11)}`],
+    ["named uppercase id", ({ beamId }) => `/beam/current-title-${beamId.slice(0, 12).toUpperCase()}`],
+    ["named nonhex id", ({ beamId }) => `/beam/current-title-${beamId.slice(0, 11)}g`],
+    ["named long id", ({ beamId }) => `/beam/current-title-${beamId}0`],
     [
       "wrong prefix",
       ({ beamId }) => `/beam/${beamId[0] === "0" ? "1" : "0"}${beamId.slice(1, 12)}`,
+    ],
+    [
+      "named wrong prefix",
+      ({ beamId }) => `/beam/current-title-${beamId[0] === "0" ? "1" : "0"}${beamId.slice(1, 12)}`,
     ],
     ["extra segment", ({ beamId }) => `/beam/${beamId.slice(0, 12)}/extra`],
     ["query", ({ beamId }) => `/beam/${beamId.slice(0, 12)}?view=debug`],


### PR DESCRIPTION
Beam share URLs can include a title slug before their stable ID, matching regular session links. The client currently rejects that valid response after the upload succeeds. Accept an optional bounded title slug while continuing to validate the authoritative ID suffix, endpoint origin and base path, and absence of query strings, fragments, or credentials.

Bare-ID links and exact legacy catalog-query responses remain accepted. Earlier title slugs remain valid after renaming. This does not change title discovery: the existing redacted `--title` or first shared user message still supplies the title. Update the client before deploying named receiver responses.

Validation: the named-response regression failed before the change; all 49 Beam tests pass, syntax checks and `scripts/validate-skills` (8 skills) pass, and independent Codex review found no actionable P0-P2 issues. Production delta: +5/-3; tests: +41/-25; docs: +13/-5.
