### PR TITLE
docs(autoreview): clarify convergence workflow

### DIFF
--- a/skills/autoreview/SKILL.md
+++ b/skills/autoreview/SKILL.md
@@ -125,6 +125,23 @@ it does not include the committed PR merely because the checkout is on a PR
 branch. `--mode uncommitted` is an alias for `--mode local`. A clean local checkout
 without an explicit base has no local patch to review.
 
+### Converge after a fix
+
+Review the smallest fix delta before rebundling the branch:
+
+```bash
+# Fix is still uncommitted.
+"$AUTOREVIEW" --mode uncommitted
+
+# Fix is already committed.
+"$AUTOREVIEW" --mode commit --commit HEAD
+```
+
+When several reviewers are required, select them in one `--reviewers` invocation
+so they receive the same frozen bundle. Narrow checks validate each repair; run
+one full `--mode branch --base <base>` review only after the focused fixes pass,
+and use that full review as the final convergence gate.
+
 To review a dirty candidate against an explicit base, including a resolved merge
 that has not been committed:
 

--- a/skills/autoreview/SKILL.md
+++ b/skills/autoreview/SKILL.md
@@ -137,10 +137,11 @@ Review the smallest fix delta before rebundling the branch:
 "$AUTOREVIEW" --mode commit --commit HEAD
 ```
 
-When several reviewers are required, select them in one `--reviewers` invocation
-so they receive the same frozen bundle. Narrow checks validate each repair; run
-one full `--mode branch --base <base>` review only after the focused fixes pass,
-and use that full review as the final convergence gate.
+The helper runs one reviewer per invocation and has no `--reviewers` flag. When
+an orchestration layer supports reviewer panels, select all reviewers there so
+they receive the same frozen bundle. Otherwise run explicit narrow invocations
+against the same commit. After the focused fixes pass, run one full
+`--mode branch --base <base>` review as the final convergence gate.
 
 To review a dirty candidate against an explicit base, including a resolved merge
 that has not been committed:
@@ -277,7 +278,7 @@ independently semantic artifacts merely to shrink the review.
 
 ## Models and thinking
 
-The helper accepts `--model` globally or per engine (`engine=model`) and `--thinking` globally or per engine (`engine=level`). Repeat either flag for multiple reviewers.
+The helper accepts `--model` globally or per engine (`engine=model`) and `--thinking` globally or per engine (`engine=level`). Repeating these flags configures engine-specific values; it does not add reviewers.
 
 Recommended model defaults:
 


### PR DESCRIPTION
## Summary

Clarify how to converge Autoreview after addressing findings:

- review the smallest uncommitted or committed fix delta first
- document that one CLI invocation runs one reviewer and that repeated model flags configure engines rather than add reviewers
- run a final full branch review after focused fixes pass

This removes guidance for the unsupported `--reviewers` flag and makes single-reviewer CLI behavior explicit.

## Verification

- parsed `skills/autoreview/SKILL.md` frontmatter successfully
- `git diff --check origin/main..HEAD` passes

The two commits are unchanged from the local canonical history; the PR comes from a fork because the current account does not have direct write access to `openclaw/agent-skills`.
