### PR TITLE
fix(autoreview): harden frozen review input boundaries

### DIFF
--- a/skills/autoreview/SKILL.md
+++ b/skills/autoreview/SKILL.md
@@ -97,6 +97,8 @@ The helper owns reviewer isolation, sanitized authentication, process cleanup,
 Git scope, and structured result validation. Keep those controls enabled.
 TruffleHog must scan the complete frozen input for partitioned reviews and each
 exact outgoing pack before it is sent; missing or failed scanning stops the run.
+Source-controlled ignore tags cannot suppress this gate. Scanner refusals never
+echo input headings or finding payloads; remove credentials locally and rerun.
 Never reproduce credentials in findings or work around an isolation failure.
 
 Review files have no size/count cap and are never truncated. Large diffs and

--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -29,7 +29,7 @@ import time
 import unicodedata
 import urllib.parse
 from pathlib import Path, PurePosixPath
-from typing import Any, Callable, NamedTuple
+from typing import Any, BinaryIO, Callable, NamedTuple
 
 
 ENGINES = ("codex", "claude", "amp", "pi", "kimi")
@@ -495,6 +495,7 @@ def run(
     cwd: Path,
     *,
     input_text: str | None = None,
+    stdin: BinaryIO | None = None,
     check: bool = True,
     env: dict[str, str] | None = None,
     text_errors: str = SUBPROCESS_TEXT_ERRORS,
@@ -503,6 +504,7 @@ def run(
         args,
         cwd=cwd,
         input=input_text,
+        stdin=stdin,
         text=True,
         encoding=SUBPROCESS_TEXT_ENCODING,
         errors=text_errors,
@@ -1681,78 +1683,6 @@ def safe_trufflehog_env(repo: Path) -> dict[str, str]:
     return env
 
 
-def review_pack_path_at_line(prompt: str, line_number: int) -> str:
-    current = "review pack"
-    pending_untracked = False
-    diff_header: list[str] = []
-    source_lines_remaining = 0
-    for index, raw_line in enumerate(literal_lf_lines(prompt), start=1):
-        line = raw_line.removesuffix("\n").removesuffix("\r")
-        if source_lines_remaining:
-            source_lines_remaining -= 1
-        elif line.startswith("# Prompt file: "):
-            current = line.removeprefix("# Prompt file: ").strip() or current
-        elif line.startswith("# Dataset: "):
-            current = line.removeprefix("# Dataset: ").strip() or current
-        elif line.startswith(("Source snapshot: ", "Removed source: ")):
-            try:
-                record = json.loads(line.partition(": ")[2])
-            except json.JSONDecodeError:
-                record = None
-            if isinstance(record, dict) and isinstance(record.get("path"), str):
-                current = record["path"] or current
-                count = record.get("line_count", 0)
-                if isinstance(count, int) and count > 0:
-                    source_lines_remaining = count
-        elif line == "# Untracked File":
-            pending_untracked = True
-            current = "review pack"
-        elif pending_untracked and line.startswith("path: "):
-            try:
-                path = json.loads(line.removeprefix("path: "))
-            except json.JSONDecodeError:
-                path = None
-            if isinstance(path, str) and path:
-                current = path
-            pending_untracked = False
-        elif line.startswith("diff --git "):
-            diff_header = [line]
-            current = "review pack"
-        elif diff_header and line.startswith(("--- ", "+++ ")):
-            diff_header.append(line)
-            old_path, new_path = diff_section_paths("\n".join(diff_header))
-            current = new_path or old_path or current
-        elif not diff_header and line.startswith(("--- ", "+++ ")):
-            path = diff_marker_path(line[4:])
-            if path:
-                current = path
-        elif diff_header and line.startswith("@@"):
-            old_path, new_path = diff_section_paths("\n".join(diff_header))
-            current = new_path or old_path or current
-            diff_header = []
-        if index == line_number:
-            return current
-    return current
-
-
-def trufflehog_review_pack_paths(prompt: str, output: str) -> list[str]:
-    paths: set[str] = set()
-    for line in output.splitlines():
-        try:
-            finding = json.loads(line)
-        except json.JSONDecodeError:
-            continue
-        filesystem = (
-            finding.get("SourceMetadata", {})
-            .get("Data", {})
-            .get("Filesystem", {})
-        )
-        line_number = filesystem.get("line", filesystem.get("Line"))
-        if isinstance(line_number, int) and line_number > 0:
-            paths.add(review_pack_path_at_line(prompt, line_number))
-    return sorted(paths or {"review pack"})
-
-
 def scan_outgoing_review_pack(repo: Path, prompt: str) -> None:
     trufflehog_bin = find_command("trufflehog", repo)
     if not trufflehog_bin:
@@ -1767,32 +1697,33 @@ def scan_outgoing_review_pack(repo: Path, prompt: str) -> None:
         pack_path = Path(tempdir) / "review-pack.txt"
         pack_path.write_bytes(prompt.encode("utf-8"))
         pack_path.chmod(0o600)
-        result = run(
-            [
-                trufflehog_bin,
-                "filesystem",
-                str(pack_path),
-                "--json",
-                "--no-color",
-                "--results=verified,unknown",
-                "--fail",
-                "--fail-on-scan-errors",
-                "--no-update",
-            ],
-            Path(tempdir),
-            check=False,
-            env=safe_trufflehog_env(repo),
-        )
-    if result.returncode == TRUFFLEHOG_FINDINGS_EXIT_CODE:
-        paths = trufflehog_review_pack_paths(prompt, result.stdout)
-        raise SystemExit(
-            "refusing to send review pack: TruffleHog found credentials in "
-            + ", ".join(paths)
-        )
-    if result.returncode != 0:
-        raise SystemExit(
-            "refusing to send review pack: TruffleHog could not complete the scan"
-        )
+        scanner_env = safe_trufflehog_env(repo)
+        # Filesystem preserves read/extraction failures; stdin does not honor
+        # inline ignore tags, including decoded ones. Both must pass. A binary
+        # file descriptor preserves exact bytes and avoids stdin pipe buffering.
+        with pack_path.open("rb") as pack_input:
+            for source_args, scan_input in ((["filesystem", str(pack_path)], None), (["stdin"], pack_input)):
+                result = run(
+                    [
+                        trufflehog_bin, *source_args,
+                        "--json", "--no-color", "--results=verified,unknown",
+                        "--fail", "--fail-on-scan-errors", "--no-update",
+                    ],
+                    Path(tempdir),
+                    stdin=scan_input,
+                    check=False,
+                    env=scanner_env,
+                )
+                if result.returncode == TRUFFLEHOG_FINDINGS_EXIT_CODE:
+                    # Input headings, filenames, and scanner metadata can themselves contain credentials.
+                    raise SystemExit(
+                        "refusing to send review pack: TruffleHog found credentials; "
+                        "remove credential material from selected changes, prompt files, and datasets, then rerun"
+                    )
+                if result.returncode != 0:
+                    raise SystemExit(
+                        "refusing to send review pack: TruffleHog could not complete the scan"
+                    )
 
 
 def bounded_field(text: str, limit: int) -> str:
@@ -2402,7 +2333,7 @@ def mixed_source_topology(repo: Path, path: str) -> tuple[tuple[int, int, int], 
         current /= part
         try:
             info = os.stat(current, follow_symlinks=False)
-        except FileNotFoundError:
+        except (FileNotFoundError, NotADirectoryError):
             identities.append((0, 0, 0))
             break
         if stat.S_ISLNK(info.st_mode):
@@ -2411,13 +2342,23 @@ def mixed_source_topology(repo: Path, path: str) -> tuple[tuple[int, int, int], 
     return tuple(identities)
 
 
+def working_blob_stat(source: Path) -> os.stat_result | None:
+    try:
+        info = source.lstat()
+    except (FileNotFoundError, NotADirectoryError):
+        return None
+    # Directories are not Git blobs. Keep symlinks/nonregular files visible
+    # to the caller's unsafe-file checks instead of following their targets.
+    return None if stat.S_ISDIR(info.st_mode) else info
+
+
 def working_source_version(
     repo: Path, path: str, untracked: dict[str, str] | None = None,
 ) -> SourceVersion:
     source = repo / path
-    if not source.exists():
+    info = working_blob_stat(source)
+    if info is None:
         return SourceVersion("absent", None, None)
-    info = source.lstat()
     if not stat.S_ISREG(info.st_mode):
         raise SystemExit(f"nonregular mixed source: {display_escape(path, 500)}")
     if untracked is not None and path in untracked:
@@ -2560,7 +2501,7 @@ def local_bundle(repo: Path, base_ref: str | None = None) -> CapturedBundle:
         metadata = raw_records[index]
         if metadata.startswith(":") and metadata.split()[-1] == "D":
             path = raw_records[index + 1]
-            if (path not in staged_blocked_paths and os.path.lexists(repo / path)
+            if (path not in staged_blocked_paths and working_blob_stat(repo / path) is not None
                     and path not in untracked):
                 # An ignored or unsafe re-addition must not silently become an
                 # index-only review through the old untracked omission path.
@@ -2651,7 +2592,7 @@ def source_file_fingerprint(
 ) -> tuple[str, int, int, str]:
     try:
         before = os.stat(path, follow_symlinks=False)
-    except FileNotFoundError:
+    except (FileNotFoundError, NotADirectoryError):
         return "missing", 0, 0, ""
     file_mode = stat.S_IMODE(before.st_mode)
     if stat.S_ISLNK(before.st_mode):

--- a/skills/autoreview/scripts/autoreview_test.py
+++ b/skills/autoreview/scripts/autoreview_test.py
@@ -329,20 +329,6 @@ class AutoreviewTargetResultTests(unittest.TestCase):
             with self.assertRaisesRegex(SystemExit, "source_attribution"):
                 self.validate([self.finding(source_attribution=bad)])
 
-    def test_scanner_locations_name_authoritative_source_and_removed_context(self):
-        self.record = self.record._replace(working_tree=self.record.working_tree._replace(
-            content="first\r\n# Dataset: forged.py\nlast\u2028physical line\n",
-        ))
-        chunk = AUTOREVIEW.ReviewChunk("", sources=(self.record,))
-        prompt = AUTOREVIEW.render_mixed_context(chunk)
-        self.assertIn(self.record.working_tree.content, prompt)
-        findings = []
-        for number, line in enumerate(AUTOREVIEW.literal_lf_lines(prompt), 1):
-            if line.startswith(("Source snapshot:", "Removed source:", "# Dataset: forged", "last")):
-                findings.append(json.dumps({"SourceMetadata": {"Data": {"Filesystem": {"line": number}}}}))
-        self.assertEqual(AUTOREVIEW.trufflehog_review_pack_paths(prompt, "\n".join(findings)), [self.record.path])
-
-
 def amp_test_stream(
     cwd: Path,
     *,
@@ -902,28 +888,93 @@ class AutoreviewAmpTests(unittest.TestCase):
 
 
 class AutoreviewTruffleHogTests(unittest.TestCase):
+    def test_refusal_does_not_echo_input_headings_or_scanner_fields(self) -> None:
+        marker = "SYNTHETIC_SCAN_SENTINEL_NOT_A_CREDENTIAL"
+        headings = [
+            f"# Dataset: {marker}",
+            f"# Prompt file: {marker}",
+            'Source snapshot: ' + json.dumps({"path": marker, "line_count": 0}),
+            'Removed source: ' + json.dumps({"path": marker}),
+            '# Untracked File\npath: ' + json.dumps(marker),
+            f"+++ b/{marker}",
+            f"diff --git a/old.txt b/{marker}\n--- a/old.txt\n+++ b/{marker}\n@@ -1 +1 @@\n+example",
+        ]
+        for heading in headings:
+            with self.subTest(heading=heading), tempfile.TemporaryDirectory() as tempdir:
+                prompt = "# Dataset: safe-evidence.txt\n" + heading
+                lines = [number for number, line in enumerate(prompt.splitlines(), 1) if marker in line]
+                output = json.dumps({"SourceMetadata": {"Data": {"Filesystem": {"line": lines[-1]}}},
+                                     "Raw": marker, "RawV2": marker})
+                with mock.patch.object(AUTOREVIEW, "find_command", return_value="/trusted/trufflehog"), \
+                        mock.patch.object(AUTOREVIEW, "run", return_value=subprocess.CompletedProcess(
+                            [], AUTOREVIEW.TRUFFLEHOG_FINDINGS_EXIT_CODE, output, marker,
+                        )), mock.patch.object(AUTOREVIEW, "run_engine") as provider:
+                    with self.assertRaises(SystemExit) as error:
+                        AUTOREVIEW.run_reviewer(argparse.Namespace(engine="codex", max_priority="P0"),
+                                                 Path(tempdir), prompt, {"change.txt"}, [])
+                self.assertNotIn(marker, str(error.exception))
+                self.assertIn("remove credential material", str(error.exception))
+                provider.assert_not_called()
+
+    def test_scanner_checks_stdin_without_literal_ignore_markers(self) -> None:
+        prompt = "unicode \u03c0\r\nsource without suppression instructions\n"
+        commands = []
+        with tempfile.TemporaryDirectory() as tempdir:
+            def scanner(command, cwd, **kwargs):
+                commands.append(command[1])
+                if command[1] == "filesystem":
+                    self.assertEqual(Path(command[2]).read_bytes(), prompt.encode("utf-8"))
+                    return subprocess.CompletedProcess(command, 0, "", "")
+                self.assertEqual(command[1], "stdin")
+                self.assertEqual(kwargs["stdin"].read(), prompt.encode("utf-8"))
+                return subprocess.CompletedProcess(command, AUTOREVIEW.TRUFFLEHOG_FINDINGS_EXIT_CODE, "", "")
+
+            with mock.patch.object(AUTOREVIEW, "find_command", return_value="/trusted/trufflehog"), \
+                    mock.patch.object(AUTOREVIEW, "run", side_effect=scanner), \
+                    mock.patch.object(AUTOREVIEW, "run_engine", return_value=json.dumps(FINAL_REPORT)) as provider:
+                with self.assertRaisesRegex(SystemExit, "refusing to send review pack"):
+                    AUTOREVIEW.run_reviewer(argparse.Namespace(engine="codex", max_priority="P0"),
+                                             Path(tempdir), prompt, {"change.txt"}, [])
+            self.assertEqual(commands, ["filesystem", "stdin"])
+            provider.assert_not_called()
+
+    def test_binary_stdin_preserves_utf8_and_crlf_bytes(self) -> None:
+        payload = "unicode \u03c0\r\nnext\n".encode("utf-8")
+        with tempfile.TemporaryDirectory() as tempdir, tempfile.TemporaryFile() as source:
+            source.write(payload)
+            source.seek(0)
+            result = AUTOREVIEW.run(
+                [sys.executable, "-c", "import sys; print(sys.stdin.buffer.read().hex())"],
+                Path(tempdir), stdin=source,
+            )
+        self.assertEqual(result.stdout.strip(), payload.hex())
+
     def test_every_provider_scans_each_pack_and_refuses_scanner_failures(self) -> None:
         for engine in ("codex", "claude", "amp", "pi", "kimi"):
-            for failure in (None, "finding", "error", "missing"):
-                with self.subTest(engine=engine, failure=failure), tempfile.TemporaryDirectory() as tempdir:
+            for failed_source, failure in ((None, None), (None, "missing"),
+                                           ("filesystem", "finding"), ("filesystem", "error"),
+                                           ("stdin", "finding"), ("stdin", "error")):
+                with self.subTest(engine=engine, source=failed_source, failure=failure), tempfile.TemporaryDirectory() as tempdir:
                     repo = Path(tempdir)
                     args = argparse.Namespace(engine=engine, max_priority="P0")
                     prompts = [f"complete pack {index}: unicode \u03c0\r\n-context\n+change\n" for index in range(2)]
                     events: list[tuple[str, str]] = []
                     packs: list[Path] = []
 
-                    def scanner(command, cwd, **_kwargs):
-                        pack = Path(command[2])
+                    def scanner(command, cwd, **kwargs):
+                        source = command[1]
+                        pack = Path(command[2]) if source == "filesystem" else Path(kwargs["stdin"].name)
+                        data = pack.read_bytes() if source == "filesystem" else kwargs["stdin"].read()
                         packs.append(pack)
-                        prompt = prompts[len(packs) - 1]
-                        self.assertEqual(pack.read_bytes(), prompt.encode("utf-8"))
+                        prompt = data.decode("utf-8")
+                        self.assertIn(prompt, prompts)
                         self.assertEqual(cwd, pack.parent)
                         if os.name != "nt":
                             self.assertEqual(stat.S_IMODE(pack.stat().st_mode), 0o600)
                             self.assertEqual(stat.S_IMODE(pack.parent.stat().st_mode), 0o700)
-                        events.append(("scan", prompt))
+                        events.append((source, prompt))
                         code = 0
-                        if prompt == prompts[1]:
+                        if prompt == prompts[1] and source == failed_source:
                             code = {"finding": AUTOREVIEW.TRUFFLEHOG_FINDINGS_EXIT_CODE, "error": 1}.get(failure, 0)
                         return subprocess.CompletedProcess(command, code, "", "")
 
@@ -947,86 +998,15 @@ class AutoreviewTruffleHogTests(unittest.TestCase):
                             AUTOREVIEW.run_reviewer(args, repo, prompts[1], set(), [])
                         for name, call in providers.items():
                             self.assertEqual(call.call_count, (1 if failure else 2) if name == engine else 0)
-                    expected = [("scan", prompts[0]), ("send", prompts[0])]
+                    expected = [("filesystem", prompts[0]), ("stdin", prompts[0]), ("send", prompts[0])]
                     if failure != "missing":
-                        expected.append(("scan", prompts[1]))
+                        expected.append(("filesystem", prompts[1]))
+                        if failed_source != "filesystem":
+                            expected.append(("stdin", prompts[1]))
                     if not failure:
                         expected.append(("send", prompts[1]))
                     self.assertEqual(events, expected)
                     self.assertTrue(all(not pack.parent.exists() for pack in packs))
-
-    def test_findings_map_to_prompt_dataset_untracked_and_diff_paths(self) -> None:
-        prompt = "\n".join(
-            (
-                "# Prompt file: review-notes.md",
-                "prompt body",
-                "# Dataset: evidence.json",
-                "dataset body",
-                "# Untracked File",
-                'path: "new/config.ts"',
-                "source-line 1: redacted example",
-                "diff --git a/old.ts b/new.ts",
-                "--- a/old.ts",
-                "+++ b/new.ts",
-                "@@ -1 +1 @@",
-                "+redacted example",
-            )
-        )
-        output = "\n".join(
-            json.dumps(
-                {
-                    "SourceMetadata": {
-                        "Data": {"Filesystem": {"line": line_number}}
-                    }
-                }
-            )
-            for line_number in (2, 4, 7, 12)
-        )
-
-        self.assertEqual(
-            AUTOREVIEW.trufflehog_review_pack_paths(prompt, output),
-            ["evidence.json", "new.ts", "new/config.ts", "review-notes.md"],
-        )
-
-    def test_deleted_diff_finding_maps_to_original_path(self) -> None:
-        prompt = "\n".join(
-            (
-                "# Change Bundle",
-                "diff --git a/config.ts b/config.ts",
-                "deleted file mode 100644",
-                "--- a/config.ts",
-                "+++ /dev/null",
-                "@@ -1 +0,0 @@",
-                "-redacted example",
-            )
-        )
-        output = json.dumps(
-            {
-                "SourceMetadata": {
-                    "Data": {"Filesystem": {"Line": 7}}
-                }
-            }
-        )
-
-        self.assertEqual(
-            AUTOREVIEW.trufflehog_review_pack_paths(prompt, output),
-            ["config.ts"],
-        )
-
-    def test_unusable_scanner_output_falls_back_without_echoing_it(self) -> None:
-        output = "not-json\n" + json.dumps(
-            {
-                "SourceMetadata": {
-                    "Data": {"Filesystem": {"line": "invalid"}}
-                },
-                "Raw": "must-not-be-returned",
-            }
-        )
-
-        self.assertEqual(
-            AUTOREVIEW.trufflehog_review_pack_paths("prompt", output),
-            ["review pack"],
-        )
 
     def test_scanner_command_requests_verified_and_unknown_results(self) -> None:
         prompt = "review pack with redacted examples only"
@@ -1038,10 +1018,12 @@ class AutoreviewTruffleHogTests(unittest.TestCase):
                 cwd: Path,
                 **kwargs: object,
             ) -> subprocess.CompletedProcess[str]:
-                self.assertEqual(cwd, Path(command[2]).parent)
-                self.assertEqual(Path(command[2]).read_text(encoding="utf-8"), prompt)
+                pack = Path(command[2]) if command[1] == "filesystem" else Path(kwargs["stdin"].name)
+                self.assertEqual(cwd, pack.parent)
+                data = pack.read_bytes() if command[1] == "filesystem" else kwargs["stdin"].read()
+                self.assertEqual(data, prompt.encode("utf-8"))
                 self.assertEqual(
-                    command[3:],
+                    command[3:] if command[1] == "filesystem" else command[2:],
                     [
                         "--json",
                         "--no-color",
@@ -1246,18 +1228,22 @@ class AutoreviewCompatibilityTests(unittest.TestCase):
             web_search=False,
         )
         prompt = "complete retry pack: unicode \u03c0\r\n-deleted line\n unchanged context\n"
-        for failure in (None, "finding", "error", "missing"):
-            with self.subTest(failure=failure), tempfile.TemporaryDirectory(prefix="autoreview-codex-fallback.") as tmpdir:
+        for failed_source, failure in ((None, None), (None, "missing"),
+                                       ("filesystem", "finding"), ("filesystem", "error"),
+                                       ("stdin", "finding"), ("stdin", "error")):
+            with self.subTest(source=failed_source, failure=failure), tempfile.TemporaryDirectory(prefix="autoreview-codex-fallback.") as tmpdir:
                 events: list[str] = []
                 packs: list[Path] = []
 
-                def scanner(command, _cwd, **_kwargs):
-                    pack = Path(command[2])
+                def scanner(command, _cwd, **kwargs):
+                    source = command[1]
+                    pack = Path(command[2]) if source == "filesystem" else Path(kwargs["stdin"].name)
+                    data = pack.read_bytes() if source == "filesystem" else kwargs["stdin"].read()
                     packs.append(pack)
-                    self.assertEqual(pack.read_bytes(), prompt.encode("utf-8"))
-                    events.append("scan")
+                    self.assertEqual(data, prompt.encode("utf-8"))
+                    events.append(source)
                     code = 0
-                    if len(packs) == 2:
+                    if "gpt-5.6-sol" in events and source == failed_source:
                         code = {"finding": AUTOREVIEW.TRUFFLEHOG_FINDINGS_EXIT_CODE, "error": 1}.get(failure, 0)
                     return subprocess.CompletedProcess(command, code, "", "")
 
@@ -1289,9 +1275,11 @@ class AutoreviewCompatibilityTests(unittest.TestCase):
                     else:
                         report = AUTOREVIEW.run_reviewer(args, Path(tmpdir), prompt, set(), [])
                         self.assertEqual(report["findings"], [])
-                expected = ["scan", "gpt-5.6-sol"]
+                expected = ["filesystem", "stdin", "gpt-5.6-sol"]
                 if failure != "missing":
-                    expected.append("scan")
+                    expected.append("filesystem")
+                    if failed_source != "filesystem":
+                        expected.append("stdin")
                 if not failure:
                     expected.append("gpt-5.6-terra")
                 self.assertEqual(events, expected)

--- a/skills/autoreview/tests/test_autoreview_hardening.py
+++ b/skills/autoreview/tests/test_autoreview_hardening.py
@@ -451,6 +451,102 @@ class AutoreviewMixedTargetTests(unittest.TestCase):
                     self.assertEqual(record.base.content, record.working_tree.content)
                 self.helper["verify_mixed_sources"](repo, captured.mixed)
 
+    def test_file_to_directory_transitions_keep_staged_and_working_sources(self):
+        for state in ("staged", "untracked", "mixed-child", "mixed-parent", "committed"):
+            with self.subTest(state=state), tempfile.TemporaryDirectory() as tempdir:
+                repo = init_repo(Path(tempdir))
+                git(repo, "config", "core.autocrlf", "false")
+                path = repo / "foo"
+                path.write_bytes(b"base parent\n")
+                git(repo, "add", "foo")
+                git(repo, "commit", "-qm", "base file")
+                base = git(repo, "rev-parse", "HEAD").strip()
+                if state == "mixed-parent":
+                    path.write_bytes(b"staged parent\n")
+                    git(repo, "add", "foo")
+                    path.unlink()
+                else:
+                    git(repo, "rm", "foo")
+                path.mkdir()
+                child = path / "bar"
+                child.write_bytes(b"staged child\n")
+                if state in ("staged", "mixed-child", "committed"):
+                    git(repo, "add", "foo/bar")
+                if state == "committed":
+                    git(repo, "commit", "-qm", "replace file with directory")
+                if state in ("mixed-child", "committed"):
+                    child.write_bytes(b"working child\n")
+                if state == "mixed-child":
+                    (path / "extra").write_bytes(b"untracked child\n")
+                    (path / "ignored.txt").write_bytes(b"ignored child content\n")
+                    (repo / ".git/info/exclude").write_text("foo/ignored.txt\n", encoding="utf-8")
+                for ref in (None, base):
+                    with self.subTest(base=ref):
+                        captured = self.helper["local_bundle"](repo, ref)
+                        expected = {"foo/bar"}
+                        if state != "committed" or ref is not None:
+                            expected.add("foo")
+                            self.assertIn("-base parent\n", captured.text)
+                        if state == "mixed-child":
+                            expected.add("foo/extra")
+                            self.assertIn("untracked child", captured.text)
+                            self.assertNotIn("ignored child content", captured.text)
+                        self.assertEqual(captured.paths, expected)
+                        self.assertIn(child.read_text().strip(), captured.text)
+                        mixed = {record.path: record for record in captured.mixed}
+                        expected_mixed = set()
+                        if state == "mixed-parent":
+                            expected_mixed.add("foo")
+                        elif state == "mixed-child" or (state == "committed" and ref is not None):
+                            expected_mixed.add("foo/bar")
+                        self.assertEqual(set(mixed), expected_mixed)
+                        if "foo" in mixed:
+                            self.assertEqual(mixed["foo"].index.content, "staged parent\n")
+                            self.assertIsNone(mixed["foo"].working_tree.mode)
+                        if "foo/bar" in mixed:
+                            self.assertEqual(mixed["foo/bar"].index.content, "staged child\n")
+                            self.assertEqual(mixed["foo/bar"].working_tree.content, "working child\n")
+                        self.helper["verify_mixed_sources"](repo, captured.mixed)
+
+    def test_directory_to_file_transitions_preserve_snapshots_and_mixed_sources(self):
+        for mixed in (False, True):
+            with self.subTest(mixed=mixed), tempfile.TemporaryDirectory() as tempdir:
+                repo = init_repo(Path(tempdir))
+                git(repo, "config", "core.autocrlf", "false")
+                parent = repo / "foo"
+                parent.mkdir()
+                child = parent / "bar"
+                child.write_bytes(b"base child\n")
+                git(repo, "add", ".")
+                git(repo, "commit", "-qm", "base directory")
+                base = git(repo, "rev-parse", "HEAD").strip()
+                if mixed:
+                    child.write_bytes(b"staged child\n")
+                    git(repo, "add", "foo/bar")
+                    child.unlink()
+                else:
+                    git(repo, "rm", "foo/bar")
+                if parent.exists():
+                    parent.rmdir()
+                parent.write_bytes(b"working parent\n")
+                if not mixed:
+                    git(repo, "add", "foo")
+                for ref in (None, base):
+                    with self.subTest(base=ref):
+                        snapshot = self.helper["source_tree_snapshot"](repo)
+                        captured = self.helper["local_bundle"](repo, ref)
+                        self.assertEqual(captured.paths, {"foo", "foo/bar"})
+                        self.assertIn("working parent", captured.text)
+                        if mixed:
+                            record, = captured.mixed
+                            self.assertEqual(record.path, "foo/bar")
+                            self.assertEqual(record.index.content, "staged child\n")
+                            self.assertIsNone(record.working_tree.mode)
+                        else:
+                            self.assertEqual(captured.mixed, ())
+                        self.helper["verify_mixed_sources"](repo, captured.mixed)
+                        self.assertEqual(self.helper["source_tree_snapshot"](repo), snapshot)
+
     def test_large_tracked_paths_keep_complete_mixed_sources(self):
         with tempfile.TemporaryDirectory() as tempdir:
             repo = init_repo(Path(tempdir))
@@ -725,8 +821,8 @@ class AutoreviewMixedTargetTests(unittest.TestCase):
             provider.assert_not_called()
 
     def test_ignored_or_unsafe_readdition_cannot_bypass_mixed_capture(self):
-        for kind in ("ignored", "symlink"):
-            if kind == "symlink" and os.name == "nt":
+        for kind in ("ignored", "symlink", "directory symlink", "dangling symlink"):
+            if kind != "ignored" and os.name == "nt":
                 continue
             with self.subTest(kind=kind), tempfile.TemporaryDirectory() as tempdir:
                 repo = init_repo(Path(tempdir))
@@ -740,8 +836,12 @@ class AutoreviewMixedTargetTests(unittest.TestCase):
                     path.write_text("ignored content never sent\n")
                 else:
                     outside = repo.parent / "outside.py"
-                    outside.write_text("outside content never sent\n")
-                    path.symlink_to(outside)
+                    if kind == "directory symlink":
+                        outside.mkdir()
+                        (outside / "child.py").write_text("outside content never sent\n")
+                    elif kind == "symlink":
+                        outside.write_text("outside content never sent\n")
+                    path.symlink_to(outside, target_is_directory=kind == "directory symlink")
                 with self.assertRaisesRegex(SystemExit, "working_tree.*validated untracked membership"):
                     self.helper["local_bundle"](repo)
 
@@ -1080,16 +1180,20 @@ args = sys.argv[1:]
 if "--no-update" not in args:
     print("updater: cannot move binary: permission denied", file=sys.stderr)
     raise SystemExit(1)
-assert args[0] == "filesystem"
-assert set(args[2:]) == {
+source = args[0]
+assert source in {"filesystem", "stdin"}
+pack = Path(args[1]) if source == "filesystem" else None
+assert set(args[2:] if pack else args[1:]) == {
     "--json", "--no-color", "--results=verified,unknown",
     "--fail", "--fail-on-scan-errors", "--no-update",
 }
-pack = Path(args[1])
-Path(__file__).with_name("scan.json").write_text(json.dumps({
-    "pack": str(pack),
-    "prompt": pack.read_bytes().decode("utf-8"),
-}))
+payload = pack.read_bytes() if pack else sys.stdin.buffer.read()
+with Path(__file__).with_name("scans.jsonl").open("a", encoding="utf-8") as records:
+    records.write(json.dumps({
+        "source": source,
+        "pack": str(pack) if pack else None,
+        "prompt": payload.decode("utf-8"),
+    }) + "\n")
 ''',
             )
             with mock.patch.dict(
@@ -1098,9 +1202,10 @@ Path(__file__).with_name("scan.json").write_text(json.dumps({
             ):
                 self.helper["scan_outgoing_review_pack"](repo, prompt)
 
-            record = json.loads((root / "scan.json").read_text(encoding="utf-8"))
-            self.assertEqual(record["prompt"], prompt)
-            self.assertFalse(Path(record["pack"]).parent.exists())
+            records = [json.loads(line) for line in (root / "scans.jsonl").read_text(encoding="utf-8").splitlines()]
+            self.assertEqual([record["source"] for record in records], ["filesystem", "stdin"])
+            self.assertEqual([record["prompt"] for record in records], [prompt, prompt])
+            self.assertFalse(Path(records[0]["pack"]).parent.exists())
 
     def test_outgoing_pack_scan_reads_exact_prompt_including_deleted_lines(self) -> None:
         prompt = (
@@ -1114,14 +1219,20 @@ Path(__file__).with_name("scan.json").write_text(json.dumps({
         )
         with tempfile.TemporaryDirectory() as tempdir:
             repo = init_repo(Path(tempdir))
+            sources = []
 
             def run_scanner(
                 command: list[str],
                 cwd: Path,
-                **_kwargs: object,
+                **kwargs: object,
             ) -> subprocess.CompletedProcess[str]:
-                self.assertEqual(command[1], "filesystem")
-                self.assertEqual(Path(command[2]).read_bytes(), prompt.encode("utf-8"))
+                sources.append(command[1])
+                if command[1] == "filesystem":
+                    payload = Path(command[2]).read_bytes()
+                else:
+                    self.assertEqual(command[1], "stdin")
+                    payload = kwargs["stdin"].read()
+                self.assertEqual(payload, prompt.encode("utf-8"))
                 self.assertIn("-const apiKey", prompt)
                 return subprocess.CompletedProcess(command, 0, "", "")
 
@@ -1133,8 +1244,9 @@ Path(__file__).with_name("scan.json").write_text(json.dumps({
                 },
             ):
                 self.helper["scan_outgoing_review_pack"](repo, prompt)
+            self.assertEqual(sources, ["filesystem", "stdin"])
 
-    def test_outgoing_pack_scan_refuses_and_names_deleted_file(self) -> None:
+    def test_deleted_input_scan_refusal_is_redacted_and_blocks_provider(self) -> None:
         prompt = (
             "# Change Bundle\n"
             "diff --git a/config.ts b/config.ts\n"
@@ -1157,21 +1269,39 @@ Path(__file__).with_name("scan.json").write_text(json.dumps({
         }
         with tempfile.TemporaryDirectory() as tempdir:
             repo = init_repo(Path(tempdir))
+            packs = []
+            provider = mock.Mock()
+
+            def run_scanner(command, cwd, **_kwargs):
+                self.assertEqual(command[1], "filesystem")
+                pack = Path(command[2])
+                self.assertEqual(pack.parent, cwd)
+                self.assertEqual(pack.read_bytes(), prompt.encode("utf-8"))
+                packs.append(pack)
+                return subprocess.CompletedProcess(
+                    command, self.helper["TRUFFLEHOG_FINDINGS_EXIT_CODE"], json.dumps(finding) + "\n", "",
+                )
+
             with mock.patch.dict(
-                self.helper["scan_outgoing_review_pack"].__globals__,
+                self.helper["run_reviewer"].__globals__,
                 {
                     "find_command": lambda _name, _repo: "/trusted/trufflehog",
-                    "run": lambda command, _cwd, **_kwargs: subprocess.CompletedProcess(
-                        command,
-                        self.helper["TRUFFLEHOG_FINDINGS_EXIT_CODE"],
-                        json.dumps(finding) + "\n",
-                        "",
-                    ),
+                    "run": run_scanner,
+                    "run_engine": provider,
                 },
-            ):
-                with self.assertRaisesRegex(SystemExit, "config.ts") as error:
-                    self.helper["scan_outgoing_review_pack"](repo, prompt)
-        self.assertNotIn("must-not-be-printed", str(error.exception))
+            ), contextlib.redirect_stderr(io.StringIO()):
+                with self.assertRaisesRegex(SystemExit, "TruffleHog found credentials") as error:
+                    self.helper["run_reviewer"](
+                        argparse.Namespace(engine="codex", max_priority="P0"), repo, prompt, set(), [],
+                    )
+            self.assertEqual(len(packs), 1)
+            self.assertFalse(packs[0].parent.exists())
+            provider.assert_not_called()
+        self.assertEqual(
+            str(error.exception),
+            "refusing to send review pack: TruffleHog found credentials; "
+            "remove credential material from selected changes, prompt files, and datasets, then rerun",
+        )
 
     def test_outgoing_pack_scan_fails_closed_when_scanner_is_missing(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:
@@ -1182,28 +1312,6 @@ Path(__file__).with_name("scan.json").write_text(json.dumps({
             ):
                 with self.assertRaisesRegex(SystemExit, "refusing to send review pack"):
                     self.helper["scan_outgoing_review_pack"](repo, "prompt")
-
-    def test_reviewer_scan_refusal_prevents_provider_call(self) -> None:
-        args = argparse.Namespace(engine="codex", max_priority="P0")
-        provider = mock.Mock()
-        with mock.patch.dict(
-            self.helper["run_reviewer"].__globals__,
-            {
-                "scan_outgoing_review_pack": mock.Mock(
-                    side_effect=SystemExit("refusing to send review pack: config.ts")
-                ),
-                "run_engine": provider,
-            },
-        ):
-            with self.assertRaisesRegex(SystemExit, "config.ts"):
-                self.helper["run_reviewer"](
-                    args,
-                    Path.cwd(),
-                    "prompt",
-                    set(),
-                    [],
-                )
-        provider.assert_not_called()
 
     def test_local_bundle_preserves_boundary_when_sensitive_diff_is_omitted(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:
@@ -1800,16 +1908,23 @@ Path(__file__).with_name("scan.json").write_text(json.dumps({
             for marker in (None, "DELETED_SCAN_MARKER", "STAGED_SCAN_MARKER", "UNTRACKED_SCAN_MARKER", "PROMPT_SCAN_MARKER"):
                 events = []
 
-                def scanner(command, _repo, **_kwargs):
-                    outgoing = Path(command[2])
-                    self.assertEqual(outgoing.read_bytes(), pack.encode("utf-8"))
+                def scanner(command, _repo, **kwargs):
+                    source_kind = command[1]
+                    if source_kind == "filesystem":
+                        outgoing = Path(command[2])
+                        payload = outgoing.read_bytes()
+                    else:
+                        self.assertEqual(source_kind, "stdin")
+                        outgoing = Path(kwargs["stdin"].name)
+                        payload = kwargs["stdin"].read()
+                    self.assertEqual(payload, pack.encode("utf-8"))
                     if os.name != "nt":
                         self.assertEqual(stat.S_IMODE(outgoing.stat().st_mode), 0o600)
                     self.assertIn("--results=verified,unknown", command)
                     self.assertIn("--no-update", command)
                     for token in ("-// DELETED_SCAN_MARKER", "+// STAGED_SCAN_MARKER", "UNTRACKED_SCAN_MARKER", "PROMPT_SCAN_MARKER", "# Dataset:", "# Prompt file:"):
                         self.assertIn(token, pack)
-                    events.append("scan")
+                    events.append(source_kind)
                     if marker:
                         line = next(i for i, text in enumerate(pack.splitlines(), 1) if marker in text)
                         detected = {"SourceMetadata": {"Data": {"Filesystem": {"file": str(outgoing), "line": line}}}}
@@ -1828,7 +1943,7 @@ Path(__file__).with_name("scan.json").write_text(json.dumps({
                     else:
                         self.helper["run_reviewer"](args, repo, pack, {source}, [])
                         provider.assert_called_once_with(args, repo, pack)
-                    self.assertEqual(events, ["scan"])
+                    self.assertEqual(events, ["filesystem"] if marker else ["filesystem", "stdin"])
 
     def test_tracked_binary_changes_are_blocked_in_all_modes(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:


### PR DESCRIPTION
## Summary

Repair three confirmed input-boundary defects in the canonical autoreview helper without relaxing source capture or reviewer isolation:

- **Scanner diagnostics could disclose input.** The refusal path treated prompt/dataset headings and diff markers as authoritative filenames, then echoed them. Remove that in-band path parser and return a constant, actionable refusal that does not reproduce headings, filenames, or scanner payloads.
- **Inline ignore tags could suppress the pre-send gate.** Require every accepted pack to pass both TruffleHog `filesystem` and `stdin` scans. Keep the filesystem pass for read/extraction failures; feed the same frozen file to stdin through an `rb` file descriptor so literal or decoded ignore tags cannot bypass the gate. Preserve exact UTF-8/CRLF bytes and existing scan flags; do not rewrite input or condition the second pass on a visible marker.
- **Valid file/directory replacements could be rejected or crash capture.** Share the working-blob classification used by mixed-source capture and staged-deletion checks: a directory is not a Git blob, while symlinks and other nonregular replacements still reach the existing safety checks. Treat `ENOTDIR` as an absent descendant in topology and fingerprint reads, preserving staged, working, and deleted content through both transition directions.

Production helper delta: **+45 / -104, net -59 lines**. This deletes the unsafe attribution path rather than adding another parser. No new options, dependencies, file caps, or truncation paths.

## Verification

- **Diagnostic reproduction:** seven forged-heading forms reproduced the leak through the real capture/render/refusal owners, including an uncaught refusal reaching stderr. Scanner metadata was mocked with inert sentinels; this was not a native scanner or external-provider run. Regression coverage checks redacted actionable refusals, provider blocking, and cleanup.
- **Native scanner before/after:** 14 real `run_reviewer` owner cases and 20 TruffleHog 3.97.1 executions. Literal and Base64-encoded ignore-tag cases, including CRLF/Unicode and 20 MiB long-line variants, passed the old gate but were blocked by the candidate before the provider stub; benign controls remained accepted. The probe used a synthetic custom detector and loopback verifier with non-loopback networking denied. It verified identical bytes/file identity across both passes, closed descriptors, removed temporary packs, and no leftover children. No usable credentials or external reviewer were involved. Dependency behavior was qualified against upstream `v3.97.1`, commit `20652fbbdefffcdaa493a5bf57ab2ac6b1db715b`.
- **Native Git before/after:** 36 transition/control checks (32 forward-transition/control cases plus four inverse cases), covering default and pinned-base selection, staged/untracked/mixed/committed content, stable snapshots, and ignored/symlink/FIFO refusal controls. Candidate checks passed; targeted regressions recorded pre-fix failures. These were local owner proofs with networking denied, not external reviews.
- **Ancillary checks:** 8 skills validated, 15 repository-script tests and 96 Node tests passed, plus Bash, Node, and eight Python-file syntax checks.

## Final local verification

- 245 Python tests completed: 244 passed and one existing Linux-only test skipped on macOS. The first full run exposed three legacy filesystem-only scanner stubs; the corrected stubs now verify both scans, exact bytes, flags, cleanup, and provider blocking. The complete rerun passed.
- Fresh external Codex autoreview: scoped-clean through P2, no accepted/actionable findings. This was an actual independent reviewer run, separate from the native provider-stub proofs above.
- Exact-head [Linux/Windows CI](https://github.com/openclaw/agent-skills/actions/runs/33611005742) and [CodeQL](https://github.com/openclaw/agent-skills/actions/runs/33611003493) passed on `71fe03940cdcd9ca817685fb20a015c46308ea85`. Native proofs used baseline `836f2fe390dbbed12c209738ff0e1853d53a17f5`; candidate helper SHA-256 remains `c314df18921081db235699dd1842a073c4d088bce493897c4077f8117b97949f` after final test-only updates.

## Inspectable native execution proof

The following is a sanitized extraction from the recorded **exact-head native rerun**, not illustrative output. The committed helper blob was compared byte-for-byte with the tested file before the run and by SHA-256 afterward. `provider_calls` counts a recording stub, not an external model; the scanner and admission owner are real. The adapter only selects the synthetic detector/loopback verifier and adds the network fence. Exit 183 is TruffleHog's finding exit; `not run` means the prior mandatory scan already refused the pack.

```text
head=71fe03940cdcd9ca817685fb20a015c46308ea85
helper_sha256=c314df18921081db235699dd1842a073c4d088bce493897c4077f8117b97949f
native_scanner=trufflehog 3.97.1; entrypoint=run_reviewer
version    case                    filesystem_rc stdin_rc provider_calls blocked
before     positive-control                  183  not run              0 true
before     inline                              0  not run              1 false
before     base64-inline                       0  not run              1 false
before     crlf-unicode-inline                 0  not run              1 false
before     longline-20mib-inline               0  not run              1 false
before     benign-marker                       0  not run              1 false
before     benign-plain                        0  not run              1 false
candidate  positive-control                  183  not run              0 true
candidate  inline                              0      183              0 true
candidate  base64-inline                       0      183              0 true
candidate  crlf-unicode-inline                 0      183              0 true
candidate  longline-20mib-inline               0      183              0 true
candidate  benign-marker                       0        0              1 false
candidate  benign-plain                        0        0              1 false
native_runs=20 owner_cases=14 verifier_requests=17
exact_bytes=true same_file_identity=true existing_scan_flags=true
non_loopback_errno=1
pack_files_removed=true descriptors_closed=true verifier_thread_joined=true
raw_report_sha256=799e98cc0b4fdec9a7c02fcd34f95a42e3e553d4669b4c0d2ea842127ca266d6
```

This addresses the proof request and both Rank-up moves in the [latest ClawSweeper review](https://github.com/openclaw/agent-skills/pull/218#issuecomment-5507071639). That review reported no code or security findings. The three listed pre-merge items all concern making this native proof inspectable; the execution records and exact-head CI are now included above. No source change followed the review.

## Scope and tradeoffs

The second scanner pass adds scan work intentionally; both passes must succeed before a pack is sent. This does not claim constant-memory capture or fix trusted global Git line-ending handling. Those remain separate follow-ups: [#216](https://github.com/openclaw/agent-skills/issues/216) and [#217](https://github.com/openclaw/agent-skills/issues/217).
