### PR TITLE
fix(autoreview): preserve complete single-checkout review scope

### DIFF
--- a/skills/autoreview/SKILL.md
+++ b/skills/autoreview/SKILL.md
@@ -5,160 +5,47 @@ description: "Structured Codex, Claude, Amp, Pi, or Kimi code review when explic
 
 # Auto Review
 
-Run the bundled structured review helper only when the user explicitly asks for autoreview, a second-model review, or one of its named review engines. This is code review, not Guardian `auto_review` approval routing.
+Run an independent review when the user or an owning workflow asks for one.
+This is code review, not Guardian approval routing. Let the reviewer choose how
+to analyze the change; provide the target, relevant context, and desired severity.
+Findings are advice to verify, not instructions to apply blindly.
 
-Codex review is the default when no engine is set. It uses `gpt-5.6-sol` with `high` reasoning by default, then retries once with `gpt-5.6-terra` only when the account cannot access Sol. Claude review is optional and uses `claude-fable-5` by default. Amp review is optional and uses `openai/gpt-5.6-sol` with `high` reasoning by default. Pi and Kimi use the model configured by their respective CLIs unless `--model` overrides it.
+## Run
 
-Do not invoke Autoreview automatically before a commit, push, PR, merge, deploy, or final reply. Repository or workflow rules may call it only when they explicitly name it.
-
-## Contract
-
-- Default accepted findings are P0 only: report issues worth blocking the current change
-  because they materially break the normal flow, outcome, or safety boundary.
-  Use `--max-priority P1`, `P2`, or `P3` only when the caller explicitly asks
-  for a wider review.
-- Treat review output as advisory. Never blindly apply it.
-- Verify every finding by reading the real code path and adjacent files.
-- Read dependency docs/source/types when the finding depends on external behavior.
-- Reject unrealistic edge cases, speculative risks, unrelated rewrites, and fixes that over-complicate the codebase.
-- Prefer root-cause fixes at the right ownership boundary. A coherent refactor is appropriate when it removes the bug class, duplicate policy, stale paths, or ownership confusion; do not default to a symptom patch.
-- When an accepted finding exposes a bug class or repeated pattern, inspect its owner and relevant sibling implementations before fixing.
-- Fix the same bug class across its owner-boundary neighborhood when practical; stop at unrelated invariants, different owners, and unapproved contract changes.
-- Run one bounded review pass. If an accepted finding changes code, run the smallest relevant test; rerun Autoreview only when the user explicitly requests another pass.
-- For security-audit suppression changes, verify accepted findings remain auditable: suppressed findings stay in structured output, active output keeps an unsuppressible suppression notice, and aggregate findings cannot hide unrelated active risk.
-- Never switch or override the requested review engine/model except for the documented Codex Sol-to-Terra account-access fallback. Capacity, rate-limit, and unrelated failures keep the same engine/model.
-- Be patient with large bundles. Structured review can take up to 30 minutes while the model call is active, especially with Codex tools or web search.
-- Treat heartbeat lines like `review still running: ... elapsed=... pid=...` as healthy progress, not a hang. Let the helper continue while heartbeats are advancing. Pass `--stream-engine-output` when live engine text is useful; Codex and Claude filter tool/file chatter, other runnable engines pass raw output through.
-- Do not kill a review just because it has been quiet for 2-5 minutes, or because it is still running under the 30-minute window. Inspect the process only after missing multiple expected heartbeats, after 30 minutes, or after an obviously failed subprocess; prefer letting the same helper command finish.
-- Tools are useful in review mode. Codex receives the validated bundle in an empty workspace so ignored files and linked-worktree metadata remain unreadable; web search stays available for dependency contracts and upstream docs.
-- Security perspective is always included, but it should not cripple legitimate functionality. Report security findings only when the change creates a concrete, actionable risk or removes an important safety check.
-- Reviewer subprocesses preserve engine authentication and non-credentialed proxy variables needed by headless or restricted-network environments while stripping process-injection, Git override, and credentialed proxy values.
-- Immediately before every provider call, autoreview writes the exact outgoing review pack to an owner-only temporary file and scans it with TruffleHog using `verified,unknown`. It uses the installed binary with `--no-update` to disable self-update checks and attempts. The scan covers prompt and dataset inputs, untracked content, and every diff line, including deleted lines. A finding, scanner error, or missing TruffleHog binary refuses the send and names the implicated repository file when it can be resolved; credentials are never redacted and forwarded. Security-sensitive paths remain omitted. Safe large diffs are sent as one pass while they fit the aggregate prompt limit, then partitioned into complete bounded passes without truncation.
-- Reviewer credential checks remain defense in depth alongside the restored mandatory pre-send scanner. Reviewers inspect the entire change bundle for accidentally committed credentials and report every suspected real credential as a P0 security finding without reproducing its value.
-- Regression provenance needs patch proof, not blame alone. `git log -S/-G`, `git blame`, commit subjects, and PR metadata locate candidates. Before saying `introduced by`, inspect raw parents with `git --no-replace-objects cat-file -p <sha>` and verify the implicated behavior changed in `git --no-replace-objects diff --no-ext-diff --no-textconv <raw-parent> <sha> -- <path>`; a genuine root needs raw-header proof that it has no parents.
-- Blame `^sha`, porcelain `boundary`, and shallow/grafted history alone are not introduction proof. `--root` can hide boundary markers; `git show` or `rev-list --parents` can make a shallow boundary look like a root. An available raw parent permits explicit comparison even at a shallow boundary; missing parents or an unverifiable patch require `unknown` with the gap. Use `carried forward` only for verified preexisting behavior and `made visible` only for a verified trigger. Apply the same bar to finding prose, summaries, and owner hints.
-- Keep code author, introducing PR author, merger, committer, automation trigger, and current PR author separate; none of those roles alone proves causation. Cite the verified commit/PR/date. If no PR is traceable, use the verified commit and known author identity; unknown identities stay unknown, and missing PR metadata is not a separate finding.
-- For automation merges, identify the human trigger only from explicit timeline/comment/event evidence, such as a maintainer automerge command or arming label. Report `automerge triggered by @login` only when verified; otherwise say trigger unknown. Triggering or merging is not proof of authorship or introduction.
-- Do not invoke built-in `codex review`, nested reviewers, or review panels from inside the review. The helper builds one validated bundle, calls the selected engine once for normal inputs or once per complete bounded chunk for oversized inputs, validates the structured results, and stops.
-- Stop as soon as the helper exits 0 with no accepted/actionable findings. Do not run an extra review just to get a nicer "clean" line, a second opinion, or clearer closeout wording.
-- Treat `scoped-clean` with exit 0 as clean only for the selected Git target and requested priority. `filtered` is not a correctness certificate; `incomplete` requires resolving the scope mismatch or missing required finding before claiming clean.
-- If rejecting a finding as intentional/not worth fixing, add a brief inline code comment only when it explains a real invariant or ownership decision that future reviewers should know.
-- If `gh`/Gitcrawl reports `database disk image is malformed`, run `gitcrawl doctor --json` once to let the portable cache repair before retrying review; do not bypass the shim unless repair fails and freshness requires live GitHub.
-- If Gitcrawl reports a portable manifest mismatch, source/runtime DB health error, or stale portable-store checkout, run `gitcrawl doctor --json` and inspect `source_db_health`, `runtime_db_health`, and `portable_store_status` before falling back to live GitHub.
-- Do not push just to review. Push only when the user requested push/ship/PR update.
-
-## Scope
-
-Autoreview does not expand the task. Fix only verified blockers in the requested path. Mention unrelated findings without opening a new workstream, and stop when the requested review pass is complete.
-
-## Skill Path (set once)
-
-Set the skill script paths once, then use `"$AUTOREVIEW"` and `"$AUTOREVIEW_HARNESS"` in the examples below.
-
-Choose one:
+Use `scripts/autoreview` beside this skill. Keep its custom `codex exec` path:
+native `codex review` cannot combine explicit Git target flags with custom instructions.
+The helper combines those with evidence, severity filtering, and validated JSON;
+it leaves review judgment to Codex. For an OpenClaw checkout:
 
 ```bash
-# Project-local skill in the current repo for Codex and other agents:
-export AUTOREVIEW=".agents/skills/autoreview/scripts/autoreview"
-export AUTOREVIEW_HARNESS=".agents/skills/autoreview/scripts/test-review-harness"
-```
-
-```bash
-# Claude Code project-local skill in the current repo:
-export AUTOREVIEW=".claude/skills/autoreview/scripts/autoreview"
-export AUTOREVIEW_HARNESS=".claude/skills/autoreview/scripts/test-review-harness"
-```
-
-```bash
-# Source checkout of openclaw/agent-skills:
-export AUTOREVIEW="skills/autoreview/scripts/autoreview"
-export AUTOREVIEW_HARNESS="skills/autoreview/scripts/test-review-harness"
-```
-
-```bash
-# Global skill:
-export AGENTS_HOME="${AGENTS_HOME:-$HOME/.agents}"
-export AUTOREVIEW="$AGENTS_HOME/skills/autoreview/scripts/autoreview"
-export AUTOREVIEW_HARNESS="$AGENTS_HOME/skills/autoreview/scripts/test-review-harness"
-```
-
-When using Claude Code, set `AGENTS_HOME="$HOME/.claude"` for global skills.
-
-On native Windows, choose the matching pair:
-
-```powershell
-# Project-local skill in the current repo for Codex and other agents:
-$AUTOREVIEW = ".agents\skills\autoreview\scripts\autoreview"
-$AUTOREVIEW_HARNESS = ".agents\skills\autoreview\scripts\test-review-harness.ps1"
-```
-
-```powershell
-# Claude Code project-local skill in the current repo:
-$AUTOREVIEW = ".claude\skills\autoreview\scripts\autoreview"
-$AUTOREVIEW_HARNESS = ".claude\skills\autoreview\scripts\test-review-harness.ps1"
-```
-
-```powershell
-# Source checkout of openclaw/agent-skills:
-$AUTOREVIEW = "skills\autoreview\scripts\autoreview"
-$AUTOREVIEW_HARNESS = "skills\autoreview\scripts\test-review-harness.ps1"
-```
-
-```powershell
-# Global skill:
-$AgentsHome = if ($env:AGENTS_HOME) { $env:AGENTS_HOME } else { Join-Path $HOME ".agents" }
-$AUTOREVIEW = Join-Path $AgentsHome "skills\autoreview\scripts\autoreview"
-$AUTOREVIEW_HARNESS = Join-Path $AgentsHome "skills\autoreview\scripts\test-review-harness.ps1"
-```
-
-## Pick Target
-
-Dirty local work relative to HEAD:
-
-```bash
+AUTOREVIEW=".agents/skills/autoreview/scripts/autoreview"
 "$AUTOREVIEW" --mode local
 ```
 
-Without `--base`, this reviews HEAD-to-index, index-to-working-tree, and validated
-untracked files only. `--mode auto` selects the same HEAD-based scope when dirty;
-it does not include the committed PR merely because the checkout is on a PR
-branch. `--mode uncommitted` is an alias for `--mode local`. A clean local checkout
-without an explicit base has no local patch to review.
+In the canonical agent-skills repo, the path is
+`skills/autoreview/scripts/autoreview`. On Windows, invoke the helper with Python.
+Use `--help` for the complete flags and environment overrides.
 
-To review a dirty candidate against an explicit base, including a resolved merge
-that has not been committed:
+Choose the Git target explicitly when the default is ambiguous:
 
-```bash
-"$AUTOREVIEW" --mode local --base origin/main
-```
+| Target                         | Arguments                      | Scope                                                       |
+| ------------------------------ | ------------------------------ | ----------------------------------------------------------- |
+| Local work                     | `--mode local`                 | HEAD → index → working tree, plus untracked files           |
+| Local candidate against a base | `--mode local --base <ref>`    | Pinned base → index → working tree, plus untracked files    |
+| Committed branch/PR            | `--mode branch --base <ref>`   | Merge-base → HEAD; excludes dirty work                      |
+| One commit                     | `--mode commit --commit <ref>` | Raw parent → commit; a root compares against the empty tree |
 
-The helper pins that base to a commit at target selection. It reviews base-to-index
-changes and index-to-working-tree changes separately, plus validated untracked
-files. Only files identical across the base, index, and working tree are outside
-the change bundle; staged changes later undone remain included. Actual binary
-or submodule changes still refuse review. The bundle labels its pinned
-staged base. Git status remains relative to HEAD and does not define review scope.
-Without `--base`, local mode retains its usual HEAD-to-index behavior; it never
-infers a base from an in-progress merge.
+`--mode auto` selects local work when dirty, otherwise a branch review using the
+PR base or `origin/main`. Clean main has no implicit review target.
+`--mode uncommitted` is an alias for local. The helper does not fetch refs.
 
-For a local path changed in both transitions, capture retains immutable base,
-index, and working-tree identities, modes and absence states. Every pass with
-that path's delta includes its complete authoritative index and working-tree
-sources plus validated removed-line context. Re-additions and staged changes
-undone in the working tree remain in scope. A genuine index defect remains
-actionable, visibly `INDEX-only`, even when the working tree corrects it.
-Datasets never replace these source records. Nonmixed local paths and branch or
-commit reviews retain their existing patch-based source contract.
+Registered nested linked checkouts from the same repository are outside the
+current review scope. Their presence or edits do not make the parent dirty;
+ordinary adjacent files remain included and scanned. Worktree boundaries are
+revalidated without changing Git ignore rules.
 
-Committed-only branch/PR work:
-
-```bash
-"$AUTOREVIEW" --mode branch --base origin/main
-```
-
-Branch mode reviews `BASE...HEAD` (merge-base-to-HEAD); staged, unstaged, and
-untracked changes are excluded even in a dirty checkout. To review the **complete
-PR candidate including dirty rewrites**, pin the PR merge base and use local mode:
+For a complete PR candidate **including dirty rewrites**, use local mode with
+its pinned merge base—not branch mode:
 
 ```bash
 pr_base=$(gh pr view --json baseRefName --jq .baseRefName)
@@ -166,305 +53,76 @@ merge_base=$(git merge-base HEAD "origin/$pr_base")
 "$AUTOREVIEW" --mode local --base "$merge_base"
 ```
 
-The remote base must already be available and current locally; the helper does
-not fetch. The pinned merge base avoids including unrelated upstream changes.
-Add `--max-priority P2` when the caller requests P2 findings. An explicit `--base`
-also applies when auto selects local, but explicit local mode avoids changing
-targets when the checkout becomes clean.
+When a file has both staged and unstaged changes, both states are reviewed.
+A defect in the index remains actionable even if the working tree fixes it;
+the report labels it `INDEX-only`.
 
-Optional review context is first-class. Prompt files and datasets must be repo-relative so review bundles cannot pull arbitrary host files. Context never expands the selected Git target, even if it contains a complete candidate diff or asks to review the whole PR. Finding membership is checked by changed file, not individual hunk:
+## Context and severity
 
-```bash
-"$AUTOREVIEW" --mode branch --base origin/main --prompt-file review-notes.md --dataset evidence.json
-```
+Use `--prompt` for task-specific guidance, or `--prompt-file` and `--dataset` for
+repository-relative context files. Context does not expand the selected Git
+target. The reviewer cannot read unchanged repository files from its empty
+sandbox; supply relevant source or dependency evidence when the diff is insufficient.
 
-If an open PR exists, use its actual base:
-
-```bash
-base=$(gh pr view --json baseRefName --jq .baseRefName)
-"$AUTOREVIEW" --mode branch --base "origin/$base"
-```
-
-Committed single change:
+The default threshold is **P0 only**: material blockers to normal operation or
+safety. Use `--max-priority P1`, `P2`, or `P3` when the caller requests a wider
+review. Do not add unrelated redesign goals or prescribe file counts, reading
+sequences, or ritual extra passes. Historical blame requires a verified
+parent-relative patch; otherwise leave the attribution unknown.
 
 ```bash
-"$AUTOREVIEW" --mode commit --commit HEAD
+"$AUTOREVIEW" --mode local --prompt-file review-notes.md --dataset evidence.json
 ```
 
-Use commit review for already-landed or already-pushed work on `main`. Reviewing
-clean `main` against `origin/main` is usually an empty diff after push. For a
-small stack, review each commit explicitly or review the branch before merging
-with `--base`. Commit review compares the raw recorded parent with the selected
-commit, ignoring replacement refs and legacy grafts. A genuine root compares
-against the empty tree. Missing parent objects stop review: explicitly deepen/fetch the needed
-history and rerun. The helper does not fetch it automatically.
+## Engines
 
-## Oversized Bundles
+Codex is the default: `gpt-5.6-sol`, high reasoning, with a `gpt-5.6-terra` retry
+only for an account-access failure. Honor explicit engine/model choices; do not
+switch because a review is slow or rate-limited.
 
