### PR TITLE
fix(autoreview): resolve exact Git source versions

### DIFF
--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -2301,19 +2301,21 @@ def mixed_source_text(path: str, version: str, data: bytes) -> str:
 
 
 def git_source_version(repo: Path, path: str, ref: str | None) -> SourceVersion:
-    pathspec = f":(literal){path}"
-    if ref is None:
-        entries = git_path_list(repo, "ls-files", "--stage", "-z", "--", pathspec)
-    else:
-        entries = git_path_list(repo, "ls-tree", "-z", ref, "--", path)
+    command = ("ls-files", "--stage", "-z") if ref is None else ("ls-tree", "-z", ref)
+    entries = git_path_list(repo, "--literal-pathspecs", *command, "--", path)
+    # Directory queries return a tree or its descendants, not a blob here.
+    # Keep only exact entries, preserving their conflict stages and unsafe modes.
+    entries = [
+        metadata for metadata, actual in (entry.split("\t", 1) for entry in entries)
+        if actual == path and not (ref is not None and metadata.startswith("040000 tree "))
+    ]
     if not entries:
         return SourceVersion("absent", None, None)
     if len(entries) != 1:
         raise SystemExit(f"unmerged mixed source: {display_escape(path, 500)}")
-    metadata, actual = entries[0].split("\t", 1)
-    mode, middle, last = metadata.split()
+    mode, middle, last = entries[0].split()
     oid = middle if ref is None else last
-    if actual != path or (ref is None and last != "0") or mode not in {"100644", "100755"}:
+    if (ref is None and last != "0") or mode not in {"100644", "100755"}:
         raise SystemExit(f"unsafe mixed source mode: {display_escape(path, 500)} ({mode})")
     return SourceVersion(f"git:{oid}:{mode}", mode, None)
 

--- a/skills/autoreview/tests/test_autoreview_hardening.py
+++ b/skills/autoreview/tests/test_autoreview_hardening.py
@@ -666,8 +666,9 @@ class AutoreviewMixedTargetTests(unittest.TestCase):
                     oid = git(repo, "rev-parse", "HEAD" if mutation == "index gitlink" else ":src/migrate-0.py").strip()
                     if mutation == "index conflict":
                         git(repo, "update-index", "--force-remove", "--", "src/migrate-0.py")
+                        # Text-mode stdin on Windows adds a CR to Git's pathname.
                         subprocess.run(["git", "update-index", "--index-info"], cwd=repo, check=True,
-                                       input=f"100644 {oid} 2\tsrc/migrate-0.py\n", text=True, capture_output=True)
+                                       input=f"100644 {oid} 2\tsrc/migrate-0.py\n".encode(), capture_output=True)
                     else:
                         mode = "160000" if mutation == "index gitlink" else "120000"
                         git(repo, "update-index", "--cacheinfo", f"{mode},{oid},src/migrate-0.py")

--- a/skills/autoreview/tests/test_autoreview_hardening.py
+++ b/skills/autoreview/tests/test_autoreview_hardening.py
@@ -418,10 +418,14 @@ class AutoreviewMixedTargetTests(unittest.TestCase):
                     self.assertTrue(any("Continuation" in chunk.context for chunk in splits))
 
     def test_staged_undone_add_remove_readd_and_modes(self):
-        for state in ("undone", "new", "removed", "readd", "unborn"):
+        for state in ("undone", "new", "removed", "readd", "unborn", "literal"):
+            if state == "literal" and os.name == "nt":
+                continue  # Windows filenames cannot contain a colon.
             with self.subTest(state=state), tempfile.TemporaryDirectory() as tempdir:
                 repo = init_repo(Path(tempdir))
-                path = repo / "source.py"
+                path = repo / (":source.py" if state == "literal" else "source.py")
+                if state == "literal":
+                    (repo / "source.py").write_bytes(b"unrelated base\n")
                 # These versions must be byte-identical even with Windows text translation.
                 if state != "unborn":
                     if state != "new":
@@ -431,19 +435,27 @@ class AutoreviewMixedTargetTests(unittest.TestCase):
                 if state == "readd":
                     git(repo, "rm", "source.py")
                 else:
-                    path.write_bytes(b"staged()\n")
+                    path.write_bytes(b"base()\nstaged()\n" if state == "literal" else b"staged()\n")
                     git(repo, "add", ".")
                 if state == "removed":
                     path.unlink()
+                elif state == "literal":
+                    path.write_bytes(b"base()\nstaged()\nworking()\n")
                 else:
                     path.write_bytes(b"base()\n" if state == "undone" else b"working()\n")
                 captured = self.helper["local_bundle"](repo)
                 record, = captured.mixed
-                self.assertIn("source.py", captured.paths)
+                self.assertEqual(captured.paths, {path.name})
                 self.assertEqual(record.index.mode is None, state == "readd")
                 self.assertEqual(record.base.mode is None, state in ("new", "unborn"))
                 self.assertEqual(record.working_tree.mode is None, state == "removed")
-                self.assertEqual(bool(record.working_tree_removed), state != "readd")
+                self.assertEqual(bool(record.working_tree_removed), state not in ("readd", "literal"))
+                if state == "literal":
+                    base_oid = git(repo, "rev-parse", f"HEAD:{path.name}").strip()
+                    self.assertEqual(record.base.identity, f"git:{base_oid}:100644")
+                    self.assertEqual(record.index.content, "base()\nstaged()\n")
+                    self.assertEqual(record.working_tree.content, "base()\nstaged()\nworking()\n")
+                    self.assertNotIn("unrelated base", captured.text)
                 if state == "readd":
                     self.assertIn("# Untracked File", record.unstaged)
                     self.assertEqual(record.index_removed, ((1, "base()"),))
@@ -452,7 +464,8 @@ class AutoreviewMixedTargetTests(unittest.TestCase):
                 self.helper["verify_mixed_sources"](repo, captured.mixed)
 
     def test_file_to_directory_transitions_keep_staged_and_working_sources(self):
-        for state in ("staged", "untracked", "mixed-child", "mixed-parent", "committed"):
+        for state in ("staged", "untracked", "mixed-child", "mixed-parent", "committed",
+                      "restored-parent", "restored-parent-siblings"):
             with self.subTest(state=state), tempfile.TemporaryDirectory() as tempdir:
                 repo = init_repo(Path(tempdir))
                 git(repo, "config", "core.autocrlf", "false")
@@ -470,8 +483,13 @@ class AutoreviewMixedTargetTests(unittest.TestCase):
                 path.mkdir()
                 child = path / "bar"
                 child.write_bytes(b"staged child\n")
-                if state in ("staged", "mixed-child", "committed"):
-                    git(repo, "add", "foo/bar")
+                restored = state in ("restored-parent", "restored-parent-siblings")
+                children = {"foo/bar": "staged child\n"}
+                if state == "restored-parent-siblings":
+                    (path / "baz").write_bytes(b"staged sibling\n")
+                    children["foo/baz"] = "staged sibling\n"
+                if state in ("staged", "mixed-child", "committed") or restored:
+                    git(repo, "add", "foo")
                 if state == "committed":
                     git(repo, "commit", "-qm", "replace file with directory")
                 if state in ("mixed-child", "committed"):
@@ -480,10 +498,16 @@ class AutoreviewMixedTargetTests(unittest.TestCase):
                     (path / "extra").write_bytes(b"untracked child\n")
                     (path / "ignored.txt").write_bytes(b"ignored child content\n")
                     (repo / ".git/info/exclude").write_text("foo/ignored.txt\n", encoding="utf-8")
+                if restored:
+                    for rel in children:
+                        (repo / rel).unlink()
+                    path.rmdir()
+                    path.write_bytes(b"working parent\n")
                 for ref in (None, base):
                     with self.subTest(base=ref):
+                        snapshot = self.helper["source_tree_snapshot"](repo)
                         captured = self.helper["local_bundle"](repo, ref)
-                        expected = {"foo/bar"}
+                        expected = set(children)
                         if state != "committed" or ref is not None:
                             expected.add("foo")
                             self.assertIn("-base parent\n", captured.text)
