### PR TITLE
fix(transcript): bound reads and disclose partial sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Bound agent-transcript session reads to 8 MiB and disclose partial source content in render, preview, append-body, and HTML output. Thanks @SebTardif.
 - Rescan the exact outgoing Autoreview pack before Codex access-fallback retries, refusing findings, scanner errors, and missing scanners before another provider invocation.
 - Show Autoreview preparation progress, reuse captured bundle membership, and guard explicit evidence against content and path changes while preserving full-tree integrity checks.
 - Verify raw Git parents in Autoreview commit bundles, preserving true roots and refusing unsupported attribution from shallow boundaries, grafts, or misleading metadata.

--- a/skills/agent-transcript/SKILL.md
+++ b/skills/agent-transcript/SKILL.md
@@ -46,6 +46,8 @@ skills/agent-transcript/scripts/agent-transcript find \
 
 `find` scans the newest 400 matching local JSONL logs by default across Codex, Claude, Pi, and OpenClaw agent sessions. Use `--max-files N` for a wider local search.
 
+`render`, `preview`, `append-body`, and `html` read at most 8 MiB of each session file (head and tail) before JSONL parse. Use `--max-read-bytes N` with a positive integer to change the limit. Output includes a visible partial-transcript notice and `sourceTruncated` in its stats if the read limit or the existing 12,000-line parse limit omits source content.
+
 In a downstream repo that syncs shared skills under `.agents/skills`, replace
 `skills/agent-transcript` with `.agents/skills/agent-transcript`.
 

--- a/skills/agent-transcript/scripts/agent-transcript
+++ b/skills/agent-transcript/scripts/agent-transcript
@@ -9,15 +9,16 @@ const MARKER_START = "<!-- agent-transcript:start -->";
 const MARKER_END = "<!-- agent-transcript:end -->";
 const DEFAULT_MAX_CHARS = 50000;
 const DEFAULT_ENTRY_MAX_CHARS = 6000;
+const MAX_TRANSCRIPT_BYTES = 8 * 1024 * 1024;
 
 function usage() {
   console.log(`Usage:
   agent-transcript find --query TEXT [--cwd PATH] [--since-days N] [--max-files N] [--root PATH...]
-  agent-transcript render --session FILE [--app-server] [--thread-id ID] [--out FILE] [--max-chars N] [--entry-max-chars N] [--title TEXT] [--url URL]
+  agent-transcript render --session FILE [--app-server] [--thread-id ID] [--out FILE] [--max-chars N] [--entry-max-chars N] [--max-read-bytes N] [--title TEXT] [--url URL]
   agent-transcript render-thread --thread-id ID [--out FILE] [--max-chars N] [--entry-max-chars N] [--title TEXT] [--url URL]
-  agent-transcript preview --session FILE [--app-server] [--thread-id ID] [--out FILE] [--max-chars N] [--entry-max-chars N] [--title TEXT] [--url URL]
-  agent-transcript append-body --body FILE --session FILE [--app-server] [--thread-id ID] [--out FILE] [--max-chars N] [--entry-max-chars N]
-  agent-transcript html --prs FILE [--out FILE] [--since-days N] [--min-score N] [--root PATH...] [--exclude-session FILE...]
+  agent-transcript preview --session FILE [--app-server] [--thread-id ID] [--out FILE] [--max-chars N] [--entry-max-chars N] [--max-read-bytes N] [--title TEXT] [--url URL]
+  agent-transcript append-body --body FILE --session FILE [--app-server] [--thread-id ID] [--out FILE] [--max-chars N] [--entry-max-chars N] [--max-read-bytes N]
+  agent-transcript html --prs FILE [--out FILE] [--since-days N] [--min-score N] [--max-read-bytes N] [--root PATH...] [--exclude-session FILE...]
 
 Local-only. No network calls.`);
 }
@@ -134,18 +135,27 @@ function walkJsonl(root, sinceMs, out = []) {
   return out;
 }
 