-The helper validates the complete patch before partitioning it. For partitioned
-reviews it scans the complete frozen input first, so credentials cannot evade
-detection by crossing a chunk boundary. It also scans each exact outgoing review
-pack before sending it. A safe bundle that fits
-the aggregate prompt limit remains one integrated review pass. Larger bundles
-are split at bundle sections and file boundaries where possible; an oversized
-single-file block is split at line boundaries with repeated file/hunk context
-and an absolute new- or old-file line offset. Untracked snapshots use
-injection-safe source-line records so continuation passes retain reportable
-locations. A single physical diff line split across passes also retains its
-original addition, deletion, or context marker.
-Prompt instructions remain whole in every pass. Large datasets are grouped from
-their validated file records, never by reparsing headings inside evidence.
-Individual oversized datasets split at lines or UTF-8 boundaries with their
-original path and byte offset. Each evidence batch is paired with the complete
-change bundle: every original change byte appears exactly once per evidence
-batch, and every evidence byte is retained. All validated reports are merged
-before required-finding and exit-status checks.
-There is no fixed pass-count ceiling: the complete frozen input determines the
-finite pass sequence. The helper prints its size and pass count before running
-passes serially. Each pass retains the same prompt-size limit, secret scan, and
-reviewer isolation; a failed pass aborts without publishing a partial verdict.
+Use `--engine`, `--model`, and `--thinking` to override the defaults.
+`--codex-speed fast` selects priority service when supported. Only Claude accepts
+`--fallback-model`. Per-engine environment overrides use `AUTOREVIEW_<ENGINE>_*`.
 
-Mixed-path ownership travels as structured capture metadata through file, hunk,
-and physical-line splits. Repeated authoritative sources have separate identities
-and cannot be scheduled independently of their original delta fragments. Full
-source capture uses the existing sensitive-path, binary, gitlink, UTF-8 and
-180,000-byte file safeguards. Required context increases pack sizes and may
-increase pass counts or refuse a review. Evidence is rebatched first; if intact
-instructions and mandatory context cannot fit the existing engine/continuation
-limits, preparation stops before any provider call with a safe path, version,
-size and limit diagnosis. No limits are raised and no original bytes are dropped.
-Whole-input and exact outgoing-pack scans include the newly sent source context.
+| Optional engine | Prerequisites                                                                                         |
+| --------------- | ----------------------------------------------------------------------------------------------------- |
+| Claude          | CLI 2.1.169+; safe mode with web-only tools                                                           |
+| Amp             | `AMP_API_KEY` for a plugin-free account; local POSIX execution, no custom endpoint or cloud/orb agent |
+| Pi              | CLI 0.79.0+; configured model; no tools or project resources                                          |
+| Kimi            | CLI 0.30.0+; configured model; Python 3.11+ or `tomli` for TOML config                                |
 
-Preparation prints immediate phase updates and periodic elapsed time to stderr,
-with file/byte counts during hashing and no filenames or contents. These updates
-are separate from provider heartbeats and do not count against engine deadlines.
-Bundle construction captures finding membership alongside validated text; normal
-and dry runs reuse that record without reopening untracked files for membership.
+## Runtime boundaries
 
-Dry runs reuse capture and scanning without whole-tree integrity sweeps. Real
-reviews retain full fresh tree hashing before bundle construction, before review,
-and before publication, including unrelated tracked files, nonignored untracked files, index
-state, and initialized submodules. Explicit prompt files and datasets also retain
-their own frozen bytes and raw path identities, regardless of Git ignore status
-or finding scope. They are revalidated before sending each pass and before
-publication; content changes, replacements, and leaf or ancestor symlink swaps
-refuse stale results. These endpoint checks are not atomic filesystem snapshots
-and cannot guarantee detection of transient changes restored between checks.
+The helper owns reviewer isolation, sanitized authentication, process cleanup,
+Git scope, and structured result validation. Keep those controls enabled.
+TruffleHog must scan the complete frozen input for partitioned reviews and each
+exact outgoing pack before it is sent; missing or failed scanning stops the run.
+Never reproduce credentials in findings or work around an isolation failure.
 
-Evidence batches can multiply the pass count. Chunking cannot give one model
-call every cross-file implementation detail. For architecture-heavy changes, still prefer
-a coherent branch or PR shape whose semantic decision surface fits one pass.
-Removing verified non-authoritative generated noise remains useful, but never
-drop lockfiles, generated clients, policies, manifests, schemas, or other
-independently semantic artifacts merely to shrink the review.
+Review files have no size/count cap and are never truncated. Large diffs and
+datasets are partitioned automatically. Intact instructions and required mixed
+source context must still fit the per-pass prompt budget. A failed pass does not
+produce a partial clean verdict.
 
-## Models and thinking
+Do not edit inputs during a review: the helper verifies captured sources before
+sending and publishing results. Long reviews are normal; advancing heartbeats
+mean progress. Use `--stream-engine-output` for visibility, not extra reviewer
+runs. `--dry-run` checks preparation and startup without contacting a reviewer.
 
-The helper accepts `--model` globally or per engine (`engine=model`) and `--thinking` globally or per engine (`engine=level`). Repeat either flag for multiple reviewers.
+## Results
 
-Recommended model defaults:
+`--output` and `--json-output` paths must be outside the reviewed repository.
 
-| Engine              | Default model                                      | Source note                                           |
-| ------------------- | -------------------------------------------------- | ----------------------------------------------------- |
-| **codex** (default) | `gpt-5.6-sol` -> `gpt-5.6-terra` on access failure | OpenClaw org review default                           |
-| **claude**          | `claude-fable-5`                                   | Anthropic's most capable widely released Claude model |
-| **amp**             | `openai/gpt-5.6-sol`                               | Amp structured-generation review default              |
+| Exit | Meaning                                                                         |
+| ---- | ------------------------------------------------------------------------------- |
+| `0`  | `scoped-clean`, or a correct verdict with only filtered lower-priority findings |
+| `1`  | Accepted findings or an incorrect provider verdict                              |
+| `2`  | Incomplete scope/attribution, or a missing required finding                     |
 
-CLI flags and environment variables override these defaults. Amp model IDs must use `provider/model` form. Pi and Kimi do not get built-in model defaults because their configured model catalogs may vary by installation.
+Treat `scoped-clean` as clean only for the selected target and requested priority.
+`filtered` is not clean; resolve `incomplete` before claiming completion.
+Verify findings against the actual code and task before changing anything.
+No extra review rounds for a nicer verdict; follow the owning workflow after fixes.
 