@@ -492,25 +516,33 @@ class AutoreviewMixedTargetTests(unittest.TestCase):
                             self.assertIn("untracked child", captured.text)
                             self.assertNotIn("ignored child content", captured.text)
                         self.assertEqual(captured.paths, expected)
-                        self.assertIn(child.read_text().strip(), captured.text)
+                        self.assertIn("staged child", captured.text)
                         mixed = {record.path: record for record in captured.mixed}
                         expected_mixed = set()
-                        if state == "mixed-parent":
+                        if restored:
+                            expected_mixed = {"foo", *children}
+                        elif state == "mixed-parent":
                             expected_mixed.add("foo")
                         elif state == "mixed-child" or (state == "committed" and ref is not None):
                             expected_mixed.add("foo/bar")
                         self.assertEqual(set(mixed), expected_mixed)
                         if "foo" in mixed:
-                            self.assertEqual(mixed["foo"].index.content, "staged parent\n")
-                            self.assertIsNone(mixed["foo"].working_tree.mode)
-                        if "foo/bar" in mixed:
-                            self.assertEqual(mixed["foo/bar"].index.content, "staged child\n")
-                            self.assertEqual(mixed["foo/bar"].working_tree.content, "working child\n")
+                            self.assertEqual(mixed["foo"].base.content, "base parent\n")
+                            self.assertEqual(mixed["foo"].index.content, None if restored else "staged parent\n")
+                            self.assertEqual(mixed["foo"].working_tree.content, "working parent\n" if restored else None)
+                            absent = mixed["foo"].index if restored else mixed["foo"].working_tree
+                            self.assertEqual(absent, self.helper["SourceVersion"]("absent", None, None))
+                        for rel in set(children) & set(mixed):
+                            self.assertEqual(mixed[rel].index.content, children[rel])
+                            self.assertEqual(mixed[rel].working_tree.content, None if restored else "working child\n")
+                            if restored:
+                                self.assertEqual(mixed[rel].working_tree, self.helper["SourceVersion"]("absent", None, None))
                         self.helper["verify_mixed_sources"](repo, captured.mixed)
+                        self.assertEqual(self.helper["source_tree_snapshot"](repo), snapshot)
 
     def test_directory_to_file_transitions_preserve_snapshots_and_mixed_sources(self):
-        for mixed in (False, True):
-            with self.subTest(mixed=mixed), tempfile.TemporaryDirectory() as tempdir:
+        for state in ("staged", "mixed-child", "mixed-parent", "working-directory"):
+            with self.subTest(state=state), tempfile.TemporaryDirectory() as tempdir:
                 repo = init_repo(Path(tempdir))
                 git(repo, "config", "core.autocrlf", "false")
                 parent = repo / "foo"
@@ -520,7 +552,7 @@ class AutoreviewMixedTargetTests(unittest.TestCase):
                 git(repo, "add", ".")
                 git(repo, "commit", "-qm", "base directory")
                 base = git(repo, "rev-parse", "HEAD").strip()
-                if mixed:
+                if state == "mixed-child":
                     child.write_bytes(b"staged child\n")
                     git(repo, "add", "foo/bar")
                     child.unlink()
@@ -528,22 +560,35 @@ class AutoreviewMixedTargetTests(unittest.TestCase):
                     git(repo, "rm", "foo/bar")
                 if parent.exists():
                     parent.rmdir()
-                parent.write_bytes(b"working parent\n")
-                if not mixed:
+                parent.write_bytes(b"working parent\n" if state == "mixed-child" else b"staged parent\n")
+                if state != "mixed-child":
                     git(repo, "add", "foo")
+                if state == "mixed-parent":
+                    parent.write_bytes(b"working parent\n")
+                elif state == "working-directory":
+                    parent.unlink()
+                    parent.mkdir()
+                    child.write_bytes(b"working child\n")
                 for ref in (None, base):
                     with self.subTest(base=ref):
                         snapshot = self.helper["source_tree_snapshot"](repo)
                         captured = self.helper["local_bundle"](repo, ref)
                         self.assertEqual(captured.paths, {"foo", "foo/bar"})
