### PR TITLE
fix(transcript): bound discovery with exact file limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Bound agent-transcript `find` and `html` discovery to 20,000 session files, with an integer override and correct exact-limit handling. Thanks @SebTardif.
 - Rescan the exact outgoing Autoreview pack before Codex access-fallback retries, refusing findings, scanner errors, and missing scanners before another provider invocation.
 - Show Autoreview preparation progress, reuse captured bundle membership, and guard explicit evidence against content and path changes while preserving full-tree integrity checks.
 - Verify raw Git parents in Autoreview commit bundles, preserving true roots and refusing unsupported attribution from shallow boundaries, grafts, or misleading metadata.

--- a/skills/agent-transcript/SKILL.md
+++ b/skills/agent-transcript/SKILL.md
@@ -44,7 +44,7 @@ skills/agent-transcript/scripts/agent-transcript find \
   --since-days 14
 ```
 
-`find` scans the newest 400 matching local JSONL logs by default across Codex, Claude, Pi, and OpenClaw agent sessions. Use `--max-files N` for a wider local search.
+`find` scans the newest 400 matching local JSONL logs by default across Codex, Claude, Pi, and OpenClaw agent sessions. Use `--max-files N` for a wider local search. `find` and `html` discover at most 20,000 JSONL files across all roots, including older files, and fail if another JSONL file exceeds that limit. Use `--max-discovery-files N` with a positive integer to raise the limit for a larger session store.
 
 In a downstream repo that syncs shared skills under `.agents/skills`, replace
 `skills/agent-transcript` with `.agents/skills/agent-transcript`.

--- a/skills/agent-transcript/scripts/agent-transcript
+++ b/skills/agent-transcript/scripts/agent-transcript
@@ -9,15 +9,16 @@ const MARKER_START = "<!-- agent-transcript:start -->";
 const MARKER_END = "<!-- agent-transcript:end -->";
 const DEFAULT_MAX_CHARS = 50000;
 const DEFAULT_ENTRY_MAX_CHARS = 6000;
+const MAX_DISCOVERY_FILES = 20_000;
 
 function usage() {
   console.log(`Usage:
-  agent-transcript find --query TEXT [--cwd PATH] [--since-days N] [--max-files N] [--root PATH...]
+  agent-transcript find --query TEXT [--cwd PATH] [--since-days N] [--max-files N] [--max-discovery-files N] [--root PATH...]
   agent-transcript render --session FILE [--app-server] [--thread-id ID] [--out FILE] [--max-chars N] [--entry-max-chars N] [--title TEXT] [--url URL]
   agent-transcript render-thread --thread-id ID [--out FILE] [--max-chars N] [--entry-max-chars N] [--title TEXT] [--url URL]
   agent-transcript preview --session FILE [--app-server] [--thread-id ID] [--out FILE] [--max-chars N] [--entry-max-chars N] [--title TEXT] [--url URL]
   agent-transcript append-body --body FILE --session FILE [--app-server] [--thread-id ID] [--out FILE] [--max-chars N] [--entry-max-chars N]