-function readJsonl(file, maxLines = 12000) {
-  const text = fs.readFileSync(file, "utf8");
-  const lines = text.split(/\n+/).filter(Boolean).slice(0, maxLines);
+function transcriptReadLimit(options = {}) {
+  const value = options.maxReadBytes ?? options["max-read-bytes"] ?? MAX_TRANSCRIPT_BYTES;
+  const maxBytes = Number(value);
+  if (typeof value === "boolean" || !Number.isSafeInteger(maxBytes) || maxBytes < 1) {
+    throw new Error("--max-read-bytes must be a positive integer");
+  }
+  return maxBytes;
+}
+
+function readJsonl(file, maxLines = 12000, maxBytes = MAX_TRANSCRIPT_BYTES) {
+  const { text, truncated } = readBoundedText(file, maxBytes);
+  const lines = text.split(/\n+/).filter(Boolean);
   const rows = [];
-  for (const line of lines) {
+  for (const line of lines.slice(0, maxLines)) {
     try {
       rows.push(JSON.parse(line));
     } catch {
       rows.push({ type: "unparsed", text: line });
     }
   }
-  return rows;
+  return { rows, sourceTruncated: truncated || lines.length > maxLines };
 }
 
 function sessionThreadId(file) {
@@ -407,10 +417,11 @@ function expandCompactedReplacementItems(row) {
 }
 
 function renderSession(file, options = {}) {
-  const rows = readJsonl(file);
+  const { rows, sourceTruncated } = readJsonl(file, 12000, transcriptReadLimit(options));
   const agent = detectAgent(file, rows);
   const stats = {
     agent,
+    sourceTruncated,
     entries: 0,
     user: 0,
     assistant: 0,
@@ -480,7 +491,7 @@ function renderSession(file, options = {}) {
 
 \`\`\`\`text
 source: [LOCAL_SESSION]
-redaction: local paths, emails, phone-shaped strings, token-shaped strings, auth headers, auth query params
+${sourceTruncated ? "source truncated: the read or line limit omitted session content; this transcript is partial.\n" : ""}redaction: local paths, emails, phone-shaped strings, token-shaped strings, auth headers, auth query params
 omitted: raw tool outputs, system/developer prompts, local paths, secrets, browser/session/auth details
 stats: ${JSON.stringify(stats)}
 
@@ -659,15 +670,18 @@ function readBoundedText(file, maxBytes = 220000) {
     const stat = fs.fstatSync(fd);
     if (stat.size <= maxBytes) {
       const buffer = Buffer.alloc(stat.size);
-      fs.readSync(fd, buffer, 0, stat.size, 0);
-      return buffer.toString("utf8");
+      const bytesRead = fs.readSync(fd, buffer, 0, stat.size, 0);
+      return { text: buffer.subarray(0, bytesRead).toString("utf8"), truncated: false };
     }
     const half = Math.floor(maxBytes / 2);
     const head = Buffer.alloc(half);
     const tail = Buffer.alloc(half);
-    fs.readSync(fd, head, 0, half, 0);
-    fs.readSync(fd, tail, 0, half, Math.max(0, stat.size - half));
-    return `${head.toString("utf8")}\n[...middle omitted for scan...]\n${tail.toString("utf8")}`;
+    const headBytes = fs.readSync(fd, head, 0, half, 0);
+    const tailBytes = fs.readSync(fd, tail, 0, half, Math.max(0, stat.size - half));
+    return {
+      text: `${head.subarray(0, headBytes).toString("utf8")}\n[...middle omitted for scan...]\n${tail.subarray(0, tailBytes).toString("utf8")}`,
+      truncated: true,
+    };
   } finally {
     fs.closeSync(fd);
   }
@@ -680,7 +694,7 @@ function sessionScanRecord(file, maxBytes) {
     file,
     agent,
     mtime: new Date(stat.mtimeMs).toISOString(),
-    haystack: `${file}\n${readBoundedText(file, maxBytes)}`.toLowerCase(),
+    haystack: `${file}\n${readBoundedText(file, maxBytes).text}`.toLowerCase(),
   };
 }
 

--- a/skills/agent-transcript/scripts/agent-transcript.test.mjs
+++ b/skills/agent-transcript/scripts/agent-transcript.test.mjs
@@ -142,3 +142,108 @@ test("find labels explicit roots under trailing-slash CLAUDE_CONFIG_DIR as Claud
   assert.equal(matches[0].file, session);
   assert.equal(matches[0].agent, "claude");
 });
+
+function oversizedSession(dir) {
+  const session = path.join(dir, "session.jsonl");
+  const pad = JSON.stringify({
+    type: "user",
+    message: { role: "user", content: `pad-${"x".repeat(80)}` },
+  });
+  const lines = [
+    JSON.stringify({ type: "user", message: { role: "user", content: "HEAD_READ_BOUND_MARKER" } }),
+    ...Array.from({ length: 40 }, () => pad),
+    JSON.stringify({ type: "user", message: { role: "user", content: "MIDDLE_READ_BOUND_MARKER" } }),
+    ...Array.from({ length: 40 }, () => pad),
+    JSON.stringify({ type: "user", message: { role: "user", content: "TAIL_READ_BOUND_MARKER" } }),
+  ];
+  fs.writeFileSync(session, `${lines.join("\n")}\n`);
+  return session;
+}
+
+test("render bounds oversized JSONL reads before parse", () => {
+  const dir = tempDir();
+  const session = oversizedSession(dir);
+
+  const output = run(["render", "--session", session, "--max-read-bytes", "400"]);
+  assert.match(output, /HEAD_READ_BOUND_MARKER/);
+  assert.match(output, /TAIL_READ_BOUND_MARKER/);
+  assert.doesNotMatch(output, /MIDDLE_READ_BOUND_MARKER/);
+  assert.match(output, /source truncated:/);
+  assert.match(output, /"sourceTruncated":true/);
+});
+
+test("html bounds oversized JSONL reads before parse", () => {
+  const dir = tempDir();
+  const home = tempDir();
+  oversizedSession(dir);
+  const prs = path.join(dir, "prs.json");
+  fs.writeFileSync(prs, JSON.stringify([{ title: "HEAD_READ_BOUND_MARKER", url: "https://example.com/pr/1" }]));
+
+  const output = run(
+    ["html", "--prs", prs, "--root", dir, "--since-days", "1", "--min-score", "1", "--max-read-bytes", "400"],
+    { env: { ...process.env, HOME: home } },
+  );
+  assert.match(output, /HEAD_READ_BOUND_MARKER/);
+  assert.match(output, /TAIL_READ_BOUND_MARKER/);
+  assert.doesNotMatch(output, /MIDDLE_READ_BOUND_MARKER/);
+  assert.match(output, /source truncated:/);
+  assert.match(output, /&quot;sourceTruncated&quot;:true/);
+});
+
+test("preview and append-body retain source truncation notices even when output is shortened", () => {
+  const dir = tempDir();
+  const session = oversizedSession(dir);
+  const body = path.join(dir, "body.md");
+  fs.writeFileSync(body, "# Synthetic PR\n");
+  for (const command of [["render"], ["preview"], ["append-body", "--body", body]]) {
+    const output = run([...command, "--session", session, "--max-read-bytes", "400", "--max-chars", "1"]);
+    assert.match(output, /source truncated:/);
+    assert.match(output, /this transcript is partial/);
+  }
+});
+
+test("default read cap discloses omitted content in a file larger than eight MiB", () => {
+  const dir = tempDir();
+  const session = path.join(dir, "large.jsonl");
+  const row = (content) => ({ type: "user", message: { role: "user", content } });
+  writeJsonl(session, [row("HEAD_DEFAULT_MARKER"), row("x".repeat(5 * 1024 * 1024)), row("MIDDLE_DEFAULT_MARKER"), row("y".repeat(5 * 1024 * 1024)), row("TAIL_DEFAULT_MARKER")]);
+  const output = run(["render", "--session", session]);
+  assert.match(output, /HEAD_DEFAULT_MARKER/);
+  assert.match(output, /TAIL_DEFAULT_MARKER/);
+  assert.doesNotMatch(output, /MIDDLE_DEFAULT_MARKER/);
+  assert.match(output, /source truncated:/);
+});
+
+test("exact byte limit and small sessions remain complete", () => {
+  const dir = tempDir();
+  const session = path.join(dir, "small.jsonl");
+  writeJsonl(session, [{ type: "user", message: { role: "user", content: "complete-session-marker" } }]);
+  for (const options of [[], ["--max-read-bytes", String(fs.statSync(session).size)]]) {
+    const output = run(["render", "--session", session, ...options]);
+    assert.match(output, /complete-session-marker/);
+    assert.match(output, /"sourceTruncated":false/);
+    assert.doesNotMatch(output, /source truncated:/);
+  }
+});
+
+test("line-limited sessions disclose omitted source content", () => {
+  const dir = tempDir();
+  const session = path.join(dir, "many-lines.jsonl");
+  const row = { type: "user", message: { role: "user", content: "line-cap-marker" } };
+  writeJsonl(session, Array.from({ length: 12001 }, () => row));
+  const output = run(["render", "--session", session]);
+  assert.match(output, /source truncated:/);
+  assert.match(output, /"sourceTruncated":true/);
+});
+
+test("render rejects invalid and missing byte limits", () => {
+  const dir = tempDir();
+  const session = path.join(dir, "small.jsonl");
+  writeJsonl(session, []);
+  for (const value of ["1.5", "0", "-1", "NaN", "Infinity", "9007199254740992", null]) {
+    assert.throws(
+      () => run(["render", "--session", session, "--max-read-bytes", ...(value === null ? [] : [value])]),
+      (error) => /--max-read-bytes must be a positive integer/.test(String(error.stderr)),
+    );
+  }
+});


### PR DESCRIPTION
Local transcript rendering reads the entire JSONL file before applying its line limit. This carries forward #206's 8 MiB head/tail read cap and fixes its silent partial-output behavior: truncation metadata now survives parsing and produces a visible notice in render, preview, append-body, and HTML output. The notice also covers the existing 12,000-line parse limit and survives output character truncation. Byte overrides require a positive safe integer.

This is a maintained replacement for fork PR #206, with contributor credit preserved. The original remains open for the maintainer to close after landing this version.

Validation: 12 transcript tests pass, all 8 skills validate, `git diff --check` passes, and Codex autoreview is scoped-clean at its default P0 threshold. Tests cover the default cap on a file larger than 8 MiB, byte-limit equality, small files, line limits, all output forms, and malformed overrides.

Real CLI proof used a disposable 10,486,057-byte session containing head/middle/tail dialogue markers separated by two 5 MiB non-dialogue padding records:

```sh
node skills/agent-transcript/scripts/agent-transcript render --session "$SESSION"
node skills/agent-transcript/scripts/agent-transcript preview --session "$SESSION"
node skills/agent-transcript/scripts/agent-transcript append-body --body "$BODY" --session "$SESSION"
node skills/agent-transcript/scripts/agent-transcript html --prs "$PRS" --root "$SESSION" --min-score 1
node skills/agent-transcript/scripts/agent-transcript render --session "$SMALL_SESSION"
```

```text
main, all four commands: exit=0; head=true; middle=true; tail=true; notice=false
original PR, all four commands: exit=0; head=true; middle=false; tail=true; notice=false
repaired, all four commands: exit=0; head=true; middle=false; tail=true; notice=true
repaired small session: exit=0; complete=true; notice=false
```

The commands use the default 8 MiB limit and the actual CLI without mocks. Discovery remains independently addressed by #210.