-                        self.assertIn("working parent", captured.text)
-                        if mixed:
-                            record, = captured.mixed
-                            self.assertEqual(record.path, "foo/bar")
-                            self.assertEqual(record.index.content, "staged child\n")
-                            self.assertIsNone(record.working_tree.mode)
-                        else:
-                            self.assertEqual(captured.mixed, ())
+                        self.assertIn("working parent" if state == "mixed-child" else "staged parent", captured.text)
+                        expected = {}
+                        if state in ("mixed-child", "working-directory"):
+                            expected["foo/bar"] = ("base child\n", "staged child\n", None) if state == "mixed-child" else (
+                                "base child\n", None, "working child\n",
+                            )
+                        if state in ("mixed-parent", "working-directory"):
+                            expected["foo"] = (None, "staged parent\n", "working parent\n" if state == "mixed-parent" else None)
+                        self.assertEqual({record.path for record in captured.mixed}, set(expected))
+                        for record in captured.mixed:
+                            for source, content in zip((record.base, record.index, record.working_tree), expected[record.path]):
+                                if content is None:
+                                    self.assertEqual(source, self.helper["SourceVersion"]("absent", None, None))
+                                else:
+                                    self.assertEqual(source.content, content)
                         self.helper["verify_mixed_sources"](repo, captured.mixed)
                         self.assertEqual(self.helper["source_tree_snapshot"](repo), snapshot)
 
@@ -606,8 +651,9 @@ class AutoreviewMixedTargetTests(unittest.TestCase):
             self.assertNotIn("SYNTHETIC_", captured.text)
 
     def test_mixed_source_mutations_and_topology_refuse_later_sends(self):
-        for mutation in ("index", "content", "replace", "ancestor", "delete", "leaf symlink", "ancestor symlink"):
-            if "symlink" in mutation and os.name == "nt":
+        for mutation in ("index", "index conflict", "index symlink", "index gitlink", "content",
+                         "replace", "ancestor", "delete", "leaf symlink", "ancestor symlink"):
+            if mutation in ("leaf symlink", "ancestor symlink") and os.name == "nt":
                 continue
             with self.subTest(mutation=mutation), self.migration() as (repo, *_):
                 captured = self.helper["local_bundle"](repo)
@@ -616,6 +662,15 @@ class AutoreviewMixedTargetTests(unittest.TestCase):
                 source = path.read_bytes()
                 if mutation == "index":
                     git(repo, "add", str(path))
+                elif mutation.startswith("index "):
+                    oid = git(repo, "rev-parse", "HEAD" if mutation == "index gitlink" else ":src/migrate-0.py").strip()
+                    if mutation == "index conflict":
+                        git(repo, "update-index", "--force-remove", "--", "src/migrate-0.py")
+                        subprocess.run(["git", "update-index", "--index-info"], cwd=repo, check=True,
+                                       input=f"100644 {oid} 2\tsrc/migrate-0.py\n", text=True, capture_output=True)
+                    else:
+                        mode = "160000" if mutation == "index gitlink" else "120000"
+                        git(repo, "update-index", "--cacheinfo", f"{mode},{oid},src/migrate-0.py")
                 elif mutation == "content":
                     before = path.stat()
                     path.write_bytes(source.replace(b"corrected", b"different"))
@@ -641,7 +696,8 @@ class AutoreviewMixedTargetTests(unittest.TestCase):
                 with mock.patch.dict(self.helper["run_reviewer"].__globals__, {
                     "scan_outgoing_review_pack": lambda *_: None, "run_engine": provider,
                 }), contextlib.redirect_stderr(io.StringIO()):
-                    with self.assertRaisesRegex(SystemExit, "mixed source changed|symlinked mixed source"):
+                    refusal = "unsafe mixed source mode" if mutation.startswith("index ") else "mixed source changed|symlinked mixed source"
+                    with self.assertRaisesRegex(SystemExit, refusal):
                         self.helper["run_reviewer"](argparse.Namespace(engine="codex", max_priority="P0"),
                                                      repo, passes[0], captured, [])
                 provider.assert_not_called()