-| Engine              | Model flag                 | Example model IDs                                                            | Thinking flag                             | Accepted levels                                            |
-| ------------------- | -------------------------- | ---------------------------------------------------------------------------- | ----------------------------------------- | ---------------------------------------------------------- |
-| **codex** (default) | `codex --model X exec ...` | `gpt-5.6-sol`, then `gpt-5.6-terra` on Sol access failure                    | `-c model_reasoning_effort=Y`             | `none`, `minimal`, `low`, `medium`, `high`, `xhigh`, `max` |
-| **claude**          | `claude --model X`         | `claude-fable-5`, `claude-opus-4-8`, `claude-sonnet-4-6`, `claude-haiku-4-5` | `--effort Y`                              | `low`, `medium`, `high`, `xhigh`, `max`                    |
-| **amp**             | Amp `amp.ai.generate`      | `openai/gpt-5.6-sol`                                                         | `reasoningEffort`                         | `none`, `low`, `medium`, `high`, `xhigh`, `max`            |
-| **pi**              | `pi --model X`             | `anthropic/claude-sonnet-4`, `openai/gpt-4o`                                 | `--thinking Y`                            | `off`, `minimal`, `low`, `medium`, `high`, `xhigh`         |
-| **kimi**            | `kimi --model X`           | A model alias from the user's Kimi config                                    | `[thinking] enabled` in the staged config | `on`, `off`                                                |
-
-Claude also supports `--fallback-model a,b` for availability-based fallback chains ([model-config](https://code.claude.com/docs/en/model-config)). Current Claude docs note that auth, billing, rate-limit, request-size, and transport errors do not trigger fallback, and the changelog documents interactive-session support in `v2.1.166`.
-
-[OpenAI's model guidance](https://developers.openai.com/api/docs/guides/latest-model) identifies Sol as the GPT-5.6 frontier-capability route and documents `max` support. Autoreview keeps `high` as its default; use `max` only for the hardest quality-first reviews after comparing its latency and cost with `xhigh` on representative changes.
-
-Examples matching current `main` behavior:
-
-```bash
-# Codex with explicit model and reasoning
-"$AUTOREVIEW" --engine codex --model gpt-5.6-sol --thinking high
-
-# Codex fast mode (priority service tier); needs a model whose catalog lists the tier, silently standard otherwise
-"$AUTOREVIEW" --engine codex --codex-speed fast
-
-# Safe Codex model/response tuning overrides (--codex-speed wins over a service_tier here)
-"$AUTOREVIEW" --engine codex --codex-config 'service_tier="fast"'
-
-# Claude Code aliases or full model names, with optional availability fallback
-"$AUTOREVIEW" --engine claude --model claude-fable-5 --thinking max
-"$AUTOREVIEW" --engine claude --model claude-fable-5 --fallback-model claude-opus-4-8,claude-sonnet-4-6
-
-# Amp direct structured generation (requires AMP_API_KEY)
-"$AUTOREVIEW" --engine amp --model openai/gpt-5.6-sol --thinking high --amp-bin amp
-
-# Pi with explicit model and thinking level
-"$AUTOREVIEW" --engine pi --model anthropic/claude-sonnet-4 --thinking high --pi-bin pi
-
-# Kimi with its configured default model, or a configured model alias
-"$AUTOREVIEW" --engine kimi --thinking on --kimi-bin kimi
-"$AUTOREVIEW" --engine kimi --model kimi-model-alias
-
-```
-
-### Environment defaults
-
-CLI flags take precedence over environment variables.
-
-Store persistent personal defaults in your shell startup file or launcher
-environment. For repository-local defaults, use an existing local environment
-loader such as an untracked `.envrc`; the helper does not write a config file.
-
-| Variable                            | Purpose                                                                                                                          |
-| ----------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
-| `AUTOREVIEW_MODEL`                  | Override the built-in default `--model` for all engines                                                                          |
-| `AUTOREVIEW_THINKING`               | Default `--thinking` for all engines                                                                                             |
-| `AUTOREVIEW_FALLBACK_MODEL`         | Default Claude `--fallback-model` chain                                                                                          |
-| `AUTOREVIEW_ENGINE_TIMEOUT_SECONDS` | Optional positive wall-clock limit for each reviewer process; disabled by default                                                |
-| `AUTOREVIEW_<ENGINE>_MODEL`         | Per-engine model override, for example `AUTOREVIEW_CODEX_MODEL=gpt-5.6-sol`                                                      |
-| `AUTOREVIEW_<ENGINE>_THINKING`      | Per-engine thinking override                                                                                                     |
-| `AUTOREVIEW_CODEX_CONFIG`           | Safe Codex model/response tuning overrides, semicolon-separated, e.g. `service_tier="fast"`; capability-bearing keys fail closed |
-| `AUTOREVIEW_CODEX_SPEED`            | Codex service tier override: `fast` (priority), `flex`, or `default`; silently standard when the model does not list the tier    |
-| `AUTOREVIEW_CLAUDE_FALLBACK_MODEL`  | Claude-only fallback chain                                                                                                       |
-| `AUTOREVIEW_PROVIDER_ENV_ALLOW`     | Comma-separated custom Pi credential variable names; names must end in a recognized credential suffix                            |
-| `AMP_API_KEY`                       | Required Amp API credential; file/keychain auth is intentionally excluded from the isolated runtime                              |
-
-Codex maps thinking to `model_reasoning_effort`. Claude maps thinking to `--effort`. Amp maps thinking to `amp.ai.generate.reasoningEffort`. Pi maps thinking to `--thinking`. Kimi maps `on` and `off` to `[thinking] enabled` in the staged review config. Only Claude accepts `--fallback-model`; global CLI/env fallback requires at least one Claude reviewer, and engine-specific fallback overrides require that reviewer to be selected. Non-Claude fallback overrides, including `AUTOREVIEW_<NONCLAUDE>_FALLBACK_MODEL`, fail closed instead of being silently ignored.
-
-Amp receives only `AMP_API_KEY` from the caller. Autoreview intentionally ignores `AMP_URL`, user settings, stored authentication, inherited MCP configuration, and other runtime variables. The API key's authenticated account and workspace must have no personal or workspace plugins: current normal Amp execution loads every authenticated plugin, so the preflight requests the complete inventory and fails before creating the review prompt unless the generated adapter is the only plugin. A dedicated Amp API key/account without plugins is the safest setup. Amp can still discover personal and workspace skill metadata, but the isolated settings deny every local and remote MCP server before use, and the outer adapter has no skill tool. Custom Amp endpoints are not supported because forwarding an arbitrary endpoint could disclose the API key and review bundle. Native Windows is refused because its `chmod` behavior cannot establish or attest the POSIX private-file permissions used here; use Linux, macOS, or WSL.
-
-## Review engine isolation
-
-When autoreview runs inside the repository under review, external reviewer CLIs must not load project-local trust or configuration that the branch controls.
-
-| Engine     | Isolation flags                                                                                                                                                                                                                                                                                               | Reference                                                                      |
-| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
-| **codex**  | Auth-only config overrides, isolated workspace, `exec --ignore-user-config --ignore-rules --skip-git-repo-check`, plus read-only sandbox                                                                                                                                                                      | Codex CLI `exec --help`                                                        |
-| **claude** | `--safe-mode --setting-sources user --strict-mcp-config --disallowedTools mcp__*`; auto-memory and filesystem/shell tools disabled; empty external workspace; WebSearch by default (`v2.1.169+`)                                                                                                              | Claude Code [CLI reference](https://code.claude.com/docs/en/cli-reference)     |
-| **amp**    | Empty external workspace and isolated HOME/XDG roots; complete authenticated plugin inventory must contain only the generated adapter; catch-all MCP denial with a process-spawn probe; fixed outer trigger and one input-free adapter tool; private prompt only reaches schema-constrained `amp.ai.generate` | Amp [plugin API](https://ampcode.com/manual/plugin-api) and local CLI `--help` |
-| **pi**     | `--no-approve --no-session --no-context-files --no-extensions --no-skills --no-prompt-templates --no-themes --no-tools`                                                                                                                                                                                       | Pi CLI `--help`; requires Pi `v0.79.0+`                                        |
-| **kimi**   | Empty external workspace; staged `KIMI_CODE_HOME` with sanitized config; Markdown custom agent with no tools/subagents; explicit empty `--skills-dir`; isolated runtime state                                                                                                                                 | Kimi Code CLI `--help`; requires Kimi `v0.30.0+`                               |
-
-Codex `--ignore-user-config` skips config loading for the exec run. Autoreview reconstructs only the documented `cli_auth_credentials_store`, `forced_login_method`, and `forced_chatgpt_workspace_id` settings from `CODEX_HOME/config.toml`, keeping authentication usable without forwarding unrelated user configuration. Codex runs in an empty temporary workspace: the validated bundle is its sole repository input, ignored files and linked-worktree metadata remain unreadable, and the zero project-doc budget keeps workspace instructions out of the prompt. `--ignore-rules` skips user/project execpolicy rules. Claude `--safe-mode` disables project hooks, skills, plugins, MCP servers, and CLAUDE.md; autoreview supplies WebSearch by default, permits only explicitly domain-constrained WebFetch rules, and exposes no filesystem or shell tools. Amp runs its local CLI with isolated HOME/XDG roots and one generated adapter plugin whose name includes a fresh 128-bit random suffix. Current normal Amp execution loads all authenticated plugins, so the preflight deliberately requests that same complete inventory and fails before writing the private prompt unless the generated adapter is the only active plugin, with exactly its expected tool, agent, and mode. Users with personal or workspace plugins must use a dedicated plugin-free Amp API key/account. Isolated `amp.mcpPermissions` reject every local command and remote URL. Before writing the private prompt, autoreview creates a temporary skill whose MCP command would write a marker, runs `amp tools list`, and requires Amp to report the policy rejection without creating the marker; it removes that skill before continuing. A custom outer mode then receives only a fixed harmless trigger and exposes exactly one trusted, input-free `autoreview_generate` tool. That tool reads the private prompt file and calls `amp.ai.generate` directly with an explicit system prompt and report schema, so the untrusted patch never enters the outer agent context. Autoreview requires the stream's leading init event to attest the empty working directory, the exact singleton adapter-tool inventory, and `mcp_servers: []`; it then requires exactly one correctly ordered empty-input tool call/result and one terminal result before consuming the permission-checked private structured-result file. Native Windows is refused; Linux, macOS, and WSL use permission-checked private files. Pi runs from a neutral temporary directory with project resources disabled and `--no-tools`. Kimi (`-p`, `stream-json`) runs from an empty external workspace with a staged `KIMI_CODE_HOME`: sanitized model/provider config only (no services, hooks, or extra skill/agent dirs), its OAuth credential directory linked in and device identity copied so native token refreshes remain durable without exposing the rest of the user's Kimi state. A Markdown `--agent-file` with `tools: []` and `subagents: []` plus an empty `--skills-dir` keep project instructions, tools, and MCP servers out of the review; the prompt travels as the `--prompt` argument, so per-pass prompts are capped at a platform-safe argv budget (120 KiB POSIX, 30 KiB Windows) and larger bundles partition into bounded passes.
-
-Amp cloud/orb agent execution is deliberately unsupported. In current Amp CLI behavior, `--orb-execute` does not preserve the local tool isolation and can expose shell, patch, thread, and reviewer tools. Autoreview therefore never passes `--orb-execute`: the local isolated adapter may call Amp's cloud inference service through `amp.ai.generate`, but it does not launch a cloud Amp agent over an untrusted diff.
-
-Codex uses a named permission profile that grants read access only to an empty temporary workspace. This is narrower than repository-root access, which would expose ignored credentials, and narrower than the legacy `read-only` sandbox, which permits reads across the host filesystem.
-
-## Context Efficiency
-
-Run the helper directly so target selection, engine choice, structured validation, and exit status all stay in one path. If output is noisy, summarize the completed helper output after it returns; do not ask another agent or reviewer to rerun the review.
-
-## Helper
-
-After setting `AUTOREVIEW` and `AUTOREVIEW_HARNESS` above:
-
-```bash
-"$AUTOREVIEW" --help
-```
-
-The smoke harness has thin shell wrappers over a shared Python implementation:
-
-```bash
-"$AUTOREVIEW_HARNESS" --fixture benign --engine codex
-```
-
-On native Windows, invoke the extensionless Python helper through Python:
-
-```powershell
-python $AUTOREVIEW --help
-```
-
-and the smoke harness:
-
-```powershell
-& $AUTOREVIEW_HARNESS -Fixture benign -Engine codex
-```
-
-The helper:
-
-- chooses dirty local changes first
-- accepts `--mode uncommitted` as an alias for `--mode local`
-- otherwise uses current PR base if `gh pr view` works
-- otherwise uses `origin/main` for non-main branches
-- does not fetch automatically during branch review; the selected base ref must already resolve locally
-- supports `codex`, `claude`, `amp`, `pi`, and `kimi`; default is `AUTOREVIEW_ENGINE` or `codex`
-- resolves bare `git`, `gh`, reviewer, and PowerShell shell commands from absolute `PATH` entries only, never from the reviewed checkout; explicit `--*-bin` paths are interpreted from the reviewed repository root when relative and accepted only when both the supplied path and resolved target stay outside the reviewed repository
-- use `--mode commit --commit <ref>` for already-committed work, especially clean `main` after landing
-- validates complete Git patches, scans every outgoing review pack, reviews them in one pass up to the aggregate prompt limit, and automatically uses complete bounded passes above it
-- uses branch mode for committed-only PR work, or explicit local mode with a pinned merge base for a complete PR plus dirty candidate
-- writes reports to stdout and optionally to `--output` or `--json-output` files; preparation progress and provider heartbeats use stderr
-- supports `--dry-run` (validates bundle construction, reviewer CLI resolution, and local isolation startup with version/help probes without contacting a provider; exits nonzero if any check fails), an opt-in per-reviewer wall-clock bound via `--engine-timeout-seconds`, `--prompt`, repo-relative `--prompt-file`, repo-relative `--dataset`, `--no-tools`, `--no-web-search`, repeatable Codex-only safe model/response tuning with `--codex-config key=value`, Codex-only `--codex-speed fast|flex|default`, and commit refs
-- supports `--stream-engine-output` or `AUTOREVIEW_STREAM_ENGINE_OUTPUT=1` for live engine text while preserving structured validation; Codex and Claude hide tool/file event details, emit compact activity summaries, and report usage at turn completion
-- supports per-engine `--model`, `--thinking`, and Claude `--fallback-model`
-- uses built-in defaults `codex=gpt-5.6-sol` with `high` reasoning and an access-only `gpt-5.6-terra` retry, `claude=claude-fable-5`, and `amp=openai/gpt-5.6-sol` with `high` reasoning; honors `AUTOREVIEW_MODEL`, `AUTOREVIEW_THINKING`, `AUTOREVIEW_FALLBACK_MODEL`, and per-engine `AUTOREVIEW_<ENGINE>_MODEL` / `AUTOREVIEW_<ENGINE>_THINKING` environment overrides when CLI flags are omitted
-- gives Codex the bundle in an empty workspace with web search available; Claude receives the bundle plus WebSearch by default and optional domain-constrained WebFetch; Amp sends the bundle only through direct schema-constrained generation; Pi and Kimi receive the bundle with no tools
-- runs Claude with `--safe-mode` (`v2.1.169+`), `--setting-sources user`, MCP and auto-memory disabled, no filesystem/shell tools, an empty external workspace, and `--fallback-model` when set
-- runs Amp locally from an empty temporary workspace with isolated runtime roots, complete plugin inventory attestation that fails if any authenticated personal/workspace plugin exists, catch-all MCP denial verified by a no-spawn marker probe, a fixed outer trigger, one input-free adapter tool, and direct `amp.ai.generate`; requires `AMP_API_KEY`, refuses native Windows, and refuses cloud/orb agent execution
-- runs Pi `v0.79.0+` from neutral temporary directories with `--no-approve`, `--no-session`, disabled Pi context/resource loading, and `--no-tools` because its built-in read tools are not repository-confined
-- runs Kimi Code CLI `v0.30.0+` from an empty temporary workspace with a staged `KIMI_CODE_HOME`, sanitized config, an empty `--skills-dir`, and a no-tools/no-subagents Markdown `--agent-file`
-- prints `review still running: <engine> elapsed=<seconds>s pid=<pid>` to stderr at long-running intervals while waiting for the selected review engine, unless streamed output or compact Codex activity has been visible recently
-- prints `autoreview scoped-clean` only when no findings were rejected or filtered and the provider returned a correct verdict
-- exits nonzero for accepted findings, a provider's incorrect verdict, or an incomplete result
-
-## Result handling
-
-Filtering never rewrites provider correctness, explanation, or confidence.
-`findings` contains accepted findings at the requested priority; local JSON and
-text results retain `scope_rejected_findings` and `priority_filtered_findings`
-separately. Any scope rejection makes `review_status` `incomplete` and exits 2,
-including when other findings remain or `--expect-findings` is set. Resolve the
-target mismatch explicitly; do not infer a broader target from prompt prose.
-
-The shared provider schema adds nullable `source_attribution`; older findings
-without this field remain valid only for nonmixed paths. Mixed-path findings
-must explicitly supply `target` (`index` or `working_tree`), `record_id`,
-`source_id`, `side` (`present` or `removed`), `column`, and `excerpt`.
-`code_location.line` and `column` are 1-based; the excerpt must match exactly
-within that physical source line at the Unicode character column. Removed-side
-anchors must identify a line actually removed from the target's predecessor.
-Validation checks identity, bounds, exact source and availability in that pass
-before filtering or aggregation. Missing or incorrect attribution is retained
-with a reason in `attribution_rejected_findings`, makes the result `incomplete`,
-and exits 2 even if other findings are accepted or `--expect-findings` is set.
-Source anchoring proves attribution, not the correctness of the provider's claim.
-
-With no scope rejection, status is `findings` for accepted findings, `filtered`
-when only lower-priority findings remain, `incorrect` for an incorrect verdict
-without findings, or `scoped-clean` otherwise. Exit 1 means accepted findings or
-an incorrect provider verdict; even a priority-filtered incorrect verdict stays
-nonzero. Exit 0 for a filtered correct verdict does not certify correctness.
-`--expect-findings` accepts retained findings for harness checks, never scope
-rejections. `--require-finding` checks only accepted findings after both filters
-across every pass; missing text is retained in `missing_required_findings` and
-exits 2 after writing results.
-
-Chunked results retain each provider report under `pass_reports`, print each
-provider explanation, and use the minimum pass confidence rather than promoting
-confidence from another pass. Provider JSON remains strictly validated before
-the helper adds local audit metadata. All engines use this same result path.
-
-`provider_report` preserves the well-formed provider conclusion before path
-normalization or enrichment. Mixed reviews retain `pass_reports` for one pass
-as well as multiple passes. Mixed observations group by target, record/source,
-anchor and category, never title. Exact repeated bodies share a claim variant;
-distinct bodies remain visible in `claim_variants`, with every contributing
-pass, title, priority and confidence. Index and working-tree findings never
-collapse together. Required-finding checks inspect accepted observations before
-deduplication; grouping cannot remove a provider verdict or hide a rejection.
-
-The exact source filename `CredentialFile.swift` is allowed for untracked and
-evidence inputs only outside sensitive parent paths, matching its existing
-tracked-source treatment. This is not a general source-extension exemption:
-credential stores, credential directories, `.env`, PEM, and key files retain
-their exclusions. TruffleHog still scans the exact outgoing pack, including
-source content, deleted lines, prompts, and datasets, before every provider call.
-
-## Final Report
-
-Report material findings and the resulting status in chat. If there are none, say so plainly. Do not add command logs, test ledgers, proof blocks, or review receipts unless the user asks for them.
+Report material findings and status plainly. Do not add transcripts, proof
+ledgers, commits, pushes, or a new workstream unless requested.

--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -153,7 +153,6 @@ TRACKED_TOKEN_CREDENTIAL_EXTENSIONS = {
     ".yaml",
     ".yml",
 }
-MAX_BUNDLE_TEXT_BYTES = 180_000
 MAX_REVIEW_PROMPT_BYTES = 512_000
 # Kimi takes the prompt as a single `--prompt` argv element (no stdin mode),
 # so its per-pass ceiling must respect platform argv limits: Linux caps one
@@ -179,10 +178,14 @@ class ReviewDataset(NamedTuple):
 
 class CapturedBundle(NamedTuple):
     text: str
-    truncated: bool
     paths: set[str]
     mixed: tuple[MixedPath, ...] = ()
     spans: tuple[SourceSpan, ...] = ()
+
+
+class UntrackedSources(NamedTuple):
+    files: list[str]
+    worktrees: tuple[tuple[str, object], ...] = ()
 
 
 class SourceVersion(NamedTuple):
@@ -227,14 +230,12 @@ class EvidenceFile(NamedTuple):
     label: str
     path: Path
     content: str
-    truncated: bool
     topology: tuple[tuple[int, int, int], ...]
 
 
 class EvidenceInputs(NamedTuple):
     prompt: str
     datasets: list[ReviewDataset]
-    truncated: bool
     files: list[EvidenceFile]
 
 
@@ -1510,12 +1511,8 @@ def current_branch(repo: Path) -> str:
 
 def is_dirty(repo: Path) -> bool:
     return bool(
-        git(
-            repo,
-            *global_excludes_git_args(repo),
-            "status",
-            "--porcelain",
-        ).strip()
+        git(repo, "status", "--porcelain", "--untracked-files=no").strip()
+        or untracked_sources(repo).files
     )
 
 
@@ -1798,20 +1795,6 @@ def scan_outgoing_review_pack(repo: Path, prompt: str) -> None:
         )
 
 
-def bounded(text: str, limit: int = 180_000) -> str:
-    if len(text) <= limit:
-        return text
-    return text[:limit] + f"\n\n[truncated at {limit} characters]\n"
-
-
-def ensure_reviewer_input_complete(reviewer: argparse.Namespace, input_truncated: bool) -> None:
-    if input_truncated:
-        raise SystemExit(
-            f"{reviewer.engine} engine refused truncated review input because it cannot recover omitted diff hunks; "
-            "reduce the change/input size"
-        )
-
-
 def bounded_field(text: str, limit: int) -> str:
     if len(text) <= limit:
         return text
@@ -1850,7 +1833,9 @@ def stream_display_escape(text: str) -> str:
     )
 
 
-def read_prefix(path: Path, limit: int) -> tuple[bytes, bool]:
+def read_file_bytes(path: Path, limit: int | None = None) -> bytes:
+    # Review files are captured whole; only local auth validation supplies a
+    # limit. Prompt partitioning, not file reads, owns review capacity.
     descriptor: int | None = None
     try:
         # os.stat, not Path.stat: the follow_symlinks kwarg on pathlib needs
@@ -1872,13 +1857,12 @@ def read_prefix(path: Path, limit: int) -> tuple[bytes, bool]:
         ):
             raise OSError("file changed while opening")
         chunks: list[bytes] = []
-        remaining = limit + 1
-        while remaining:
-            chunk = os.read(descriptor, remaining)
-            if not chunk:
-                break
+        size = 0
+        while chunk := os.read(descriptor, 64 * 1024):
             chunks.append(chunk)
-            remaining -= len(chunk)
+            size += len(chunk)
+            if limit is not None and size > limit:
+                raise OSError(f"file exceeds {limit} bytes")
         after = os.fstat(descriptor)
         if (
             (opened.st_dev, opened.st_ino, opened.st_size, opened.st_mtime_ns)
@@ -1894,30 +1878,7 @@ def read_prefix(path: Path, limit: int) -> tuple[bytes, bool]:
     finally:
         if descriptor is not None:
             os.close(descriptor)
-    return data[:limit], len(data) > limit
-
-
-def read_text_with_status(path: Path, limit: int = MAX_BUNDLE_TEXT_BYTES) -> tuple[str, bool]:
-    try:
-        data, truncated = read_prefix(path, limit)
-    except SystemExit as exc:
-        return f"[unreadable: {exc}]", True
-    if b"\0" in data:
-        return "[binary file omitted]", True
-    try:
-        text = data.decode("utf-8")
-    except UnicodeDecodeError:
-        return "[non-UTF-8 file omitted]", True
-    if len(text) > limit:
-        text = text[:limit]
-        truncated = True
-    if truncated:
-        return text + f"\n\n[truncated at {limit} characters]\n", True
-    return text, False
-
-
-def read_text(path: Path, limit: int = MAX_BUNDLE_TEXT_BYTES) -> str:
-    return read_text_with_status(path, limit)[0]
+    return data
 
 
 def path_has_sensitive_part(rel: str | Path) -> bool:
@@ -2177,17 +2138,9 @@ def omit_tracked_sensitive_diff_units(
 
 
 def validate_review_patch(
-    label: str,
     paths: list[str],
     patch: str,
-    limit: int | None = None,
 ) -> str:
-    patch_bytes = len(patch.encode("utf-8"))
-    if limit is not None and patch_bytes > limit:
-        raise SystemExit(
-            f"{label} is too large to review safely "
-            f"({patch_bytes} bytes; limit {limit}); split the change into smaller review targets"
-        )
     blocked_paths = tracked_sensitive_paths(paths)
     return omit_tracked_sensitive_diff_units(patch, paths, blocked_paths)
 
@@ -2247,62 +2200,85 @@ def require_no_gitlink_diff(label: str, raw_diff: str) -> None:
         )
 
 
-def file_bundle_risk(
-    repo: Path,
-    path: Path,
-    rel: str,
-    *,
-    allow_binary_omission: bool = False,
-) -> str | None:
-    return file_bundle_snapshot(
-        repo,
-        path,
-        rel,
-        allow_binary_omission=allow_binary_omission,
-    )[2]
-
-
 def file_bundle_snapshot(
     repo: Path,
     path: Path,
     rel: str,
-    *,
-    allow_binary_omission: bool = False,
-) -> tuple[str, bool, str | None]:
+) -> tuple[str, str | None]:
     normalized = rel.replace(os.sep, "/")
     path_risk = sensitive_repo_path_risk(normalized)
     if path_risk:
-        return "", True, path_risk
+        return "", path_risk
     if path.is_symlink():
-        return "", True, "symlink"
+        return "", "symlink"
     try:
         resolved = path.resolve(strict=True)
     except OSError as exc:
-        return "", True, f"unreadable file: {exc}"
+        return "", f"unreadable file: {exc}"
     if not is_within(resolved, repo.resolve()):
-        return "", True, "path outside repository"
+        return "", "path outside repository"
     if not path.is_file():
-        return "", True, "not a regular file"
+        return "", "not a regular file"
     try:
-        data, truncated = read_prefix(path, MAX_BUNDLE_TEXT_BYTES)
+        data = read_file_bytes(path)
     except SystemExit as exc:
-        return "", True, str(exc)
+        return "", str(exc)
     if b"\0" in data:
-        if allow_binary_omission:
-            return "[binary file omitted]", True, None
-        return "", True, "binary file"
-    if truncated:
-        return "", True, "file too large to scan safely"
+        return "", "binary file"
     try:
         text = data.decode("utf-8")
     except UnicodeDecodeError:
-        return "", True, "non-UTF-8 file"
-    return text, False, None
+        return "", "non-UTF-8 file"
+    return text, None
 
 
-def collect_untracked_file_snapshots(
-    repo: Path,
-) -> tuple[list[tuple[str, str, bool]], int]:
+def linked_worktree_boundary(
+    repo: Path, path: Path, common_dir: Path, worktrees_dir: Path,
+) -> tuple[object, ...] | None:
+    git_file = path / ".git"
+    if git_file.is_symlink() or not git_file.is_file():
+        return None
+    relative_git_file = str(git_file.relative_to(repo.resolve()))
+    topology = mixed_source_topology(repo, relative_git_file)
+    before = source_file_fingerprint(git_file)
+    # Keep the original root as the executable/env trust anchor: using the
+    # child here could admit a parent-controlled bin/git from PATH.
+    results = [
+        git_result(repo, "-C", str(path), "rev-parse", flag, check=False)
+        for flag in ("--show-toplevel", "--absolute-git-dir", "--git-common-dir")
+    ]
+    if any(result.returncode != 0 for result in results):
+        return None
+    top, git_dir, child_common = (
+        (path / result.stdout.removesuffix("\n")).resolve() for result in results
+    )
+    # A listed path may be stale; its .git pointer must name a private owner
+    # from this repository's actual worktree registry, not a copied admin dir.
+    if top != path or child_common != common_dir or git_dir.parent != worktrees_dir:
+        return None
+    backlink = git_dir / "gitdir"
+    try:
+        if backlink.is_symlink():
+            return None
+        backlink_bytes = read_file_bytes(backlink)
+        target = backlink_bytes.decode("utf-8").rstrip("\r\n")
+        if (git_dir / target).resolve() != git_file:
+            return None
+        owner = git_dir.stat()
+    except (OSError, UnicodeDecodeError):
+        return None
+    if (source_file_fingerprint(git_file) != before
+            or mixed_source_topology(repo, relative_git_file) != topology):
+        raise SystemExit("worktree boundary changed while being captured")
+    # Only the boundary belongs to this snapshot. Child HEAD/index/content
+    # belong to its independent review; replacing its owner must still fence us.
+    return ("linked-worktree", str(git_dir), owner.st_dev, owner.st_ino,
+            topology, before, hashlib.sha256(backlink_bytes).hexdigest())
+
+
+def untracked_sources(
+    repo: Path, claimed_paths: list[str] | tuple[str, ...] = (),
+) -> UntrackedSources:
     files = git_path_list(
         repo,
         *global_excludes_git_args(repo),
@@ -2311,21 +2287,54 @@ def collect_untracked_file_snapshots(
         "--exclude-standard",
         "-z",
     )
+    directories = [
+        rel for rel in files
+        if rel.endswith("/") and not any(
+            claim == rel[:-1] or claim.startswith(rel) or rel.startswith(claim + "/")
+            for claim in claimed_paths
+        )
+    ]
+    if not directories:
+        return UntrackedSources(files)
+    registered = {
+        Path(record.removeprefix("worktree ")).resolve()
+        for record in git_path_list(repo, "worktree", "list", "--porcelain", "-z")
+        if record.startswith("worktree ")
+    }
+    root = repo.resolve()
+    common_dir = (root / git(repo, "rev-parse", "--git-common-dir").removesuffix("\n")).resolve()
+    worktrees_dir = (root / git(repo, "rev-parse", "--git-path", "worktrees").removesuffix("\n")).resolve()
+    worktrees = []
+    for rel in directories:
+        candidate = root / rel
+        path = candidate.resolve()
+        if (candidate.is_symlink() or path == root
+                or not is_within(path, root) or path not in registered):
+            continue
+        if boundary := linked_worktree_boundary(repo, path, common_dir, worktrees_dir):
+            worktrees.append((rel, boundary))
+    excluded = {rel for rel, _boundary in worktrees}
+    return UntrackedSources([rel for rel in files if rel not in excluded], tuple(sorted(worktrees)))
+
+
+def collect_untracked_file_snapshots(
+    repo: Path,
+    claimed_paths: list[str] | tuple[str, ...] = (),
+) -> tuple[list[tuple[str, str]], int]:
+    files = untracked_sources(repo, claimed_paths).files
     omitted = 0
-    included: list[tuple[str, str, bool]] = []
+    included: list[tuple[str, str]] = []
     for rel in files:
-        content, truncated, risk = file_bundle_snapshot(
+        content, risk = file_bundle_snapshot(
             repo,
             repo / rel,
             rel,
-            allow_binary_omission=True,
         )
         if risk:
             if (
                 sensitive_repo_path_risk(rel) is not None
                 or risk
                 in {
-                    "secret-like content",
                     "symlink",
                     "path outside repository",
                 }
@@ -2337,7 +2346,7 @@ def collect_untracked_file_snapshots(
                     f"{display_escape(rel, 500)}: {risk}"
                 )
         else:
-            included.append((rel, content, truncated))
+            included.append((rel, content))
     return included, omitted
 
 
@@ -2352,8 +2361,6 @@ def local_status(repo: Path, untracked: list[str], *, redact: bool = False) -> s
 
 def mixed_source_text(path: str, version: str, data: bytes) -> str:
     label = f"mixed source {display_escape(path, 500)} ({version})"
-    if len(data) > MAX_BUNDLE_TEXT_BYTES:
-        raise SystemExit(f"{label}: {len(data)} bytes; limit {MAX_BUNDLE_TEXT_BYTES}")
     if b"\0" in data:
         raise SystemExit(f"{label}: binary file")
     try:
@@ -2384,12 +2391,6 @@ def read_git_source(repo: Path, path: str, version: str, source: SourceVersion) 
     if source.mode is None:
         return source
     oid = source.identity.split(":")[1]
-    size = int(git(repo, "cat-file", "-s", oid))
-    if size > MAX_BUNDLE_TEXT_BYTES:
-        raise SystemExit(
-            f"mixed source {display_escape(path, 500)} ({version}): "
-            f"{size} bytes; limit {MAX_BUNDLE_TEXT_BYTES}"
-        )
     content = mixed_source_text(path, version, git_bytes(repo, "cat-file", "blob", oid).stdout)
     return source._replace(content=content)
 
@@ -2411,7 +2412,7 @@ def mixed_source_topology(repo: Path, path: str) -> tuple[tuple[int, int, int], 
 
 
 def working_source_version(
-    repo: Path, path: str, untracked: dict[str, tuple[str, bool]] | None = None,
+    repo: Path, path: str, untracked: dict[str, str] | None = None,
 ) -> SourceVersion:
     source = repo / path
     if not source.exists():
@@ -2420,19 +2421,9 @@ def working_source_version(
     if not stat.S_ISREG(info.st_mode):
         raise SystemExit(f"nonregular mixed source: {display_escape(path, 500)}")
     if untracked is not None and path in untracked:
-        content, truncated = untracked[path]
-        if truncated:
-            raise SystemExit(f"incomplete mixed source: {display_escape(path, 500)} (working_tree)")
-        data = content.encode("utf-8")
+        data = untracked[path].encode("utf-8")
     else:
-        if info.st_size > MAX_BUNDLE_TEXT_BYTES:
-            raise SystemExit(
-                f"mixed source {display_escape(path, 500)} (working_tree): "
-                f"{info.st_size} bytes; limit {MAX_BUNDLE_TEXT_BYTES}"
-            )
-        data, truncated = read_prefix(source, MAX_BUNDLE_TEXT_BYTES)
-        if truncated:
-            raise SystemExit(f"mixed source grew beyond limit {MAX_BUNDLE_TEXT_BYTES}: {display_escape(path, 500)}")
+        data = read_file_bytes(source)
     content = mixed_source_text(path, "working_tree", data)
     mode = "100755" if info.st_mode & stat.S_IXUSR else "100644"
     return SourceVersion(f"sha256:{hashlib.sha256(data).hexdigest()}:{mode}", mode, content)
@@ -2464,7 +2455,7 @@ def local_patch_ownership(patch: str, paths: list[str]) -> list[tuple[str, str]]
 def capture_mixed_paths(
     repo: Path, base_ref: str | None, paths: set[str],
     staged: dict[str, str], unstaged: dict[str, str],
-    untracked: dict[str, tuple[str, bool]],
+    untracked: dict[str, str],
 ) -> tuple[MixedPath, ...]:
     records = []
     if base_ref is None:
@@ -2548,8 +2539,10 @@ def local_bundle(repo: Path, base_ref: str | None = None) -> CapturedBundle:
         "--name-only",
         "-z",
     )
-    untracked_snapshots, omitted_untracked = collect_untracked_file_snapshots(repo)
-    untracked = [rel for rel, _content, _truncated in untracked_snapshots]
+    untracked_snapshots, omitted_untracked = collect_untracked_file_snapshots(
+        repo, staged_paths + unstaged_paths,
+    )
+    untracked = [rel for rel, _content in untracked_snapshots]
     omitted_tracked = len(
         tracked_sensitive_paths(staged_paths) | tracked_sensitive_paths(unstaged_paths)
     )
@@ -2578,8 +2571,8 @@ def local_bundle(repo: Path, base_ref: str | None = None) -> CapturedBundle:
     mixed_paths = (set(staged_paths) & (set(unstaged_paths) | set(untracked))) - staged_blocked_paths - unstaged_blocked_paths
     staged_units = local_patch_ownership(staged_patch, staged_paths) if mixed_paths else []
     unstaged_units = local_patch_ownership(unstaged_patch, unstaged_paths) if mixed_paths else []
-    staged_patch = validate_review_patch("local staged diff", staged_paths, staged_patch)
-    unstaged_patch = validate_review_patch("local unstaged diff", unstaged_paths, unstaged_patch)
+    staged_patch = validate_review_patch(staged_paths, staged_patch)
+    unstaged_patch = validate_review_patch(unstaged_paths, unstaged_patch)
     parts = [
         "# Git Status",
         local_status(
@@ -2613,11 +2606,9 @@ def local_bundle(repo: Path, base_ref: str | None = None) -> CapturedBundle:
             ),
         ]
         owned_parts = {index + 3: value for index, value in owned_parts.items()}
-    input_truncated = False
     if untracked:
         parts.append("# Untracked Files")
-        for rel, content, truncated in untracked_snapshots:
-            input_truncated = input_truncated or truncated
+        for rel, content in untracked_snapshots:
             records = literal_lf_lines(content) or [""]
             parts.append(
                 "# Untracked File\n"
@@ -2649,10 +2640,10 @@ def local_bundle(repo: Path, base_ref: str | None = None) -> CapturedBundle:
         offset += utf8_size(part) + 2
     mixed = capture_mixed_paths(
         repo, base_ref, mixed_paths, transitions["index"], transitions["working_tree"],
-        {path: (content, truncated) for path, content, truncated in untracked_snapshots},
+        dict(untracked_snapshots),
     ) if mixed_paths else ()
     paths = (set(staged_paths) - staged_blocked_paths) | (set(unstaged_paths) - unstaged_blocked_paths)
-    return CapturedBundle("\n\n".join(parts), input_truncated, paths | set(untracked), mixed, tuple(spans))
+    return CapturedBundle("\n\n".join(parts), paths | set(untracked), mixed, tuple(spans))
 
 
 def source_file_fingerprint(
@@ -2790,16 +2781,9 @@ def source_tree_snapshot(
         if record and "\t" in record
         for metadata, rel in (record.split("\t", 1),)
     }
-    untracked = git_path_list(
-        repo,
-        *global_excludes_git_args(repo),
-        "ls-files",
-        "--others",
-        "--exclude-standard",
-        "-z",
-    )
-    fingerprints = []
-    for rel in sorted(set(tracked + untracked)):
+    untracked = untracked_sources(repo, tracked)
+    fingerprints = list(untracked.worktrees)
+    for rel in sorted(set(tracked + untracked.files)):
         fingerprints.append((
             rel,
             source_tree_snapshot(repo / rel, progress)
@@ -2809,7 +2793,7 @@ def source_tree_snapshot(
         ))
         if progress is not None:
             progress.advance(files=1)
-    return head, index_entries, tuple(fingerprints)
+    return head, index_entries, tuple(sorted(fingerprints))
 
 
 def branch_bundle(repo: Path, base_ref: str) -> CapturedBundle:
@@ -2860,7 +2844,6 @@ def branch_bundle(repo: Path, base_ref: str) -> CapturedBundle:
     )
     omitted_tracked = bool(tracked_sensitive_paths(branch_paths))
     branch_patch = validate_review_patch(
-        "branch diff",
         branch_paths,
         branch_patch,
     )
@@ -2882,7 +2865,7 @@ def branch_bundle(repo: Path, base_ref: str) -> CapturedBundle:
             ),
             branch_patch,
         ]
-    ), False, set(branch_paths) - tracked_sensitive_paths(branch_paths))
+    ), set(branch_paths) - tracked_sensitive_paths(branch_paths))
 
 
 def commit_diff_refs(repo: Path, commit_ref: str) -> tuple[str, ...]:
@@ -2926,7 +2909,7 @@ def commit_bundle(repo: Path, commit_ref: str) -> CapturedBundle:
         git(repo, "diff-tree", *COMMIT_DIFF_FLAGS, "--raw", "-z", *refs),
     )
     blocked_paths = tracked_sensitive_paths(commit_paths)
-    commit_patch = validate_review_patch("commit diff", commit_paths, commit_patch)
+    commit_patch = validate_review_patch(commit_paths, commit_patch)
     commit_summary = REVIEW_SECURITY_OMISSION
     if not blocked_paths:
         commit_summary = git(repo, "show", "--no-patch", "--format=fuller", refs[-1])
@@ -2942,7 +2925,7 @@ def commit_bundle(repo: Path, commit_ref: str) -> CapturedBundle:
         ]
     )
     paths = set(commit_paths) - blocked_paths
