### PR TITLE
fix(autoreview): preserve mixed targets and pre-send scans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Validate explicit index/working-tree targets for mixed local Autoreview paths, preserving source anchors, rejected-attribution audit and distinct claim variants while repeating mandatory context within existing capacity limits.
+- Restore mandatory Autoreview TruffleHog `verified,unknown` pre-send scans removed in #209, retaining reviewer P0 credential checks as defense in depth.
 - Bound agent-transcript session reads to 8 MiB and disclose partial source content in render, preview, append-body, and HTML output. Thanks @SebTardif.
 - Bound agent-transcript `find` and `html` discovery to 20,000 session files, with an integer override and correct exact-limit handling. Thanks @SebTardif.
 - Rescan the exact outgoing Autoreview pack before Codex access-fallback retries, refusing findings, scanner errors, and missing scanners before another provider invocation.

--- a/skills/autoreview/SKILL.md
+++ b/skills/autoreview/SKILL.md
@@ -33,7 +33,8 @@ Do not invoke Autoreview automatically before a commit, push, PR, merge, deploy,
 - Tools are useful in review mode. Codex receives the validated bundle in an empty workspace so ignored files and linked-worktree metadata remain unreadable; web search stays available for dependency contracts and upstream docs.
 - Security perspective is always included, but it should not cripple legitimate functionality. Report security findings only when the change creates a concrete, actionable risk or removes an important safety check.
 - Reviewer subprocesses preserve engine authentication and non-credentialed proxy variables needed by headless or restricted-network environments while stripping process-injection, Git override, and credentialed proxy values.
-- Credential checking belongs to the reviewer: the hard rules require inspection of the entire change bundle for accidentally committed credentials and require every suspected real credential to be reported as a P0 security finding without reproducing its value. The helper does not invoke an external credential scanner. Security-sensitive paths remain omitted. Safe large diffs are sent as one pass while they fit the aggregate prompt limit, then partitioned into complete bounded passes without truncation.
+- Immediately before every provider call, autoreview writes the exact outgoing review pack to an owner-only temporary file and scans it with TruffleHog using `verified,unknown`. It uses the installed binary with `--no-update` to disable self-update checks and attempts. The scan covers prompt and dataset inputs, untracked content, and every diff line, including deleted lines. A finding, scanner error, or missing TruffleHog binary refuses the send and names the implicated repository file when it can be resolved; credentials are never redacted and forwarded. Security-sensitive paths remain omitted. Safe large diffs are sent as one pass while they fit the aggregate prompt limit, then partitioned into complete bounded passes without truncation.
+- Reviewer credential checks remain defense in depth alongside the restored mandatory pre-send scanner. Reviewers inspect the entire change bundle for accidentally committed credentials and report every suspected real credential as a P0 security finding without reproducing its value.
 - Regression provenance needs patch proof, not blame alone. `git log -S/-G`, `git blame`, commit subjects, and PR metadata locate candidates. Before saying `introduced by`, inspect raw parents with `git --no-replace-objects cat-file -p <sha>` and verify the implicated behavior changed in `git --no-replace-objects diff --no-ext-diff --no-textconv <raw-parent> <sha> -- <path>`; a genuine root needs raw-header proof that it has no parents.
 - Blame `^sha`, porcelain `boundary`, and shallow/grafted history alone are not introduction proof. `--root` can hide boundary markers; `git show` or `rev-list --parents` can make a shallow boundary look like a root. An available raw parent permits explicit comparison even at a shallow boundary; missing parents or an unverifiable patch require `unknown` with the gap. Use `carried forward` only for verified preexisting behavior and `made visible` only for a verified trigger. Apply the same bar to finding prose, summaries, and owner hints.
 - Keep code author, introducing PR author, merger, committer, automation trigger, and current PR author separate; none of those roles alone proves causation. Cite the verified commit/PR/date. If no PR is traceable, use the verified commit and known author identity; unknown identities stay unknown, and missing PR metadata is not a separate finding.
@@ -140,6 +141,15 @@ staged base. Git status remains relative to HEAD and does not define review scop
 Without `--base`, local mode retains its usual HEAD-to-index behavior; it never
 infers a base from an in-progress merge.
 