-  agent-transcript html --prs FILE [--out FILE] [--since-days N] [--min-score N] [--root PATH...] [--exclude-session FILE...]
+  agent-transcript html --prs FILE [--out FILE] [--since-days N] [--min-score N] [--max-discovery-files N] [--root PATH...] [--exclude-session FILE...]
 
 Local-only. No network calls.`);
 }
@@ -115,21 +116,65 @@ function defaultRoots() {
   ];
 }
 
-function walkJsonl(root, sinceMs, out = []) {
+function discoveryLimit(options = {}) {
+  const value = options.maxDiscoveryFiles ?? options["max-discovery-files"] ?? MAX_DISCOVERY_FILES;
+  const maxFiles = Number(value);
+  if (typeof value === "boolean" || !Number.isSafeInteger(maxFiles) || maxFiles < 1) {
+    throw new Error("--max-discovery-files must be a positive integer");
+  }
+  return maxFiles;
+}
+
+function walkJsonl(root, sinceMs, out, state) {
   if (!root || !fs.existsSync(root)) return out;
-  const stat = fs.statSync(root);
-  if (stat.isFile()) {
-    if (root.endsWith(".jsonl") && stat.mtimeMs >= sinceMs) out.push(root);
+  let stat;
+  try {
+    stat = fs.statSync(root);
+  } catch {
     return out;
   }
-  for (const entry of fs.readdirSync(root, { withFileTypes: true })) {
+  if (stat.isFile()) {
+    if (root.endsWith(".jsonl")) {
+      if (state.files >= state.maxFiles) throw new Error("session discovery exceeded its file limit");
+      state.files++;
+      if (stat.mtimeMs >= sinceMs) out.push(root);
+    }
+    return out;
+  }
+  let entries;
+  try {
+    entries = fs.readdirSync(root, { withFileTypes: true });
+  } catch {
+    return out;
+  }
+  for (const entry of entries) {
     if (entry.name === "node_modules" || entry.name === ".git") continue;
     const file = path.join(root, entry.name);
-    if (entry.isDirectory()) walkJsonl(file, sinceMs, out);
-    else if (entry.isFile() && entry.name.endsWith(".jsonl")) {
+    if (entry.isDirectory()) {
+      walkJsonl(file, sinceMs, out, state);
+      continue;
+    }
+    if (!entry.isFile() || !entry.name.endsWith(".jsonl")) continue;
+    if (state.files >= state.maxFiles) throw new Error("session discovery exceeded its file limit");
+    state.files++;
+    try {
       const entryStat = fs.statSync(file);
       if (entryStat.mtimeMs >= sinceMs) out.push(file);
+    } catch {
+      // File disappeared during discovery.
     }
+  }
+  return out;
+}
+
+function discoverSessionFiles(roots, sinceMs, options = {}) {
+  const state = {
+    files: 0,
+    maxFiles: discoveryLimit(options),
+  };
+  const out = [];
+  for (const root of roots) {
+    walkJsonl(root, sinceMs, out, state);
   }
   return out;
 }
@@ -722,7 +767,7 @@ function recentFiles(files, maxFiles) {
 }
 
 function candidateFiles(roots, terms, sinceMs, options = {}) {
-  return recentFiles(roots.flatMap((root) => walkJsonl(root, sinceMs)), Number(options["max-files"] || 400));
+  return recentFiles(discoverSessionFiles(roots, sinceMs, options), Number(options["max-files"] || 400));
 }
 
 function findSessions(options) {
@@ -749,8 +794,7 @@ function sessionScanRecords(options) {
   const sinceMs = Date.now() - sinceDays * 24 * 60 * 60 * 1000;
   const roots = asArray(options.root).length ? asArray(options.root) : defaultRoots();
   const excluded = new Set(asArray(options["exclude-session"]).map((file) => path.resolve(file)));
-  return roots
-    .flatMap((root) => walkJsonl(root, sinceMs))
+  return discoverSessionFiles(roots, sinceMs, options)
     .filter((file) => !excluded.has(path.resolve(file)))
     .map((file) => sessionScanRecord(file, Number(options["scan-bytes"] || 90000)));
 }

--- a/skills/agent-transcript/scripts/agent-transcript.test.mjs
+++ b/skills/agent-transcript/scripts/agent-transcript.test.mjs
@@ -142,3 +142,107 @@ test("find labels explicit roots under trailing-slash CLAUDE_CONFIG_DIR as Claud
   assert.equal(matches[0].file, session);
   assert.equal(matches[0].agent, "claude");
 });
+
+test("find fails closed when session discovery exceeds the walk cap", () => {
+  const dir = tempDir();
+  const home = tempDir();
+  writeJsonl(path.join(dir, "a.jsonl"), [
+    { type: "user", message: { role: "user", content: "walk-cap-find-marker" } },
+  ]);
+  writeJsonl(path.join(dir, "b.jsonl"), [
+    { type: "user", message: { role: "user", content: "walk-cap-find-marker" } },
+  ]);
+
+  assert.throws(
+    () =>
+      run(
+        [
+          "find",
+          "--query",
+          "walk-cap-find-marker",
+          "--root",
+          dir,
+          "--since-days",
+          "1",
+          "--max-files",
+          "20",
+          "--max-discovery-files",
+          "1",
+        ],
+        { env: { ...process.env, HOME: home } },
+      ),
+    (error) => {
+      assert.match(String(error.stderr || ""), /session discovery exceeded its file limit/);
+      return true;
+    },
+  );
+});
+
+test("html fails closed when session discovery exceeds the walk cap", () => {
+  const dir = tempDir();
+  const home = tempDir();
+  writeJsonl(path.join(dir, "a.jsonl"), [
+    { type: "user", message: { role: "user", content: "walk-cap-html-marker" } },
+  ]);
+  writeJsonl(path.join(dir, "b.jsonl"), [
+    { type: "user", message: { role: "user", content: "walk-cap-html-marker" } },
+  ]);
+  const prs = path.join(dir, "prs.json");
+  fs.writeFileSync(prs, JSON.stringify([{ title: "walk-cap-html-marker", url: "https://example.com/pr/1" }]));
+
+  assert.throws(
+    () =>
+      run(["html", "--prs", prs, "--root", dir, "--since-days", "1", "--max-discovery-files", "1"], {
+        env: { ...process.env, HOME: home },
+      }),
+    (error) => {
+      assert.match(String(error.stderr || ""), /session discovery exceeded its file limit/);
+      return true;
+    },
+  );
+});
+
+test("discovery accepts exactly the cap across roots and ignores trailing non-session entries", () => {
+  const dir = tempDir();
+  const empty = tempDir();
+  writeJsonl(path.join(dir, "a.jsonl"), [
+    { type: "user", message: { role: "user", content: "exact-cap-marker" } },
+  ]);
+  fs.mkdirSync(path.join(dir, "z-empty"));
+  fs.writeFileSync(path.join(dir, "z-not-session.txt"), "ignored");
+  const prs = path.join(empty, "prs.json");
+  fs.writeFileSync(prs, JSON.stringify([{ title: "exact-cap-marker", url: "https://example.com/pr/1" }]));
+  for (const root of [dir, path.join(dir, "a.jsonl")]) {
+    const options = ["--root", root, "--root", empty, "--max-discovery-files", "1"];
+    const matches = JSON.parse(run(["find", "--query", "exact-cap-marker", ...options]));
+    assert.equal(matches.length, 1);
+    assert.match(run(["html", "--prs", prs, "--min-score", "1", ...options]), /exact-cap-marker/);
+  }
+});
+
+test("discovery shares its cap across roots and counts old JSONL files", () => {
+  const dir = tempDir();
+  const roots = ["a.jsonl", "b.jsonl"].map((name) => path.join(dir, name));
+  for (const file of roots) {
+    writeJsonl(file, [{ type: "user", message: { role: "user", content: "old-marker" } }]);
+    fs.utimesSync(file, new Date(0), new Date(0));
+  }
+  assert.throws(
+    () => run(["find", "--query", "old-marker", "--root", roots[0], "--root", roots[1], "--since-days", "1", "--max-discovery-files", "1"]),
+    (error) => /session discovery exceeded its file limit/.test(String(error.stderr)),
+  );
+});
+
+test("discovery rejects invalid and missing file limits", () => {
+  const dir = tempDir();
+  const prs = path.join(dir, "prs.json");
+  fs.writeFileSync(prs, "[]");
+  for (const value of ["1.5", "0", "-1", "NaN", "Infinity", "9007199254740992", null]) {
+    for (const command of [["find", "--query", "marker"], ["html", "--prs", prs]]) {
+      assert.throws(
+        () => run([...command, "--root", dir, "--max-discovery-files", ...(value === null ? [] : [value])]),
+        (error) => /--max-discovery-files must be a positive integer/.test(String(error.stderr)),
+      );
+    }
+  }
+});


### PR DESCRIPTION
Session discovery currently walks every JSONL file before applying the newest-file scan budget. This carries forward #204's 20,000-file bound and fixes its boundary checks: exactly N files succeeds across roots and trailing directories; only the next JSONL file causes failure. The override rejects fractional, missing, and unsafe integer values.

This is a maintained replacement for fork PR #204, with contributor credit preserved. The original remains open for the maintainer to close after landing this version. The default intentionally rejects larger session stores; `--max-discovery-files N` is the documented override.

Validation: 10 transcript tests pass, all 8 skill manifests validate, `git diff --check` passes, and Codex autoreview is scoped-clean at its default P0 threshold.

Real CLI proof used a disposable three-file JSONL tree and an empty second root:

```sh
node skills/agent-transcript/scripts/agent-transcript find --query walk-live-marker --root "$TREE" --root "$EMPTY" --max-discovery-files 3
node skills/agent-transcript/scripts/agent-transcript find --query walk-live-marker --root "$TREE" --max-discovery-files 1
node skills/agent-transcript/scripts/agent-transcript find --query walk-live-marker --root "$TREE" --max-discovery-files 3.5
node skills/agent-transcript/scripts/agent-transcript html --prs "$PRS" --root "$TREE" --root "$EMPTY" --min-score 1 --max-discovery-files 3
node skills/agent-transcript/scripts/agent-transcript html --prs "$PRS" --root "$TREE" --max-discovery-files 1
```

```text
main: overflow find exits 0 with 3 matches; overflow html exits 0
original PR: exact cap with empty later root exits 1 in both commands; fractional limit exits 0
repaired: exact-cap find exits 0 with 3 matches; exact-cap html exits 0 with session content
repaired: overflow find/html exit 1: session discovery exceeded its file limit
repaired: fractional limit exits 1: --max-discovery-files must be a positive integer
```

This proof exercises the actual CLI without filesystem mocks; it does not claim a bound on non-JSONL directory entries.