### PR DESCRIPTION
## Summary

Fix mixed-source capture when a file and directory replace one another across the base, index, and working tree. This completes the Git-object side of #218; the working-tree classifier was already correct, but the Git reader still mistook a base directory for an unsafe file and indexed children for an ambiguous parent file.

`git_source_version` now uses one explicitly literal query for the index and base, selects only the exact requested pathname, and treats a base `040000 tree` entry as an absent blob. Literal lookup matters for names such as `:foo`: plain `ls-tree` can select a different file and incorrectly imply the base is absent on append-only edits. Git documents the [literal-pathspec switch](https://git-scm.com/docs/git#Documentation/git.txt---literal-pathspecs). Children remain separate paths in the complete review bundle. Exact-path conflict stages, including a single nonzero stage, and the symlink/gitlink mode refusals remain intact. This follows Git's documented [tree output](https://git-scm.com/docs/git-ls-tree) and [index-stage output](https://git-scm.com/docs/git-ls-files) contracts.

The repair stays in the existing source-version owner: no recursive tree walk, downstream workaround, new autoreview flag/configuration, or schema change. Production delta is +10/-8 (net +2: the two invariant-comment lines; executable LOC is neutral); tests are +89/-32 (net +57). The shared query replaces the previous branch-specific lookup setup and normalizes real Git representations at their producer.

## Regression and native proof

The two existing transition tests failed on the previous helper with eight errors: four base-tree `040000` refusals, two index-child `100644` refusals, and two false `unmerged` refusals. The same tests pass with this fix in both default and pinned-base modes. An additional append-only colon-name case, with a tracked same-name distractor, failed against the intermediate reader and now verifies the exact base object identity and index/working contents. The existing mutation test also passes with new single-stage-conflict, index-symlink, and index-gitlink cases, verifying rejection before the provider can be called.

```text
python -m unittest -v \
  skills.autoreview.tests.test_autoreview_hardening.AutoreviewMixedTargetTests.test_staged_undone_add_remove_readd_and_modes \
  skills.autoreview.tests.test_autoreview_hardening.AutoreviewMixedTargetTests.test_file_to_directory_transitions_keep_staged_and_working_sources \
  skills.autoreview.tests.test_autoreview_hardening.AutoreviewMixedTargetTests.test_directory_to_file_transitions_preserve_snapshots_and_mixed_sources \
  skills.autoreview.tests.test_autoreview_hardening.AutoreviewMixedTargetTests.test_mixed_source_mutations_and_topology_refuse_later_sends
Ran 4 tests in 22.793s
OK
```

Native macOS Git 2.54 proof ran the complete frozen production helper in a network-denied sandbox.
All 36 scenario checks passed: 22 valid captures retained their exact paths/source identities and contents,
and 14 unsafe cases were refused. This includes the original 22-case directory transition matrix,
six literal/tab-path and single-stage-conflict checks, and eight append-only captures for colon,
magic-looking, glob, and tab filenames in both default and pinned-base modes.

The append-only cases include a tracked distractor with the non-literal name. The correct base remains
present with its exact object identity, index/working contents are preserved, and no distractor content
enters the bundle. Base/index directories normalize to an absent blob without losing descendant changes.
Symlink, gitlink, and one-/multiple-stage conflicts retain their refusals.

The original c314 helper had eight false refusals in the transition matrix. The intermediate 3ed helper
also reproduced false base absence for colon names. Both earlier proof artifacts remain intact.
Final tested working-tree helper SHA256:
0992a59a1c888b43d825c4d26799ce041ca2d99897d8c2f7c688909a6c2787d3
Base commit: faf3aca26abd310e05221a7b619f0be457ffbbbe.

Source snapshots and index bytes stayed unchanged in all 36 checks. Child processes joined,
fixture directories were removed, and stderr was empty. No provider or scanner was invoked.
This proves native local Git/input-capture behavior, not Linux/Windows or provider end-to-end behavior.

The following values are extracted from the completed execution report, not illustrative output. Full-capture unsafe cases can stop at patch ownership before the mode gate; separate direct producer assertions verify the mode/stage refusals.

```json
{
  "canonicalBaseCommit": "faf3aca26abd310e05221a7b619f0be457ffbbbe",
  "baseHelperSha256": "c314df18921081db235699dd1842a073c4d088bce493897c4077f8117b97949f",
  "testedWorkingTreeHelperSha256": "0992a59a1c888b43d825c4d26799ce041ca2d99897d8c2f7c688909a6c2787d3",
  "summary": {
    "originalMatrixCases": 22,
    "originalValidAccepted": 10,
    "originalUnsafeRejected": 12,
    "extraCases": 6,
    "extraValidAccepted": 4,
    "extraUnsafeRejected": 2,
    "literalAppendOnlyCases": 8,
    "literalAppendOnlyAccepted": 8,
    "totalCases": 36,
    "totalValidAccepted": 22,
    "totalUnsafeRejected": 14
  },
  "all36ContractsMet": true,
  "allSnapshotsAndIndexBytesUnchanged": true,
  "networkDenied": true,
  "exitCode": 0,
  "allChildrenJoined": true,
  "remainingProcessGroupMembers": [],
  "remainingFixtureDirectories": [],
  "reportSha256": "02d63bf7dae47115f5c9227795f1724450d98e4f947ad0340a06a4718e3b8545"
}
```

## Final validation

At `6170c73`, before the fixture-only Windows correction described below, the actual frozen candidate passed 42 unit tests and 203 hardening tests: **244 passed, one existing raw-non-UTF-8-filename skip**. The real TruffleHog 3.97.1 companion ran and passed. Eight skill metadata checks, 15 repository-script tests, 96 Node tests, and Bash/Node/Python syntax checks also passed. All 13 skill entries retained identical bytes/modes/symlink identity throughout; every subprocess joined and temporary fixtures were removed.

Local scope was macOS, Python 3.12.13 and Node 24.19.0. The exact-head Linux/Windows, Node 26 CI jobs and all CodeQL checks also passed at `45eb1e1`. Local validation report SHA256: `101de3ee3b09594e6c7c3801b85b459275d4957b30e8f4b4bc3095d881a5b364`.

Independent Codex autoreview is **P2 scoped-clean**, with no accepted/actionable findings after the literal-path correction. It received the complete patch, production helper, skill instructions, and all changed test/fixture functions. The earlier optional full-test-module context was correctly stopped by the credential gate due to an unchanged negative URI fixture; that unrelated context was omitted, without weakening scanning or hiding any changed code.

## Windows CI correction

The [first CI run](https://github.com/openclaw/agent-skills/actions/runs/33616074225) passed Linux but exposed one test-fixture error on Windows/Python 3.14.7. Text-mode stdin translated the index-info record's LF to CRLF; Git retained the CR in the filename, so the fixture exercised a missing source instead of the intended exact-path conflict. A native Git LF/CRLF probe reproduced both the corrupted index pathname and the exact CI refusal. This matches [Python's documented text-mode conversion](https://docs.python.org/3/library/subprocess.html#frequently-used-arguments).

Commit `45eb1e1` sends those fixture bytes in binary mode. It does not change production code, relax the refusal assertion, add a retry, or skip the case. The affected mutation method passed again locally (8.152s), and the test-only follow-up received a fresh P2 scoped-clean review. The production helper is still byte-identical to the 36-scenario native proof above. The [new exact-head CI run](https://github.com/openclaw/agent-skills/actions/runs/33617048604) passed on both Linux and Windows, and all CodeQL checks passed.

The [completed ClawSweeper review](https://github.com/openclaw/agent-skills/pull/219#issuecomment-5507721870) reported no actionable findings or before-merge moves and accepted the native owner evidence. Its latest completed review covers exact head `45eb1e1`, including this fixture correction.

Known separate follow-ups #216 (global Git line-ending configuration) and #217 (streaming memory) are unchanged. The OpenClaw copy will be synchronized only after this canonical change lands.