+For a local path changed in both transitions, capture retains immutable base,
+index, and working-tree identities, modes and absence states. Every pass with
+that path's delta includes its complete authoritative index and working-tree
+sources plus validated removed-line context. Re-additions and staged changes
+undone in the working tree remain in scope. A genuine index defect remains
+actionable, visibly `INDEX-only`, even when the working tree corrects it.
+Datasets never replace these source records. Nonmixed local paths and branch or
+commit reviews retain their existing patch-based source contract.
+
 Committed-only branch/PR work:
 
 ```bash
@@ -191,7 +201,10 @@ history and rerun. The helper does not fetch it automatically.
 
 ## Oversized Bundles
 
-The helper validates the complete patch before partitioning it. A bundle that fits
+The helper validates the complete patch before partitioning it. For partitioned
+reviews it scans the complete frozen input first, so credentials cannot evade
+detection by crossing a chunk boundary. It also scans each exact outgoing review
+pack before sending it. A safe bundle that fits
 the aggregate prompt limit remains one integrated review pass. Larger bundles
 are split at bundle sections and file boundaries where possible; an oversized
 single-file block is split at line boundaries with repeated file/hunk context
@@ -208,8 +221,19 @@ batch, and every evidence byte is retained. All validated reports are merged
 before required-finding and exit-status checks.
 There is no fixed pass-count ceiling: the complete frozen input determines the
 finite pass sequence. The helper prints its size and pass count before running
-passes serially. Each pass retains the same prompt-size limit and
+passes serially. Each pass retains the same prompt-size limit, secret scan, and
 reviewer isolation; a failed pass aborts without publishing a partial verdict.
+
+Mixed-path ownership travels as structured capture metadata through file, hunk,
+and physical-line splits. Repeated authoritative sources have separate identities
+and cannot be scheduled independently of their original delta fragments. Full
+source capture uses the existing sensitive-path, binary, gitlink, UTF-8 and
+180,000-byte file safeguards. Required context increases pack sizes and may
+increase pass counts or refuse a review. Evidence is rebatched first; if intact
+instructions and mandatory context cannot fit the existing engine/continuation
+limits, preparation stops before any provider call with a safe path, version,
+size and limit diagnosis. No limits are raised and no original bytes are dropped.
+Whole-input and exact outgoing-pack scans include the newly sent source context.
 
 Preparation prints immediate phase updates and periodic elapsed time to stderr,
 with file/byte counts during hashing and no filenames or contents. These updates
@@ -217,7 +241,7 @@ are separate from provider heartbeats and do not count against engine deadlines.
 Bundle construction captures finding membership alongside validated text; normal
 and dry runs reuse that record without reopening untracked files for membership.
 
-Dry runs reuse captured inputs and prompt construction without whole-tree integrity sweeps. Real
+Dry runs reuse capture and scanning without whole-tree integrity sweeps. Real
 reviews retain full fresh tree hashing before bundle construction, before review,
 and before publication, including unrelated tracked files, nonignored untracked files, index
 state, and initialized submodules. Explicit prompt files and datasets also retain
@@ -372,7 +396,7 @@ The helper:
 - supports `codex`, `claude`, `amp`, `pi`, and `kimi`; default is `AUTOREVIEW_ENGINE` or `codex`
 - resolves bare `git`, `gh`, reviewer, and PowerShell shell commands from absolute `PATH` entries only, never from the reviewed checkout; explicit `--*-bin` paths are interpreted from the reviewed repository root when relative and accepted only when both the supplied path and resolved target stay outside the reviewed repository
 - use `--mode commit --commit <ref>` for already-committed work, especially clean `main` after landing
-- validates complete Git patches, reviews them in one pass up to the aggregate prompt limit, and automatically uses complete bounded passes above it
+- validates complete Git patches, scans every outgoing review pack, reviews them in one pass up to the aggregate prompt limit, and automatically uses complete bounded passes above it
 - uses branch mode for committed-only PR work, or explicit local mode with a pinned merge base for a complete PR plus dirty candidate
 - writes reports to stdout and optionally to `--output` or `--json-output` files; preparation progress and provider heartbeats use stderr
 - supports `--dry-run` (validates bundle construction, reviewer CLI resolution, and local isolation startup with version/help probes without contacting a provider; exits nonzero if any check fails), an opt-in per-reviewer wall-clock bound via `--engine-timeout-seconds`, `--prompt`, repo-relative `--prompt-file`, repo-relative `--dataset`, `--no-tools`, `--no-web-search`, repeatable Codex-only safe model/response tuning with `--codex-config key=value`, Codex-only `--codex-speed fast|flex|default`, and commit refs
@@ -397,6 +421,19 @@ separately. Any scope rejection makes `review_status` `incomplete` and exits 2,
 including when other findings remain or `--expect-findings` is set. Resolve the
 target mismatch explicitly; do not infer a broader target from prompt prose.
 
+The shared provider schema adds nullable `source_attribution`; older findings
+without this field remain valid only for nonmixed paths. Mixed-path findings
+must explicitly supply `target` (`index` or `working_tree`), `record_id`,
+`source_id`, `side` (`present` or `removed`), `column`, and `excerpt`.
+`code_location.line` and `column` are 1-based; the excerpt must match exactly
+within that physical source line at the Unicode character column. Removed-side
+anchors must identify a line actually removed from the target's predecessor.
+Validation checks identity, bounds, exact source and availability in that pass
+before filtering or aggregation. Missing or incorrect attribution is retained
+with a reason in `attribution_rejected_findings`, makes the result `incomplete`,
+and exits 2 even if other findings are accepted or `--expect-findings` is set.
+Source anchoring proves attribution, not the correctness of the provider's claim.
+
 With no scope rejection, status is `findings` for accepted findings, `filtered`
 when only lower-priority findings remain, `incorrect` for an incorrect verdict
 without findings, or `scoped-clean` otherwise. Exit 1 means accepted findings or
@@ -412,12 +449,21 @@ provider explanation, and use the minimum pass confidence rather than promoting
 confidence from another pass. Provider JSON remains strictly validated before
 the helper adds local audit metadata. All engines use this same result path.
 
+`provider_report` preserves the well-formed provider conclusion before path
+normalization or enrichment. Mixed reviews retain `pass_reports` for one pass
+as well as multiple passes. Mixed observations group by target, record/source,
+anchor and category, never title. Exact repeated bodies share a claim variant;
+distinct bodies remain visible in `claim_variants`, with every contributing
+pass, title, priority and confidence. Index and working-tree findings never
+collapse together. Required-finding checks inspect accepted observations before
+deduplication; grouping cannot remove a provider verdict or hide a rejection.
+
 The exact source filename `CredentialFile.swift` is allowed for untracked and
 evidence inputs only outside sensitive parent paths, matching its existing
 tracked-source treatment. This is not a general source-extension exemption:
 credential stores, credential directories, `.env`, PEM, and key files retain
-their exclusions. Reviewers inspect the source content, deleted lines, prompts,
-and datasets present in each outgoing pack for accidentally committed credentials.
+their exclusions. TruffleHog still scans the exact outgoing pack, including
+source content, deleted lines, prompts, and datasets, before every provider call.
 
 ## Final Report
 

--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -166,6 +166,9 @@ MAX_REVIEW_CHUNK_CONTEXT_BYTES = 64_000
 class ReviewChunk(NamedTuple):
     content: str
     context: str = ""
+    byte_offset: int = 0
+    sources: tuple[MixedPath, ...] = ()
+    transitions: tuple[tuple[str, str], ...] = ()
 
 
 class ReviewDataset(NamedTuple):
@@ -178,6 +181,45 @@ class CapturedBundle(NamedTuple):
     text: str
     truncated: bool
     paths: set[str]
+    mixed: tuple[MixedPath, ...] = ()
+    spans: tuple[SourceSpan, ...] = ()
+
+
+class SourceVersion(NamedTuple):
+    identity: str
+    mode: str | None
+    content: str | None
+
+
+class MixedPath(NamedTuple):
+    path: str
+    identity: str
+    base: SourceVersion
+    index: SourceVersion
+    working_tree: SourceVersion
+    staged: str
+    unstaged: str
+    index_removed: tuple[tuple[int, str], ...]
+    working_tree_removed: tuple[tuple[int, str], ...]
+    topology: tuple[tuple[int, int, int], ...]
+
+
+class SourceSpan(NamedTuple):
+    start: int
+    end: int
+    path: str
+    target: str
+
+
+class ReviewPass(NamedTuple):
+    prompt: str
+    chunk: ReviewChunk
+    datasets: tuple[ReviewDataset, ...] = ()
+    evidence_batch: int = 1
+
+
+class MixedContextCapacityError(SystemExit):
+    """A pack may fit after rebatching evidence, never by detaching source."""
 
 
 class EvidenceFile(NamedTuple):
@@ -396,6 +438,7 @@ SCHEMA: dict[str, Any] = {
                     "confidence",
                     "category",
                     "code_location",
+                    "source_attribution",
                 ],
                 "properties": {
                     "title": {"type": "string", "minLength": 1, "maxLength": 140},
@@ -414,6 +457,24 @@ SCHEMA: dict[str, Any] = {
                             "file_path": {"type": "string", "minLength": 1},
                             "line": {"type": "integer", "minimum": 1},
                         },
+                    },
+                    "source_attribution": {
+                        "anyOf": [
+                            {"type": "null"},
+                            {
+                                "type": "object",
+                                "additionalProperties": False,
+                                "required": ["target", "record_id", "source_id", "side", "column", "excerpt"],
+                                "properties": {
+                                    "target": {"type": "string", "enum": ["index", "working_tree"]},
+                                    "record_id": {"type": "string"},
+                                    "source_id": {"type": "string"},
+                                    "side": {"type": "string", "enum": ["present", "removed"]},
+                                    "column": {"type": "integer", "minimum": 1},
+                                    "excerpt": {"type": "string", "minLength": 1},
+                                },
+                            },
+                        ],
                     },
                 },
             },
@@ -1566,6 +1627,10 @@ def validate_git_ref(repo: Path, ref: str, label: str, *, pin: bool = False) -> 
     return result.strip() if pin else ref
 
 
+TRUFFLEHOG_INSTALL_URL = "https://github.com/trufflesecurity/trufflehog#installation"
+TRUFFLEHOG_FINDINGS_EXIT_CODE = 183
+
+
 def git_bytes(
     repo: Path,
     *args: str,
@@ -1593,6 +1658,144 @@ def git_bytes(
             f"{display_escape(detail, 1000, multiline=True)}"
         )
     return result
+
+
+def safe_trufflehog_env(repo: Path) -> dict[str, str]:
+    env = safe_git_env(repo)
+    for key in (
+        "ALL_PROXY",
+        "HTTP_PROXY",
+        "HTTPS_PROXY",
+        "NO_PROXY",
+        "all_proxy",
+        "http_proxy",
+        "https_proxy",
+        "no_proxy",
+    ):
+        value = os.environ.get(key)
+        if not value:
+            continue
+        if key.casefold() != "no_proxy" and not safe_proxy_url(value):
+            raise SystemExit(
+                f"unsafe credentialed or malformed proxy URL in {key}; "
+                "configure a credential-free proxy URL before running autoreview"
+            )
+        env[key] = value
+    return env
+
+
+def review_pack_path_at_line(prompt: str, line_number: int) -> str:
+    current = "review pack"
+    pending_untracked = False
+    diff_header: list[str] = []
+    source_lines_remaining = 0
+    for index, raw_line in enumerate(literal_lf_lines(prompt), start=1):
+        line = raw_line.removesuffix("\n").removesuffix("\r")
+        if source_lines_remaining:
+            source_lines_remaining -= 1
+        elif line.startswith("# Prompt file: "):
+            current = line.removeprefix("# Prompt file: ").strip() or current
+        elif line.startswith("# Dataset: "):
+            current = line.removeprefix("# Dataset: ").strip() or current
+        elif line.startswith(("Source snapshot: ", "Removed source: ")):
+            try:
+                record = json.loads(line.partition(": ")[2])
+            except json.JSONDecodeError:
+                record = None
+            if isinstance(record, dict) and isinstance(record.get("path"), str):
+                current = record["path"] or current
+                count = record.get("line_count", 0)
+                if isinstance(count, int) and count > 0:
+                    source_lines_remaining = count
+        elif line == "# Untracked File":
+            pending_untracked = True
+            current = "review pack"
+        elif pending_untracked and line.startswith("path: "):
+            try:
+                path = json.loads(line.removeprefix("path: "))
+            except json.JSONDecodeError:
+                path = None
+            if isinstance(path, str) and path:
+                current = path
+            pending_untracked = False
+        elif line.startswith("diff --git "):
+            diff_header = [line]
+            current = "review pack"
+        elif diff_header and line.startswith(("--- ", "+++ ")):
+            diff_header.append(line)
+            old_path, new_path = diff_section_paths("\n".join(diff_header))
+            current = new_path or old_path or current
+        elif not diff_header and line.startswith(("--- ", "+++ ")):
+            path = diff_marker_path(line[4:])
+            if path:
+                current = path
+        elif diff_header and line.startswith("@@"):
+            old_path, new_path = diff_section_paths("\n".join(diff_header))
+            current = new_path or old_path or current
+            diff_header = []
+        if index == line_number:
+            return current
+    return current
+
+
+def trufflehog_review_pack_paths(prompt: str, output: str) -> list[str]:
+    paths: set[str] = set()
+    for line in output.splitlines():
+        try:
+            finding = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        filesystem = (
+            finding.get("SourceMetadata", {})
+            .get("Data", {})
+            .get("Filesystem", {})
+        )
+        line_number = filesystem.get("line", filesystem.get("Line"))
+        if isinstance(line_number, int) and line_number > 0:
+            paths.add(review_pack_path_at_line(prompt, line_number))
+    return sorted(paths or {"review pack"})
+
+
+def scan_outgoing_review_pack(repo: Path, prompt: str) -> None:
+    trufflehog_bin = find_command("trufflehog", repo)
+    if not trufflehog_bin:
+        raise SystemExit(
+            "refusing to send review pack: TruffleHog is required but was not found. "
+            f"Install it using the official instructions, then rerun autoreview: {TRUFFLEHOG_INSTALL_URL}"
+        )
+    with tempfile.TemporaryDirectory(
+        prefix="autoreview-pack-scan.",
+        dir=safe_temp_root(repo),
+    ) as tempdir:
+        pack_path = Path(tempdir) / "review-pack.txt"
+        pack_path.write_bytes(prompt.encode("utf-8"))
+        pack_path.chmod(0o600)
+        result = run(
+            [
+                trufflehog_bin,
+                "filesystem",
+                str(pack_path),
+                "--json",
+                "--no-color",
+                "--results=verified,unknown",
+                "--fail",
+                "--fail-on-scan-errors",
+                "--no-update",
+            ],
+            Path(tempdir),
+            check=False,
+            env=safe_trufflehog_env(repo),
+        )
+    if result.returncode == TRUFFLEHOG_FINDINGS_EXIT_CODE:
+        paths = trufflehog_review_pack_paths(prompt, result.stdout)
+        raise SystemExit(
+            "refusing to send review pack: TruffleHog found credentials in "
+            + ", ".join(paths)
+        )
+    if result.returncode != 0:
+        raise SystemExit(
+            "refusing to send review pack: TruffleHog could not complete the scan"
+        )
 
 
 def bounded(text: str, limit: int = 180_000) -> str:
@@ -2147,12 +2350,174 @@ def local_status(repo: Path, untracked: list[str], *, redact: bool = False) -> s
     return "\n".join(lines)
 
 
+def mixed_source_text(path: str, version: str, data: bytes) -> str:
+    label = f"mixed source {display_escape(path, 500)} ({version})"
+    if len(data) > MAX_BUNDLE_TEXT_BYTES:
+        raise SystemExit(f"{label}: {len(data)} bytes; limit {MAX_BUNDLE_TEXT_BYTES}")
+    if b"\0" in data:
+        raise SystemExit(f"{label}: binary file")
+    try:
+        return data.decode("utf-8")
+    except UnicodeDecodeError:
+        raise SystemExit(f"{label}: non-UTF-8 file") from None
+
+
+def git_source_version(repo: Path, path: str, ref: str | None) -> SourceVersion:
+    pathspec = f":(literal){path}"
+    if ref is None:
+        entries = git_path_list(repo, "ls-files", "--stage", "-z", "--", pathspec)
+    else:
+        entries = git_path_list(repo, "ls-tree", "-z", ref, "--", path)
+    if not entries:
+        return SourceVersion("absent", None, None)
+    if len(entries) != 1:
+        raise SystemExit(f"unmerged mixed source: {display_escape(path, 500)}")
+    metadata, actual = entries[0].split("\t", 1)
+    mode, middle, last = metadata.split()
+    oid = middle if ref is None else last
+    if actual != path or (ref is None and last != "0") or mode not in {"100644", "100755"}:
+        raise SystemExit(f"unsafe mixed source mode: {display_escape(path, 500)} ({mode})")
+    return SourceVersion(f"git:{oid}:{mode}", mode, None)
+
+
+def read_git_source(repo: Path, path: str, version: str, source: SourceVersion) -> SourceVersion:
+    if source.mode is None:
+        return source
+    oid = source.identity.split(":")[1]
+    size = int(git(repo, "cat-file", "-s", oid))
+    if size > MAX_BUNDLE_TEXT_BYTES:
+        raise SystemExit(
+            f"mixed source {display_escape(path, 500)} ({version}): "
+            f"{size} bytes; limit {MAX_BUNDLE_TEXT_BYTES}"
+        )
+    content = mixed_source_text(path, version, git_bytes(repo, "cat-file", "blob", oid).stdout)
+    return source._replace(content=content)
+
+
+def mixed_source_topology(repo: Path, path: str) -> tuple[tuple[int, int, int], ...]:
+    current = repo.resolve()
+    identities = []
+    for part in Path(path).parts:
+        current /= part
+        try:
+            info = os.stat(current, follow_symlinks=False)
+        except FileNotFoundError:
+            identities.append((0, 0, 0))
+            break
+        if stat.S_ISLNK(info.st_mode):
+            raise SystemExit(f"symlinked mixed source: {display_escape(path, 500)}")
+        identities.append((info.st_dev, info.st_ino, info.st_mode))
+    return tuple(identities)
+
+
+def working_source_version(
+    repo: Path, path: str, untracked: dict[str, tuple[str, bool]] | None = None,
+) -> SourceVersion:
+    source = repo / path
+    if not source.exists():
+        return SourceVersion("absent", None, None)
+    info = source.lstat()
+    if not stat.S_ISREG(info.st_mode):
+        raise SystemExit(f"nonregular mixed source: {display_escape(path, 500)}")
+    if untracked is not None and path in untracked:
+        content, truncated = untracked[path]
+        if truncated:
+            raise SystemExit(f"incomplete mixed source: {display_escape(path, 500)} (working_tree)")
+        data = content.encode("utf-8")
+    else:
+        if info.st_size > MAX_BUNDLE_TEXT_BYTES:
+            raise SystemExit(
+                f"mixed source {display_escape(path, 500)} (working_tree): "
+                f"{info.st_size} bytes; limit {MAX_BUNDLE_TEXT_BYTES}"
+            )
+        data, truncated = read_prefix(source, MAX_BUNDLE_TEXT_BYTES)
+        if truncated:
+            raise SystemExit(f"mixed source grew beyond limit {MAX_BUNDLE_TEXT_BYTES}: {display_escape(path, 500)}")
+    content = mixed_source_text(path, "working_tree", data)
+    mode = "100755" if info.st_mode & stat.S_IXUSR else "100644"
+    return SourceVersion(f"sha256:{hashlib.sha256(data).hexdigest()}:{mode}", mode, content)
+
+
+def removed_source_lines(patch: str) -> tuple[tuple[int, str], ...]:
+    removed = []
+    old_line = None
+    for line in literal_lf_lines(patch):
+        match = re.match(r"^@@ -(\d+)(?:,\d+)? \+\d+(?:,\d+)? @@", line)
+        if match:
+            old_line = int(match[1])
+        elif old_line is not None and line.startswith(("-", " ")):
+            if line.startswith("-"):
+                removed.append((old_line, line[1:].removesuffix("\n")))
+            old_line += 1
+    return tuple(removed)
+
+
+def local_patch_ownership(patch: str, paths: list[str]) -> list[tuple[str, str]]:
+    # Git supplies the path order. Never infer identity from source-controlled
+    # path headings; require a one-to-one mapping before attaching ownership.
+    units = review_bundle_units(patch)
+    if len(units) != len(paths) or any(not unit.startswith("diff --git ") for unit in units):
+        raise SystemExit("cannot establish mixed local patch ownership")
+    return list(zip(paths, units))
+
+
+def capture_mixed_paths(
+    repo: Path, base_ref: str | None, paths: set[str],
+    staged: dict[str, str], unstaged: dict[str, str],
+    untracked: dict[str, tuple[str, bool]],
+) -> tuple[MixedPath, ...]:
+    records = []
+    if base_ref is None:
+        head = git_result(repo, "rev-parse", "--verify", "HEAD", check=False)
+        base_ref = head.stdout.strip() if head.returncode == 0 else None
+    for path in sorted(paths):
+        # Tracked role policy is authoritative here; datasets keep their own
+        # stricter policy and can never stand in for these source records.
+        if tracked_sensitive_repo_path_risk(path):
+            raise SystemExit("sensitive mixed source was not omitted")
+        topology = mixed_source_topology(repo, path)
+        base = git_source_version(repo, path, base_ref) if base_ref else SourceVersion("absent", None, None)
+        index = read_git_source(repo, path, "index", git_source_version(repo, path, None))
+        working = working_source_version(repo, path, untracked)
+        index_removed = removed_source_lines(staged[path])
+        working_removed = removed_source_lines(unstaged[path])
+        if index_removed:
+            base = read_git_source(repo, path, "base", base)
+        for source, removed in ((base, index_removed), (index, working_removed)):
+            lines = literal_lf_lines(source.content or "")
+            if any(line < 1 or line > len(lines) or lines[line - 1].removesuffix("\n") != text
+                   for line, text in removed):
+                raise SystemExit(f"mixed deletion source does not match patch: {display_escape(path, 500)}")
+        if mixed_source_topology(repo, path) != topology:
+            raise SystemExit("mixed source changed while being captured")
+        identity = hashlib.sha256(json.dumps(
+            [path, base_ref, base.identity, index.identity, working.identity, staged[path], unstaged[path]],
+            ensure_ascii=True,
+        ).encode()).hexdigest()
+        records.append(MixedPath(path, identity, base, index, working, staged[path], unstaged[path],
+                                 index_removed, working_removed, topology))
+    return tuple(records)
+
+
+def verify_mixed_sources(repo: Path, records: tuple[MixedPath, ...]) -> None:
+    for record in records:
+        if (mixed_source_topology(repo, record.path) != record.topology
+                or git_source_version(repo, record.path, None).identity != record.index.identity
+                or working_source_version(repo, record.path) != record.working_tree):
+            raise SystemExit("mixed source changed; rerun autoreview against the updated inputs")
+
+
 def local_bundle(repo: Path, base_ref: str | None = None) -> CapturedBundle:
     if base_ref is not None:
         base_ref = validate_git_ref(repo, base_ref, "base", pin=True)
     staged_base = ("--end-of-options", base_ref) if base_ref is not None else ()
-    staged_patch = git(repo, "diff", *SAFE_DIFF_FLAGS, "--cached", "--patch", *staged_base)
-    unstaged_patch = git(repo, "diff", *SAFE_DIFF_FLAGS, "--patch")
+    # Text-mode subprocess output normalizes CRLF, which cannot serve as an
+    # exact source anchor. Keep the original transition bytes in local capture.
+    try:
+        staged_patch = git_bytes(repo, "diff", *SAFE_DIFF_FLAGS, "--cached", "--patch", *staged_base).stdout.decode("utf-8")
+        unstaged_patch = git_bytes(repo, "diff", *SAFE_DIFF_FLAGS, "--patch").stdout.decode("utf-8")
+    except UnicodeDecodeError:
+        raise SystemExit("refusing non-UTF-8 Git output in local patch") from None
     require_no_binary_diff(
         "local staged diff",
         git(repo, "diff", *SAFE_DIFF_FLAGS, "--cached", "--numstat", "-z", *staged_base),
@@ -2161,10 +2526,8 @@ def local_bundle(repo: Path, base_ref: str | None = None) -> CapturedBundle:
         "local unstaged diff",
         git(repo, "diff", *SAFE_DIFF_FLAGS, "--numstat", "-z"),
     )
-    require_no_gitlink_diff(
-        "local staged diff",
-        git(repo, "diff", *SAFE_DIFF_FLAGS, "--cached", "--raw", "-z", *staged_base),
-    )
+    staged_raw = git(repo, "diff", *SAFE_DIFF_FLAGS, "--cached", "--raw", "-z", *staged_base)
+    require_no_gitlink_diff("local staged diff", staged_raw)
     require_no_gitlink_diff(
         "local unstaged diff",
         git(repo, "diff", *SAFE_DIFF_FLAGS, "--raw", "-z"),
@@ -2199,6 +2562,22 @@ def local_bundle(repo: Path, base_ref: str | None = None) -> CapturedBundle:
         raise SystemExit("no local changes to review")
     staged_blocked_paths = tracked_sensitive_paths(staged_paths)
     unstaged_blocked_paths = tracked_sensitive_paths(unstaged_paths)
+    raw_records = staged_raw.split("\0")
+    for index in range(0, len(raw_records) - 1, 2):
+        metadata = raw_records[index]
+        if metadata.startswith(":") and metadata.split()[-1] == "D":
+            path = raw_records[index + 1]
+            if (path not in staged_blocked_paths and os.path.lexists(repo / path)
+                    and path not in untracked):
+                # An ignored or unsafe re-addition must not silently become an
+                # index-only review through the old untracked omission path.
+                raise SystemExit(
+                    f"mixed source {display_escape(path, 500)} (working_tree): "
+                    "re-addition is not in validated untracked membership"
+                )
+    mixed_paths = (set(staged_paths) & (set(unstaged_paths) | set(untracked))) - staged_blocked_paths - unstaged_blocked_paths
+    staged_units = local_patch_ownership(staged_patch, staged_paths) if mixed_paths else []
+    unstaged_units = local_patch_ownership(unstaged_patch, unstaged_paths) if mixed_paths else []
     staged_patch = validate_review_patch("local staged diff", staged_paths, staged_patch)
     unstaged_patch = validate_review_patch("local unstaged diff", unstaged_paths, unstaged_patch)
     parts = [
@@ -2223,6 +2602,7 @@ def local_bundle(repo: Path, base_ref: str | None = None) -> CapturedBundle:
         ),
         unstaged_patch,
     ]
+    owned_parts = {4: (staged_units, "index"), 7: (unstaged_units, "working_tree")}
     if omitted_tracked or omitted_untracked:
         parts[0:0] = [
             "# Review Input Omissions",
@@ -2232,6 +2612,7 @@ def local_bundle(repo: Path, base_ref: str | None = None) -> CapturedBundle:
                 f"omitted untracked files: {omitted_untracked}."
             ),
         ]
+        owned_parts = {index + 3: value for index, value in owned_parts.items()}
     input_truncated = False
     if untracked:
         parts.append("# Untracked Files")
@@ -2246,8 +2627,32 @@ def local_bundle(repo: Path, base_ref: str | None = None) -> CapturedBundle:
                     for line_number, record in enumerate(records, start=1)
                 )
             )
+            if rel in mixed_paths:
+                owned_parts[len(parts) - 1] = ([(rel, parts[-1])], "working_tree")
+    spans = []
+    offset = 0
+    transitions = {"index": {}, "working_tree": {}}
+    for part_index, part in enumerate(parts):
+        if part_index in owned_parts and mixed_paths:
+            units, target = owned_parts[part_index]
+            retained = [(path, unit) for path, unit in units if not tracked_sensitive_repo_path_risk(path)]
+            prefix = REVIEW_SECURITY_OMISSION + "\n" if len(retained) != len(units) else ""
+            if prefix + "".join(unit for _, unit in retained) != part:
+                raise SystemExit("cannot establish mixed local bundle coverage")
+            unit_offset = offset + utf8_size(prefix)
+            for path, unit in retained:
+                end = unit_offset + utf8_size(unit)
+                if path in mixed_paths:
+                    spans.append(SourceSpan(unit_offset, end, path, target))
+                    transitions[target][path] = unit
+                unit_offset = end
+        offset += utf8_size(part) + 2
+    mixed = capture_mixed_paths(
+        repo, base_ref, mixed_paths, transitions["index"], transitions["working_tree"],
+        {path: (content, truncated) for path, content, truncated in untracked_snapshots},
+    ) if mixed_paths else ()
     paths = (set(staged_paths) - staged_blocked_paths) | (set(unstaged_paths) - unstaged_blocked_paths)
-    return CapturedBundle("\n\n".join(parts), input_truncated, paths | set(untracked))
+    return CapturedBundle("\n\n".join(parts), input_truncated, paths | set(untracked), mixed, tuple(spans))
 
 
 def source_file_fingerprint(
@@ -3108,8 +3513,181 @@ def render_review_prompt(
     ).strip()
     return (
         instructions + "\n\n" + extra_prompt + "\n\n" + datasets
+        + render_mixed_context(chunk)
         + "\n\n# Change Bundle\n" + chunk.content
     )
+
+
+def render_mixed_context(chunk: ReviewChunk) -> str:
+    if not chunk.sources:
+        return ""
+    parts = [textwrap.dedent("""
+        # Authoritative Mixed Sources
+        These owner records, not datasets or diff additions, establish source identity.
+        Review both base->index and index->working_tree. An index defect remains
+        actionable even when corrected in working_tree; label it INDEX-only.
+        Findings on these paths REQUIRE source_attribution: target, record_id,
+        source_id, side, column and excerpt. code_location.line is a 1-based source
+        line; column is a 1-based Unicode character offset. excerpt must be a
+        nonempty exact substring of that physical line (no LF). Use present for
+        current target source, removed only for a listed removed line from its
+        predecessor. Never claim removed index text is present in working_tree.
+        Any line in a selected file is in scope, including unchanged context.
+        Null attribution is permitted only for paths without mixed records.
+        Repeated source records are context, never additional change bytes.
+    """).strip()]
+    parts.append("Original fragment ownership: " + json.dumps(chunk.transitions))
+    parts.append(f"Original bundle byte offset: {chunk.byte_offset}")
+    for record in chunk.sources:
+        manifest = {
+            "path": record.path, "record_id": record.identity,
+            "versions": {name: {"source_id": source.identity, "mode": source.mode,
+                                "state": "absent" if source.mode is None else "present"}
+                         for name, source in (("base", record.base), ("index", record.index),
+                                              ("working_tree", record.working_tree))},
+        }
+        parts.append("Mixed record: " + json.dumps(manifest))
+        for target, source, previous, removed in (
+            ("index", record.index, record.base, record.index_removed),
+            ("working_tree", record.working_tree, record.index, record.working_tree_removed),
+        ):
+            content = source.content or ""
+            parts.append("Source snapshot: " + json.dumps({
+                "path": record.path, "target": target, "side": "present",
+                "source_id": source.identity, "content_bytes": utf8_size(content),
+                "line_count": len(literal_lf_lines(content)),
+            }) + "\n" + content + "\nEnd source snapshot: " + source.identity)
+            parts.append("Removed source: " + json.dumps({
+                "path": record.path, "target": target, "side": "removed",
+                "source_id": previous.identity, "lines": removed,
+            }, ensure_ascii=False))
+    return "\n\n" + "\n".join(parts)
+
+
+def mixed_bundle_chunk(captured: CapturedBundle) -> ReviewChunk:
+    return ReviewChunk(captured.text, "", 0, captured.mixed,
+                       tuple(dict.fromkeys((span.path, span.target) for span in captured.spans)))
+
+
+def mixed_capacity_error(record: MixedPath, required: int, limit: int) -> MixedContextCapacityError:
+    sizes = ", ".join(f"{name}={utf8_size(source.content or '')} bytes"
+                      for name, source in (("index", record.index), ("working_tree", record.working_tree)))
+    return MixedContextCapacityError(
+        f"mixed source {display_escape(record.path, 500)} ({sizes}; "
+        f"base removed={utf8_size(json.dumps(record.index_removed, ensure_ascii=False))} bytes): "
+        f"mandatory context/instructions/continuation and fragment require {required} bytes; "
+        f"prompt limit {limit}; cannot split authoritative context"
+    )
+
+
+def build_mixed_change_passes(
+    branch: str, target: str, target_ref: str | None, captured: CapturedBundle,
+    extra_prompt: str, datasets: list[ReviewDataset], max_prompt_bytes: int,
+) -> list[ReviewPass]:
+    rendered = render_datasets(datasets)
+    full = mixed_bundle_chunk(captured)
+    prompt = render_review_prompt(branch, target, target_ref, full, extra_prompt, rendered)
+    if utf8_size(prompt) <= max_prompt_bytes:
+        return [ReviewPass(prompt, full, tuple(datasets))]
+    records = {record.path: record for record in captured.mixed}
+    data = captured.text.encode("utf-8")
+    ranges = []
+    offset = 0
+    for span in captured.spans:
+        if offset < span.start:
+            ranges.append((offset, span.start, (), ()))
+        ranges.append((span.start, span.end, (records[span.path],), ((span.path, span.target),)))
+        offset = span.end
+    if offset < len(data):
+        ranges.append((offset, len(data), (), ()))
+    chunks = []
+    for start, end, sources, transitions in ranges:
+        template = ReviewChunk("", "", start, sources, transitions)
+        overhead = utf8_size(render_review_prompt(
+            branch, target, target_ref, template, extra_prompt, rendered, (999_999, 999_999),
+        ))
+        limit = max_prompt_bytes - overhead
+        while limit >= 4:
+            pieces = split_review_bundle(data[start:end].decode("utf-8"), limit)
+            owned = []
+            position = start
+            for piece in pieces:
+                owned.append(piece._replace(byte_offset=position, sources=sources, transitions=transitions))
+                position += utf8_size(piece.content)
+            largest = max(utf8_size(render_review_prompt(
+                branch, target, target_ref, piece, extra_prompt, rendered, (999_999, 999_999),
+            )) for piece in owned)
+            if largest <= max_prompt_bytes:
+                chunks.extend(owned)
+                break
+            limit -= largest - max_prompt_bytes
+        else:
+            required = max_prompt_bytes - limit + 4
+            if sources:
+                raise mixed_capacity_error(sources[0], required, max_prompt_bytes)
+            raise MixedContextCapacityError(
+                f"review instructions/evidence/continuation and fragment require {required} bytes; "
+                f"prompt limit {max_prompt_bytes}"
+            )
+    if "".join(chunk.content for chunk in chunks) != captured.text:
+        raise SystemExit("internal error: mixed bundle coverage changed")
+    return [ReviewPass(render_review_prompt(
+        branch, target, target_ref, chunk, extra_prompt, rendered, (index, len(chunks)),
+    ), chunk, tuple(datasets)) for index, chunk in enumerate(chunks, 1)]
+
+
+def build_mixed_review_passes(
+    repo: Path, target: str, target_ref: str | None, captured: CapturedBundle,
+    extra_prompt: str, datasets: list[ReviewDataset], max_prompt_bytes: int,
+) -> list[ReviewPass]:
+    branch = current_branch(repo)
+    full = mixed_bundle_chunk(captured)
+    prompt = render_review_prompt(branch, target, target_ref, full, extra_prompt, render_datasets(datasets))
+    if utf8_size(prompt) <= max_prompt_bytes:
+        return [ReviewPass(prompt, full, tuple(datasets))]
+    # Establish that every mandatory record fits even with no evidence before
+    # spending time rebatching. Source context is never scheduled independently.
+    for record in captured.mixed:
+        chunk = ReviewChunk("xxxx", "", 0, (record,), ((record.path, "working_tree"),))
+        required = utf8_size(render_review_prompt(
+            branch, target, target_ref, chunk, extra_prompt, "", (999_999, 999_999),
+        ))
+        if required > max_prompt_bytes:
+            raise mixed_capacity_error(record, required, max_prompt_bytes)
+    try:
+        return build_mixed_change_passes(
+            branch, target, target_ref, captured, extra_prompt, datasets, max_prompt_bytes,
+        )
+    except MixedContextCapacityError:
+        if not datasets:
+            raise
+    minimum_evidence = max(
+        utf8_size(render_datasets([ReviewDataset(item.path, "", utf8_size(item.content))])) + 4
+        for item in datasets
+    )
+    evidence_limit = max_prompt_bytes // 2
+    while True:
+        evidence_limit = max(evidence_limit, minimum_evidence)
+        batches = split_review_datasets(datasets, evidence_limit)
+        passes = []
+        for index, batch in enumerate(batches, 1):
+            instructions = extra_prompt + (
+                f"\n\nEvidence batch: {index}/{len(batches)}\n"
+                "Every original change byte appears once in this batch. Dataset fragments "
+                "are context only; missing evidence is not proof of missing behavior."
+            )
+            try:
+                batch_passes = build_mixed_change_passes(
+                    branch, target, target_ref, captured, instructions, batch, max_prompt_bytes,
+                )
+            except MixedContextCapacityError:
+                if evidence_limit == minimum_evidence:
+                    raise
+                break
+            passes.extend(item._replace(evidence_batch=index) for item in batch_passes)
+        else:
+            return passes
+        evidence_limit //= 2
 
 
 def build_change_review_prompts(
@@ -3173,11 +3751,15 @@ def build_review_prompts(
     repo: Path,
     target: str,
     target_ref: str | None,
-    bundle: str,
+    bundle: str | CapturedBundle,
     extra_prompt: str,
     datasets: list[ReviewDataset],
     max_prompt_bytes: int = MAX_REVIEW_PROMPT_BYTES,
-) -> list[str]:
+) -> list[str] | list[ReviewPass]:
+    if isinstance(bundle, CapturedBundle):
+        if bundle.mixed:
+            return build_mixed_review_passes(repo, target, target_ref, bundle, extra_prompt, datasets, max_prompt_bytes)
+        bundle = bundle.text
     branch = current_branch(repo)
     rendered_datasets = render_datasets(datasets)
     full_prompt = render_review_prompt(
@@ -3236,14 +3818,23 @@ def prepare_review_prompts(
     repo: Path,
     target: str,
     target_ref: str | None,
-    bundle: str,
+    bundle: str | CapturedBundle,
     extra_prompt: str,
     datasets: list[ReviewDataset],
     max_prompt_bytes: int,
-) -> list[str]:
-    return build_review_prompts(
+) -> list[str] | list[ReviewPass]:
+    prompts = build_review_prompts(
         repo, target, target_ref, bundle, extra_prompt, datasets, max_prompt_bytes,
     )
+    if len(prompts) > 1:
+        # A credential can span a partition boundary. Scan the complete frozen
+        # input before any send, in addition to each exact outgoing pack.
+        chunk = mixed_bundle_chunk(bundle) if isinstance(bundle, CapturedBundle) else ReviewChunk(bundle)
+        scan_outgoing_review_pack(repo, render_review_prompt(
+            current_branch(repo), target, target_ref, chunk,
+            extra_prompt, render_datasets(datasets),
+        ))
+    return prompts
 
 
 def write_json_temp(data: dict[str, Any], temp_root: Path) -> Path:
@@ -4164,6 +4755,10 @@ def run_codex(args: argparse.Namespace, repo: Path, prompt: str) -> str:
                     model,
                     force_file_auth=file_auth_linked,
                 )
+                if index:
+                    # The initial send was scanned by run_reviewer; a retry is
+                    # a new provider invocation even with the same frozen pack.
+                    scan_outgoing_review_pack(repo, prompt)
                 result = run_with_heartbeat(
                     cmd,
                     review_root,
@@ -5242,11 +5837,63 @@ def parse_json_candidate(text: str) -> Any | None:
     return parsed
 
 
+def validate_attribution_shape(value: Any, index: int) -> None:
+    if value is None:
+        return
+    keys = {"target", "record_id", "source_id", "side", "column", "excerpt"}
+    if not isinstance(value, dict) or set(value) != keys:
+        raise SystemExit(f"finding {index} has invalid source_attribution keys")
+    if (value["target"] not in {"index", "working_tree"}
+            or value["side"] not in {"present", "removed"}
+            or not all(isinstance(value[key], str) for key in ("record_id", "source_id", "excerpt"))
+            or not value["excerpt"]
+            or not isinstance(value["column"], int) or isinstance(value["column"], bool)
+            or value["column"] < 1):
+        raise SystemExit(f"finding {index} has invalid source_attribution")
+
+
+def mixed_attribution_error(
+    finding: dict[str, Any], record: MixedPath, available: set[str],
+) -> str | None:
+    attribution = finding.get("source_attribution")
+    if attribution is None:
+        return "mixed path requires explicit source attribution"
+    if attribution["record_id"] != record.identity:
+        return "mixed source record identity does not match"
+    if record.identity not in available:
+        return "mixed source record was not available in this pass"
+    target = attribution["target"]
+    removed = attribution["side"] == "removed"
+    source = (record.base if target == "index" else record.index) if removed else getattr(record, target)
+    if attribution["source_id"] != source.identity:
+        return "target/side source identity does not match"
+    if source.mode is None:
+        return "anchor refers to an absent source"
+    line = finding["code_location"]["line"]
+    if removed:
+        lines = dict(record.index_removed if target == "index" else record.working_tree_removed)
+        if line not in lines:
+            return "anchor is not a genuinely removed line of this transition"
+        text = lines[line]
+    else:
+        lines = literal_lf_lines(source.content or "")
+        if line > len(lines):
+            return "source anchor line is out of range"
+        text = lines[line - 1].removesuffix("\n")
+    column = attribution["column"] - 1
+    excerpt = attribution["excerpt"]
+    if "\n" in excerpt or text[column:column + len(excerpt)] != excerpt:
+        return "source anchor excerpt does not match exactly at line/column"
+    return None
+
+
 def _validate_report(
     report: dict[str, Any],
     repo: Path,
     changed_paths: set[str],
     required: list[str],
+    mixed: tuple[MixedPath, ...] = (),
+    available: set[str] | None = None,
 ) -> None:
     allowed_top = {"findings", "overall_correctness", "overall_explanation", "overall_confidence"}
     extra_top = set(report) - allowed_top
@@ -5267,16 +5914,19 @@ def _validate_report(
         raise SystemExit("review JSON overall_confidence must be numeric")
     kept_findings: list[dict[str, Any]] = []
     ignored_findings: list[tuple[int, dict[str, Any], str, int]] = []
+    attribution_rejected = []
+    records = {record.path: record for record in mixed}
     for index, finding in enumerate(report["findings"]):
         if not isinstance(finding, dict):
             raise SystemExit(f"finding {index} must be an object")
         allowed_finding = {"title", "body", "priority", "confidence", "category", "code_location"}
-        extra_finding = set(finding) - allowed_finding
+        extra_finding = set(finding) - allowed_finding - {"source_attribution"}
         if extra_finding:
             raise SystemExit(f"finding {index} has unexpected keys: {sorted(extra_finding)}")
         for key in allowed_finding:
             if key not in finding:
                 raise SystemExit(f"finding {index} missing required key: {key}")
+        validate_attribution_shape(finding.get("source_attribution"), index)
         title = finding.get("title")
         if not isinstance(title, str) or not title or len(title) > 140:
             raise SystemExit(f"finding {index} has invalid title")
@@ -5318,6 +5968,16 @@ def _validate_report(
         if rel not in changed_paths:
             ignored_findings.append((index, finding, rel, line))
             continue
+        reason = None
+        if rel in records:
+            reason = mixed_attribution_error(finding, records[rel], available or set())
+        elif finding.get("source_attribution") is not None:
+            reason = "source attribution has no owner-built mixed record for this path"
+        if reason:
+            rejected = copy.deepcopy(finding)
+            rejected["attribution_rejection_reason"] = reason
+            attribution_rejected.append(rejected)
+            continue
         kept_findings.append(finding)
     if ignored_findings:
         for index, finding, rel, line in ignored_findings:
@@ -5336,8 +5996,10 @@ def _validate_report(
                 ),
                 file=sys.stderr,
             )
-        report["findings"] = kept_findings
         report["scope_rejected_findings"] = [finding for _, finding, _, _ in ignored_findings]
+    report["findings"] = kept_findings
+    if attribution_rejected:
+        report["attribution_rejected_findings"] = attribution_rejected
     require_findings(report, required)
 
 
@@ -5362,9 +6024,11 @@ def validate_report(
     repo: Path,
     changed_paths: set[str],
     required: list[str],
+    mixed: tuple[MixedPath, ...] = (),
+    available: set[str] | None = None,
 ) -> None:
     try:
-        _validate_report(report, repo, changed_paths, required)
+        _validate_report(report, repo, changed_paths, required, mixed, available)
     except SystemExit as exc:
         if isinstance(exc.code, str):
             raise SystemExit(
@@ -5397,7 +6061,8 @@ def number_in_range(value: Any) -> bool:
 
 
 def review_status(report: dict[str, Any]) -> str:
-    if report.get("scope_rejected_findings") or report.get("missing_required_findings"):
+    if (report.get("scope_rejected_findings") or report.get("missing_required_findings")
+            or report.get("attribution_rejected_findings")):
         return "incomplete"
     if report["findings"]:
         return "findings"
@@ -5413,7 +6078,21 @@ def print_findings(findings: list[dict[str, Any]]) -> None:
         loc = finding["code_location"]
         print(f"[{finding['priority']}] {display_escape(finding['title'], 140)}")
         print(f"{display_escape(loc['file_path'], 500)}:{loc['line']}")
+        if attribution := finding.get("source_attribution"):
+            target = "INDEX-only" if attribution["target"] == "index" else "WORKING_TREE"
+            print(f"target: {target}; side: {attribution['side']}; "
+                  f"source: {display_escape(attribution['source_id'], 200)}")
         print(display_escape(finding["body"], 2000, multiline=True))
+        if reason := finding.get("attribution_rejection_reason"):
+            print(f"Rejected attribution: {reason}")
+        for index, variant in enumerate(finding.get("claim_variants", []), 1):
+            print(f"Claim variant {index}:")
+            print(display_escape(variant["body"], 2000, multiline=True))
+            for observation in variant["observations"]:
+                print(display_escape(
+                    f"{observation['pass']}: [{observation['priority']}] {observation['title']} "
+                    f"(confidence {observation['confidence']})", 500,
+                ))
         print()
 
 
@@ -5440,6 +6119,7 @@ def print_report(report: dict[str, Any], *, label: str = "autoreview") -> None:
     print_findings(findings)
     for key, description in (
         ("scope_rejected_findings", "Rejected out-of-scope findings (retained for audit)"),
+        ("attribution_rejected_findings", "Rejected source attributions (retained for audit)"),
         ("priority_filtered_findings", "Findings below the requested priority (retained for audit)"),
     ):
         if report.get(key):
@@ -5816,8 +6496,9 @@ def dry_run_preflight(
     and pass the same repo-relative/existence checks the real run applies
     via capture_evidence_inputs, that the assembled prompt(s) pass
     the same aggregate-size/partition and truncation-refusal checks the
-    real run applies via build_review_prompts/ensure_reviewer_input_complete,
-    and that each configured reviewer's CLI binary resolves and
+    real run applies via build_review_prompts/ensure_reviewer_input_complete
+    and the same fail-closed TruffleHog scan of each exact outgoing prompt
+    used by a real run, and that each configured reviewer's CLI binary resolves and
     its configuration (including, for Kimi, load_kimi_review_config and
     validate_kimi_runtime_auth_sources, and for Claude, the tool
     inventory) is one a real run would actually accept. Returns the
@@ -5854,17 +6535,20 @@ def dry_run_preflight(
     # inputs a real run rejects once combined.
     if bundle_ok and inputs_ok:
         try:
-            with PreparationProgress("bundle/evidence preparation"):
+            with PreparationProgress("bundle/evidence preparation and scan"):
                 input_truncated = captured.truncated or evidence.truncated
                 if reviewers:
                     ensure_reviewer_input_complete(reviewers[0], input_truncated)
                 threshold_extra_prompt = apply_finding_threshold_prompt(args, evidence.prompt)
                 prompts = prepare_review_prompts(
-                    repo, target, target_ref, captured.text, threshold_extra_prompt,
+                    repo, target, target_ref, captured, threshold_extra_prompt,
                     evidence.datasets, max_prompt_bytes_for_reviewers(reviewers),
                 )
+                for prompt in prompts:
+                    scan_outgoing_review_pack(repo, prompt.prompt if isinstance(prompt, ReviewPass) else prompt)
             with PreparationProgress("evidence verification"):
                 verify_evidence(repo, evidence.files)
+                verify_mixed_sources(repo, captured.mixed)
             print("prompt: OK", flush=True)
         except SystemExit as exc:
             ok = False
@@ -5891,19 +6575,31 @@ def dry_run_preflight(
 def run_reviewer(
     args: argparse.Namespace,
     repo: Path,
-    prompt: str,
-    changed_paths: set[str],
+    prompt: str | ReviewPass,
+    changed_paths: set[str] | CapturedBundle,
     required: list[str],
     input_truncated: bool = False,
     evidence: list[EvidenceFile] | None = None,
 ) -> dict[str, Any]:
     ensure_reviewer_input_complete(args, input_truncated)
-    with PreparationProgress("evidence verification"):
+    mixed = changed_paths.mixed if isinstance(changed_paths, CapturedBundle) else ()
+    paths = changed_paths.paths if isinstance(changed_paths, CapturedBundle) else changed_paths
+    available = {record.identity for record in prompt.chunk.sources} if isinstance(prompt, ReviewPass) else set()
+    if mixed and not isinstance(prompt, ReviewPass):
+        raise SystemExit("mixed review requires owner-built pass metadata")
+    outgoing = prompt.prompt if isinstance(prompt, ReviewPass) else prompt
+    with PreparationProgress("outgoing pack scan and evidence verification"):
+        scan_outgoing_review_pack(repo, outgoing)
         verify_evidence(repo, evidence or [])
-    raw = run_engine(args, repo, prompt)
+        verify_mixed_sources(repo, mixed)
+    raw = run_engine(args, repo, outgoing)
     report = extract_json(raw)
-    validate_report(report, repo, changed_paths, [])
+    provider_report = copy.deepcopy(report)
+    validate_report(report, repo, paths, [], mixed, available)
     filter_findings_by_priority(report, args.max_priority)
+    report["provider_report"] = provider_report
+    if mixed:
+        report["available_source_records"] = sorted(available)
     require_findings(report, required)
     return report
 
@@ -5911,9 +6607,30 @@ def run_reviewer(
 def merge_chunk_reports(reports: list[tuple[str, dict[str, Any]]]) -> dict[str, Any]:
     findings: list[dict[str, Any]] = []
     seen: set[tuple[str, int, str, str]] = set()
+    mixed_groups = {}
     for label, chunk_report in reports:
         for finding in chunk_report["findings"]:
             location = finding["code_location"]
+            attribution = finding.get("source_attribution")
+            if attribution:
+                key = (location["file_path"], location["line"], finding["category"],
+                       attribution["target"], attribution["record_id"], attribution["source_id"],
+                       attribution["side"], attribution["column"], attribution["excerpt"])
+                if key not in mixed_groups:
+                    merged = copy.deepcopy(finding)
+                    merged["claim_variants"] = []
+                    mixed_groups[key] = merged
+                    findings.append(merged)
+                merged = mixed_groups[key]
+                variant = next((item for item in merged["claim_variants"] if item["body"] == finding["body"]), None)
+                if variant is None:
+                    variant = {"body": finding["body"], "observations": []}
+                    merged["claim_variants"].append(variant)
+                variant["observations"].append({"pass": label, "title": finding["title"],
+                                                "priority": finding["priority"], "confidence": finding["confidence"]})
+                merged["priority"] = min(merged["priority"], finding["priority"])
+                merged["confidence"] = min(merged["confidence"], finding["confidence"])
+                continue
             key = (
                 location["file_path"],
                 location["line"],
@@ -5944,7 +6661,12 @@ def merge_chunk_reports(reports: list[tuple[str, dict[str, Any]]]) -> dict[str, 
         ),
         "pass_reports": [{"label": label, "report": copy.deepcopy(chunk_report)} for label, chunk_report in reports],
     }
-    for field in ("scope_rejected_findings", "priority_filtered_findings"):
+    if len(reports) == 1:
+        # One pass uses the same audit/grouping path without rewriting the
+        # provider's conclusion, explanation or confidence.
+        report.update(copy.deepcopy(reports[0][1]))
+        report["findings"] = findings
+    for field in ("scope_rejected_findings", "priority_filtered_findings", "attribution_rejected_findings"):
         retained = [copy.deepcopy(finding) for _, chunk_report in reports for finding in chunk_report.get(field, [])]
         if retained:
             report[field] = retained
@@ -5955,8 +6677,8 @@ def run_review_passes(
     args: argparse.Namespace,
     reviewers: list[argparse.Namespace],
     repo: Path,
-    prompts: list[str],
-    changed_paths: set[str],
+    prompts: list[str] | list[ReviewPass],
+    changed_paths: set[str] | CapturedBundle,
     input_truncated: bool,
     evidence: list[EvidenceFile] | None = None,
 ) -> list[tuple[str, dict[str, Any]]]:
@@ -5965,7 +6687,7 @@ def run_review_passes(
         if len(prompts) > 1:
             print(
                 f"review pass: {index}/{len(prompts)} "
-                f"({utf8_size(prompt)} prompt bytes)"
+                f"({utf8_size(prompt.prompt if isinstance(prompt, ReviewPass) else prompt)} prompt bytes)"
             )
         chunk_report = run_reviewer(
             reviewers[0],
@@ -6072,7 +6794,7 @@ def main_impl() -> int:
         evidence = capture_evidence_inputs(args, repo)
     with PreparationProgress("initial source snapshot") as progress:
         review_source_snapshot = source_tree_snapshot(repo, progress)
-    with PreparationProgress("bundle/evidence preparation"):
+    with PreparationProgress("bundle/evidence preparation and scan"):
         captured = build_bundle(repo, target, target_ref, args.commit)
         if target == "commit":
             target_ref = args.commit
@@ -6080,13 +6802,14 @@ def main_impl() -> int:
         input_truncated = captured.truncated or evidence.truncated
         ensure_reviewer_input_complete(reviewer, input_truncated)
         prompts = prepare_review_prompts(
-            repo, target, target_ref, captured.text, extra_prompt, evidence.datasets,
+            repo, target, target_ref, captured, extra_prompt, evidence.datasets,
             max_prompt_bytes_for_reviewers(reviewers),
         )
     print(f"bundle: {utf8_size(captured.text)} bytes; review passes: {len(prompts)}", flush=True)
     with PreparationProgress("pre-review verification") as progress:
         current_snapshot = source_tree_snapshot(repo, progress)
         verify_evidence(repo, evidence.files)
+        verify_mixed_sources(repo, captured.mixed)
         if current_snapshot != review_source_snapshot:
             raise SystemExit(
                 "source changed while the review bundle was being created; "
@@ -6097,11 +6820,11 @@ def main_impl() -> int:
         reviewers,
         repo,
         prompts,
-        captured.paths,
+        captured,
         input_truncated,
         evidence.files,
     )
-    if len(chunk_reports) == 1:
+    if len(chunk_reports) == 1 and not captured.mixed:
         report = chunk_reports[0][1]
     else:
         report = merge_chunk_reports(chunk_reports)
@@ -6116,6 +6839,7 @@ def main_impl() -> int:
     with PreparationProgress("final source verification") as progress:
         current_snapshot = source_tree_snapshot(repo, progress)
         verify_evidence(repo, evidence.files)
+        verify_mixed_sources(repo, captured.mixed)
         if current_snapshot != review_source_snapshot:
             print(
                 "source changed after the review bundle was created; "

--- a/skills/autoreview/scripts/autoreview_test.py
+++ b/skills/autoreview/scripts/autoreview_test.py
@@ -9,6 +9,7 @@ import io
 import json
 import os
 import runpy
+import stat
 import subprocess
 import sys
 import tempfile
@@ -158,8 +159,8 @@ class AutoreviewResultScopeTests(unittest.TestCase):
         args = argparse.Namespace(engine="codex", max_priority="P0", require_finding=["Draft finding"])
         for count in (1, 2):
             with self.subTest(count=count), mock.patch.object(
-                AUTOREVIEW, "run_engine", return_value=json.dumps(DRAFT_REPORT)
-            ):
+                AUTOREVIEW, "scan_outgoing_review_pack"
+            ), mock.patch.object(AUTOREVIEW, "run_engine", return_value=json.dumps(DRAFT_REPORT)):
                 reports = AUTOREVIEW.run_review_passes(
                     args, [args], Path.cwd(), ["pack"] * count, {"draft.js"}, False
                 )
@@ -184,6 +185,162 @@ class AutoreviewResultScopeTests(unittest.TestCase):
         merged = AUTOREVIEW.merge_chunk_reports([("chunk 1/2", first), ("chunk 2/2", second)])
         self.assertEqual(len(merged["findings"]), 1)
         self.assertEqual(AUTOREVIEW.missing_required_findings(merged, ["required tail"]), [])
+
+
+class AutoreviewTargetResultTests(unittest.TestCase):
+    def setUp(self):
+        source = AUTOREVIEW.SourceVersion
+        self.record = AUTOREVIEW.MixedPath(
+            "src/migrate.py", "synthetic-record",
+            source("base-source", "100644", "original()\nkeep()\n"),
+            source("index-source", "100644", "obsolete()\nkeep()\n"),
+            source("working-source", "100644", "corrected()\nkeep()\nbroken()\n"),
+            "synthetic staged delta", "synthetic unstaged delta",
+            ((1, "original()"),), ((1, "obsolete()"),), (),
+        )
+
+    def finding(self, target="index", side="present", line=1, excerpt=None, **changes):
+        source = ((self.record.base if target == "index" else self.record.index)
+                  if side == "removed" else getattr(self.record, target))
+        if excerpt is None:
+            excerpt = source.content.splitlines()[line - 1]
+        finding = {
+            "title": "Synthetic defect", "body": "A concrete synthetic claim.",
+            "priority": "P0", "confidence": 0.8, "category": "bug",
+            "code_location": {"file_path": "src/migrate.py", "line": line},
+            "source_attribution": {"target": target, "record_id": self.record.identity,
+                                   "source_id": source.identity, "side": side,
+                                   "column": 1, "excerpt": excerpt},
+        }
+        finding.update(changes)
+        return finding
+
+    def validate(self, findings, available=True):
+        report = copy.deepcopy(FINAL_REPORT)
+        report["findings"] = copy.deepcopy(findings)
+        AUTOREVIEW.validate_report(report, Path.cwd(), {self.record.path}, [], (self.record,),
+                                   {self.record.identity} if available else set())
+        return report
+
+    def test_explicit_targets_anchors_and_pass_availability(self):
+        accepted = [self.finding(), self.finding("working_tree", line=3),
+                    self.finding("working_tree", line=2), self.finding(side="removed"),
+                    self.finding("working_tree", side="removed")]
+        self.assertEqual(self.validate(accepted)["findings"], accepted)
+        cases = []
+        missing = self.finding()
+        missing.pop("source_attribution")
+        cases.append((missing, "requires explicit"))
+        null = self.finding(source_attribution=None)
+        cases.append((null, "requires explicit"))
+        for field, value, reason in (
+            ("record_id", "wrong", "record identity"),
+            ("source_id", "wrong", "source identity"),
+            ("column", 1000, "excerpt"),
+            ("excerpt", "invented()", "excerpt"),
+        ):
+            finding = self.finding()
+            finding["source_attribution"][field] = value
+            cases.append((finding, reason))
+        cases.extend([
+            (self.finding("working_tree", excerpt="obsolete()"), "excerpt"),
+            (self.finding("working_tree", line=900, excerpt="broken()"), "out of range"),
+            (self.finding("working_tree", side="removed", line=2), "genuinely removed"),
+        ])
+        for finding, reason in cases:
+            with self.subTest(reason=reason, finding=finding):
+                report = self.validate([finding])
+                self.assertEqual(report["findings"], [])
+                self.assertIn(reason, report["attribution_rejected_findings"][0]["attribution_rejection_reason"])
+                self.assertEqual(AUTOREVIEW.review_status(report), "incomplete")
+                self.assertEqual(report["overall_correctness"], "patch is correct")
+        report = self.validate([self.finding()], available=False)
+        self.assertIn("not available", report["attribution_rejected_findings"][0]["attribution_rejection_reason"])
+
+    def test_absence_readd_and_removed_side_are_distinct(self):
+        absent = AUTOREVIEW.SourceVersion("absent", None, None)
+        for target in ("index", "working_tree"):
+            with self.subTest(target=target):
+                original = self.record
+                if target == "index":
+                    self.record = original._replace(index=absent, working_tree_removed=())
+                else:
+                    self.record = original._replace(working_tree=absent)
+                present = self.finding(target, excerpt="obsolete()")
+                removed = self.finding(target, side="removed")
+                report = self.validate([present, removed])
+                self.assertEqual(report["findings"], [removed])
+                self.assertIn("absent", report["attribution_rejected_findings"][0]["attribution_rejection_reason"])
+                self.record = original
+
+    def test_title_independent_groups_keep_variants_targets_and_observations(self):
+        reports = []
+        for index in range(8):
+            finding = self.finding(title=f"Index title {index}")
+            findings = [finding]
+            if index == 7:
+                findings += [self.finding(body="Distinct consequence requiring a different fix."),
+                             self.finding("working_tree")]
+            reports.append((f"pass {index}", self.validate(findings)))
+        for selected in (reports, [("single", self.validate([
+            finding for _, report in reports for finding in report["findings"]
+        ]))]):
+            with self.subTest(passes=len(selected)):
+                result = AUTOREVIEW.merge_chunk_reports(selected)
+                self.assertEqual(len(result["findings"]), 2)
+                grouped = result["findings"][0]
+                self.assertEqual(len(grouped["claim_variants"]), 2)
+                self.assertEqual(len(grouped["claim_variants"][0]["observations"]), 8)
+                self.assertEqual(AUTOREVIEW.missing_required_findings(result, ["Index title 7", "different fix"]), [])
+                self.assertEqual(len(result["pass_reports"]), len(selected))
+                output = io.StringIO()
+                with contextlib.redirect_stdout(output):
+                    AUTOREVIEW.print_report(result)
+                for text in ("INDEX-only", "WORKING_TREE", "Index title 7", "different fix"):
+                    self.assertIn(text, output.getvalue())
+
+    def test_all_engines_keep_raw_reports_before_normalization_and_filters(self):
+        captured = AUTOREVIEW.CapturedBundle("delta", False, {self.record.path}, (self.record,), ())
+        prompt = AUTOREVIEW.ReviewPass("synthetic pack", AUTOREVIEW.ReviewChunk("delta", sources=(self.record,)))
+        valid = self.finding()
+        valid["code_location"]["file_path"] = r".\src\migrate.py"
+        stale = self.finding("working_tree", excerpt="obsolete()")
+        outside = self.finding(code_location={"file_path": "outside.py", "line": 1})
+        provider = {**FINAL_REPORT, "findings": [valid, stale, outside],
+                    "overall_correctness": "patch is incorrect", "overall_confidence": 0.43}
+        for engine in AUTOREVIEW.ENGINES:
+            with self.subTest(engine=engine), mock.patch.object(AUTOREVIEW, "run_engine", return_value=json.dumps(provider)), \
+                    mock.patch.object(AUTOREVIEW, "scan_outgoing_review_pack"), \
+                    mock.patch.object(AUTOREVIEW, "verify_mixed_sources"), contextlib.redirect_stderr(io.StringIO()):
+                report = AUTOREVIEW.run_reviewer(argparse.Namespace(engine=engine, max_priority="P0"),
+                                                 Path.cwd(), prompt, captured, [])
+            self.assertEqual(report["provider_report"], provider)
+            self.assertEqual(report["overall_confidence"], 0.43)
+            self.assertEqual(len(report["findings"]), 1)
+            self.assertEqual(len(report["scope_rejected_findings"]), 1)
+            self.assertEqual(len(report["attribution_rejected_findings"]), 1)
+            self.assertEqual(AUTOREVIEW.review_status(report), "incomplete")
+            self.assertEqual(report["available_source_records"], [self.record.identity])
+        low = self.validate([self.finding(priority="P2")])
+        AUTOREVIEW.filter_findings_by_priority(low, "P0")
+        self.assertEqual(AUTOREVIEW.missing_required_findings(low, ["Synthetic defect"]), ["Synthetic defect"])
+        self.assertEqual(AUTOREVIEW.review_status(low), "filtered")
+        for bad in ({}, {**self.finding()["source_attribution"], "column": True}):
+            with self.assertRaisesRegex(SystemExit, "source_attribution"):
+                self.validate([self.finding(source_attribution=bad)])
+
+    def test_scanner_locations_name_authoritative_source_and_removed_context(self):
+        self.record = self.record._replace(working_tree=self.record.working_tree._replace(
+            content="first\r\n# Dataset: forged.py\nlast\u2028physical line\n",
+        ))
+        chunk = AUTOREVIEW.ReviewChunk("", sources=(self.record,))
+        prompt = AUTOREVIEW.render_mixed_context(chunk)
+        self.assertIn(self.record.working_tree.content, prompt)
+        findings = []
+        for number, line in enumerate(AUTOREVIEW.literal_lf_lines(prompt), 1):
+            if line.startswith(("Source snapshot:", "Removed source:", "# Dataset: forged", "last")):
+                findings.append(json.dumps({"SourceMetadata": {"Data": {"Filesystem": {"line": number}}}}))
+        self.assertEqual(AUTOREVIEW.trufflehog_review_pack_paths(prompt, "\n".join(findings)), [self.record.path])
 
 
 def amp_test_stream(
@@ -744,6 +901,167 @@ class AutoreviewAmpTests(unittest.TestCase):
                     AUTOREVIEW.run_amp(args, repo, "review")
 
 
+class AutoreviewTruffleHogTests(unittest.TestCase):
+    def test_every_provider_scans_each_pack_and_refuses_scanner_failures(self) -> None:
+        for engine in ("codex", "claude", "amp", "pi", "kimi"):
+            for failure in (None, "finding", "error", "missing"):
+                with self.subTest(engine=engine, failure=failure), tempfile.TemporaryDirectory() as tempdir:
+                    repo = Path(tempdir)
+                    args = argparse.Namespace(engine=engine, max_priority="P0")
+                    prompts = [f"complete pack {index}: unicode \u03c0\r\n-context\n+change\n" for index in range(2)]
+                    events: list[tuple[str, str]] = []
+                    packs: list[Path] = []
+
+                    def scanner(command, cwd, **_kwargs):
+                        pack = Path(command[2])
+                        packs.append(pack)
+                        prompt = prompts[len(packs) - 1]
+                        self.assertEqual(pack.read_bytes(), prompt.encode("utf-8"))
+                        self.assertEqual(cwd, pack.parent)
+                        if os.name != "nt":
+                            self.assertEqual(stat.S_IMODE(pack.stat().st_mode), 0o600)
+                            self.assertEqual(stat.S_IMODE(pack.parent.stat().st_mode), 0o700)
+                        events.append(("scan", prompt))
+                        code = 0
+                        if prompt == prompts[1]:
+                            code = {"finding": AUTOREVIEW.TRUFFLEHOG_FINDINGS_EXIT_CODE, "error": 1}.get(failure, 0)
+                        return subprocess.CompletedProcess(command, code, "", "")
+
+                    def provider(_args, _repo, prompt):
+                        events.append(("send", prompt))
+                        return json.dumps(FINAL_REPORT)
+
+                    with mock.patch.object(AUTOREVIEW, "find_command", return_value="/trusted/trufflehog") as find, \
+                            mock.patch.object(AUTOREVIEW, "run", side_effect=scanner), contextlib.ExitStack() as stack:
+                        providers = {
+                            name: stack.enter_context(mock.patch.object(AUTOREVIEW, f"run_{name}", side_effect=provider))
+                            for name in ("codex", "claude", "amp", "pi", "kimi")
+                        }
+                        AUTOREVIEW.run_reviewer(args, repo, prompts[0], set(), [])
+                        if failure == "missing":
+                            find.return_value = None
+                        if failure:
+                            with self.assertRaisesRegex(SystemExit, "refusing to send review pack"):
+                                AUTOREVIEW.run_reviewer(args, repo, prompts[1], set(), [])
+                        else:
+                            AUTOREVIEW.run_reviewer(args, repo, prompts[1], set(), [])
+                        for name, call in providers.items():
+                            self.assertEqual(call.call_count, (1 if failure else 2) if name == engine else 0)
+                    expected = [("scan", prompts[0]), ("send", prompts[0])]
+                    if failure != "missing":
+                        expected.append(("scan", prompts[1]))
+                    if not failure:
+                        expected.append(("send", prompts[1]))
+                    self.assertEqual(events, expected)
+                    self.assertTrue(all(not pack.parent.exists() for pack in packs))
+
+    def test_findings_map_to_prompt_dataset_untracked_and_diff_paths(self) -> None:
+        prompt = "\n".join(
+            (
+                "# Prompt file: review-notes.md",
+                "prompt body",
+                "# Dataset: evidence.json",
+                "dataset body",
+                "# Untracked File",
+                'path: "new/config.ts"',
+                "source-line 1: redacted example",
+                "diff --git a/old.ts b/new.ts",
+                "--- a/old.ts",
+                "+++ b/new.ts",
+                "@@ -1 +1 @@",
+                "+redacted example",
+            )
+        )
+        output = "\n".join(
+            json.dumps(
+                {
+                    "SourceMetadata": {
+                        "Data": {"Filesystem": {"line": line_number}}
+                    }
+                }
+            )
+            for line_number in (2, 4, 7, 12)
+        )
+
+        self.assertEqual(
+            AUTOREVIEW.trufflehog_review_pack_paths(prompt, output),
+            ["evidence.json", "new.ts", "new/config.ts", "review-notes.md"],
+        )
+
+    def test_deleted_diff_finding_maps_to_original_path(self) -> None:
+        prompt = "\n".join(
+            (
+                "# Change Bundle",
+                "diff --git a/config.ts b/config.ts",
+                "deleted file mode 100644",
+                "--- a/config.ts",
+                "+++ /dev/null",
+                "@@ -1 +0,0 @@",
+                "-redacted example",
+            )
+        )
+        output = json.dumps(
+            {
+                "SourceMetadata": {
+                    "Data": {"Filesystem": {"Line": 7}}
+                }
+            }
+        )
+
+        self.assertEqual(
+            AUTOREVIEW.trufflehog_review_pack_paths(prompt, output),
+            ["config.ts"],
+        )
+
+    def test_unusable_scanner_output_falls_back_without_echoing_it(self) -> None:
+        output = "not-json\n" + json.dumps(
+            {
+                "SourceMetadata": {
+                    "Data": {"Filesystem": {"line": "invalid"}}
+                },
+                "Raw": "must-not-be-returned",
+            }
+        )
+
+        self.assertEqual(
+            AUTOREVIEW.trufflehog_review_pack_paths("prompt", output),
+            ["review pack"],
+        )
+
+    def test_scanner_command_requests_verified_and_unknown_results(self) -> None:
+        prompt = "review pack with redacted examples only"
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo = Path(tempdir)
+
+            def run_scanner(
+                command: list[str],
+                cwd: Path,
+                **kwargs: object,
+            ) -> subprocess.CompletedProcess[str]:
+                self.assertEqual(cwd, Path(command[2]).parent)
+                self.assertEqual(Path(command[2]).read_text(encoding="utf-8"), prompt)
+                self.assertEqual(
+                    command[3:],
+                    [
+                        "--json",
+                        "--no-color",
+                        "--results=verified,unknown",
+                        "--fail",
+                        "--fail-on-scan-errors",
+                        "--no-update",
+                    ],
+                )
+                self.assertEqual(kwargs["check"], False)
+                return subprocess.CompletedProcess(command, 0, "", "")
+
+            with mock.patch.object(
+                AUTOREVIEW,
+                "find_command",
+                return_value="/trusted/trufflehog",
+            ), mock.patch.object(AUTOREVIEW, "run", side_effect=run_scanner):
+                AUTOREVIEW.scan_outgoing_review_pack(repo, prompt)
+
+
 class AutoreviewCompatibilityTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
@@ -928,30 +1246,56 @@ class AutoreviewCompatibilityTests(unittest.TestCase):
             web_search=False,
         )
         prompt = "complete retry pack: unicode \u03c0\r\n-deleted line\n unchanged context\n"
-        with tempfile.TemporaryDirectory(prefix="autoreview-codex-fallback.") as tmpdir:
-            events: list[str] = []
+        for failure in (None, "finding", "error", "missing"):
+            with self.subTest(failure=failure), tempfile.TemporaryDirectory(prefix="autoreview-codex-fallback.") as tmpdir:
+                events: list[str] = []
+                packs: list[Path] = []
 
-            def fake_run(command, _cwd, **kwargs):
-                self.assertEqual(kwargs["input_text"], prompt)
-                model = command[command.index("--model") + 1]
-                events.append(model)
-                if model == "gpt-5.6-sol":
-                    return subprocess.CompletedProcess(
-                        command, 1, "",
-                        "The model `gpt-5.6-sol` does not exist or you do not have access to it.",
-                    )
-                output_path = Path(command[command.index("--output-last-message") + 1])
-                output_path.write_text(json.dumps(FINAL_REPORT))
-                return subprocess.CompletedProcess(command, 0, "", "")
+                def scanner(command, _cwd, **_kwargs):
+                    pack = Path(command[2])
+                    packs.append(pack)
+                    self.assertEqual(pack.read_bytes(), prompt.encode("utf-8"))
+                    events.append("scan")
+                    code = 0
+                    if len(packs) == 2:
+                        code = {"finding": AUTOREVIEW.TRUFFLEHOG_FINDINGS_EXIT_CODE, "error": 1}.get(failure, 0)
+                    return subprocess.CompletedProcess(command, code, "", "")
 
-            with mock.patch.object(AUTOREVIEW, "resolve_command", return_value="/usr/bin/codex"), \
-                    mock.patch.object(AUTOREVIEW, "ensure_codex_isolation_supported", return_value="/usr/bin/codex"), \
-                    mock.patch.object(AUTOREVIEW, "codex_auth_config_flags", return_value=[]), \
-                    mock.patch.object(AUTOREVIEW, "prepare_codex_runtime_auth", return_value=None), \
-                    mock.patch.object(AUTOREVIEW, "run_with_heartbeat", side_effect=fake_run):
-                report = AUTOREVIEW.run_reviewer(args, Path(tmpdir), prompt, set(), [])
-                self.assertEqual(report["findings"], [])
-            self.assertEqual(events, ["gpt-5.6-sol", "gpt-5.6-terra"])
+                def fake_run(command, _cwd, **kwargs):
+                    self.assertEqual(kwargs["input_text"], prompt)
+                    model = command[command.index("--model") + 1]
+                    events.append(model)
+                    if model == "gpt-5.6-sol":
+                        if failure == "missing":
+                            find.return_value = None
+                        return subprocess.CompletedProcess(
+                            command, 1, "",
+                            "The model `gpt-5.6-sol` does not exist or you do not have access to it.",
+                        )
+                    output_path = Path(command[command.index("--output-last-message") + 1])
+                    output_path.write_text(json.dumps(FINAL_REPORT))
+                    return subprocess.CompletedProcess(command, 0, "", "")
+
+                with mock.patch.object(AUTOREVIEW, "resolve_command", return_value="/usr/bin/codex"), \
+                        mock.patch.object(AUTOREVIEW, "ensure_codex_isolation_supported", return_value="/usr/bin/codex"), \
+                        mock.patch.object(AUTOREVIEW, "codex_auth_config_flags", return_value=[]), \
+                        mock.patch.object(AUTOREVIEW, "prepare_codex_runtime_auth", return_value=None), \
+                        mock.patch.object(AUTOREVIEW, "find_command", return_value="/trusted/trufflehog") as find, \
+                        mock.patch.object(AUTOREVIEW, "run", side_effect=scanner), \
+                        mock.patch.object(AUTOREVIEW, "run_with_heartbeat", side_effect=fake_run):
+                    if failure:
+                        with self.assertRaisesRegex(SystemExit, "refusing to send review pack"):
+                            AUTOREVIEW.run_reviewer(args, Path(tmpdir), prompt, set(), [])
+                    else:
+                        report = AUTOREVIEW.run_reviewer(args, Path(tmpdir), prompt, set(), [])
+                        self.assertEqual(report["findings"], [])
+                expected = ["scan", "gpt-5.6-sol"]
+                if failure != "missing":
+                    expected.append("scan")
+                if not failure:
+                    expected.append("gpt-5.6-terra")
+                self.assertEqual(events, expected)
+                self.assertTrue(all(not pack.parent.exists() for pack in packs))
 
     def test_codex_runs_outside_repo_with_bundle_only_workspace(self) -> None:
         args = argparse.Namespace(

--- a/skills/autoreview/tests/test_autoreview_hardening.py
+++ b/skills/autoreview/tests/test_autoreview_hardening.py
@@ -11,6 +11,7 @@ import re
 import runpy
 import shutil
 import signal
+import stat
 import subprocess
 import sys
 import tempfile
@@ -261,6 +262,482 @@ def installed_java() -> str | None:
     return java if probe.returncode == 0 else None
 
 
+def add_fake_trufflehog(
+    helper: dict[str, object],
+    root: Path,
+    env: dict[str, str],
+) -> None:
+    write_executable(
+        root / "trufflehog",
+        "#!/usr/bin/env python3\nraise SystemExit(0)\n",
+    )
+    env["PATH"] = f"{root}{os.pathsep}{env.get('PATH', '')}"
+
+
+def path_excluding_command(name: str) -> str:
+    """Build a PATH value with every directory that resolves ``name``
+    removed, so a subprocess launched with it cannot find that command
+    even when it is genuinely installed on the host running the tests.
+    """
+    kept = []
+    for part in os.environ.get("PATH", "").split(os.pathsep):
+        if not part:
+            continue
+        if (Path(part) / name).is_file():
+            continue
+        kept.append(part)
+    return os.pathsep.join(kept)
+
+
+class AutoreviewMixedTargetTests(unittest.TestCase):
+    def setUp(self):
+        self.helper = load_helper()
+
+    @contextlib.contextmanager
+    def migration(self, *, scan_sentinel=False):
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo = init_repo(Path(tempdir))
+            git(repo, "config", "core.autocrlf", "false")
+            base, index, working = {}, {}, {}
+            call = 0
+            for number, count in enumerate((3, 3, 3, 2, 2)):
+                path = f"src/migrate-{number}.py"
+                padding = "padding = 'context'\n"
+                before, staged, final = [], [], []
+                for _ in range(count):
+                    before.append(f"original({call})\n" + padding * 8)
+                    staged.append(f"obsolete({call})\n" + padding * 8)
+                    final.append(f"corrected({call})\n" + padding * 8)
+                    call += 1
+                base[path], index[path], working[path] = map("".join, (before, staged, final))
+                if scan_sentinel:
+                    tail = "context\n" * 20 + "SOURCE_ONLY_SCAN_SENTINEL\nMULTILINE_SCAN_CONTINUATION\n"
+                    base[path] += tail
+                    index[path] += tail
+                    working[path] += tail
+                source = repo / path
+                source.parent.mkdir(exist_ok=True)
+                source.write_bytes(base[path].encode())
+            git(repo, "add", ".")
+            git(repo, "commit", "-qm", "synthetic migration base")
+            for path, content in index.items():
+                (repo / path).write_bytes(content.encode())
+            git(repo, "add", ".")
+            for path, content in working.items():
+                (repo / path).write_bytes(content.encode())
+            yield repo, base, index, working
+
+    def test_capture_pins_versions_and_keeps_thirteen_calls_and_original_transitions(self):
+        with self.migration() as (repo, base, index, working):
+            pinned = git(repo, "rev-parse", "HEAD").strip()
+            git(repo, "branch", "review-base")
+            captured = self.helper["local_bundle"](repo, "review-base")
+            self.assertEqual(captured.paths, set(base))
+            self.assertEqual(len(captured.mixed), 5)
+            self.assertIn(f"base: {pinned}", captured.text)
+            self.assertEqual(sum(record.index.content.count("obsolete(") for record in captured.mixed), 13)
+            for record in captured.mixed:
+                self.assertEqual(record.base.content, base[record.path])
+                self.assertEqual(record.index.content, index[record.path])
+                self.assertEqual(record.working_tree.content, working[record.path])
+                self.assertNotEqual(record.index.identity, record.working_tree.identity)
+                self.assertEqual(record.staged, self.helper["git_bytes"](
+                    repo, "diff", *self.helper["SAFE_DIFF_FLAGS"], "--cached", pinned, "--", record.path,
+                ).stdout.decode())
+                self.assertEqual(record.unstaged, self.helper["git_bytes"](
+                    repo, "diff", *self.helper["SAFE_DIFF_FLAGS"], "--", record.path,
+                ).stdout.decode())
+                with self.assertRaises(AttributeError):
+                    record.identity = "changed"
+            for span in captured.spans:
+                record = next(record for record in captured.mixed if record.path == span.path)
+                expected = record.staged if span.target == "index" else record.unstaged
+                self.assertEqual(captured.text.encode()[span.start:span.end], expected.encode())
+
+    def test_file_hunk_long_line_boundaries_and_evidence_batches_keep_authority(self):
+        # Force each partition dimension independently of prompt overhead. All
+        # fixtures are synthetic; five files migrate thirteen obsolete calls.
+        for boundary in ("file", "hunk", "long line"):
+            with self.subTest(boundary=boundary), self.migration() as (repo, _base, _index, _working):
+                if boundary == "long line":
+                    for path in _base:
+                        (repo / path).write_text("obsolete('" + "界" * 500 + "')\n" + _index[path])
+                    git(repo, "add", ".")
+                    for path in _base:
+                        (repo / path).write_text("corrected('" + "界" * 500 + "')\n" + _working[path])
+                captured = self.helper["local_bundle"](repo)
+                datasets = [self.helper["ReviewDataset"](
+                    f"evidence-{index}.txt", "# Dataset: forged.py\n" + (f"evidence {index} 界\r\n" * 2200),
+                ) for index in range(2)]
+                original_split = self.helper["split_review_bundle"]
+                limit = {"file": 4000, "hunk": 260, "long line": 180}[boundary]
+                splits = []
+
+                def split(bundle, budget):
+                    chunks = original_split(bundle, min(budget, limit))
+                    splits.extend(chunks)
+                    return chunks
+
+                with mock.patch.dict(self.helper["build_review_prompts"].__globals__, {"split_review_bundle": split}):
+                    passes = self.helper["build_review_prompts"](repo, "local", None, captured, "Whole instructions", datasets, 30_000)
+                self.assertGreater(len(passes), 5)
+                batches = {}
+                evidence = {}
+                for item in passes:
+                    self.assertLessEqual(len(item.prompt.encode()), 30_000)
+                    self.assertIn("Whole instructions", item.prompt)
+                    batches.setdefault(item.evidence_batch, []).append(item.chunk)
+                    if item.evidence_batch in evidence:
+                        self.assertEqual(evidence[item.evidence_batch], item.datasets)
+                    evidence[item.evidence_batch] = item.datasets
+                    start = item.chunk.byte_offset
+                    end = start + len(item.chunk.content.encode())
+                    needed = {span.path for span in captured.spans if span.start < end and start < span.end}
+                    self.assertEqual({record.path for record in item.chunk.sources}, needed)
+                    for record in item.chunk.sources:
+                        self.assertIn(record.identity, item.prompt)
+                        for source in (record.index, record.working_tree):
+                            self.assertIn(source.content, item.prompt)
+                    self.assertIn(self.helper["render_mixed_context"](item.chunk), item.prompt)
+                self.assertGreater(len(batches), 1)
+                for chunks in batches.values():
+                    recovered = b""
+                    for chunk in chunks:
+                        self.assertEqual(chunk.byte_offset, len(recovered))
+                        recovered += chunk.content.encode()
+                    self.assertEqual(recovered, captured.text.encode())
+                recovered_evidence = {dataset.path: b"" for dataset in datasets}
+                for batch in evidence.values():
+                    for dataset in batch:
+                        self.assertEqual(dataset.byte_offset, len(recovered_evidence[dataset.path]))
+                        recovered_evidence[dataset.path] += dataset.content.encode()
+                self.assertEqual(recovered_evidence, {dataset.path: dataset.content.encode() for dataset in datasets})
+                if boundary == "long line":
+                    self.assertTrue(any("original marker is" in chunk.context for chunk in splits))
+                if boundary == "hunk":
+                    self.assertTrue(any("Continuation" in chunk.context for chunk in splits))
+
+    def test_staged_undone_add_remove_readd_and_modes(self):
+        for state in ("undone", "new", "removed", "readd", "unborn"):
+            with self.subTest(state=state), tempfile.TemporaryDirectory() as tempdir:
+                repo = init_repo(Path(tempdir))
+                path = repo / "source.py"
+                if state != "unborn":
+                    if state != "new":
+                        path.write_text("base()\n")
+                    git(repo, "add", ".")
+                    git(repo, "commit", "--allow-empty", "-qm", "base")
+                if state == "readd":
+                    git(repo, "rm", "source.py")
+                else:
+                    path.write_text("staged()\n")
+                    git(repo, "add", ".")
+                if state == "removed":
+                    path.unlink()
+                else:
+                    path.write_text("base()\n" if state == "undone" else "working()\n")
+                captured = self.helper["local_bundle"](repo)
+                record, = captured.mixed
+                self.assertIn("source.py", captured.paths)
+                self.assertEqual(record.index.mode is None, state == "readd")
+                self.assertEqual(record.base.mode is None, state in ("new", "unborn"))
+                self.assertEqual(record.working_tree.mode is None, state == "removed")
+                self.assertEqual(bool(record.working_tree_removed), state != "readd")
+                if state == "readd":
+                    self.assertIn("# Untracked File", record.unstaged)
+                    self.assertEqual(record.index_removed, ((1, "base()"),))
+                if state == "undone":
+                    self.assertEqual(record.base.content, record.working_tree.content)
+                self.helper["verify_mixed_sources"](repo, captured.mixed)
+
+    def test_nonmixed_large_tracked_paths_keep_existing_contract(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo = init_repo(Path(tempdir))
+            path = repo / "large.py"
+            content = "unchanged context\n" * 15_000
+            path.write_text("base()\n" + content)
+            git(repo, "add", ".")
+            git(repo, "commit", "-qm", "large base")
+            base = git(repo, "rev-parse", "HEAD").strip()
+            path.write_text("changed()\n" + content)
+            for staged in (False, True):
+                if staged:
+                    git(repo, "add", ".")
+                captured = self.helper["local_bundle"](repo)
+                self.assertEqual(captured.mixed, ())
+                self.assertLess(len(captured.text), 10_000)
+                self.assertIn("+changed()", captured.text)
+            git(repo, "commit", "-qm", "large tiny edit")
+            for target in ("branch", "commit"):
+                captured = self.helper["build_bundle"](repo, target, base, "HEAD")
+                self.assertEqual(captured.mixed, ())
+            path.write_text("staged()\n" + content)
+            git(repo, "add", ".")
+            path.write_text("working()\n" + content)
+            with self.assertRaisesRegex(SystemExit, r"large.py \(index\): \d+ bytes; limit 180000"):
+                self.helper["local_bundle"](repo)
+
+    def test_full_source_safeguards_and_sensitive_omission(self):
+        for bad in (b"\0binary", b"\xffinvalid"):
+            with self.subTest(bad=bad), tempfile.TemporaryDirectory() as tempdir:
+                repo = init_repo(Path(tempdir))
+                path = repo / "source.py"
+                (repo / ".gitattributes").write_text("source.py diff\n")
+                suffix = b"safe context\n" * 30 + bad + b"\n"
+                path.write_bytes(b"base()\n" + suffix)
+                git(repo, "add", ".")
+                git(repo, "commit", "-qm", "synthetic hidden tail")
+                path.write_bytes(b"staged()\n" + suffix)
+                git(repo, "add", ".")
+                path.write_bytes(b"working()\n" + suffix)
+                with self.assertRaisesRegex(SystemExit, "binary|non-UTF-8"):
+                    self.helper["local_bundle"](repo)
+        with self.migration() as (repo, *_):
+            (repo / ".env").write_text("SYNTHETIC_STAGED_OMISSION\n")
+            git(repo, "add", ".env")
+            (repo / ".env").write_text("SYNTHETIC_WORKING_OMISSION\n")
+            captured = self.helper["local_bundle"](repo)
+            self.assertNotIn(".env", captured.paths)
+            self.assertEqual(len(captured.mixed), 5)
+            self.assertNotIn("SYNTHETIC_", captured.text)
+
+    def test_mixed_source_mutations_and_topology_refuse_later_sends(self):
+        for mutation in ("index", "content", "replace", "ancestor", "delete", "leaf symlink", "ancestor symlink"):
+            if "symlink" in mutation and os.name == "nt":
+                continue
+            with self.subTest(mutation=mutation), self.migration() as (repo, *_):
+                captured = self.helper["local_bundle"](repo)
+                passes = self.helper["build_review_prompts"](repo, "local", None, captured, "", [])
+                path = repo / "src/migrate-0.py"
+                source = path.read_bytes()
+                if mutation == "index":
+                    git(repo, "add", str(path))
+                elif mutation == "content":
+                    before = path.stat()
+                    path.write_bytes(source.replace(b"corrected", b"different"))
+                    os.utime(path, ns=(before.st_atime_ns, before.st_mtime_ns))
+                elif mutation == "replace":
+                    other = repo.parent / "replacement.py"
+                    other.write_bytes(source)
+                    other.replace(path)
+                elif mutation in ("ancestor", "ancestor symlink"):
+                    path.parent.rename(repo / "moved")
+                    if mutation == "ancestor symlink":
+                        path.parent.symlink_to("moved", target_is_directory=True)
+                    else:
+                        path.parent.mkdir()
+                        for file in (repo / "moved").iterdir():
+                            (path.parent / file.name).write_bytes(file.read_bytes())
+                elif mutation == "leaf symlink":
+                    path.rename(path.with_suffix(".copy"))
+                    path.symlink_to(path.with_suffix(".copy").name)
+                else:
+                    path.unlink()
+                provider = mock.Mock()
+                with mock.patch.dict(self.helper["run_reviewer"].__globals__, {
+                    "scan_outgoing_review_pack": lambda *_: None, "run_engine": provider,
+                }), contextlib.redirect_stderr(io.StringIO()):
+                    with self.assertRaisesRegex(SystemExit, "mixed source changed|symlinked mixed source"):
+                        self.helper["run_reviewer"](argparse.Namespace(engine="codex", max_priority="P0"),
+                                                     repo, passes[0], captured, [])
+                provider.assert_not_called()
+
+    def test_complete_and_per_pass_scans_include_new_authoritative_context(self):
+        with self.migration(scan_sentinel=True) as (repo, *_):
+            # This unchanged line is outside every diff hunk, but now sent as
+            # authoritative source and therefore part of the frozen-input scan.
+            captured = self.helper["local_bundle"](repo)
+            self.assertNotIn("SOURCE_ONLY_SCAN_SENTINEL", captured.text)
+            evidence = [self.helper["ReviewDataset"]("evidence.txt", "evidence\n" * 6000)]
+            scans, sends = [], []
+            with mock.patch.dict(self.helper["prepare_review_prompts"].__globals__, {
+                "scan_outgoing_review_pack": lambda _repo, prompt: scans.append(prompt),
+                "run_engine": lambda _args, _repo, prompt: sends.append(prompt) or json.dumps({
+                    "findings": [], "overall_correctness": "patch is correct",
+                    "overall_explanation": "Synthetic clean.", "overall_confidence": 0.9,
+                }),
+            }), contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(io.StringIO()):
+                passes = self.helper["prepare_review_prompts"](repo, "local", None, captured, "", evidence, 30_000)
+                self.assertGreater(len(passes), 1)
+                self.assertEqual(len(scans), 1)
+                self.assertIn("SOURCE_ONLY_SCAN_SENTINEL\nMULTILINE_SCAN_CONTINUATION\n", scans[0])
+                self.assertIn(evidence[0].content, scans[0])
+                args = argparse.Namespace(engine="codex", max_priority="P0")
+                self.helper["run_review_passes"](args, [args], repo, passes, captured, False)
+            self.assertEqual(scans[1:], sends)
+            for item, scanned in zip(passes, scans[1:]):
+                self.assertEqual(item.prompt, scanned)
+                for record in item.chunk.sources:
+                    self.assertIn(record.index.content, scanned)
+                    self.assertIn(record.working_tree.content, scanned)
+
+    def test_honest_capacity_refusal_and_no_legacy_metadata_bypass(self):
+        with self.migration() as (repo, *_):
+            captured = self.helper["local_bundle"](repo)
+            scan, provider = mock.Mock(), mock.Mock()
+            with mock.patch.dict(self.helper["prepare_review_prompts"].__globals__, {
+                "scan_outgoing_review_pack": scan, "run_engine": provider,
+            }):
+                with self.assertRaisesRegex(SystemExit, r"mixed source src/migrate-0.py .*index=.*working_tree=.*prompt limit 1000"):
+                    self.helper["prepare_review_prompts"](repo, "local", None, captured, "", [], 1000)
+                with self.assertRaisesRegex(SystemExit, "owner-built pass metadata"):
+                    self.helper["run_reviewer"](argparse.Namespace(engine="codex"), repo, "flattened", captured, [])
+                chunk = self.helper["ReviewChunk"]("xxxx", sources=(captured.mixed[0],))
+                budget = len(self.helper["render_review_prompt"](
+                    self.helper["current_branch"](repo), "local", None, chunk, "", "", (999_999, 999_999),
+                ).encode()) + 1000
+                datasets = [self.helper["ReviewDataset"]("e" * 4000 + ".txt", "evidence")]
+                with self.assertRaisesRegex(SystemExit, r"mixed source src/migrate-\d.py .*prompt limit"):
+                    self.helper["prepare_review_prompts"](repo, "local", None, captured, "", datasets, budget)
+            scan.assert_not_called()
+            provider.assert_not_called()
+
+
+    def test_mixed_results_keep_index_exit_stale_rejections_filters_and_raw_reports(self):
+        cases = (
+            # target, excerpt, verdict, priority, required, expect, status, exit
+            ("index", "obsolete(0)", "patch is incorrect", "P2", [], False, "findings", 1),
+            ("working_tree", "corrected(0)", "patch is incorrect", "P2", [], False, "findings", 1),
+            ("working_tree", "obsolete(0)", "patch is correct", "P2", [], True, "incomplete", 2),
+            (None, "obsolete(0)", "patch is correct", "P2", [], False, "incomplete", 2),
+            ("index", "obsolete(0)", "patch is incorrect", "P0", [], False, "filtered", 1),
+            ("index", "obsolete(0)", "patch is correct", "P0", [], False, "filtered", 0),
+            ("index", "obsolete(0)", "patch is correct", "P0", ["Synthetic claim"], True, "incomplete", 2),
+            ("index", "obsolete(0)", "patch is incorrect", "P2", ["Synthetic claim"], True, "findings", 0),
+        )
+        with self.migration() as (repo, *_):
+            captured = self.helper["local_bundle"](repo)
+            record = captured.mixed[0]
+            original_prepare = self.helper["prepare_review_prompts"]
+            for count in (1, 2):
+                for target, excerpt, verdict, priority, required, expect, expected_status, expected_exit in cases:
+                    with self.subTest(count=count, target=target, excerpt=excerpt, priority=priority, expect=expect):
+                        finding = {
+                            "title": "Synthetic claim", "body": "A concrete migration defect.",
+                            "priority": "P2", "confidence": 0.8, "category": "bug",
+                            "code_location": {"file_path": record.path, "line": 1},
+                        }
+                        if target:
+                            finding["source_attribution"] = {
+                                "target": target, "record_id": record.identity,
+                                "source_id": getattr(record, target).identity,
+                                "side": "present", "column": 1, "excerpt": excerpt,
+                            }
+                        provider = {"findings": [finding], "overall_correctness": verdict,
+                                    "overall_explanation": "Synthetic provider conclusion.", "overall_confidence": 0.61}
+                        output = repo.parent / "result.json"
+                        argv = [str(SCRIPT), "--mode", "local", "--max-priority", priority,
+                                "--json-output", str(output)]
+                        for needle in required:
+                            argv += ["--require-finding", needle]
+                        if expect:
+                            argv.append("--expect-findings")
+                        text = io.StringIO()
+                        with mock.patch.dict(self.helper["main_impl"].__globals__, {
+                            "repo_root": lambda: repo,
+                            "prepare_review_prompts": lambda *args: original_prepare(*args) * count,
+                            "scan_outgoing_review_pack": lambda *_: None,
+                            "run_engine": lambda *_: json.dumps(provider),
+                        }), mock.patch.object(sys, "argv", argv), contextlib.redirect_stdout(text), \
+                                contextlib.redirect_stderr(io.StringIO()):
+                            self.assertEqual(self.helper["main_impl"](), expected_exit)
+                        report = json.loads(output.read_text())
+                        self.assertEqual(report["review_status"], expected_status)
+                        self.assertEqual(report["overall_confidence"], 0.61)
+                        self.assertEqual(report["overall_correctness"], verdict)
+                        self.assertEqual(len(report["pass_reports"]), count)
+                        for entry in report["pass_reports"]:
+                            self.assertEqual(entry["report"]["provider_report"], provider)
+                        self.assertNotIn("scoped-clean", text.getvalue())
+                        if target == "index":
+                            self.assertIn("INDEX-only", text.getvalue())
+                        if expected_status == "incomplete" and not required:
+                            self.assertTrue(report["attribution_rejected_findings"])
+                        if expected_status == "findings":
+                            self.assertEqual(len(report["findings"]), 1)
+                            self.assertEqual(len(report["findings"][0]["claim_variants"][0]["observations"]), count)
+
+    def test_mixed_crlf_absence_and_executable_mode_keep_exact_source_bytes(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo = init_repo(Path(tempdir))
+            git(repo, "config", "core.autocrlf", "false")
+            path = repo / "source.py"
+            path.write_bytes(b"base()\r\nkeep()\r\n")
+            git(repo, "add", ".")
+            git(repo, "commit", "-qm", "CRLF base")
+            path.write_bytes(b"obsolete()\r\nkeep()\r\n")
+            if os.name != "nt":
+                path.chmod(0o755)
+            git(repo, "add", ".")
+            path.write_bytes(b"corrected()\r\nkeep()\r\n")
+            captured = self.helper["local_bundle"](repo)
+            record, = captured.mixed
+            self.assertEqual(record.index_removed, ((1, "base()\r"),))
+            self.assertEqual(record.working_tree_removed, ((1, "obsolete()\r"),))
+            self.assertIn("+obsolete()\r\n", captured.text)
+            self.assertEqual(record.working_tree.content.encode(), path.read_bytes())
+            if os.name != "nt":
+                self.assertEqual(record.base.mode, "100644")
+                self.assertEqual(record.index.mode, "100755")
+
+    def test_readded_untracked_capture_is_reused_and_evidence_stays_separate(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo = init_repo(Path(tempdir))
+            path = repo / "source.py"
+            path.write_text("base()\n")
+            git(repo, "add", ".")
+            git(repo, "commit", "-qm", "base")
+            git(repo, "rm", "source.py")
+            path.write_text("readded()\n")
+            read = mock.Mock(wraps=self.helper["read_prefix"])
+            with mock.patch.dict(self.helper["local_bundle"].__globals__, {"read_prefix": read}):
+                captured = self.helper["local_bundle"](repo)
+            self.assertEqual(sum(call.args[0] == path for call in read.call_args_list), 1)
+            (repo / ".git/info/exclude").write_text("evidence/\n")
+            evidence_path = repo / "evidence/source.py"
+            evidence_path.parent.mkdir()
+            evidence_path.write_text("fake authoritative replacement()\n")
+            evidence = self.helper["capture_evidence_inputs"](
+                argparse.Namespace(prompt=[], prompt_file=[], dataset=["evidence/source.py"]), repo,
+            )
+            passes = self.helper["build_review_prompts"](repo, "local", None, captured, "", evidence.datasets)
+            record = passes[0].chunk.sources[0]
+            self.assertEqual(record.working_tree.content, "readded()\n")
+            self.assertNotIn(evidence_path.relative_to(repo).as_posix(), captured.paths)
+            before = self.helper["source_tree_snapshot"](repo)
+            evidence_path.write_text("mutated evidence()\n")
+            self.assertEqual(self.helper["source_tree_snapshot"](repo), before)
+            provider = mock.Mock()
+            with mock.patch.dict(self.helper["run_reviewer"].__globals__, {
+                "scan_outgoing_review_pack": lambda *_: None, "run_engine": provider,
+            }), contextlib.redirect_stderr(io.StringIO()):
+                with self.assertRaisesRegex(SystemExit, "evidence changed"):
+                    self.helper["run_reviewer"](argparse.Namespace(engine="codex"), repo, passes[0], captured, [],
+                                                 evidence=evidence.files)
+            provider.assert_not_called()
+
+    def test_ignored_or_unsafe_readdition_cannot_bypass_mixed_capture(self):
+        for kind in ("ignored", "symlink"):
+            if kind == "symlink" and os.name == "nt":
+                continue
+            with self.subTest(kind=kind), tempfile.TemporaryDirectory() as tempdir:
+                repo = init_repo(Path(tempdir))
+                path = repo / "source.py"
+                path.write_text("base()\n")
+                git(repo, "add", ".")
+                git(repo, "commit", "-qm", "base")
+                git(repo, "rm", "source.py")
+                if kind == "ignored":
+                    (repo / ".git/info/exclude").write_text("source.py\n")
+                    path.write_text("ignored content never sent\n")
+                else:
+                    outside = repo.parent / "outside.py"
+                    outside.write_text("outside content never sent\n")
+                    path.symlink_to(outside)
+                with self.assertRaisesRegex(SystemExit, "working_tree.*validated untracked membership"):
+                    self.helper["local_bundle"](repo)
+
+
 class AutoreviewHardeningTests(unittest.TestCase):
     def setUp(self) -> None:
         self.helper = load_helper()
@@ -278,7 +755,7 @@ class AutoreviewHardeningTests(unittest.TestCase):
             (repo / "source.md").write_text("after\n")
             (repo / "evidence").mkdir()
             (repo / "evidence/note.md").write_text("frozen evidence\r\n")
-            sends = []
+            sends, scans = [], []
             stdout, stderr = io.StringIO(), io.StringIO()
 
             def engine(_args, _repo, prompt):
@@ -293,15 +770,16 @@ class AutoreviewHardeningTests(unittest.TestCase):
             with mock.patch.dict(self.helper["main_impl"].__globals__, {
                 "repo_root": lambda: repo,
                 "run_engine": engine,
+                "scan_outgoing_review_pack": lambda _repo, prompt: scans.append(prompt),
                 "resolve_engine_binary": lambda *_args: (True, None),
             }), mock.patch.object(sys, "argv", [str(SCRIPT), "--mode", "local", *options]), \
                     contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
-                yield repo, sends, stdout, stderr
+                yield repo, sends, scans, stdout, stderr
 
     def test_preparation_reuses_untracked_capture_and_keeps_three_full_snapshots(self):
         for explicit in (False, True):
             options = ("--dataset", "note.md") if explicit else ()
-            with self.subTest(explicit=explicit), self.preparation_fixture(*options) as (repo, sends, _out, err):
+            with self.subTest(explicit=explicit), self.preparation_fixture(*options) as (repo, sends, scans, _out, err):
                 (repo / "note.md").write_text("untracked evidence\n")
                 read = mock.Mock(wraps=self.helper["file_bundle_snapshot"])
                 fingerprint = mock.Mock(wraps=self.helper["source_file_fingerprint"])
@@ -309,6 +787,7 @@ class AutoreviewHardeningTests(unittest.TestCase):
                     "file_bundle_snapshot": read, "source_file_fingerprint": fingerprint,
                 }):
                     self.assertEqual(self.helper["main_impl"](), 0)
+                self.assertEqual(scans, sends)
                 # Explicit evidence has its own initial capture and three fresh
                 # checks; finding membership never adds another content read.
                 self.assertEqual(read.call_count, 5 if explicit else 1)
@@ -334,7 +813,7 @@ class AutoreviewHardeningTests(unittest.TestCase):
             self.assertFalse(sends)
 
     def test_preparation_progress_precedes_snapshot(self):
-        with self.preparation_fixture() as (_repo, sends, _out, err):
+        with self.preparation_fixture() as (_repo, sends, _scans, _out, err):
             def snapshot(*_args, **_kwargs):
                 self.assertIn("preparation: initial source snapshot", err.getvalue())
                 self.assertFalse(sends)
@@ -345,19 +824,20 @@ class AutoreviewHardeningTests(unittest.TestCase):
                     self.helper["main_impl"]()
 
     def test_dry_run_reuses_capture_without_whole_tree_snapshots(self):
-        with self.preparation_fixture("--dry-run", "--dataset", "evidence/note.md") as (_repo, sends, *_):
+        with self.preparation_fixture("--dry-run", "--dataset", "evidence/note.md") as (_repo, sends, scans, *_):
             snapshot = mock.Mock(side_effect=AssertionError("dry run must not sweep the checkout"))
             with mock.patch.dict(self.helper["main_impl"].__globals__, {"source_tree_snapshot": snapshot}):
                 self.assertEqual(self.helper["main_impl"](), 0)
             snapshot.assert_not_called()
+            self.assertTrue(scans)
             self.assertFalse(sends)
 
     def test_evidence_mutations_refuse_stale_publication_and_later_passes(self):
         for tracked in (False, True):
-            for timing in ("construction", "review", "between passes"):
+            for timing in ("construction", "scan", "review", "between passes"):
                 with self.subTest(tracked=tracked, timing=timing), self.preparation_fixture(
                     "--prompt-file", "evidence/note.md", "--dataset", "evidence/note.md",
-                ) as (repo, sends, out, _err):
+                ) as (repo, sends, _scans, out, _err):
                     evidence = repo / "evidence/note.md"
                     if tracked:
                         git(repo, "add", "-f", "evidence/note.md")
@@ -385,6 +865,8 @@ class AutoreviewHardeningTests(unittest.TestCase):
                         return result
 
                     patches = {"run_engine": engine, "build_bundle": build}
+                    if timing == "scan":
+                        patches["scan_outgoing_review_pack"] = lambda *_args: mutate()
                     if timing == "between passes":
                         original_prepare = self.helper["prepare_review_prompts"]
                         patches["prepare_review_prompts"] = lambda *args: original_prepare(*args) * 2
@@ -439,7 +921,7 @@ class AutoreviewHardeningTests(unittest.TestCase):
         with self.preparation_fixture(
             "--prompt-file", "evidence/note.md", "--dataset", "evidence/note.md",
             "--dataset", "evidence/note.md",
-        ) as (repo, sends, *_):
+        ) as (repo, sends, scans, *_):
             evidence = (repo / "evidence/note.md").read_bytes().decode()
             original = self.helper["prepare_review_prompts"]
             with mock.patch.dict(self.helper["main_impl"].__globals__, {
@@ -447,6 +929,7 @@ class AutoreviewHardeningTests(unittest.TestCase):
             }):
                 self.assertEqual(self.helper["main_impl"](), 0)
             self.assertEqual(len(sends), 2)
+            self.assertEqual(scans, sends)
             for prompt in sends:
                 self.assertEqual(prompt.count(evidence), 3)
 
@@ -571,6 +1054,148 @@ class AutoreviewHardeningTests(unittest.TestCase):
                 self.assertIn("+task change", captured.text)
                 self.assertFalse(captured.truncated)
 
+    def test_outgoing_pack_scan_disables_installed_scanner_updates(self) -> None:
+        prompt = "harmless review pack\npreserved CRLF\r\nfinal line\r"
+        with tempfile.TemporaryDirectory() as tempdir:
+            root = Path(tempdir)
+            repo = root / "repo"
+            repo.mkdir()
+            write_executable(
+                root / "trufflehog",
+                r'''#!/usr/bin/env python3
+import json
+from pathlib import Path
+import sys
+
+args = sys.argv[1:]
+if "--no-update" not in args:
+    print("updater: cannot move binary: permission denied", file=sys.stderr)
+    raise SystemExit(1)
+assert args[0] == "filesystem"
+assert set(args[2:]) == {
+    "--json", "--no-color", "--results=verified,unknown",
+    "--fail", "--fail-on-scan-errors", "--no-update",
+}
+pack = Path(args[1])
+Path(__file__).with_name("scan.json").write_text(json.dumps({
+    "pack": str(pack),
+    "prompt": pack.read_bytes().decode("utf-8"),
+}))
+''',
+            )
+            with mock.patch.dict(
+                os.environ,
+                {"PATH": f"{root}{os.pathsep}{os.environ.get('PATH', '')}"},
+            ):
+                self.helper["scan_outgoing_review_pack"](repo, prompt)
+
+            record = json.loads((root / "scan.json").read_text(encoding="utf-8"))
+            self.assertEqual(record["prompt"], prompt)
+            self.assertFalse(Path(record["pack"]).parent.exists())
+
+    def test_outgoing_pack_scan_reads_exact_prompt_including_deleted_lines(self) -> None:
+        prompt = (
+            "# Change Bundle\n"
+            "diff --git a/config.ts b/config.ts\n"
+            "deleted file mode 100644\n"
+            "--- a/config.ts\n"
+            "+++ /dev/null\n"
+            "@@ -1 +0,0 @@\n"
+            "-const apiKey = \"removed-but-still-sensitive\";\n"
+        )
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo = init_repo(Path(tempdir))
+
+            def run_scanner(
+                command: list[str],
+                cwd: Path,
+                **_kwargs: object,
+            ) -> subprocess.CompletedProcess[str]:
+                self.assertEqual(command[1], "filesystem")
+                self.assertEqual(Path(command[2]).read_bytes(), prompt.encode("utf-8"))
+                self.assertIn("-const apiKey", prompt)
+                return subprocess.CompletedProcess(command, 0, "", "")
+
+            with mock.patch.dict(
+                self.helper["scan_outgoing_review_pack"].__globals__,
+                {
+                    "find_command": lambda _name, _repo: "/trusted/trufflehog",
+                    "run": run_scanner,
+                },
+            ):
+                self.helper["scan_outgoing_review_pack"](repo, prompt)
+
+    def test_outgoing_pack_scan_refuses_and_names_deleted_file(self) -> None:
+        prompt = (
+            "# Change Bundle\n"
+            "diff --git a/config.ts b/config.ts\n"
+            "deleted file mode 100644\n"
+            "--- a/config.ts\n"
+            "+++ /dev/null\n"
+            "@@ -1 +0,0 @@\n"
+            "-const apiKey = \"removed-but-still-sensitive\";\n"
+        )
+        finding = {
+            "SourceMetadata": {
+                "Data": {
+                    "Filesystem": {
+                        "file": "review-pack.txt",
+                        "line": 7,
+                    }
+                }
+            },
+            "Raw": "must-not-be-printed",
+        }
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo = init_repo(Path(tempdir))
+            with mock.patch.dict(
+                self.helper["scan_outgoing_review_pack"].__globals__,
+                {
+                    "find_command": lambda _name, _repo: "/trusted/trufflehog",
+                    "run": lambda command, _cwd, **_kwargs: subprocess.CompletedProcess(
+                        command,
+                        self.helper["TRUFFLEHOG_FINDINGS_EXIT_CODE"],
+                        json.dumps(finding) + "\n",
+                        "",
+                    ),
+                },
+            ):
+                with self.assertRaisesRegex(SystemExit, "config.ts") as error:
+                    self.helper["scan_outgoing_review_pack"](repo, prompt)
+        self.assertNotIn("must-not-be-printed", str(error.exception))
+
+    def test_outgoing_pack_scan_fails_closed_when_scanner_is_missing(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo = init_repo(Path(tempdir))
+            with mock.patch.dict(
+                self.helper["scan_outgoing_review_pack"].__globals__,
+                {"find_command": lambda _name, _repo: None},
+            ):
+                with self.assertRaisesRegex(SystemExit, "refusing to send review pack"):
+                    self.helper["scan_outgoing_review_pack"](repo, "prompt")
+
+    def test_reviewer_scan_refusal_prevents_provider_call(self) -> None:
+        args = argparse.Namespace(engine="codex", max_priority="P0")
+        provider = mock.Mock()
+        with mock.patch.dict(
+            self.helper["run_reviewer"].__globals__,
+            {
+                "scan_outgoing_review_pack": mock.Mock(
+                    side_effect=SystemExit("refusing to send review pack: config.ts")
+                ),
+                "run_engine": provider,
+            },
+        ):
+            with self.assertRaisesRegex(SystemExit, "config.ts"):
+                self.helper["run_reviewer"](
+                    args,
+                    Path.cwd(),
+                    "prompt",
+                    set(),
+                    [],
+                )
+        provider.assert_not_called()
+
     def test_local_bundle_preserves_boundary_when_sensitive_diff_is_omitted(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:
             repo = init_repo(Path(tempdir))
@@ -581,7 +1206,7 @@ class AutoreviewHardeningTests(unittest.TestCase):
             path.write_text("TOKEN=changed-placeholder\n", encoding="utf-8")
             git(repo, "add", path.name)
 
-            bundle, truncated, _paths = self.helper["local_bundle"](repo)
+            bundle, truncated, _paths, _mixed, _spans = self.helper["local_bundle"](repo)
 
             self.assertIn(self.helper["REVIEW_SECURITY_OMISSION"], bundle)
             self.assertFalse(truncated)
@@ -605,7 +1230,7 @@ class AutoreviewHardeningTests(unittest.TestCase):
                 path.write_text("placeholder=true\n", encoding="utf-8")
                 (repo / "review.py").write_text("print('review me')\n", encoding="utf-8")
 
-                bundle, truncated, _paths = self.helper["local_bundle"](repo)
+                bundle, truncated, _paths, _mixed, _spans = self.helper["local_bundle"](repo)
 
                 self.assertIn("# Review Input Omissions", bundle)
                 self.assertIn(self.helper["REVIEW_SECURITY_OMISSION"], bundle)
@@ -619,7 +1244,7 @@ class AutoreviewHardeningTests(unittest.TestCase):
             repo = init_repo(Path(tempdir))
             (repo / "image.bin").write_bytes(b"\x89PNG\r\n\0binary-content")
 
-            bundle, truncated, _paths = self.helper["local_bundle"](repo)
+            bundle, truncated, _paths, _mixed, _spans = self.helper["local_bundle"](repo)
 
             self.assertIn(
                 '# Untracked File\npath: "image.bin"\n'
@@ -654,7 +1279,7 @@ class AutoreviewHardeningTests(unittest.TestCase):
                 self.helper["local_bundle"].__globals__,
                 {"read_prefix": read_once},
             ):
-                bundle, truncated, _paths = self.helper["local_bundle"](repo)
+                bundle, truncated, _paths, _mixed, _spans = self.helper["local_bundle"](repo)
 
             expected_record = json.dumps("review me" + os.linesep)
             self.assertIn(
@@ -696,6 +1321,7 @@ class AutoreviewHardeningTests(unittest.TestCase):
             # Expected patches must use the same protected Git policy.
             staged = self.helper["git"](repo, "diff", *self.helper["SAFE_DIFF_FLAGS"], "--cached", incoming)
             unstaged = self.helper["git"](repo, "diff", *self.helper["SAFE_DIFF_FLAGS"])
+            scanned: list[str] = []
             sent: list[str] = []
             report = {
                 "findings": [{
@@ -718,6 +1344,7 @@ class AutoreviewHardeningTests(unittest.TestCase):
             main = self.helper["main_impl"]
             with mock.patch.dict(main.__globals__, {
                 "repo_root": lambda: repo,
+                "scan_outgoing_review_pack": lambda _repo, prompt: scanned.append(prompt),
                 "run_engine": run_engine,
                 "resolve_engine_binary": lambda _reviewer, _repo: (True, None),
             }):
@@ -729,6 +1356,7 @@ class AutoreviewHardeningTests(unittest.TestCase):
                         self.assertEqual(main(), 0 if dry_run else 1)
 
             self.assertEqual(len(sent), 1)
+            self.assertEqual(scanned, [sent[0], sent[0]])
             self.assertIn(f"# Staged Diff\nbase: {incoming}", sent[0])
             self.assertIn(staged.rstrip(), sent[0])
             self.assertIn(unstaged.rstrip(), sent[0])
@@ -765,7 +1393,7 @@ class AutoreviewHardeningTests(unittest.TestCase):
             snapshot = self.helper["source_tree_snapshot"](repo)
             git(repo, "update-ref", "refs/heads/review-base", "HEAD")
             self.assertEqual(self.helper["source_tree_snapshot"](repo), snapshot)
-            bundle, truncated, _paths = self.helper["local_bundle"](repo, pinned)
+            bundle, truncated, _paths, _mixed, _spans = self.helper["local_bundle"](repo, pinned)
             self.assertFalse(truncated)
             self.assertIn("+committed task change", bundle)
             self.assertEqual(
@@ -788,7 +1416,7 @@ class AutoreviewHardeningTests(unittest.TestCase):
                 if staged:
                     git(repo, "add", safe)
                 with self.subTest(staged=staged):
-                    bundle, truncated, _paths = self.helper["local_bundle"](repo)
+                    bundle, truncated, _paths, _mixed, _spans = self.helper["local_bundle"](repo)
                     self.assertFalse(truncated)
                     self.assertIn("struct CredentialFile", bundle)
                     self.assertIn(safe, self.helper["local_bundle"](repo).paths)
@@ -859,7 +1487,7 @@ class AutoreviewHardeningTests(unittest.TestCase):
             for engine in ("codex", "claude", "amp", "pi", "kimi"):
                 for mode, ref, accepted, expected_exit in cases:
                     with self.subTest(engine=engine, mode=mode, ref=bool(ref)):
-                        sends = []
+                        scans, sends = [], []
 
                         def run_engine(_args, _repo, prompt):
                             sends.append(prompt)
@@ -873,6 +1501,7 @@ class AutoreviewHardeningTests(unittest.TestCase):
                         output = io.StringIO()
                         with mock.patch.dict(self.helper["main_impl"].__globals__, {
                             "repo_root": lambda: repo, "run_engine": run_engine,
+                            "scan_outgoing_review_pack": lambda _repo, prompt: scans.append(prompt),
                         }), mock.patch.object(sys, "argv", argv), contextlib.redirect_stdout(output), contextlib.redirect_stderr(io.StringIO()):
                             self.assertEqual(self.helper["main_impl"](), expected_exit)
                         result = json.loads((root / "result.json").read_text())
@@ -887,6 +1516,7 @@ class AutoreviewHardeningTests(unittest.TestCase):
                         self.assertNotIn("clean:", text)
                         rejected = result.get("scope_rejected_findings", [])
                         self.assertEqual(len(rejected), 2 - len(accepted))
+                        self.assertEqual(scans, sends)
                         self.assertIn("# Dataset: " + str(Path(e2e)), sends[0])
                         self.assertNotIn("OMIT_STAGED_STORE", sends[0])
                         self.assertNotIn("OMIT_UNTRACKED_ENV", sends[0])
@@ -943,6 +1573,7 @@ class AutoreviewHardeningTests(unittest.TestCase):
                         with mock.patch.dict(self.helper["main_impl"].__globals__, {
                             "repo_root": lambda: repo,
                             "build_review_prompts": lambda *_args: ["synthetic pack"] * count,
+                            "scan_outgoing_review_pack": lambda *_args: None,
                             "run_engine": lambda *_args: json.dumps(provider),
                         }), mock.patch.object(sys, "argv", argv), contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(io.StringIO()):
                             self.assertEqual(self.helper["main_impl"](), exit_code)
@@ -960,47 +1591,64 @@ class AutoreviewHardeningTests(unittest.TestCase):
                         if required and expected_status == "incomplete":
                             self.assertEqual(result["missing_required_findings"], required)
 
-    def test_credential_source_exception_keeps_review_material_and_credential_rule(self) -> None:
+    def test_credential_source_exception_still_scans_every_outgoing_input(self) -> None:
         source = "Sources/Configuration/CredentialFile.swift"
         with tempfile.TemporaryDirectory() as tempdir:
             repo = init_repo(Path(tempdir))
             path = repo / source
             path.parent.mkdir(parents=True)
-            path.write_text("// DELETED_CREDENTIAL_CONTEXT\n", encoding="utf-8")
+            path.write_text("// DELETED_SCAN_MARKER\n", encoding="utf-8")
             git(repo, "add", source)
             git(repo, "commit", "-q", "-m", "base")
-            path.write_text("// STAGED_CREDENTIAL_CONTEXT\n", encoding="utf-8")
+            path.write_text("// STAGED_SCAN_MARKER\n", encoding="utf-8")
             git(repo, "add", source)
             untracked = repo / "Runtime/CredentialFile.swift"
             untracked.parent.mkdir()
-            untracked.write_text("// UNTRACKED_CREDENTIAL_CONTEXT\n", encoding="utf-8")
+            untracked.write_text("// UNTRACKED_SCAN_MARKER\n", encoding="utf-8")
             evidence = self.helper["capture_evidence_inputs"](argparse.Namespace(
-                prompt=["PROMPT_CREDENTIAL_CONTEXT"], prompt_file=[source],
+                prompt=["PROMPT_SCAN_MARKER"], prompt_file=[source],
                 dataset=[str(untracked.relative_to(repo))],
             ), repo)
             extra, datasets = evidence.prompt, evidence.datasets
-            bundle, _, _paths = self.helper["local_bundle"](repo)
+            bundle, _, _paths, _mixed, _spans = self.helper["local_bundle"](repo)
             pack, = self.helper["build_review_prompts"](repo, "local", None, bundle, extra, datasets)
             provider = mock.Mock(return_value=json.dumps({
                 "findings": [], "overall_correctness": "patch is correct",
                 "overall_explanation": "Synthetic review.", "overall_confidence": 0.8,
             }))
-            for token in (
-                "-// DELETED_CREDENTIAL_CONTEXT",
-                "+// STAGED_CREDENTIAL_CONTEXT",
-                "UNTRACKED_CREDENTIAL_CONTEXT",
-                "PROMPT_CREDENTIAL_CONTEXT",
-                "# Dataset:",
-                "# Prompt file:",
-                "Report every suspected real credential as a P0 security finding",
-            ):
-                self.assertIn(token, pack)
-            with mock.patch.dict(
-                self.helper["run_reviewer"].__globals__, {"run_engine": provider}
-            ):
-                args = argparse.Namespace(engine="codex", max_priority="P2")
-                self.helper["run_reviewer"](args, repo, pack, {source}, [])
-            provider.assert_called_once_with(args, repo, pack)
+            self.assertIn("Report every suspected real credential as a P0 security finding", pack)
+            for marker in (None, "DELETED_SCAN_MARKER", "STAGED_SCAN_MARKER", "UNTRACKED_SCAN_MARKER", "PROMPT_SCAN_MARKER"):
+                events = []
+
+                def scanner(command, _repo, **_kwargs):
+                    outgoing = Path(command[2])
+                    self.assertEqual(outgoing.read_bytes(), pack.encode("utf-8"))
+                    if os.name != "nt":
+                        self.assertEqual(stat.S_IMODE(outgoing.stat().st_mode), 0o600)
+                    self.assertIn("--results=verified,unknown", command)
+                    self.assertIn("--no-update", command)
+                    for token in ("-// DELETED_SCAN_MARKER", "+// STAGED_SCAN_MARKER", "UNTRACKED_SCAN_MARKER", "PROMPT_SCAN_MARKER", "# Dataset:", "# Prompt file:"):
+                        self.assertIn(token, pack)
+                    events.append("scan")
+                    if marker:
+                        line = next(i for i, text in enumerate(pack.splitlines(), 1) if marker in text)
+                        detected = {"SourceMetadata": {"Data": {"Filesystem": {"file": str(outgoing), "line": line}}}}
+                        return subprocess.CompletedProcess(command, self.helper["TRUFFLEHOG_FINDINGS_EXIT_CODE"], json.dumps(detected), "")
+                    return subprocess.CompletedProcess(command, 0, "", "")
+
+                provider.reset_mock()
+                with self.subTest(marker=marker), mock.patch.dict(self.helper["run_reviewer"].__globals__, {
+                    "find_command": lambda *_args: "/trusted/trufflehog", "run": scanner, "run_engine": provider,
+                }):
+                    args = argparse.Namespace(engine="codex", max_priority="P2")
+                    if marker:
+                        with self.assertRaisesRegex(SystemExit, "refusing to send review pack"):
+                            self.helper["run_reviewer"](args, repo, pack, {source}, [])
+                        provider.assert_not_called()
+                    else:
+                        self.helper["run_reviewer"](args, repo, pack, {source}, [])
+                        provider.assert_called_once_with(args, repo, pack)
+                    self.assertEqual(events, ["scan"])
 
     def test_tracked_binary_changes_are_blocked_in_all_modes(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:
@@ -1762,15 +2410,51 @@ class AutoreviewHardeningTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tempdir:
             repo = init_repo(Path(tempdir))
             bundle = "diff --git a/code.py b/code.py\n" + "+review me\n" * 20_000
-            prompts = self.helper["prepare_review_prompts"](
-                repo, "local", None, bundle, "", [], 120_000
-            )
+            with mock.patch.dict(self.helper["prepare_review_prompts"].__globals__, {
+                "scan_outgoing_review_pack": mock.Mock(),
+            }):
+                prompts = self.helper["prepare_review_prompts"](
+                    repo, "local", None, bundle, "", [], 120_000
+                )
             self.assertGreater(len(prompts), 1)
             for prompt in prompts:
                 self.assertIn(
                     "Report every suspected real credential as a P0 security finding",
                     prompt,
                 )
+
+    def test_partitioned_input_scans_complete_content_before_any_send(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo = init_repo(Path(tempdir))
+            sentinel = "synthetic scanner boundary " + "x" * 160_000 + " end sentinel"
+            for source in ("diff", "dataset"):
+                with self.subTest(source=source):
+                    bundle = "+" + (sentinel if source == "diff" else "safe") + "\n" * 30_000
+                    datasets = (
+                        [self.helper["ReviewDataset"]("evidence.txt", sentinel)]
+                        if source == "dataset" else []
+                    )
+                    prompts = self.helper["build_review_prompts"](
+                        repo, "local", None, bundle, "", datasets, 120_000
+                    )
+                    self.assertGreater(len(prompts), 1)
+                    self.assertFalse(any(sentinel in prompt for prompt in prompts))
+                    scanned = []
+
+                    def scan(_repo, prompt):
+                        scanned.append(prompt)
+                        if sentinel in prompt:
+                            raise SystemExit("complete input scanner rejection")
+
+                    with mock.patch.dict(
+                        self.helper["prepare_review_prompts"].__globals__,
+                        {"scan_outgoing_review_pack": scan},
+                    ), self.assertRaisesRegex(SystemExit, "complete input scanner rejection"):
+                        self.helper["prepare_review_prompts"](
+                            repo, "local", None, bundle, "", datasets, 120_000
+                        )
+                    self.assertEqual(len(scanned), 1)
+                    self.assertIn(sentinel, scanned[0])
 
     def test_review_prompt_preserves_bundle_ending_whitespace(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:
@@ -1804,10 +2488,15 @@ class AutoreviewHardeningTests(unittest.TestCase):
             "category": "bug",
             "code_location": {"file_path": "source.txt", "line": 1},
         }
-        for failure in (None, "engine"):
+        for failure in (None, "scan", "engine"):
             with self.subTest(failure=failure), tempfile.TemporaryDirectory() as tempdir:
                 repo = init_repo(Path(tempdir))
                 events = []
+
+                def scan(_repo, prompt):
+                    events.append(("scan", prompt))
+                    if failure == "scan" and prompt == prompts[8]:
+                        raise SystemExit("late scan failure")
 
                 def engine(_args, _repo, prompt):
                     events.append(("engine", prompt))
@@ -1827,7 +2516,7 @@ class AutoreviewHardeningTests(unittest.TestCase):
 
                 with mock.patch.dict(
                     self.helper["run_review_passes"].__globals__,
-                    {"run_engine": engine},
+                    {"scan_outgoing_review_pack": scan, "run_engine": engine},
                 ), contextlib.redirect_stdout(io.StringIO()):
                     if failure:
                         with self.assertRaisesRegex(SystemExit, f"late {failure} failure"):
@@ -1844,9 +2533,11 @@ class AutoreviewHardeningTests(unittest.TestCase):
                         self.assertEqual(
                             [item["title"] for item in report["findings"]], [finding["title"]]
                         )
-                expected = [("engine", prompt) for prompt in prompts]
+                expected = [
+                    (stage, prompt) for prompt in prompts for stage in ("scan", "engine")
+                ]
                 if failure:
-                    expected = expected[:9]
+                    expected = expected[:17 if failure == "scan" else 18]
                 self.assertEqual(events, expected)
 
     def test_review_patch_does_not_disclose_controls_in_omitted_paths(self) -> None:
@@ -1916,7 +2607,7 @@ class AutoreviewHardeningTests(unittest.TestCase):
             (repo / ".env").write_text("placeholder=true\n", encoding="utf-8")
             (repo / "base.txt").write_text("base\nreview me\n", encoding="utf-8")
             git(repo, "add", ".env", "base.txt")
-            local, local_truncated, _paths = self.helper["local_bundle"](repo)
+            local, local_truncated, _paths, _mixed, _spans = self.helper["local_bundle"](repo)
             self.assertIn(self.helper["REVIEW_SECURITY_OMISSION"], local)
             self.assertNotIn(".env", local)
             self.assertNotIn("placeholder=true", local)
@@ -1924,7 +2615,7 @@ class AutoreviewHardeningTests(unittest.TestCase):
             self.assertFalse(local_truncated)
 
             git(repo, "commit", "-q", "-m", "sensitive path")
-            for bundle, truncated, paths in (
+            for bundle, truncated, paths, _mixed, _spans in (
                 self.helper["branch_bundle"](repo, base),
                 self.helper["commit_bundle"](repo, "HEAD"),
             ):
@@ -1945,16 +2636,16 @@ class AutoreviewHardeningTests(unittest.TestCase):
             workflow = repo / ".github" / "workflows" / "secret-scan.yml"
             workflow.parent.mkdir(parents=True)
             workflow.write_text("name: Secret scan\n", encoding="utf-8")
-            untracked_bundle, _, _paths = self.helper["local_bundle"](repo)
+            untracked_bundle, _, _paths, _mixed, _spans = self.helper["local_bundle"](repo)
             self.assertIn("secret-scan.yml", untracked_bundle)
 
             git(repo, "add", str(workflow.relative_to(repo)))
-            tracked_bundle, _, _paths = self.helper["local_bundle"](repo)
+            tracked_bundle, _, _paths, _mixed, _spans = self.helper["local_bundle"](repo)
             self.assertIn("secret-scan.yml", tracked_bundle)
 
             git(repo, "commit", "-q", "-m", "add secret scanner")
-            branch_bundle, _, _paths = self.helper["branch_bundle"](repo, base)
-            commit_bundle, _, _paths = self.helper["commit_bundle"](repo, "HEAD")
+            branch_bundle, _, _paths, _mixed, _spans = self.helper["branch_bundle"](repo, base)
+            commit_bundle, _, _paths, _mixed, _spans = self.helper["commit_bundle"](repo, "HEAD")
             self.assertIn("secret-scan.yml", branch_bundle)
             self.assertIn("secret-scan.yml", commit_bundle)
 
@@ -2022,7 +2713,7 @@ class AutoreviewHardeningTests(unittest.TestCase):
             path.parent.mkdir()
             path.write_text(source, encoding="utf-8")
 
-            bundle, truncated, _paths = self.helper["local_bundle"](repo)
+            bundle, truncated, _paths, _mixed, _spans = self.helper["local_bundle"](repo)
 
             self.assertIn("ordinary-hardcoded-value-12345", bundle)
             self.assertFalse(truncated)
@@ -2205,6 +2896,29 @@ class AutoreviewHardeningTests(unittest.TestCase):
             patch,
         )
 
+    @unittest.skipUnless(
+        shutil.which("trufflehog"), "TruffleHog binary not installed"
+    )
+    def test_outgoing_pack_scan_accepts_deleted_swift_status_literals(self) -> None:
+        # Live-scanner companion to the regression above: TruffleHog must not
+        # flag the benign "ok-token" status literal in a deleted-file bundle.
+        source = (FIXTURES / "swift-benign-status-literals.swift").read_text(
+            encoding="utf-8"
+        )
+        prompt = (
+            "# Change Bundle\n"
+            "diff --git a/apps/macos/MenuContentView.swift "
+            "b/apps/macos/MenuContentView.swift\n"
+            "deleted file mode 100644\n"
+            "--- a/apps/macos/MenuContentView.swift\n"
+            "+++ /dev/null\n"
+            f"@@ -1,{len(source.splitlines())} +0,0 @@\n"
+            + "".join(f"-{line}\n" for line in source.splitlines())
+        )
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo = init_repo(Path(tempdir))
+            self.helper["scan_outgoing_review_pack"](repo, prompt)
+
     def test_review_bundle_preserves_typescript_config_paths(self) -> None:
         source = (FIXTURES / "typescript-benign-config-path-references.ts").read_text(
             encoding="utf-8"
@@ -2300,7 +3014,7 @@ class AutoreviewHardeningTests(unittest.TestCase):
             git(repo, "add", "-u")
             git(repo, "commit", "-q", "-m", "delete template")
 
-            bundle, truncated, _paths = self.helper["branch_bundle"](repo, base)
+            bundle, truncated, _paths, _mixed, _spans = self.helper["branch_bundle"](repo, base)
 
             self.assertIn("deleted file mode 100644", bundle)
             self.assertIn("------BEGIN [A-Z ]+-----", bundle)
@@ -2469,7 +3183,7 @@ class AutoreviewHardeningTests(unittest.TestCase):
 
             path.write_text('const request = { token: String() };\n', encoding="utf-8")
 
-            bundle, truncated, _paths = self.helper["local_bundle"](repo)
+            bundle, truncated, _paths, _mixed, _spans = self.helper["local_bundle"](repo)
 
             self.assertIn('-const request = { token: "test-token" };', bundle)
             self.assertFalse(truncated)
@@ -3189,6 +3903,7 @@ class AutoreviewHardeningTests(unittest.TestCase):
             )
             record_path = root / "record.json"
             env = os.environ.copy()
+            add_fake_trufflehog(self.helper, root, env)
             env.update(
                 {
                     "AUTOREVIEW_FAKE_MUTATE": str(source),
@@ -4474,6 +5189,7 @@ os.execv(target, [str(target), *sys.argv[1:]])
 ''',
             )
             env = os.environ.copy()
+            add_fake_trufflehog(self.helper, root, env)
             env.update(
                 {
                     "CODEX_HOME": str(source_home),
@@ -4570,6 +5286,7 @@ os.execv(target, [str(target), *sys.argv[1:]])
             invocations = root / "codex-invocations.jsonl"
             record = root / "codex-record.json"
             env = os.environ.copy()
+            add_fake_trufflehog(self.helper, root, env)
             env.update(
                 {
                     "AUTOREVIEW_FAKE_CODEX_INVOCATIONS": str(invocations),
@@ -4681,7 +5398,10 @@ os.execv(target, [str(target), *sys.argv[1:]])
                 root / "codex",
                 fake_codex_script(),
             )
+            # Dry run scans the exact prompt too, so use a deterministic
+            # scanner instead of relying on the host installation.
             env = os.environ.copy()
+            add_fake_trufflehog(self.helper, root, env)
 
             result = subprocess.run(
                 [
@@ -4721,6 +5441,7 @@ os.execv(target, [str(target), *sys.argv[1:]])
                 fake_codex_script(),
             )
             env = os.environ.copy()
+            add_fake_trufflehog(self.helper, root, env)
             repo_temp = repo / "tmp"
             repo_temp.mkdir()
             env.update(
@@ -4751,12 +5472,54 @@ os.execv(target, [str(target), *sys.argv[1:]])
             )
 
             self.assertEqual(result.returncode, 1, result.stdout + result.stderr)
-            self.assertIn("prompt: OK", result.stdout)
+            self.assertIn("prompt: FAILED", result.stdout)
             self.assertIn("must be outside the reviewed repository", result.stdout)
             self.assertRegex(
                 result.stdout,
                 r"engine check: codex[^\n]* UNAVAILABLE",
             )
+
+    @unittest.skipIf(os.name == "nt", "the fake executable is POSIX-only")
+    def test_dry_run_flag_exits_nonzero_when_trufflehog_missing(self) -> None:
+        # Dry run applies the same exact-pack scan as a real provider call.
+        with tempfile.TemporaryDirectory() as tempdir:
+            root = Path(tempdir)
+            repo = init_repo(root)
+            source = repo / "source.txt"
+            source.write_text("staged\n", encoding="utf-8")
+            git(repo, "add", "source.txt")
+            codex_bin = write_executable(
+                root / "codex",
+                fake_codex_script(),
+            )
+            env = os.environ.copy()
+            env["PATH"] = path_excluding_command("trufflehog")
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT),
+                    "--mode",
+                    "local",
+                    "--engine",
+                    "codex",
+                    "--codex-bin",
+                    str(codex_bin),
+                    "--dry-run",
+                ],
+                cwd=repo,
+                env=env,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+
+            self.assertEqual(result.returncode, 1, result.stdout + result.stderr)
+            self.assertIn("prompt: FAILED", result.stdout)
+            self.assertIn("TruffleHog is required but was not found", result.stdout)
+            self.assertIn(self.helper["TRUFFLEHOG_INSTALL_URL"], result.stdout)
+            # The engine itself still resolves; only trufflehog should fail.
+            self.assertRegex(result.stdout, r"engine check: codex[^\n]* OK\b")
 
     def test_dry_run_flag_exits_nonzero_when_codex_no_tools(self) -> None:
         # run_codex() unconditionally refuses --no-tools; --dry-run must
@@ -4870,6 +5633,7 @@ os.execv(target, [str(target), *sys.argv[1:]])
                 preflight.__globals__,
                 {
                     "build_review_prompts": capturing,
+                    "scan_outgoing_review_pack": lambda _repo, _prompt: None,
                 },
             ):
                 with contextlib.redirect_stdout(stdout):
@@ -4892,6 +5656,7 @@ os.execv(target, [str(target), *sys.argv[1:]])
                 fake_codex_script(),
             )
             env = os.environ.copy()
+            add_fake_trufflehog(self.helper, root, env)
 
             result = subprocess.run(
                 [
@@ -4933,6 +5698,7 @@ os.execv(target, [str(target), *sys.argv[1:]])
                 fake_pi_script(),
             )
             env = os.environ.copy()
+            add_fake_trufflehog(self.helper, root, env)
             env["AUTOREVIEW_FAKE_PI_VERSION"] = "0.50.0"
 
             result = subprocess.run(
@@ -4971,6 +5737,7 @@ os.execv(target, [str(target), *sys.argv[1:]])
                 fake_pi_script(),
             )
             env = os.environ.copy()
+            add_fake_trufflehog(self.helper, root, env)
 
             result = subprocess.run(
                 [
@@ -5009,6 +5776,7 @@ os.execv(target, [str(target), *sys.argv[1:]])
                 fake_kimi_script(),
             )
             env = os.environ.copy()
+            add_fake_trufflehog(self.helper, root, env)
             env["AUTOREVIEW_FAKE_KIMI_VERSION"] = "0.10.0"
 
             result = subprocess.run(
@@ -5047,6 +5815,7 @@ os.execv(target, [str(target), *sys.argv[1:]])
                 fake_kimi_script(),
             )
             env = os.environ.copy()
+            add_fake_trufflehog(self.helper, root, env)
             # Isolate KIMI_CODE_HOME to an empty, hermetic directory instead
             # of leaking the host's real ~/.kimi-code (which may or may not
             # exist) into this test; an empty source share has no
@@ -5094,6 +5863,7 @@ os.execv(target, [str(target), *sys.argv[1:]])
                 fake_kimi_script(),
             )
             env = os.environ.copy()
+            add_fake_trufflehog(self.helper, root, env)
             env["KIMI_CODE_HOME"] = str(repo / ".kimi-code")
 
             result = subprocess.run(
@@ -5148,6 +5918,7 @@ os.execv(target, [str(target), *sys.argv[1:]])
             source_share.mkdir()
             (source_share / "device_id").write_text("not-a-valid-id!!", encoding="utf-8")
             env = os.environ.copy()
+            add_fake_trufflehog(self.helper, root, env)
             env["KIMI_CODE_HOME"] = str(source_share)
 
             result = subprocess.run(
@@ -5200,6 +5971,7 @@ os.execv(target, [str(target), *sys.argv[1:]])
             source_share.mkdir()
             (source_share / "credentials").write_text("not-a-directory", encoding="utf-8")
             env = os.environ.copy()
+            add_fake_trufflehog(self.helper, root, env)
             env["KIMI_CODE_HOME"] = str(source_share)
 
             result = subprocess.run(
@@ -5251,6 +6023,7 @@ os.execv(target, [str(target), *sys.argv[1:]])
             )
             (source_share / "credentials").mkdir()
             env = os.environ.copy()
+            add_fake_trufflehog(self.helper, root, env)
             env["KIMI_CODE_HOME"] = str(source_share)
 
             result = subprocess.run(
@@ -5295,6 +6068,7 @@ os.execv(target, [str(target), *sys.argv[1:]])
                 fake_claude_script(),
             )
             env = os.environ.copy()
+            add_fake_trufflehog(self.helper, root, env)
 
             result = subprocess.run(
                 [
@@ -5345,6 +6119,7 @@ os.execv(target, [str(target), *sys.argv[1:]])
                 fake_kimi_script(),
             )
             env = os.environ.copy()
+            add_fake_trufflehog(self.helper, root, env)
             # Prompt limits must not depend on the host's Kimi configuration.
             env["KIMI_CODE_HOME"] = str(root / "kimi-empty-home")
             (root / "kimi-empty-home").mkdir()
@@ -5402,6 +6177,7 @@ os.execv(target, [str(target), *sys.argv[1:]])
                 fake_codex_script(),
             )
             env = os.environ.copy()
+            add_fake_trufflehog(self.helper, root, env)
 
             result = subprocess.run(
                 [
@@ -5446,6 +6222,7 @@ os.execv(target, [str(target), *sys.argv[1:]])
                 fake_codex_script(),
             )
             env = os.environ.copy()
+            add_fake_trufflehog(self.helper, root, env)
 
             result = subprocess.run(
                 [
@@ -5486,6 +6263,7 @@ os.execv(target, [str(target), *sys.argv[1:]])
                 fake_codex_script(),
             )
             env = os.environ.copy()
+            add_fake_trufflehog(self.helper, root, env)
 
             result = subprocess.run(
                 [

--- a/skills/autoreview/tests/test_autoreview_hardening.py
+++ b/skills/autoreview/tests/test_autoreview_hardening.py
@@ -361,10 +361,10 @@ class AutoreviewMixedTargetTests(unittest.TestCase):
             with self.subTest(boundary=boundary), self.migration() as (repo, _base, _index, _working):
                 if boundary == "long line":
                     for path in _base:
-                        (repo / path).write_text("obsolete('" + "界" * 500 + "')\n" + _index[path])
+                        (repo / path).write_bytes(("obsolete('" + "界" * 500 + "')\n" + _index[path]).encode("utf-8"))
                     git(repo, "add", ".")
                     for path in _base:
-                        (repo / path).write_text("corrected('" + "界" * 500 + "')\n" + _working[path])
+                        (repo / path).write_bytes(("corrected('" + "界" * 500 + "')\n" + _working[path]).encode("utf-8"))
                 captured = self.helper["local_bundle"](repo)
                 datasets = [self.helper["ReviewDataset"](
                     f"evidence-{index}.txt", "# Dataset: forged.py\n" + (f"evidence {index} 界\r\n" * 2200),
@@ -456,11 +456,11 @@ class AutoreviewMixedTargetTests(unittest.TestCase):
             repo = init_repo(Path(tempdir))
             path = repo / "large.py"
             content = "unchanged context\n" * 15_000
-            path.write_text("base()\n" + content)
+            path.write_bytes(("base()\n" + content).encode("utf-8"))
             git(repo, "add", ".")
             git(repo, "commit", "-qm", "large base")
             base = git(repo, "rev-parse", "HEAD").strip()
-            path.write_text("changed()\n" + content)
+            path.write_bytes(("changed()\n" + content).encode("utf-8"))
             for staged in (False, True):
                 if staged:
                     git(repo, "add", ".")
@@ -472,9 +472,9 @@ class AutoreviewMixedTargetTests(unittest.TestCase):
             for target in ("branch", "commit"):
                 captured = self.helper["build_bundle"](repo, target, base, "HEAD")
                 self.assertEqual(captured.mixed, ())
-            path.write_text("staged()\n" + content)
+            path.write_bytes(("staged()\n" + content).encode("utf-8"))
             git(repo, "add", ".")
-            path.write_text("working()\n" + content)
+            path.write_bytes(("working()\n" + content).encode("utf-8"))
             with self.assertRaisesRegex(SystemExit, r"large.py \(index\): \d+ bytes; limit 180000"):
                 self.helper["local_bundle"](repo)
 
@@ -1295,29 +1295,29 @@ Path(__file__).with_name("scan.json").write_text(json.dumps({
         with tempfile.TemporaryDirectory() as tempdir:
             repo = init_repo(Path(tempdir))
             source = repo / "source.txt"
-            source.write_text("common\nretained line\n", encoding="utf-8")
+            source.write_bytes(b"common\nretained line\n")
             git(repo, "add", "source.txt")
             git(repo, "commit", "-q", "-m", "base")
             common = git(repo, "rev-parse", "HEAD").strip()
             git(repo, "checkout", "-q", "-b", "incoming")
             (repo / "proof.png").write_bytes(b"\x89PNG\r\n\0upstream-proof")
-            source.write_text("upstream\nretained line\n", encoding="utf-8")
+            source.write_bytes(b"upstream\nretained line\n")
             git(repo, "add", "source.txt", "proof.png")
             git(repo, "commit", "-q", "-m", "upstream")
             incoming = git(repo, "rev-parse", "HEAD").strip()
             git(repo, "checkout", "-q", "-b", "task", common)
-            source.write_text("task\nretained line\n", encoding="utf-8")
-            (repo / "committed.txt").write_text("committed task change\n", encoding="utf-8")
+            source.write_bytes(b"task\nretained line\n")
+            (repo / "committed.txt").write_bytes(b"committed task change\n")
             git(repo, "add", "source.txt", "committed.txt")
             git(repo, "commit", "-q", "-m", "task")
             with self.assertRaises(subprocess.CalledProcessError):
                 git(repo, "merge", "--no-ff", "--no-commit", "incoming")
             self.assertEqual(git(repo, "rev-parse", "MERGE_HEAD").strip(), incoming)
-            source.write_text("resolved staged task\n", encoding="utf-8")
+            source.write_bytes(b"resolved staged task\n")
             git(repo, "add", "source.txt")
             self.assertEqual(git(repo, "diff", "--name-only", "--diff-filter=U").strip(), "")
-            source.write_text("resolved staged task\nretained line\nunstaged task\n", encoding="utf-8")
-            (repo / "notes.md").write_text("untracked task note\n", encoding="utf-8")
+            source.write_bytes(b"resolved staged task\nretained line\nunstaged task\n")
+            (repo / "notes.md").write_bytes(b"untracked task note\n")
             # Review reads ignore host Git settings, including Windows autocrlf.
             # Expected patches must use the same protected Git policy.
             staged = self.helper["git"](repo, "diff", *self.helper["SAFE_DIFF_FLAGS"], "--cached", incoming)

--- a/skills/autoreview/tests/test_autoreview_hardening.py
+++ b/skills/autoreview/tests/test_autoreview_hardening.py
@@ -422,20 +422,21 @@ class AutoreviewMixedTargetTests(unittest.TestCase):
             with self.subTest(state=state), tempfile.TemporaryDirectory() as tempdir:
                 repo = init_repo(Path(tempdir))
                 path = repo / "source.py"
+                # These versions must be byte-identical even with Windows text translation.
                 if state != "unborn":
                     if state != "new":
-                        path.write_text("base()\n")
+                        path.write_bytes(b"base()\n")
                     git(repo, "add", ".")
                     git(repo, "commit", "--allow-empty", "-qm", "base")
                 if state == "readd":
                     git(repo, "rm", "source.py")
                 else:
-                    path.write_text("staged()\n")
+                    path.write_bytes(b"staged()\n")
                     git(repo, "add", ".")
                 if state == "removed":
                     path.unlink()
                 else:
-                    path.write_text("base()\n" if state == "undone" else "working()\n")
+                    path.write_bytes(b"base()\n" if state == "undone" else b"working()\n")
                 captured = self.helper["local_bundle"](repo)
                 record, = captured.mixed
                 self.assertIn("source.py", captured.paths)
@@ -684,11 +685,11 @@ class AutoreviewMixedTargetTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tempdir:
             repo = init_repo(Path(tempdir))
             path = repo / "source.py"
-            path.write_text("base()\n")
+            path.write_bytes(b"base()\n")
             git(repo, "add", ".")
             git(repo, "commit", "-qm", "base")
             git(repo, "rm", "source.py")
-            path.write_text("readded()\n")
+            path.write_bytes(b"readded()\n")
             read = mock.Mock(wraps=self.helper["read_prefix"])
             with mock.patch.dict(self.helper["local_bundle"].__globals__, {"read_prefix": read}):
                 captured = self.helper["local_bundle"](repo)


### PR DESCRIPTION
## Summary

Fix local reviews that combine base-to-index changes with later working-tree edits. Complete diff-byte coverage was not enough: independently split fragments could lose their source-version identity, allowing an index statement to be reported as current working-tree code and repeated findings to survive under different titles.

- Capture immutable version identities and complete authoritative context for mixed paths, preserving original change/evidence bytes across bounded passes, including staged-undone changes and deletion/re-addition.
- Validate explicit index/working-tree finding attribution and exact source anchors before aggregation. Keep invalid attribution auditable as an incomplete result; genuine index-only defects remain actionable. Group repeated observations independently of titles without hiding distinct claims or provider conclusions.
- Restore TruffleHog pre-send checks removed by [#209](https://github.com/openclaw/agent-skills/pull/209), including complete-input, exact-pack, and fallback scans with `verified,unknown`. Retain reviewer-side P0 credential checks as an additional safeguard.

The existing file/pack limits, sensitive-path exclusions, reviewer isolation, and source/evidence integrity checks remain enforced. Mandatory mixed-source context may increase pass counts or cause an explicit capacity refusal rather than dropping input. Nonmixed local, branch, and commit reviews retain their patch-based source contract.

## Validation

- Integrated Autoreview Python suite: 244 tests passed, with one platform-dependent skip.
- Focused mixed-source regressions passed. An expanded local Windows-host simulation reproduced all three remaining CI failures on the previous head and passed all 13 selected tests after making fixtures explicitly UTF-8 and byte-exact, without changing production behavior or relaxing assertions.
- Repository Node suite: 96 tests passed.
- Installer and validator suites: 6 and 9 tests passed respectively.
- Skill frontmatter, Bash/Python syntax, whitespace, source-byte preservation, and unchanged safety-owner checks passed.
- Independent managed Codex review: scoped-clean at the default P0 threshold, with pre-send scanning and reviewer isolation enforced.
- Linux and Windows CI checks will be verified on the final PR head before merge.

Deterministic coverage includes mixed versions across file/hunk/long-line boundaries and evidence batches, target attribution, title-independent grouping, staged-undone changes, absence/re-addition, literal scanner inputs, mutation/topology refusal, capacity limits, and retained raw provider results.