-    return CapturedBundle(text, False, paths)
+    return CapturedBundle(text, paths)
 
 
 def build_bundle(repo: Path, target: str, target_ref: str | None, commit_ref: str) -> CapturedBundle:
@@ -2954,7 +2937,7 @@ def build_bundle(repo: Path, target: str, target_ref: str | None, commit_ref: st
     return commit_bundle(repo, commit_ref)
 
 
-def validate_evidence_file(repo: Path, raw_path: str, label: str) -> tuple[Path, str, bool]:
+def validate_evidence_file(repo: Path, raw_path: str, label: str) -> tuple[Path, str]:
     original = Path(raw_path)
     if original.is_absolute() or ".." in original.parts or not original.parts:
         raise SystemExit(f"{label} must be a repo-relative path: {raw_path}")
@@ -2967,10 +2950,10 @@ def validate_evidence_file(repo: Path, raw_path: str, label: str) -> tuple[Path,
     if not is_within(path, repo.resolve()):
         raise SystemExit(f"{label} must be inside the reviewed repository: {raw_path}")
     rel = str(path.relative_to(repo.resolve()))
-    content, truncated, risk = file_bundle_snapshot(repo, path, rel)
+    content, risk = file_bundle_snapshot(repo, path, rel)
     if risk:
         raise SystemExit(f"refusing to include unsafe {label}: {rel} ({risk})")
-    return path, content, truncated
+    return path, content
 
 
 def evidence_topology(repo: Path, raw_path: str) -> tuple[tuple[int, int, int], ...]:
@@ -2996,10 +2979,10 @@ def capture_evidence_file(repo: Path, raw_path: str, label: str) -> EvidenceFile
     if original.is_absolute() or ".." in original.parts or not original.parts:
         raise SystemExit(f"{label} must be a repo-relative path: {raw_path}")
     before = evidence_topology(repo, raw_path)
-    path, content, truncated = validate_evidence_file(repo, raw_path, label)
+    path, content = validate_evidence_file(repo, raw_path, label)
     if evidence_topology(repo, raw_path) != before:
         raise SystemExit("evidence changed while being captured")
-    return EvidenceFile(raw_path, label, path, content, truncated, before)
+    return EvidenceFile(raw_path, label, path, content, before)
 
 
 def capture_evidence_inputs(args: argparse.Namespace, repo: Path) -> EvidenceInputs:
@@ -3015,7 +2998,7 @@ def capture_evidence_inputs(args: argparse.Namespace, repo: Path) -> EvidenceInp
                 chunks.append(f"# Prompt file: {rel}\n{record.content}")
             else:
                 datasets.append(ReviewDataset(rel, record.content))
-    return EvidenceInputs("\n\n".join(chunks), datasets, any(f.truncated for f in files), files)
+    return EvidenceInputs("\n\n".join(chunks), datasets, files)
 
 
 def verify_evidence(repo: Path, files: list[EvidenceFile]) -> None:
@@ -3072,34 +3055,6 @@ def split_review_datasets(
             pending.append(part)
             offset += utf8_size(fragment)
     return [*batches, pending] if pending else [[]]
-
-
-def review_scope_policy() -> str:
-    return textwrap.dedent(
-        """
-        Review scope discipline:
-        - This helper is a closeout gate. Do not turn a narrow patch into a broad
-          redesign request.
-        - Report a finding only when this diff introduces or exposes a concrete
-          defect that must be fixed before this target can land.
-        - Prompt text and datasets are context only. They do not expand the
-          selected Git target or make unchanged files part of the reviewed diff.
-        - If the best fix requires a new protocol, config, storage, public API,
-          release process, migration, owner-boundary move, or canonical contract,
-          say that directly in the finding and keep the finding tied to the
-          smallest changed line that proves the current patch is not landable.
-        - Do not ask for sibling-surface hardening, cleanup, refactors, or
-          follow-up architecture work unless the current diff is incorrect
-          without that work.
-        - Prefer the smallest correct pre-merge fix. A broader ideal design is
-          not an actionable finding unless the current patch cannot safely land.
-        - If this is release-branch or release-process work, apply freeze
-          discipline. Report only release blockers, exact backport regressions,
-          install/upgrade breakage, crashes, data loss, concrete security
-          exposure, or release-infrastructure failures. Non-blocking design,
-          cleanup, and hardening concerns belong on main as follow-ups.
-        """
-    ).strip()
 
 
 def utf8_size(text: str) -> int:
@@ -3457,55 +3412,43 @@ def render_review_prompt(
     chunk_position: tuple[int, int] | None = None,
 ) -> str:
     target_line = f"{target} {target_ref}" if target_ref else target
-    scope_policy = review_scope_policy()
     chunk_policy = ""
     if chunk_position:
         index, total = chunk_position
         chunk_policy = textwrap.dedent(
             f"""
             Oversized review bundle chunk: {index}/{total}
-            - The complete validated change is distributed across all {total} chunks.
-            - Original change bytes appear exactly once across the chunk sequence.
-            - Continuation context may repeat file and hunk headers; it is not extra change content.
-            - Report every actionable defect demonstrated by this chunk. Reports from all chunks are merged after every pass finishes.
+            The complete change spans {total} chunks; continuation headers may repeat.
+            Report defects supported by this chunk. All reports are merged after the last pass.
             """
         ).strip()
         if chunk.context:
             chunk_policy += "\n\n# Continuation Context\n" + chunk.context
     instructions = textwrap.dedent(
         f"""
-        You are a senior code reviewer. Review the provided git change bundle only.
+        Review the selected Git change for actionable defects, ordered by severity.
+        Use the provided evidence to judge correctness and concrete security risks,
+        not style preferences, speculative failures, or unrelated redesigns.
 
-        Hard rules:
-        - Return exactly one JSON object and nothing else. Do not wrap it in Markdown.
-        - The JSON object must match this schema exactly:
-        {json.dumps(SCHEMA, indent=2)}
-        - Do not modify files.
-        - Do not invoke nested reviewers or review tools.
-        - Forbidden nested review commands include: codex review, autoreview, claude review, oracle review.
-        - The review sandbox is intentionally empty. The change bundle and explicit prompt or datasets are the only reviewed-repository source. Read-only tools cannot access unchanged repository files.
-        - You may use read-only tools and web search to inspect external dependency contracts, upstream docs, current public behavior, and security implications.
-        - Do not report a missing import, symbol, definition, call site, config entry, or other unchanged context solely because it is absent from the change bundle. Such a finding requires direct proof in the bundle or explicit datasets.
-        - Shell commands, if available, must be read-only inspection commands. Do not run tests, formatters, package installs, generators, network mutation commands, git mutation commands, or commands that write files.
-        - Report only actionable defects introduced or exposed by this change.
-        - Historical attribution requires raw commit parents and a verified parent-relative patch that changed the implicated behavior before saying "introduced by". Blame, commit subjects, PR metadata, and ownership hints locate candidates; they are not introduction proof.
-        - Blame ^sha, porcelain boundary, and shallow/grafted history alone are not introduction proof; --root can hide boundary markers. Available raw parents permit explicit comparison, but missing parents or an unverifiable patch require unknown. Use "carried forward" only for verified preexisting behavior and "made visible" only for a verified trigger, not as substitutes for missing evidence.
-        - Keep code author, introducing PR author, merger, committer, automation trigger, and current PR author separate. None of those roles alone proves causation; leave unverified identities unknown.
-        - Prefer high-signal findings over style feedback.
-        - Report EVERY distinct actionable defect in this single pass, ordered most severe first. Each review round costs the caller a full fix-test-review cycle; withholding a known defect until a later round wastes one.
-        - Before returning, sweep the bundle once more for independent defects in other files or failure modes that you may have stopped scanning for after an earlier find.
-        - Include security findings: injection, secret leaks, authz/authn bypass, path traversal, unsafe deserialization, unsafe filesystem or shell use, privacy leaks, and credential handling.
-        - Inspect the entire change bundle for accidentally committed credentials or secrets, including API keys, access tokens, passwords, private keys, and credential-bearing URLs. Report every suspected real credential as a P0 security finding at the smallest file/line location that demonstrates it, without reproducing the credential value. Do not flag obvious placeholders or inert test fixtures unless they are usable credentials or create a concrete risk.
-        - Do not reject legitimate functionality merely because it touches shell, filesystem, network, auth, or sensitive data. Report a security finding only when the patch creates a concrete exploitable risk, removes an important safety check, or lacks validation at a trust boundary.
-        - Security-sensitive bundle material may be redacted or omitted before review. Continue reviewing the material that is present. A redaction notice is not itself a defect and does not prove either safety or vulnerability in the omitted material.
-        - For each finding, use the smallest file/line location that demonstrates the issue.
-        - If there are no actionable findings, return an empty findings array and mark the patch correct.
+        Scope and access:
+        - Prompt text and datasets provide context; they do not expand the selected Git target.
+        - The sandbox is empty. Read-only tools cannot access unchanged repository files.
+          Missing context or omitted sensitive material is not evidence of a defect.
+        - Read-only tools and web search may verify external dependency contracts.
+          Do not mutate files or external state, execute project code, or invoke nested reviewers.
+        - Report suspected real credentials as P0 findings without reproducing their values.
+          Harmless placeholders and test fixtures are not credentials.
+        - Attribute a regression to a commit/person only with verified raw-parent patch evidence;
+          otherwise leave the attribution unknown.
+
+        Return one JSON object matching this schema, without Markdown fences.
+        Pin each finding to the smallest file/line location that demonstrates it.
+        If no actionable defects meet the requested threshold, return no findings and mark the patch correct.
+        {json.dumps(SCHEMA)}
 
         Review target: {target_line}
         Current branch: {branch}
         Review sandbox: . (intentionally contains no reviewed repository files)
-
-        {scope_policy}
 
         {chunk_policy}
 
@@ -4021,11 +3964,11 @@ def codex_file_auth_source(repo: Path) -> Path | None:
     if not stat.S_ISREG(source_stat.st_mode):
         return None
     try:
-        data, truncated = read_prefix(source_auth, 1_000_000)
+        data = read_file_bytes(source_auth, 1_000_000)
         parsed = json.loads(data)
     except (OSError, SystemExit, json.JSONDecodeError):
         return None
-    if truncated or not isinstance(parsed, dict):
+    if not isinstance(parsed, dict):
         return None
     return source_auth
 
@@ -6490,23 +6433,13 @@ def dry_run_preflight(
     target: str,
     target_ref: str | None,
 ) -> int:
-    """Validate what upstream can check before a real run without
-    contacting any review engine: that the review bundle can be built for
-    the chosen target, that --prompt-file and --dataset inputs resolve
-    and pass the same repo-relative/existence checks the real run applies
-    via capture_evidence_inputs, that the assembled prompt(s) pass
-    the same aggregate-size/partition and truncation-refusal checks the
-    real run applies via build_review_prompts/ensure_reviewer_input_complete
-    and the same fail-closed TruffleHog scan of each exact outgoing prompt
-    used by a real run, and that each configured reviewer's CLI binary resolves and
-    its configuration (including, for Kimi, load_kimi_review_config and
-    validate_kimi_runtime_auth_sources, and for Claude, the tool
-    inventory) is one a real run would actually accept. Returns the
-    process exit status: 0 when every check passes, 1 otherwise.
+    """Build, scan and verify real review inputs, then probe reviewer startup.
+
+    Never contact a review provider. Return 0 only when every check passes.
     """
     ok = True
     inputs_ok = True
-    evidence = EvidenceInputs("", [], False, [])
+    evidence = EvidenceInputs("", [], [])
     try:
         with PreparationProgress("evidence selection"):
             evidence = capture_evidence_inputs(args, repo)
@@ -6515,7 +6448,7 @@ def dry_run_preflight(
         ok = inputs_ok = False
         print(f"inputs: FAILED ({exc})", flush=True)
 
-    captured = CapturedBundle("", False, set())
+    captured = CapturedBundle("", set())
     bundle_ok = True
     try:
         with PreparationProgress("bundle preparation"):
@@ -6527,18 +6460,11 @@ def dry_run_preflight(
         ok = bundle_ok = False
         print(f"bundle: FAILED ({exc})", flush=True)
 
-    # The normal path (see main() below) does not stop at per-file
-    # validation: it also assembles the final prompt(s) and enforces the
-    # aggregate-size/partition limits and truncated-input refusal that
-    # build_review_prompts()/ensure_reviewer_input_complete() apply before
-    # any engine call. A dry run that skipped those would report OK for
-    # inputs a real run rejects once combined.
+    # Use the real prompt builder: individually valid inputs may exceed a
+    # pass's capacity once combined with intact instructions/source context.
     if bundle_ok and inputs_ok:
         try:
             with PreparationProgress("bundle/evidence preparation and scan"):
-                input_truncated = captured.truncated or evidence.truncated
-                if reviewers:
-                    ensure_reviewer_input_complete(reviewers[0], input_truncated)
                 threshold_extra_prompt = apply_finding_threshold_prompt(args, evidence.prompt)
                 prompts = prepare_review_prompts(
                     repo, target, target_ref, captured, threshold_extra_prompt,
@@ -6578,10 +6504,8 @@ def run_reviewer(
     prompt: str | ReviewPass,
     changed_paths: set[str] | CapturedBundle,
     required: list[str],
-    input_truncated: bool = False,
     evidence: list[EvidenceFile] | None = None,
 ) -> dict[str, Any]:
-    ensure_reviewer_input_complete(args, input_truncated)
     mixed = changed_paths.mixed if isinstance(changed_paths, CapturedBundle) else ()
     paths = changed_paths.paths if isinstance(changed_paths, CapturedBundle) else changed_paths
     available = {record.identity for record in prompt.chunk.sources} if isinstance(prompt, ReviewPass) else set()
@@ -6679,7 +6603,6 @@ def run_review_passes(
     repo: Path,
     prompts: list[str] | list[ReviewPass],
     changed_paths: set[str] | CapturedBundle,
-    input_truncated: bool,
     evidence: list[EvidenceFile] | None = None,
 ) -> list[tuple[str, dict[str, Any]]]:
     chunk_reports: list[tuple[str, dict[str, Any]]] = []
@@ -6695,7 +6618,6 @@ def run_review_passes(
             prompt,
             changed_paths,
             [],
-            input_truncated,
             evidence,
         )
         chunk_reports.append((f"chunk {index}/{len(prompts)}", chunk_report))
@@ -6799,8 +6721,6 @@ def main_impl() -> int:
         if target == "commit":
             target_ref = args.commit
         extra_prompt = apply_finding_threshold_prompt(args, evidence.prompt)
-        input_truncated = captured.truncated or evidence.truncated
-        ensure_reviewer_input_complete(reviewer, input_truncated)
         prompts = prepare_review_prompts(
             repo, target, target_ref, captured, extra_prompt, evidence.datasets,
             max_prompt_bytes_for_reviewers(reviewers),
@@ -6821,7 +6741,6 @@ def main_impl() -> int:
         repo,
         prompts,
         captured,
-        input_truncated,
         evidence.files,
     )
     if len(chunk_reports) == 1 and not captured.mixed:

--- a/skills/autoreview/scripts/autoreview_test.py
+++ b/skills/autoreview/scripts/autoreview_test.py
@@ -162,7 +162,7 @@ class AutoreviewResultScopeTests(unittest.TestCase):
                 AUTOREVIEW, "scan_outgoing_review_pack"
             ), mock.patch.object(AUTOREVIEW, "run_engine", return_value=json.dumps(DRAFT_REPORT)):
                 reports = AUTOREVIEW.run_review_passes(
-                    args, [args], Path.cwd(), ["pack"] * count, {"draft.js"}, False
+                    args, [args], Path.cwd(), ["pack"] * count, {"draft.js"}
                 )
             report = reports[0][1] if count == 1 else AUTOREVIEW.merge_chunk_reports(reports)
             self.assertEqual(
@@ -300,7 +300,7 @@ class AutoreviewTargetResultTests(unittest.TestCase):
                     self.assertIn(text, output.getvalue())
 
     def test_all_engines_keep_raw_reports_before_normalization_and_filters(self):
-        captured = AUTOREVIEW.CapturedBundle("delta", False, {self.record.path}, (self.record,), ())
+        captured = AUTOREVIEW.CapturedBundle("delta", {self.record.path}, (self.record,), ())
         prompt = AUTOREVIEW.ReviewPass("synthetic pack", AUTOREVIEW.ReviewChunk("delta", sources=(self.record,)))
         valid = self.finding()
         valid["code_location"]["file_path"] = r".\src\migrate.py"

--- a/skills/autoreview/scripts/test-review-harness.py
+++ b/skills/autoreview/scripts/test-review-harness.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 import argparse
 import os
-import runpy
 import shutil
 import stat
 import subprocess
@@ -146,23 +145,8 @@ def create_fixture_repo(repo: Path, fixture: str) -> None:
     write_fixture_file(repo, MALICIOUS_CHANGED if fixture == "malicious" else BENIGN_CHANGED)
 
 
-def validate_prompt_policy(repo: Path, autoreview: Path) -> None:
-    namespace = runpy.run_path(str(autoreview))
-    prompt, = namespace["build_review_prompts"](repo, "local", None, "fixture diff", "", [])
-    required = (
-        "This helper is a closeout gate.",
-        "Do not turn a narrow patch into a broad",
-        "If this is release-branch or release-process work",
-        "Non-blocking design,",
-    )
-    missing = [needle for needle in required if needle not in prompt]
-    if missing:
-        raise RuntimeError(f"autoreview prompt missing scope policy: {missing}")
-
-
 def run_reviews(repo: Path, script_dir: Path, fixture: str, engines: list[str]) -> None:
     autoreview = script_dir / "autoreview"
-    validate_prompt_policy(repo, autoreview)
     for engine in engines:
         print(f"== {engine} ==", flush=True)
         command = [

--- a/skills/autoreview/tests/test_autoreview_hardening.py
+++ b/skills/autoreview/tests/test_autoreview_hardening.py
@@ -451,7 +451,7 @@ class AutoreviewMixedTargetTests(unittest.TestCase):
                     self.assertEqual(record.base.content, record.working_tree.content)
                 self.helper["verify_mixed_sources"](repo, captured.mixed)
 
-    def test_nonmixed_large_tracked_paths_keep_existing_contract(self):
+    def test_large_tracked_paths_keep_complete_mixed_sources(self):
         with tempfile.TemporaryDirectory() as tempdir:
             repo = init_repo(Path(tempdir))
             path = repo / "large.py"
@@ -475,8 +475,15 @@ class AutoreviewMixedTargetTests(unittest.TestCase):
             path.write_bytes(("staged()\n" + content).encode("utf-8"))
             git(repo, "add", ".")
             path.write_bytes(("working()\n" + content).encode("utf-8"))
-            with self.assertRaisesRegex(SystemExit, r"large.py \(index\): \d+ bytes; limit 180000"):
-                self.helper["local_bundle"](repo)
+            captured = self.helper["local_bundle"](repo)
+            record, = captured.mixed
+            for source, expected in (
+                (record.base, "changed()\n" + content),
+                (record.index, "staged()\n" + content),
+                (record.working_tree, "working()\n" + content),
+            ):
+                self.assertEqual(source.content, expected)
+            self.helper["verify_mixed_sources"](repo, captured.mixed)
 
     def test_full_source_safeguards_and_sensitive_omission(self):
         for bad in (b"\0binary", b"\xffinvalid"):
@@ -484,7 +491,7 @@ class AutoreviewMixedTargetTests(unittest.TestCase):
                 repo = init_repo(Path(tempdir))
                 path = repo / "source.py"
                 (repo / ".gitattributes").write_text("source.py diff\n")
-                suffix = b"safe context\n" * 30 + bad + b"\n"
+                suffix = b"safe context\n" * 16_000 + bad + b"\n"
                 path.write_bytes(b"base()\n" + suffix)
                 git(repo, "add", ".")
                 git(repo, "commit", "-qm", "synthetic hidden tail")
@@ -564,7 +571,7 @@ class AutoreviewMixedTargetTests(unittest.TestCase):
                 self.assertIn("SOURCE_ONLY_SCAN_SENTINEL\nMULTILINE_SCAN_CONTINUATION\n", scans[0])
                 self.assertIn(evidence[0].content, scans[0])
                 args = argparse.Namespace(engine="codex", max_priority="P0")
-                self.helper["run_review_passes"](args, [args], repo, passes, captured, False)
+                self.helper["run_review_passes"](args, [args], repo, passes, captured)
             self.assertEqual(scans[1:], sends)
             for item, scanned in zip(passes, scans[1:]):
                 self.assertEqual(item.prompt, scanned)
@@ -690,8 +697,8 @@ class AutoreviewMixedTargetTests(unittest.TestCase):
             git(repo, "commit", "-qm", "base")
             git(repo, "rm", "source.py")
             path.write_bytes(b"readded()\n")
-            read = mock.Mock(wraps=self.helper["read_prefix"])
-            with mock.patch.dict(self.helper["local_bundle"].__globals__, {"read_prefix": read}):
+            read = mock.Mock(wraps=self.helper["read_file_bytes"])
+            with mock.patch.dict(self.helper["local_bundle"].__globals__, {"read_file_bytes": read}):
                 captured = self.helper["local_bundle"](repo)
             self.assertEqual(sum(call.args[0] == path for call in read.call_args_list), 1)
             (repo / ".git/info/exclude").write_text("evidence/\n")
@@ -1053,7 +1060,6 @@ class AutoreviewHardeningTests(unittest.TestCase):
                     captured = self.helper["build_bundle"](repo, target, "moving-base", "HEAD")
                 self.assertEqual(captured.paths, {"task.md"})
                 self.assertIn("+task change", captured.text)
-                self.assertFalse(captured.truncated)
 
     def test_outgoing_pack_scan_disables_installed_scanner_updates(self) -> None:
         prompt = "harmless review pack\npreserved CRLF\r\nfinal line\r"
@@ -1207,20 +1213,14 @@ Path(__file__).with_name("scan.json").write_text(json.dumps({
             path.write_text("TOKEN=changed-placeholder\n", encoding="utf-8")
             git(repo, "add", path.name)
 
-            bundle, truncated, _paths, _mixed, _spans = self.helper["local_bundle"](repo)
+            bundle, _paths, _mixed, _spans = self.helper["local_bundle"](repo)
 
             self.assertIn(self.helper["REVIEW_SECURITY_OMISSION"], bundle)
-            self.assertFalse(truncated)
 
     def test_powershell_harness_exposes_runnable_engines_only(self) -> None:
         harness = SCRIPT.with_name("test-review-harness.ps1").read_text(encoding="utf-8")
 
         self.assertIn("[ValidateSet('codex', 'claude', 'amp', 'pi', 'kimi')]", harness)
-
-    def test_smoke_harness_validates_runtime_prompt_without_provider(self) -> None:
-        harness = runpy.run_path(str(SCRIPT.with_name("test-review-harness.py")))
-        with tempfile.TemporaryDirectory() as tempdir:
-            harness["validate_prompt_policy"](init_repo(Path(tempdir)), SCRIPT)
 
     def test_local_bundle_omits_sensitive_untracked_file_without_blocking(self) -> None:
         for rel in (".env", "tokens/session.dat", "secrets/local.py"):
@@ -1231,28 +1231,26 @@ Path(__file__).with_name("scan.json").write_text(json.dumps({
                 path.write_text("placeholder=true\n", encoding="utf-8")
                 (repo / "review.py").write_text("print('review me')\n", encoding="utf-8")
 
-                bundle, truncated, _paths, _mixed, _spans = self.helper["local_bundle"](repo)
+                bundle, _paths, _mixed, _spans = self.helper["local_bundle"](repo)
 
                 self.assertIn("# Review Input Omissions", bundle)
                 self.assertIn(self.helper["REVIEW_SECURITY_OMISSION"], bundle)
                 self.assertNotIn(rel, bundle)
                 self.assertNotIn("placeholder=true", bundle)
                 self.assertIn("print('review me')", bundle)
-                self.assertFalse(truncated)
 
-    def test_local_bundle_marks_untracked_binary_input_incomplete(self) -> None:
+    def test_large_binary_and_non_utf8_tails_refuse_input_capture(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:
             repo = init_repo(Path(tempdir))
-            (repo / "image.bin").write_bytes(b"\x89PNG\r\n\0binary-content")
-
-            bundle, truncated, _paths, _mixed, _spans = self.helper["local_bundle"](repo)
-
-            self.assertIn(
-                '# Untracked File\npath: "image.bin"\n'
-                'source-line 1: "[binary file omitted]"',
-                bundle,
-            )
-            self.assertTrue(truncated)
+            path = repo / "source.txt"
+            for bad, reason in ((b"\0", "binary file"), (b"\xff", "non-UTF-8 file")):
+                path.write_bytes(b"safe context\n" * 16_000 + bad)
+                with self.subTest(reason=reason):
+                    with self.assertRaisesRegex(SystemExit, reason):
+                        self.helper["local_bundle"](repo)
+                    for label in ("--prompt-file", "--dataset"):
+                        with self.subTest(label=label), self.assertRaisesRegex(SystemExit, reason):
+                            self.helper["validate_evidence_file"](repo, "source.txt", label)
 
     def test_local_bundle_rejects_non_utf8_untracked_text(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:
@@ -1266,21 +1264,21 @@ Path(__file__).with_name("scan.json").write_text(json.dumps({
         with tempfile.TemporaryDirectory() as tempdir:
             repo = init_repo(Path(tempdir))
             (repo / "notes.txt").write_text("review me\n", encoding="utf-8")
-            original_read_prefix = self.helper["read_prefix"]
+            original_read_file_bytes = self.helper["read_file_bytes"]
             reads = 0
 
-            def read_once(path: Path, limit: int) -> tuple[bytes, bool]:
+            def read_once(path: Path) -> bytes:
                 nonlocal reads
                 reads += 1
                 if reads > 1:
                     raise AssertionError("untracked file was reopened after validation")
-                return original_read_prefix(path, limit)
+                return original_read_file_bytes(path)
 
             with mock.patch.dict(
                 self.helper["local_bundle"].__globals__,
-                {"read_prefix": read_once},
+                {"read_file_bytes": read_once},
             ):
-                bundle, truncated, _paths, _mixed, _spans = self.helper["local_bundle"](repo)
+                bundle, _paths, _mixed, _spans = self.helper["local_bundle"](repo)
 
             expected_record = json.dumps("review me" + os.linesep)
             self.assertIn(
@@ -1288,8 +1286,189 @@ Path(__file__).with_name("scan.json").write_text(json.dumps({
                 f"source-line 1: {expected_record}",
                 bundle,
             )
-            self.assertFalse(truncated)
             self.assertEqual(reads, 1)
+
+    @contextlib.contextmanager
+    def nested_worktree_fixture(self, *, linked_root=False, name="scratch/review branch"):
+        with self.preparation_fixture() as (main, sends, scans, out, err):
+            repo = main
+            if linked_root:
+                repo = main.parent / "reviewed checkout"
+                git(main, "worktree", "add", "--detach", str(repo), "HEAD")
+                (repo / "source.md").write_text("outer linked change\n", encoding="utf-8")
+            child = repo / name
+            git(main, "worktree", "add", "--detach", str(child), "HEAD")
+            yield repo, child, sends, scans, out, err
+
+    def test_nested_worktree_keeps_neighboring_untracked_files_in_outgoing_scans(self):
+        names = ["scratch/review branch"]
+        if os.name != "nt":
+            names.append("scratch/review\nbranch")
+        for name in names:
+            with self.subTest(name=name), self.nested_worktree_fixture(name=name) as (
+                repo, child, sends, scans, _out, _err,
+            ):
+                ordinary = {
+                    ".worktrees/notes.md": "OUTER_WORKTREE_DIRECTORY_NOTE\n",
+                    f"{name}-copy/notes.md": "OUTER_PREFIX_NEIGHBOR_NOTE\n",
+                }
+                for rel, content in ordinary.items():
+                    path = repo / rel
+                    path.parent.mkdir(parents=True, exist_ok=True)
+                    path.write_text(content, encoding="utf-8")
+                (child / "source.md").write_text("CHILD_SOURCE_NOT_REVIEWED\n", encoding="utf-8")
+                (child / "child-only.md").write_text("CHILD_UNTRACKED_NOT_REVIEWED\n", encoding="utf-8")
+
+                captured = self.helper["local_bundle"](repo)
+                self.assertEqual(captured.paths, {"source.md", *ordinary})
+                self.assertEqual(self.helper["main_impl"](), 0)
+                self.assertEqual(scans, sends)
+                self.assertTrue(scans)
+                for pack in scans:
+                    for marker in ordinary.values():
+                        self.assertIn(marker.strip(), pack)
+                    self.assertNotIn("CHILD_SOURCE_NOT_REVIEWED", pack)
+                    self.assertNotIn("CHILD_UNTRACKED_NOT_REVIEWED", pack)
+
+    def test_nested_worktree_alone_does_not_select_local_review(self):
+        with self.nested_worktree_fixture() as (repo, child, *_):
+            git(repo, "commit", "-qam", "finish outer changes")
+            git(repo, "branch", "-M", "main")
+            (child / "source.md").write_text("child dirty\n", encoding="utf-8")
+            (child / "new.md").write_text("child untracked\n", encoding="utf-8")
+
+            self.assertFalse(self.helper["is_dirty"](repo))
+            with self.assertRaisesRegex(SystemExit, "no review target: clean main checkout"):
+                self.helper["choose_target"](repo, "auto", None)
+            with self.assertRaisesRegex(SystemExit, "no local changes to review"):
+                self.helper["local_bundle"](repo)
+
+            (repo / ".worktrees").mkdir()
+            (repo / ".worktrees/notes.md").write_text("ordinary note\n", encoding="utf-8")
+            self.assertEqual(self.helper["choose_target"](repo, "auto", None), ("local", None))
+            self.assertEqual(self.helper["local_bundle"](repo).paths, {".worktrees/notes.md"})
+
+    def test_nested_worktree_snapshot_tracks_boundary_not_child_state(self):
+        for linked_root in (False, True):
+            with self.subTest(linked_root=linked_root), self.nested_worktree_fixture(
+                linked_root=linked_root,
+            ) as (repo, child, *_):
+                self.assertEqual(self.helper["local_bundle"](repo).paths, {"source.md"})
+                before = self.helper["source_tree_snapshot"](repo)
+                (child / "source.md").write_text("child staged change\n", encoding="utf-8")
+                git(child, "add", "source.md")
+                self.assertEqual(self.helper["source_tree_snapshot"](repo), before)
+                git(child, "commit", "-qm", "child-only commit")
+                (child / "untracked.md").write_text("child-only file\n", encoding="utf-8")
+                self.assertEqual(self.helper["source_tree_snapshot"](repo), before)
+
+                source = repo / "source.md"
+                original = source.read_bytes()
+                source.write_bytes(original + b"outer mutation\n")
+                self.assertNotEqual(self.helper["source_tree_snapshot"](repo), before)
+                source.write_bytes(original)
+                self.assertEqual(self.helper["source_tree_snapshot"](repo), before)
+
+                pointer = child / ".git"
+                replacement = child / "replacement-pointer"
+                replacement.write_bytes(pointer.read_bytes())
+                os.replace(replacement, pointer)
+                self.assertNotEqual(self.helper["source_tree_snapshot"](repo), before)
+
+    def test_nested_worktree_cannot_hide_indexed_descendants_or_base_readditions(self):
+        with self.nested_worktree_fixture() as (repo, child, *_):
+            source = child / "source.md"
+            rel = source.relative_to(repo).as_posix()
+            oid = git(repo, "hash-object", "-w", str(source)).strip()
+            git(repo, "update-index", "--add", "--cacheinfo", f"100644,{oid},{rel}")
+            source.write_text("PARENT_INDEXED_DESCENDANT\n", encoding="utf-8")
+            captured = self.helper["local_bundle"](repo)
+            self.assertIn(rel, captured.paths)
+            self.assertIn("PARENT_INDEXED_DESCENDANT", captured.text)
+            before = self.helper["source_tree_snapshot"](repo)
+            source.write_text("PARENT_INDEXED_DESCENDANT_CHANGED\n", encoding="utf-8")
+            self.assertNotEqual(self.helper["source_tree_snapshot"](repo), before)
+
+            git(repo, "commit", "-qm", "parent owns a descendant")
+            base = git(repo, "rev-parse", "HEAD").strip()
+            git(repo, "update-index", "--force-remove", rel)
+            source.write_text("RE_ADDED_PARENT_SOURCE\n", encoding="utf-8")
+            for base_ref in (None, base):
+                with self.subTest(base=base_ref), self.assertRaisesRegex(
+                    SystemExit, "cannot safely include untracked file.*not a regular file",
+                ):
+                    self.helper["local_bundle"](repo, base_ref)
+            git(repo, "commit", "-qm", "remove parent index entry")
+            with self.assertRaisesRegex(
+                SystemExit, "cannot safely include untracked file.*not a regular file",
+            ):
+                self.helper["local_bundle"](repo, base)
+
+    def test_nested_worktree_exclusion_rejects_unowned_repository_boundaries(self):
+        for kind in ("standalone", "foreign", "fake", "alias", "mismatched", "unregistered-admin"):
+            with self.subTest(kind=kind), self.preparation_fixture() as (repo, *_):
+                child = repo / "scratch" / "unowned boundary"
+                child.parent.mkdir()
+                if kind == "foreign":
+                    foreign = repo.parent / "foreign"
+                    foreign.mkdir()
+                    git(foreign, "init", "-q")
+                    git(foreign, "commit", "--allow-empty", "-qm", "foreign root")
+                    git(foreign, "worktree", "add", "--detach", str(child), "HEAD")
+                elif kind == "unregistered-admin":
+                    git(repo, "worktree", "add", "--detach", str(child), "HEAD")
+                    registered = Path(git(child, "rev-parse", "--absolute-git-dir").strip())
+                    common = Path(git(repo, "rev-parse", "--absolute-git-dir").strip())
+                    copied = repo.parent / "unregistered-admin"
+                    shutil.copytree(registered, copied)
+                    (copied / "commondir").write_text(f"{common}\n", encoding="utf-8")
+                    (copied / "gitdir").write_text(f"{child / '.git'}\n", encoding="utf-8")
+                    (child / ".git").write_text(f"gitdir: {copied}\n", encoding="utf-8")
+                    self.assertEqual(
+                        Path(git(child, "rev-parse", "--git-common-dir").strip()).resolve(),
+                        common.resolve(),
+                    )
+                elif kind in {"alias", "mismatched"}:
+                    owner = repo / "registered owner"
+                    git(repo, "worktree", "add", "--detach", str(owner), "HEAD")
+                    if kind == "mismatched":
+                        git(repo, "worktree", "add", "--detach", str(child), "HEAD")
+                    else:
+                        child.mkdir()
+                    (child / ".git").write_bytes((owner / ".git").read_bytes())
+                else:
+                    child.mkdir()
+                    if kind == "standalone":
+                        git(child, "init", "-q")
+                        git(child, "commit", "--allow-empty", "-qm", "standalone root")
+                    else:
+                        (child / ".git").write_text(f"gitdir: {repo / '.git'}\n", encoding="utf-8")
+                (child / "ordinary.md").write_text("must not silently disappear\n", encoding="utf-8")
+
+                with self.assertRaisesRegex(
+                    SystemExit, "cannot safely include untracked file.*not a regular file",
+                ):
+                    self.helper["local_bundle"](repo)
+
+    def test_nested_worktree_validation_keeps_parent_git_trust_anchor(self):
+        with self.nested_worktree_fixture() as (repo, _child, *_):
+            hostile_bin = repo / "host-bin"
+            hostile_bin.mkdir()
+            marker = repo.parent / "hostile-git-executed"
+            write_executable(
+                hostile_bin / "git",
+                "#!/usr/bin/env python3\nfrom pathlib import Path\n"
+                f"Path({str(marker)!r}).write_text('executed')\nraise SystemExit(91)\n",
+            )
+            exclude = repo / ".git/info/exclude"
+            with exclude.open("a", encoding="utf-8") as stream:
+                stream.write("\nhost-bin/\n")
+            with mock.patch.dict(os.environ, {
+                "PATH": f"{hostile_bin}{os.pathsep}{os.environ.get('PATH', '')}",
+            }):
+                self.assertEqual(self.helper["local_bundle"](repo).paths, {"source.md"})
+                self.helper["source_tree_snapshot"](repo)
+            self.assertFalse(marker.exists())
 
     def test_local_base_reviews_resolved_merge_without_upstream_binary(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:
@@ -1394,8 +1573,7 @@ Path(__file__).with_name("scan.json").write_text(json.dumps({
             snapshot = self.helper["source_tree_snapshot"](repo)
             git(repo, "update-ref", "refs/heads/review-base", "HEAD")
             self.assertEqual(self.helper["source_tree_snapshot"](repo), snapshot)
-            bundle, truncated, _paths, _mixed, _spans = self.helper["local_bundle"](repo, pinned)
-            self.assertFalse(truncated)
+            bundle, _paths, _mixed, _spans = self.helper["local_bundle"](repo, pinned)
             self.assertIn("+committed task change", bundle)
             self.assertEqual(
                 self.helper["build_bundle"](repo, target, pinned, "HEAD").paths,
@@ -1417,14 +1595,12 @@ Path(__file__).with_name("scan.json").write_text(json.dumps({
                 if staged:
                     git(repo, "add", safe)
                 with self.subTest(staged=staged):
-                    bundle, truncated, _paths, _mixed, _spans = self.helper["local_bundle"](repo)
-                    self.assertFalse(truncated)
+                    bundle, _paths, _mixed, _spans = self.helper["local_bundle"](repo)
                     self.assertIn("struct CredentialFile", bundle)
                     self.assertIn(safe, self.helper["local_bundle"](repo).paths)
                     for label in ("--dataset", "--prompt-file"):
-                        _, content, truncated = self.helper["validate_evidence_file"](repo, safe, label)
+                        _, content = self.helper["validate_evidence_file"](repo, safe, label)
                         self.assertEqual(content, source.read_bytes().decode("utf-8"))
-                        self.assertFalse(truncated)
 
             blocked = (
                 "credentials.json", "config/prod-credentials.json", "credentials/store.json",
@@ -1611,13 +1787,12 @@ Path(__file__).with_name("scan.json").write_text(json.dumps({
                 dataset=[str(untracked.relative_to(repo))],
             ), repo)
             extra, datasets = evidence.prompt, evidence.datasets
-            bundle, _, _paths, _mixed, _spans = self.helper["local_bundle"](repo)
+            bundle, _paths, _mixed, _spans = self.helper["local_bundle"](repo)
             pack, = self.helper["build_review_prompts"](repo, "local", None, bundle, extra, datasets)
             provider = mock.Mock(return_value=json.dumps({
                 "findings": [], "overall_correctness": "patch is correct",
                 "overall_explanation": "Synthetic review.", "overall_confidence": 0.8,
             }))
-            self.assertIn("Report every suspected real credential as a P0 security finding", pack)
             for marker in (None, "DELETED_SCAN_MARKER", "STAGED_SCAN_MARKER", "UNTRACKED_SCAN_MARKER", "PROMPT_SCAN_MARKER"):
                 events = []
 
@@ -1778,7 +1953,7 @@ Path(__file__).with_name("scan.json").write_text(json.dumps({
                 },
             ):
                 self.assertEqual(
-                    [rel for rel, _, _ in self.helper["collect_untracked_file_snapshots"](repo)[0]],
+                    [rel for rel, _ in self.helper["collect_untracked_file_snapshots"](repo)[0]],
                     ["hostile-gitconfig", "visible.txt"],
                 )
 
@@ -1805,30 +1980,20 @@ Path(__file__).with_name("scan.json").write_text(json.dumps({
             ):
                 self.assertFalse(self.helper["is_dirty"](repo))
 
-    def test_oversized_text_is_rejected_without_scanning_binary_tail(self) -> None:
+    def test_large_untracked_text_is_captured_completely(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:
             repo = init_repo(Path(tempdir))
-            detector_tail = "\ntoken=" + "A" * 24 + "\n"
-            content = "x" * (64_000 * 3 - 4) + detector_tail
-
+            content = "界\r\n" * 50_000 + "COMPLETE_UNTRACKED_TAIL\n"
             untracked = repo / "untracked.txt"
-            untracked.write_text(content, encoding="utf-8")
-            with self.assertRaisesRegex(SystemExit, "file too large to scan safely"):
-                [rel for rel, _, _ in self.helper["collect_untracked_file_snapshots"](repo)[0]]
-
-            untracked.unlink()
-            binary = repo / "binary.bin"
-            binary.write_bytes(b"\0" + content.encode())
-            self.assertEqual(
-                [rel for rel, _, _ in self.helper["collect_untracked_file_snapshots"](repo)[0]],
-                ["binary.bin"],
+            untracked.write_bytes(content.encode("utf-8"))
+            captured = self.helper["local_bundle"](repo)
+            records = re.findall(r"^source-line \d+: (.*)$", captured.text, re.MULTILINE)
+            self.assertEqual("".join(json.loads(record) for record in records), content)
+            passes = self.helper["build_review_prompts"](
+                repo, "local", None, captured, "", [], 50_000,
             )
-
-            binary.unlink()
-            evidence = repo / "evidence.txt"
-            evidence.write_text(content, encoding="utf-8")
-            with self.assertRaisesRegex(SystemExit, "file too large to scan safely"):
-                self.helper["validate_evidence_file"](repo, "evidence.txt", "--dataset")
+            self.assertGreater(len(passes), 1)
+            self.assertEqual("".join(prompt.split("# Change Bundle\n", 1)[1] for prompt in passes), captured.text)
 
     def test_branch_bundle_rejects_unsafe_or_unknown_base_before_diff(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:
@@ -1900,7 +2065,6 @@ Path(__file__).with_name("scan.json").write_text(json.dumps({
                                 self.helper["build_bundle"](checkout, "commit", None, "HEAD")
                         continue
                     captured = self.helper["build_bundle"](checkout, "commit", None, "HEAD")
-                    self.assertFalse(captured.truncated)
                     self.assertIn(f"parent: {expected_parent}\n", captured.text)
                     self.assertIn(expected_patch, captured.text)
                     self.assertNotIn("behavior.py", captured.text)
@@ -1912,7 +2076,6 @@ Path(__file__).with_name("scan.json").write_text(json.dumps({
             self.assertNotIn("behavior.py", captured.text)
             self.assertEqual(captured.paths, {"unrelated.txt"})
             captured = self.helper["build_bundle"](repo, "commit", None, initial)
-            self.assertFalse(captured.truncated)
             self.assertIn("parent: none (verified raw root)\n", captured.text)
             self.assertIn("+def behavior(): return 'preexisting'", captured.text)
             self.assertEqual(captured.paths, {"behavior.py"})
@@ -1939,7 +2102,6 @@ Path(__file__).with_name("scan.json").write_text(json.dumps({
                 self.assertIn(f"author {name}".encode(), raw)
                 self.assertNotIn(b"\nparent ", raw.partition(b"\n\n")[0])
                 captured = self.helper["build_bundle"](repo, "commit", None, "HEAD")
-                self.assertFalse(captured.truncated)
                 self.assertIn("parent: none (verified raw root)\n", captured.text)
                 self.assertIn("+root_content = True", captured.text)
                 self.assertEqual(captured.paths, {"code.py"})
@@ -1978,7 +2140,6 @@ Path(__file__).with_name("scan.json").write_text(json.dumps({
                                 self.helper["build_bundle"](repo, "commit", None, commit)
                             continue
                         captured = self.helper["build_bundle"](repo, "commit", None, commit)
-                        self.assertFalse(captured.truncated)
                         if label == "late":
                             self.assertEqual(git(repo, "rev-list", "--parents", "-n", "1", commit).split(), [commit])
                             self.assertIn("parent: none (verified raw root)\n", captured.text)
@@ -2012,14 +2173,6 @@ Path(__file__).with_name("scan.json").write_text(json.dumps({
             with self.assertRaisesRegex(SystemExit, "non-UTF-8 Git output"):
                 self.helper["git_path_list"](repo, "ls-files", "-z")
 
-    def test_review_patch_rejects_oversized_content(self) -> None:
-        with self.assertRaisesRegex(SystemExit, "too large to review safely"):
-            self.helper["validate_review_patch"]("local staged diff", ["safe.txt"], "x" * 25, 10)
-
-    def test_review_patch_limit_counts_utf8_bytes(self) -> None:
-        with self.assertRaisesRegex(SystemExit, r"12 bytes; limit 10"):
-            self.helper["validate_review_patch"]("local staged diff", ["safe.txt"], "界" * 4, 10)
-
     def test_review_patch_accepts_large_content_without_explicit_limit(self) -> None:
         patch = (
             "diff --git a/safe.txt b/safe.txt\n"
@@ -2031,7 +2184,6 @@ Path(__file__).with_name("scan.json").write_text(json.dumps({
 
         self.assertEqual(
             self.helper["validate_review_patch"](
-                "local staged diff",
                 ["safe.txt"],
                 patch,
             ),
@@ -2322,7 +2474,7 @@ Path(__file__).with_name("scan.json").write_text(json.dumps({
                 path = f"evidence-{index}.txt"
                 lines = [
                     f"evidence-{index}-{line}: \U0001f99e{'x' * 70}"
-                    for line in range(1_400)
+                    for line in range(2_200)
                 ]
                 expected_lines.extend(lines)
                 (repo / path).write_bytes(("\n".join(lines) + "\n").encode("utf-8"))
@@ -2331,7 +2483,6 @@ Path(__file__).with_name("scan.json").write_text(json.dumps({
                 argparse.Namespace(prompt=[], prompt_file=[], dataset=paths), repo
             )
             datasets = evidence.datasets
-            self.assertFalse(evidence.truncated)
             bundle = "# Commit Diff\n" + "+changed line\n" * 40_000
             instructions = "Complete caller instructions must appear in every pass."
             for budget in (512_000, 120_000):
@@ -2420,7 +2571,7 @@ Path(__file__).with_name("scan.json").write_text(json.dumps({
             self.assertGreater(len(prompts), 1)
             for prompt in prompts:
                 self.assertIn(
-                    "Report every suspected real credential as a P0 security finding",
+                    "Report suspected real credentials as P0 findings without reproducing their values.",
                     prompt,
                 )
 
@@ -2522,11 +2673,11 @@ Path(__file__).with_name("scan.json").write_text(json.dumps({
                     if failure:
                         with self.assertRaisesRegex(SystemExit, f"late {failure} failure"):
                             self.helper["run_review_passes"](
-                                args, [args], repo, prompts, {"source.txt"}, False
+                                args, [args], repo, prompts, {"source.txt"}
                             )
                     else:
                         reports = self.helper["run_review_passes"](
-                            args, [args], repo, prompts, {"source.txt"}, False
+                            args, [args], repo, prompts, {"source.txt"}
                         )
                         report = self.helper["merge_chunk_reports"](reports)
                         self.helper["require_findings"](report, args.require_finding)
@@ -2545,7 +2696,6 @@ Path(__file__).with_name("scan.json").write_text(json.dumps({
         path = ".env.\x1b]52;c;VEVTVA==\x07\udc9b"
 
         redacted = self.helper["validate_review_patch"](
-            "local staged diff",
             [path],
             "",
         )
@@ -2569,7 +2719,6 @@ Path(__file__).with_name("scan.json").write_text(json.dumps({
         )
 
         redacted = self.helper["validate_review_patch"](
-            "branch diff",
             [".env"],
             patch,
         )
@@ -2591,7 +2740,6 @@ Path(__file__).with_name("scan.json").write_text(json.dumps({
         ):
             with self.subTest(patch=patch):
                 validated = self.helper["validate_review_patch"](
-                    "commit diff",
                     ["src/runtime.ts"],
                     patch,
                 )
@@ -2608,15 +2756,14 @@ Path(__file__).with_name("scan.json").write_text(json.dumps({
             (repo / ".env").write_text("placeholder=true\n", encoding="utf-8")
             (repo / "base.txt").write_text("base\nreview me\n", encoding="utf-8")
             git(repo, "add", ".env", "base.txt")
-            local, local_truncated, _paths, _mixed, _spans = self.helper["local_bundle"](repo)
+            local, _paths, _mixed, _spans = self.helper["local_bundle"](repo)
             self.assertIn(self.helper["REVIEW_SECURITY_OMISSION"], local)
             self.assertNotIn(".env", local)
             self.assertNotIn("placeholder=true", local)
             self.assertIn("+review me", local)
-            self.assertFalse(local_truncated)
 
             git(repo, "commit", "-q", "-m", "sensitive path")
-            for bundle, truncated, paths, _mixed, _spans in (
+            for bundle, paths, _mixed, _spans in (
                 self.helper["branch_bundle"](repo, base),
                 self.helper["commit_bundle"](repo, "HEAD"),
             ):
@@ -2624,7 +2771,6 @@ Path(__file__).with_name("scan.json").write_text(json.dumps({
                 self.assertNotIn(".env", bundle)
                 self.assertNotIn("placeholder=true", bundle)
                 self.assertIn("+review me", bundle)
-                self.assertFalse(truncated)
 
     def test_secret_named_workflows_are_reviewable_in_all_modes(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:
@@ -2637,16 +2783,16 @@ Path(__file__).with_name("scan.json").write_text(json.dumps({
             workflow = repo / ".github" / "workflows" / "secret-scan.yml"
             workflow.parent.mkdir(parents=True)
             workflow.write_text("name: Secret scan\n", encoding="utf-8")
-            untracked_bundle, _, _paths, _mixed, _spans = self.helper["local_bundle"](repo)
+            untracked_bundle, _paths, _mixed, _spans = self.helper["local_bundle"](repo)
             self.assertIn("secret-scan.yml", untracked_bundle)
 
             git(repo, "add", str(workflow.relative_to(repo)))
-            tracked_bundle, _, _paths, _mixed, _spans = self.helper["local_bundle"](repo)
+            tracked_bundle, _paths, _mixed, _spans = self.helper["local_bundle"](repo)
             self.assertIn("secret-scan.yml", tracked_bundle)
 
             git(repo, "commit", "-q", "-m", "add secret scanner")
-            branch_bundle, _, _paths, _mixed, _spans = self.helper["branch_bundle"](repo, base)
-            commit_bundle, _, _paths, _mixed, _spans = self.helper["commit_bundle"](repo, "HEAD")
+            branch_bundle, _paths, _mixed, _spans = self.helper["branch_bundle"](repo, base)
+            commit_bundle, _paths, _mixed, _spans = self.helper["commit_bundle"](repo, "HEAD")
             self.assertIn("secret-scan.yml", branch_bundle)
             self.assertIn("secret-scan.yml", commit_bundle)
 
@@ -2714,10 +2860,9 @@ Path(__file__).with_name("scan.json").write_text(json.dumps({
             path.parent.mkdir()
             path.write_text(source, encoding="utf-8")
 
-            bundle, truncated, _paths, _mixed, _spans = self.helper["local_bundle"](repo)
+            bundle, _paths, _mixed, _spans = self.helper["local_bundle"](repo)
 
             self.assertIn("ordinary-hardcoded-value-12345", bundle)
-            self.assertFalse(truncated)
 
     def test_untracked_design_token_artifacts_remain_reviewable(self) -> None:
         for rel in (
@@ -2834,7 +2979,6 @@ Path(__file__).with_name("scan.json").write_text(json.dumps({
 
         self.assertEqual(
             self.helper["validate_review_patch"](
-                "branch diff",
                 ["provider.ts"],
                 safe_patch,
             ),
@@ -2855,7 +2999,6 @@ Path(__file__).with_name("scan.json").write_text(json.dumps({
             + "".join(f"+{line}\n" for line in source.splitlines())
         )
         validated = self.helper["validate_review_patch"](
-            "typescript credential plumbing fixture",
             ["src/credential-plumbing.ts"],
             patch,
         )
@@ -2890,7 +3033,6 @@ Path(__file__).with_name("scan.json").write_text(json.dumps({
 
         self.assertEqual(
             self.helper["validate_review_patch"](
-                "branch diff",
                 ["apps/macos/MenuContentView.swift"],
                 patch,
             ),
@@ -2934,7 +3076,6 @@ Path(__file__).with_name("scan.json").write_text(json.dumps({
         )
 
         validated = self.helper["validate_review_patch"](
-            "typescript config path references",
             ["src/config-path-references.ts"],
             patch,
         )
@@ -2962,7 +3103,6 @@ Path(__file__).with_name("scan.json").write_text(json.dumps({
         )
         self.assertEqual(
             self.helper["validate_review_patch"](
-                "typescript truncated credential calls fixture",
                 ["src/token.ts"],
                 truncated_call_patch,
             ),
@@ -2987,7 +3127,6 @@ Path(__file__).with_name("scan.json").write_text(json.dumps({
                 )
 
                 validated = self.helper["validate_review_patch"](
-                    "local unstaged diff",
                     ["fixture.py"],
                     patch,
                 )
@@ -3015,13 +3154,12 @@ Path(__file__).with_name("scan.json").write_text(json.dumps({
             git(repo, "add", "-u")
             git(repo, "commit", "-q", "-m", "delete template")
 
-            bundle, truncated, _paths, _mixed, _spans = self.helper["branch_bundle"](repo, base)
+            bundle, _paths, _mixed, _spans = self.helper["branch_bundle"](repo, base)
 
             self.assertIn("deleted file mode 100644", bundle)
             self.assertIn("------BEGIN [A-Z ]+-----", bundle)
             self.assertIn("-{{ _body }}", bundle)
             self.assertIn("------END [A-Z ]+-----", bundle)
-            self.assertFalse(truncated)
 
     def test_review_patch_preserves_redaction_placeholder_fallback(self) -> None:
         patch = (
@@ -3035,7 +3173,6 @@ Path(__file__).with_name("scan.json").write_text(json.dumps({
 
         self.assertEqual(
             self.helper["validate_review_patch"](
-                "local unstaged diff",
                 ["runtime.py"],
                 patch,
             ),
@@ -3053,7 +3190,6 @@ Path(__file__).with_name("scan.json").write_text(json.dumps({
         )
 
         redacted_patch = self.helper["validate_review_patch"](
-            "local unstaged diff",
             ["fixture.txt"],
             patch,
         )
@@ -3071,7 +3207,6 @@ Path(__file__).with_name("scan.json").write_text(json.dumps({
         )
 
         redacted = self.helper["validate_review_patch"](
-            "local unstaged diff",
             ["runtime.ts"],
             patch,
         )
@@ -3090,7 +3225,6 @@ Path(__file__).with_name("scan.json").write_text(json.dumps({
         )
 
         redacted = self.helper["validate_review_patch"](
-            "local unstaged diff",
             ["vendor"],
             patch,
         )
@@ -3109,7 +3243,6 @@ Path(__file__).with_name("scan.json").write_text(json.dumps({
         )
 
         redacted_patch = self.helper["validate_review_patch"](
-            "local unstaged diff",
             ["runtime.ts"],
             patch,
         )
@@ -3127,7 +3260,6 @@ Path(__file__).with_name("scan.json").write_text(json.dumps({
         )
 
         redacted_patch = self.helper["validate_review_patch"](
-            "local unstaged diff",
             ["runtime.ts"],
             patch,
         )
@@ -3145,7 +3277,6 @@ Path(__file__).with_name("scan.json").write_text(json.dumps({
         )
 
         redacted_patch = self.helper["validate_review_patch"](
-            "local unstaged diff",
             ["runtime.ts"],
             patch,
         )
@@ -3167,7 +3298,6 @@ Path(__file__).with_name("scan.json").write_text(json.dumps({
         )
 
         redacted_patch = self.helper["validate_review_patch"](
-            "local unstaged diff",
             ["runtime.ts"],
             patch,
         )
@@ -3184,39 +3314,9 @@ Path(__file__).with_name("scan.json").write_text(json.dumps({
 
             path.write_text('const request = { token: String() };\n', encoding="utf-8")
 
-            bundle, truncated, _paths, _mixed, _spans = self.helper["local_bundle"](repo)
+            bundle, _paths, _mixed, _spans = self.helper["local_bundle"](repo)
 
             self.assertIn('-const request = { token: "test-token" };', bundle)
-            self.assertFalse(truncated)
-
-    def test_pi_refuses_truncated_review_input(self) -> None:
-        reviewer = argparse.Namespace(engine="pi", tools=True)
-
-        with self.assertRaisesRegex(SystemExit, "pi engine refused truncated review input"):
-            self.helper["ensure_reviewer_input_complete"](
-                reviewer,
-                True,
-            )
-
-        self.helper["ensure_reviewer_input_complete"](
-            reviewer,
-            False,
-        )
-        with self.assertRaisesRegex(SystemExit, "codex engine refused truncated review input"):
-            self.helper["ensure_reviewer_input_complete"](
-                argparse.Namespace(engine="codex", tools=True),
-                True,
-            )
-        with self.assertRaisesRegex(SystemExit, "claude engine refused truncated review input"):
-            self.helper["ensure_reviewer_input_complete"](
-                argparse.Namespace(engine="claude", tools=True),
-                True,
-            )
-        with self.assertRaisesRegex(SystemExit, "kimi engine refused truncated review input"):
-            self.helper["ensure_reviewer_input_complete"](
-                argparse.Namespace(engine="kimi", tools=False),
-                True,
-            )
 
     def test_kimi_config_is_sanitized_without_losing_model_auth(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:
@@ -3375,7 +3475,6 @@ Path(__file__).with_name("scan.json").write_text(json.dumps({
             evidence = self.helper["capture_evidence_inputs"](args, repo)
 
             self.assertIn("# Prompt file: review.md", evidence.prompt)
-            self.assertFalse(evidence.truncated)
 
     def test_review_prompts_omit_absolute_repo_path_and_keep_instructions_whole(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:
@@ -3389,14 +3488,9 @@ Path(__file__).with_name("scan.json").write_text(json.dumps({
                     )
                     self.assertIn("Read-only tools cannot access unchanged repository files", prompt)
                     self.assertIn(
-                        "Do not report a missing import, symbol, definition, call site, config entry",
+                        "Missing context or omitted sensitive material is not evidence of a defect.",
                         prompt,
                     )
-                    for evidence_rule in (
-                        "raw commit parents", "^sha", "porcelain boundary", "missing parents",
-                        "parent-relative patch", "unknown", "carried forward", "merger",
-                    ):
-                        self.assertIn(evidence_rule, prompt)
                     self.assertNotIn(str(repo), prompt)
             with self.assertRaisesRegex(SystemExit, "too little room"):
                 self.helper["build_review_prompts"](
@@ -3407,26 +3501,6 @@ Path(__file__).with_name("scan.json").write_text(json.dumps({
                     "x" * self.helper["MAX_REVIEW_PROMPT_BYTES"],
                     [],
                 )
-
-    def test_read_text_truncates_without_scanning_tail(self) -> None:
-        with tempfile.TemporaryDirectory() as tempdir:
-            path = Path(tempdir) / "large.txt"
-            path.write_bytes(b"x" * 200_000 + b"\0tail")
-
-            text = self.helper["read_text"](path)
-
-            self.assertIn("[truncated at 180000 characters]", text)
-            self.assertNotEqual(text, "[binary file omitted]")
-
-    def test_read_text_marks_unreadable_input_incomplete(self) -> None:
-        with mock.patch.dict(
-            self.helper["read_text_with_status"].__globals__,
-            {"read_prefix": lambda *_args: (_ for _ in ()).throw(SystemExit("denied"))},
-        ):
-            text, incomplete = self.helper["read_text_with_status"](Path("blocked"))
-
-        self.assertIn("[unreadable:", text)
-        self.assertTrue(incomplete)
 
     def test_evidence_file_must_be_repo_relative_and_not_symlinked(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:
@@ -3727,16 +3801,17 @@ Path(__file__).with_name("scan.json").write_text(json.dumps({
         proc_b.wait.assert_called_once_with(timeout=0.5)
 
     def test_engine_interrupted_is_not_swallowed_by_except_system_exit(self) -> None:
-        # Regression: EngineInterrupted used to subclass SystemExit, so
-        # internal `except SystemExit` guards like read_text_with_status's
-        # converted an in-flight interrupt into an unreadable-file result
-        # and kept going instead of unwinding.
-        with mock.patch.dict(
-            self.helper["read_text_with_status"].__globals__,
-            {"read_prefix": mock.Mock(side_effect=self.helper["EngineInterrupted"](130))},
-        ):
-            with self.assertRaises(self.helper["EngineInterrupted"]) as ctx:
-                self.helper["read_text_with_status"](Path("irrelevant"))
+        # Input validation may translate unreadable-file errors, but an engine
+        # interrupt must unwind with its original exit code.
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo = init_repo(Path(tempdir))
+            (repo / "evidence.txt").write_text("evidence\n")
+            with mock.patch.dict(
+                self.helper["validate_evidence_file"].__globals__,
+                {"read_file_bytes": mock.Mock(side_effect=self.helper["EngineInterrupted"](130))},
+            ):
+                with self.assertRaises(self.helper["EngineInterrupted"]) as ctx:
+                    self.helper["validate_evidence_file"](repo, "evidence.txt", "--dataset")
         self.assertEqual(ctx.exception.code, 130)
 
     def test_main_converts_engine_interrupted_to_exit_code(self) -> None:
@@ -3948,9 +4023,8 @@ Path(__file__).with_name("scan.json").write_text(json.dumps({
             tracked.write_bytes(b"\0tracked-before")
             git(repo, "add", "tracked.bin")
             git(repo, "commit", "-qm", "initial")
-            limit = self.helper["MAX_BUNDLE_TEXT_BYTES"]
             untracked = repo / "generated.bin"
-            untracked.write_bytes(b"\0" + b"a" * (limit + 16))
+            untracked.write_bytes(b"\0" + b"a" * 200_000)
             before = self.helper["source_tree_snapshot"](repo)
 
             tracked.write_bytes(b"\0tracked-after!")
@@ -4981,18 +5055,44 @@ Path(__file__).with_name("scan.json").write_text(json.dumps({
                 self.assertIn("retained-pipe-reviewer engine timed out", result.stderr)
                 self.assertLess(time.monotonic() - started, 2)
 
-    def test_large_repo_relative_evidence_file_is_rejected(self) -> None:
+    def test_large_prompt_and_dataset_files_are_captured_completely(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:
             repo = init_repo(Path(tempdir))
             evidence = repo / "evidence.txt"
-            evidence.write_text("x" * 600_000, encoding="utf-8")
+            content = "界\r\n" * 120_000 + "COMPLETE_EVIDENCE_TAIL\n"
+            evidence.write_bytes(content.encode("utf-8"))
+            captured = self.helper["capture_evidence_inputs"](
+                argparse.Namespace(prompt=[], prompt_file=["evidence.txt"], dataset=["evidence.txt"]), repo,
+            )
+            self.assertEqual(captured.prompt, "# Prompt file: evidence.txt\n" + content)
+            self.assertEqual(captured.datasets[0].content, content)
+            self.helper["verify_evidence"](repo, captured.files)
 
-            with self.assertRaisesRegex(SystemExit, "file too large to scan safely"):
-                self.helper["validate_evidence_file"](
-                    repo,
-                    "evidence.txt",
-                    "--dataset",
-                )
+    def test_evidence_capture_rejects_files_changed_during_open_or_read(self) -> None:
+        for operation in ("open", "read"):
+            with self.subTest(operation=operation), tempfile.TemporaryDirectory() as tempdir:
+                repo = init_repo(Path(tempdir))
+                path = repo / "evidence.txt"
+                path.write_bytes(b"review context\n" * 20_000)
+                original = getattr(os, operation)
+                changed = False
+
+                def mutate(*args, **kwargs):
+                    nonlocal changed
+                    if operation == "open" and not changed:
+                        replacement = repo / "replacement.txt"
+                        replacement.write_bytes(path.read_bytes())
+                        replacement.replace(path)
+                    result = original(*args, **kwargs)
+                    if operation == "read" and not changed:
+                        with path.open("ab") as stream:
+                            stream.write(b"new tail\n")
+                    changed = True
+                    return result
+
+                with mock.patch.object(os, operation, side_effect=mutate):
+                    with self.assertRaisesRegex(SystemExit, "file changed while opening|file changed while reading"):
+                        self.helper["capture_evidence_file"](repo, "evidence.txt", "--dataset")
 
     def test_claude_inventory_is_bundle_and_web_only(self) -> None:
         args = argparse.Namespace(
@@ -5039,7 +5139,6 @@ Path(__file__).with_name("scan.json").write_text(json.dumps({
 
         self.assertEqual(
             self.helper["validate_review_patch"](
-                "local unstaged diff",
                 ["safe.py"],
                 patch,
             ),
@@ -6099,16 +6198,8 @@ os.execv(target, [str(target), *sys.argv[1:]])
 
     @unittest.skipIf(os.name == "nt", "the fake executable is POSIX-only")
     def test_dry_run_flag_exits_nonzero_when_prompt_unpartitionable(self) -> None:
-        # The real run does not stop at capture_evidence_inputs()'s per-file
-        # checks: main() also builds the final prompt(s) via
-        # build_review_prompts() and rejects context that cannot fit the
-        # aggregate prompt budget even after partitioning (see
-        # build_review_prompts's "leave too little room for change chunks"
-        # branch). Use the Kimi engine's smaller aggregate budget
-        # (KIMI_MAX_PROMPT_BYTES) so a single --prompt-file well under the
-        # per-file 180000-byte scan cap (MAX_BUNDLE_TEXT_BYTES) still blows
-        # the aggregate limit; --dry-run must reuse that same check instead
-        # of reporting readiness for a prompt the real run would refuse.
+        # Instructions remain whole in each pass. Dry-run must enforce the
+        # engine's aggregate prompt budget just like a real review.
         with tempfile.TemporaryDirectory() as tempdir:
             root = Path(tempdir)
             repo = init_repo(root)

--- a/skills/autoreview/tests/test_autoreview_hardening.py
+++ b/skills/autoreview/tests/test_autoreview_hardening.py
@@ -754,6 +754,8 @@ class AutoreviewHardeningTests(unittest.TestCase):
     def preparation_fixture(self, *options):
         with tempfile.TemporaryDirectory() as tempdir:
             repo = init_repo(Path(tempdir))
+            # Protected review reads ignore host Git config, including Windows autocrlf.
+            git(repo, "config", "core.autocrlf", "false")
             for index in range(24):
                 (repo / f"unchanged-{index}.txt").write_text("old\n")
             (repo / "source.md").write_text("before\n")
@@ -1423,6 +1425,7 @@ Path(__file__).with_name("scan.json").write_text(json.dumps({
                     shutil.copytree(registered, copied)
                     (copied / "commondir").write_text(f"{common}\n", encoding="utf-8")
                     (copied / "gitdir").write_text(f"{child / '.git'}\n", encoding="utf-8")
+                    (child / ".git").unlink()
                     (child / ".git").write_text(f"gitdir: {copied}\n", encoding="utf-8")
                     self.assertEqual(
                         Path(git(child, "rev-parse", "--git-common-dir").strip()).resolve(),
@@ -1433,6 +1436,7 @@ Path(__file__).with_name("scan.json").write_text(json.dumps({
                     git(repo, "worktree", "add", "--detach", str(owner), "HEAD")
                     if kind == "mismatched":
                         git(repo, "worktree", "add", "--detach", str(child), "HEAD")
+                        (child / ".git").unlink()
                     else:
                         child.mkdir()
                     (child / ".git").write_bytes((owner / ".git").read_bytes())


### PR DESCRIPTION
## What changed

Autoreview now captures complete review files and evidence instead of refusing them at the old 180,000-byte per-file cap. The existing bounded prompt partitioner still controls each provider request, and full-input plus immediate pre-send secret scanning remains fail-closed. Binary and invalid UTF-8 tails are rejected rather than producing a partial review.

Registered nested linked worktrees from the same repository are outside the current checkout's review scope. Git reports these roots as collapsed untracked directories, which previously made a clean parent look dirty and stopped real reviews with `not a regular file`. One shared classifier now supplies target selection, capture, and snapshot verification. This does not aggregate reviews across worktrees or ignore ordinary `.worktrees` directories.

The exclusion requires the parent Git executable's registration, shared common directory, registered private admin directory, and matching backlink. Adjacent files remain included and scanned; parent-indexed or base-claimed descendants cannot disappear. Snapshots retain the worktree boundary identity, but not child source, HEAD, or index state. Foreign repositories, standalone repositories, forged pointers, and copied unregistered admin directories remain fail-closed.

The accompanying prompt and skill cleanup removes redundant guidance and obsolete truncation plumbing. The skill explicitly states the single-checkout scope. No new options or repository-local variants are introduced.

## Verification

- Native-Git regression cases failed against the previous helper, including worktree-only target selection and the collapsed-directory refusal. A separate negative control exposed and then closed the copied-unregistered-admin gap.
- Full Autoreview Python suite: 245 tests run, 244 passed and one existing platform skip.
- Repository installer and validator tests: 15 passed; skill validator: all 8 skills passed.
- Node suites: all 96 tests passed.
- Python compilation, Bash and Node syntax checks, and `git diff --check`: passed.
- Fresh isolated pre-commit Codex review, supplied the full current helper and skill as context: scoped-clean at the skill's default P0 threshold. The reviewer did not execute project code; the test results above were run separately.
- The native Codex execution, configuration isolation, permission, and sandbox contracts were inspected directly in `openai/codex` at `94cbbddafc1776d5e377bca1b05932c697e82238`.

The initial Linux validation and CodeQL checks passed. Windows exposed two fixture portability problems: host line-ending conversion changed the supposedly unchanged setup files, and Python could not truncate Git-hidden pointer files. The follow-up changes only fixture setup: use an explicit local line-ending policy before the baseline commit and recreate the two deliberately forged pointers. All cases and assertions remain; no skips or production changes are added. [Exact-head Linux and Windows validation](https://github.com/openclaw/agent-skills/actions/runs/33605390673) passed at `9b01d0a`; CodeQL also passed. The full local Python suite passed again, and the final committed-branch Codex review was scoped-clean at the default P0 threshold.

## After-fix scope proof

This addresses the initial ClawSweeper real-behavior request and its scope-proof Rank-up move. A controlled temporary repository was initialized with native Git, then `git worktree add --detach` created `scratch/review branch`. The production helpers were loaded directly, with no scope, Git, scanner, or filesystem mocks. The old helper came from `6aa7eb7`; the after-fix owner came from `1191d3c`. A real TruffleHog scan checked the constructed outgoing pack. This is owner-level scope/scanning proof, not a provider review. The fixture was removed afterward.

```text
git_untracked=["scratch/review branch/"]
before_parent_dirty=true
after_parent_dirty=false
after_auto_target=no review target: clean main checkout and no forced mode
before_capture=cannot safely include untracked file scratch/review branch/: not a regular file
after_captured_paths=["scratch/notes.md"]
outgoing_pack_parent_marker=true child_markers=false
real_trufflehog_scan=PASS packs=1
child_head_index_source_change_keeps_parent_snapshot=true
parent_neighbor_change_invalidates_snapshot=true
native_scope_proof=PASS; temporary fixture removed; no provider invoked
```

## Maintainer disposition and follow-ups

The latest ClawSweeper review accepts the native scope proof and raises a late memory-capacity finding. Its source observation is correct: complete files are buffered before prompt partitioning, so sufficiently large inputs can exhaust finite process memory. The per-request prompt ceiling is not a peak-RAM bound.

Maintainer disposition: **decline this as a blocking P1 for the explicitly requested uncapped-capture scope**, while retaining and documenting the capacity limitation. No P1 failure of ordinary reviews has been demonstrated, and this change makes no arbitrary-multi-gigabyte or constant-memory guarantee. We are not restoring per-file caps or folding a whole-pipeline streaming redesign into this PR. The finding is not claimed fixed. Its Rank-up move is explicitly deferred to [Stream source/evidence capture without reintroducing file caps (#217)](https://github.com/openclaw/agent-skills/issues/217), preserving complete capture, scanning, snapshots, and isolation.

[Honor trusted Git line-ending settings in local review selection (#216)](https://github.com/openclaw/agent-skills/issues/216) records the separate, now-reproduced global-only `core.autocrlf` mismatch. Protected Git's global/system suppression predates this PR. Native-Git controls on macOS showed the false selection, a clean repository-local control, and correct real-edit selection. The explicit fixture-local setting establishes the tests' unchanged-file baseline; it does not fix or change that production policy.

## Size and downstream scope

Production helper: +168/-249, **net -81 lines**. Tests and test support: +296/-217, net +79. Skill documentation: +83/-425, net -342.

This is the canonical skill change. Downstream repositories must sync the complete `skills/autoreview` directory after merge; this PR does not edit downstream copies or introduce automatic multi-worktree review.
