### PR TITLE
fix(autoreview): preserve literal paths and empty source findings

### DIFF
--- a/skills/autoreview/SKILL.md
+++ b/skills/autoreview/SKILL.md
@@ -56,6 +56,9 @@ merge_base=$(git merge-base HEAD "origin/$pr_base")
 When a file has both staged and unstaged changes, both states are reviewed.
 A defect in the index remains actionable even if the working tree fixes it;
 the report labels it `INDEX-only`.
+Git paths and patch text retain their literal whitespace. An empty present
+source uses line 1, column 1, and an empty excerpt; empty physical lines also
+use an empty excerpt at column 1. Source identity remains mandatory.
 
 ## Context and severity
 

--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -472,7 +472,7 @@ SCHEMA: dict[str, Any] = {
                                     "source_id": {"type": "string"},
                                     "side": {"type": "string", "enum": ["present", "removed"]},
                                     "column": {"type": "integer", "minimum": 1},
-                                    "excerpt": {"type": "string", "minLength": 1},
+                                    "excerpt": {"type": "string"},
                                 },
                             },
                         ],
@@ -548,24 +548,15 @@ def global_excludes_file(repo: Path) -> Path | None:
     home = Path(env["HOME"]).expanduser()
     if not external_env_path(repo, str(home)):
         return None
-    result = run(
-        [
-            resolve_command("git", repo),
-            "--no-optional-locks",
-            *SAFE_GIT_CONFIG_ARGS,
-            "config",
-            "--global",
-            "--path",
-            "--get",
-            "core.excludesFile",
-        ],
+    result = git_result(
         repo,
+        "config", "--global", "--path", "--get", "core.excludesFile",
         check=False,
         env=env,
     )
     if result.returncode != 0:
         return None
-    raw_path = result.stdout.strip()
+    raw_path = result.stdout.removesuffix("\n")
     if not raw_path:
         return None
     candidate = Path(raw_path).expanduser()
@@ -1450,14 +1441,16 @@ def git_result(
     repo: Path,
     *args: str,
     check: bool = True,
+    env: dict[str, str] | None = None,
 ) -> subprocess.CompletedProcess[str]:
     try:
-        return run(
-            [resolve_command("git", repo), "--no-optional-locks", *SAFE_GIT_CONFIG_ARGS, *args],
-            repo,
-            check=check,
-            env=safe_git_env(repo),
-            text_errors="strict",
+        # Text-mode pipes alias CR/CRLF pathnames to LF and alter patch bytes.
+        # Decode the shared binary capture without newline translation.
+        result = git_bytes(repo, *args, check=check, env=env)
+        return subprocess.CompletedProcess(
+            result.args, result.returncode,
+            result.stdout.decode(SUBPROCESS_TEXT_ENCODING),
+            result.stderr.decode(SUBPROCESS_TEXT_ENCODING),
         )
     except UnicodeDecodeError as exc:
         raise SystemExit(
@@ -1477,24 +1470,12 @@ def git_path_list(repo: Path, *args: str, check: bool = True) -> list[str]:
 def repo_root() -> Path:
     start = Path.cwd().resolve()
     unsafe_root = discover_repo_root(start) or start
-    git_bin = find_command("git", unsafe_root)
-    if not git_bin:
+    if not find_command("git", unsafe_root):
         raise SystemExit("git executable not found. Install Git or add it to PATH.")
-    try:
-        result = subprocess.run(
-            [git_bin, "--no-optional-locks", *SAFE_GIT_CONFIG_ARGS, "rev-parse", "--show-toplevel"],
-            text=True,
-            encoding=SUBPROCESS_TEXT_ENCODING,
-            errors="strict",
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            env=safe_git_env(unsafe_root),
-        )
-    except UnicodeDecodeError as exc:
-        raise SystemExit("repository root is not valid UTF-8") from exc
+    result = git_result(unsafe_root, "rev-parse", "--show-toplevel", check=False)
     if result.returncode != 0:
         raise SystemExit("autoreview must run inside a git repository")
-    return Path(result.stdout.strip()).resolve()
+    return Path(result.stdout.removesuffix("\n")).resolve()
 
 
 def discover_repo_root(start: Path) -> Path | None:
@@ -1634,6 +1615,7 @@ def git_bytes(
     repo: Path,
     *args: str,
     check: bool = True,
+    env: dict[str, str] | None = None,
 ) -> subprocess.CompletedProcess[bytes]:
     result = subprocess.run(
         [
@@ -1645,7 +1627,7 @@ def git_bytes(
         cwd=repo,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
-        env=safe_git_env(repo),
+        env=env if env is not None else safe_git_env(repo),
     )
     if check and result.returncode != 0:
         detail = (result.stderr or result.stdout).decode(
@@ -2445,13 +2427,8 @@ def local_bundle(repo: Path, base_ref: str | None = None) -> CapturedBundle:
     if base_ref is not None:
         base_ref = validate_git_ref(repo, base_ref, "base", pin=True)
     staged_base = ("--end-of-options", base_ref) if base_ref is not None else ()
-    # Text-mode subprocess output normalizes CRLF, which cannot serve as an
-    # exact source anchor. Keep the original transition bytes in local capture.
-    try:
-        staged_patch = git_bytes(repo, "diff", *SAFE_DIFF_FLAGS, "--cached", "--patch", *staged_base).stdout.decode("utf-8")
-        unstaged_patch = git_bytes(repo, "diff", *SAFE_DIFF_FLAGS, "--patch").stdout.decode("utf-8")
-    except UnicodeDecodeError:
-        raise SystemExit("refusing non-UTF-8 Git output in local patch") from None
+    staged_patch = git(repo, "diff", *SAFE_DIFF_FLAGS, "--cached", "--patch", *staged_base)
+    unstaged_patch = git(repo, "diff", *SAFE_DIFF_FLAGS, "--patch")
     require_no_binary_diff(
         "local staged diff",
         git(repo, "diff", *SAFE_DIFF_FLAGS, "--cached", "--numstat", "-z", *staged_base),
@@ -3414,9 +3391,10 @@ def render_mixed_context(chunk: ReviewChunk) -> str:
         actionable even when corrected in working_tree; label it INDEX-only.
         Findings on these paths REQUIRE source_attribution: target, record_id,
         source_id, side, column and excerpt. code_location.line is a 1-based source
-        line; column is a 1-based Unicode character offset. excerpt must be a
-        nonempty exact substring of that physical line (no LF). Use present for
-        current target source, removed only for a listed removed line from its
+        line; column is a 1-based Unicode character offset. excerpt must be an
+        exact substring of that physical line (no LF). Empty excerpts require
+        an empty line and column 1; a present zero-byte source uses virtual line 1.
+        Use present for target content, removed only for a listed removed line from its
         predecessor. Never claim removed index text is present in working_tree.
         Any line in a selected file is in scope, including unchanged context.
         Null attribution is permitted only for paths without mixed records.
@@ -5732,7 +5710,6 @@ def validate_attribution_shape(value: Any, index: int) -> None:
     if (value["target"] not in {"index", "working_tree"}
             or value["side"] not in {"present", "removed"}
             or not all(isinstance(value[key], str) for key in ("record_id", "source_id", "excerpt"))
-            or not value["excerpt"]
             or not isinstance(value["column"], int) or isinstance(value["column"], bool)
             or value["column"] < 1):
         raise SystemExit(f"finding {index} has invalid source_attribution")
@@ -5762,13 +5739,15 @@ def mixed_attribution_error(
             return "anchor is not a genuinely removed line of this transition"
         text = lines[line]
     else:
-        lines = literal_lf_lines(source.content or "")
+        # Present empty blobs still need a file-level anchor; absent sources were rejected above.
+        lines = literal_lf_lines(source.content or "") or [""]
         if line > len(lines):
             return "source anchor line is out of range"
         text = lines[line - 1].removesuffix("\n")
     column = attribution["column"] - 1
     excerpt = attribution["excerpt"]
-    if "\n" in excerpt or text[column:column + len(excerpt)] != excerpt:
+    if ((not excerpt and (text != "" or column != 0))
+            or "\n" in excerpt or text[column:column + len(excerpt)] != excerpt):
         return "source anchor excerpt does not match exactly at line/column"
     return None
 
@@ -5837,9 +5816,9 @@ def _validate_report(
                 f"{sorted(location)}"
             )
         raw_file_path = location.get("file_path")
-        if not isinstance(raw_file_path, str) or not raw_file_path.strip():
+        if not isinstance(raw_file_path, str) or not raw_file_path:
             raise SystemExit(f"finding {index} has invalid location: {location}")
-        raw_rel = raw_file_path.strip()
+        raw_rel = raw_file_path
         normalized_rel = raw_rel if raw_rel in changed_paths else raw_rel.replace("\\", "/")
         while normalized_rel.startswith("./"):
             normalized_rel = normalized_rel[2:]

--- a/skills/autoreview/scripts/autoreview_test.py
+++ b/skills/autoreview/scripts/autoreview_test.py
@@ -207,7 +207,7 @@ class AutoreviewTargetResultTests(unittest.TestCase):
         finding = {
             "title": "Synthetic defect", "body": "A concrete synthetic claim.",
             "priority": "P0", "confidence": 0.8, "category": "bug",
-            "code_location": {"file_path": "src/migrate.py", "line": line},
+            "code_location": {"file_path": self.record.path, "line": line},
             "source_attribution": {"target": target, "record_id": self.record.identity,
                                    "source_id": source.identity, "side": side,
                                    "column": 1, "excerpt": excerpt},
@@ -256,6 +256,13 @@ class AutoreviewTargetResultTests(unittest.TestCase):
                 self.assertEqual(report["overall_correctness"], "patch is correct")
         report = self.validate([self.finding()], available=False)
         self.assertIn("not available", report["attribution_rejected_findings"][0]["attribution_rejection_reason"])
+        original = self.record
+        for path in (" src/migrate.py", "src/migrate.py ", " "):
+            with self.subTest(path=path):
+                self.record = original._replace(path=path)
+                finding = self.finding()
+                self.assertEqual(self.validate([finding])["findings"], [finding])
+            self.record = original
 
     def test_absence_readd_and_removed_side_are_distinct(self):
         absent = AUTOREVIEW.SourceVersion("absent", None, None)
@@ -272,6 +279,46 @@ class AutoreviewTargetResultTests(unittest.TestCase):
                 self.assertEqual(report["findings"], [removed])
                 self.assertIn("absent", report["attribution_rejected_findings"][0]["attribution_rejection_reason"])
                 self.record = original
+
+        original = self.record
+        for target, side, content, line in (
+            ("index", "present", "", 1), ("working_tree", "present", "", 1),
+            ("index", "present", "before()\n\n", 2), ("working_tree", "present", "before()\n\n", 2),
+            ("index", "removed", "\n", 1), ("working_tree", "removed", "\n", 1),
+        ):
+            with self.subTest(target=target, side=side, content=content):
+                owner = ("base" if target == "index" else "index") if side == "removed" else target
+                self.record = original._replace(**{owner: getattr(original, owner)._replace(content=content)})
+                if side == "removed":
+                    self.record = self.record._replace(**{target + "_removed": ((line, ""),)})
+                valid = self.finding(target, side=side, line=line, excerpt="")
+                self.assertEqual(self.validate([valid])["findings"], [valid])
+                invalid = []
+                for key, value in (("record_id", "wrong"), ("source_id", "wrong"),
+                                   ("column", 2), ("excerpt", "invented")):
+                    bad = copy.deepcopy(valid)
+                    bad["source_attribution"][key] = value
+                    invalid.append(bad)
+                bad = copy.deepcopy(valid)
+                bad["code_location"]["line"] = 2 if not content else 900
+                invalid.append(bad)
+                if side == "present" and content:
+                    bad = copy.deepcopy(valid)
+                    bad["code_location"]["line"] = 1
+                    invalid.append(bad)
+                for bad in invalid:
+                    report = self.validate([bad])
+                    self.assertEqual(report["findings"], [])
+                    self.assertEqual(AUTOREVIEW.review_status(report), "incomplete")
+                self.record = original
+        for target in ("index", "working_tree"):
+            for side in ("present", "removed"):
+                report = self.validate([self.finding(target, side=side, excerpt="")])
+                self.assertEqual(report["findings"], [])
+            self.record = original._replace(**{target: absent})
+            report = self.validate([self.finding(target, excerpt="")])
+            self.assertIn("absent", report["attribution_rejected_findings"][0]["attribution_rejection_reason"])
+            self.record = original
 
     def test_title_independent_groups_keep_variants_targets_and_observations(self):
         reports = []

--- a/skills/autoreview/tests/test_autoreview_hardening.py
+++ b/skills/autoreview/tests/test_autoreview_hardening.py
@@ -878,18 +878,25 @@ class AutoreviewMixedTargetTests(unittest.TestCase):
             provider.assert_not_called()
 
     def test_ignored_or_unsafe_readdition_cannot_bypass_mixed_capture(self):
-        for kind in ("ignored", "symlink", "directory symlink", "dangling symlink"):
-            if kind != "ignored" and os.name == "nt":
+        for kind, name in (
+            ("ignored", "source.py"),
+            ("ignored", "line\rbreak.py"),
+            ("ignored", "line\r\nbreak.py"),
+            ("symlink", "source.py"),
+            ("directory symlink", "source.py"),
+            ("dangling symlink", "source.py"),
+        ):
+            if os.name == "nt" and (kind != "ignored" or "\r" in name):
                 continue
-            with self.subTest(kind=kind), tempfile.TemporaryDirectory() as tempdir:
+            with self.subTest(kind=kind, name=name), tempfile.TemporaryDirectory() as tempdir:
                 repo = init_repo(Path(tempdir))
-                path = repo / "source.py"
+                path = repo / name
                 path.write_text("base()\n")
                 git(repo, "add", ".")
                 git(repo, "commit", "-qm", "base")
-                git(repo, "rm", "source.py")
+                git(repo, "rm", "--", name)
                 if kind == "ignored":
-                    (repo / ".git/info/exclude").write_text("source.py\n")
+                    (repo / ".git/info/exclude").write_text("*.py\n")
                     path.write_text("ignored content never sent\n")
                 else:
                     outside = repo.parent / "outside.py"
@@ -2096,42 +2103,42 @@ with Path(__file__).with_name("scans.jsonl").open("a", encoding="utf-8") as reco
         )
 
     def test_untracked_files_respect_trusted_global_excludes(self) -> None:
-        with tempfile.TemporaryDirectory() as tempdir:
-            root = Path(tempdir)
-            repo = init_repo(root)
-            home = root / "home"
-            home.mkdir()
-            excludes = root / "global-ignore"
-            excludes.write_text(
-                "ignored.local\n!settings.local\n",
-                encoding="utf-8",
-            )
-            (home / ".gitconfig").write_text(
-                f"[core]\n\texcludesFile = {excludes.as_posix()}\n",
-                encoding="utf-8",
-            )
-            (repo / "ignored.local").write_text("private notes\n", encoding="utf-8")
-            (repo / ".gitignore").write_text("settings.local\n", encoding="utf-8")
-            (repo / "settings.local").write_text("repo private\n", encoding="utf-8")
-            git(repo, "add", ".gitignore")
-            (repo / "visible.txt").write_text("review me\n", encoding="utf-8")
-            (repo / "hostile-gitconfig").write_text(
-                "[core]\n\texcludesFile = /does/not/exist\n",
-                encoding="utf-8",
-            )
-
-            with mock.patch.dict(
-                os.environ,
-                {
-                    "HOME": str(home),
-                    "USERPROFILE": str(home),
-                    "GIT_CONFIG_GLOBAL": str(repo / "hostile-gitconfig"),
-                },
-            ):
-                self.assertEqual(
-                    [rel for rel, _ in self.helper["collect_untracked_file_snapshots"](repo)[0]],
-                    ["hostile-gitconfig", "visible.txt"],
+        cases = [("external", "global-ignore"), ("missing", "global-ignore"),
+                 ("inside", "global-ignore")]
+        if os.name != "nt":
+            cases.extend([("external", "global\rignore"), ("external", "global-ignore ")])
+        for location, name in cases:
+            with self.subTest(location=location, name=name), tempfile.TemporaryDirectory() as tempdir:
+                root = Path(tempdir)
+                repo = init_repo(root)
+                home = root / "home"
+                home.mkdir()
+                excludes = (repo if location == "inside" else root) / name
+                if location != "missing":
+                    excludes.write_text("ignored.local\n!settings.local\n", encoding="utf-8")
+                if location == "inside":
+                    git(repo, "add", "--", name)
+                git(repo, "config", "--file", str(home / ".gitconfig"),
+                    "core.excludesFile", str(excludes))
+                (repo / "ignored.local").write_text("private notes\n", encoding="utf-8")
+                (repo / ".gitignore").write_text("settings.local\n", encoding="utf-8")
+                (repo / "settings.local").write_text("repo private\n", encoding="utf-8")
+                git(repo, "add", ".gitignore")
+                (repo / "visible.txt").write_text("review me\n", encoding="utf-8")
+                (repo / "hostile-gitconfig").write_text(
+                    "[core]\n\texcludesFile = /does/not/exist\n", encoding="utf-8",
                 )
+                with mock.patch.dict(os.environ, {
+                    "HOME": str(home), "USERPROFILE": str(home),
+                    "GIT_CONFIG_GLOBAL": str(repo / "hostile-gitconfig"),
+                }):
+                    expected = ["hostile-gitconfig", "visible.txt"]
+                    if location != "external":
+                        expected.insert(1, "ignored.local")
+                    self.assertEqual(
+                        [rel for rel, _ in self.helper["collect_untracked_file_snapshots"](repo)[0]],
+                        expected,
+                    )
 
     def test_dirty_check_respects_trusted_global_excludes(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:
@@ -2325,18 +2332,38 @@ with Path(__file__).with_name("scans.jsonl").open("a", encoding="utf-8") as reco
                             self.assertIn(f"parent: {parent.decode()}\n", captured.text)
                             self.assertEqual(captured.paths, set())
 
+    def test_repo_root_preserves_exact_native_paths(self) -> None:
+        names = ["repo"]
+        if os.name != "nt":
+            names.extend(["repo\rname", "repo "])
+        for name in names:
+            with self.subTest(name=name), tempfile.TemporaryDirectory() as tempdir:
+                root = Path(tempdir)
+                repo = init_repo(root)
+                if name != repo.name:
+                    repo = repo.rename(root / name)
+                nested = repo / "nested"
+                nested.mkdir()
+                previous = Path.cwd()
+                try:
+                    os.chdir(nested)
+                    self.assertEqual(self.helper["repo_root"](), repo.resolve())
+                finally:
+                    os.chdir(previous)
+
     def test_git_path_list_preserves_newline_filenames(self) -> None:
         if os.name == "nt":
             self.skipTest("Windows filesystems do not support newline path components")
         with tempfile.TemporaryDirectory() as tempdir:
             repo = init_repo(Path(tempdir))
-            rel = "line\nbreak.txt"
-            (repo / rel).write_text("content\n", encoding="utf-8")
-            git(repo, "add", rel)
+            names = [f"line{separator}break.txt" for separator in ("\n", "\r", "\r\n", "\t")]
+            for rel in names:
+                (repo / rel).write_text("content\n", encoding="utf-8")
+                git(repo, "add", "--", rel)
 
             paths = self.helper["git_path_list"](repo, "ls-files", "-z")
 
-            self.assertIn(rel, paths)
+            self.assertCountEqual(paths, names)
 
     @unittest.skipUnless(sys.platform.startswith("linux"), "requires raw non-UTF-8 filename support")
     def test_git_path_list_rejects_non_utf8_output(self) -> None:
@@ -4000,36 +4027,32 @@ with Path(__file__).with_name("scans.jsonl").open("a", encoding="utf-8") as reco
     def test_source_tree_snapshot_detects_mutations(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:
             repo = init_repo(Path(tempdir))
-            source = repo / "source.txt"
-            source.write_text("before\n", encoding="utf-8")
-            git(repo, "add", "source.txt")
+            names = ["source.txt"]
+            if os.name != "nt":
+                names.extend(("source\r.txt", "source\r\n.txt"))
+            for name in names:
+                (repo / name).write_text("before\n", encoding="utf-8")
+                git(repo, "add", "--", name)
             git(repo, "commit", "-qm", "initial")
-            before = self.helper["source_tree_snapshot"](repo)
+            for name in names:
+                with self.subTest(name=name):
+                    source = repo / name
+                    before = self.helper["source_tree_snapshot"](repo)
+                    source.write_text("after\n", encoding="utf-8")
+                    self.assertNotEqual(self.helper["source_tree_snapshot"](repo), before)
+                    source.write_text("before\n", encoding="utf-8")
+                    self.assertEqual(self.helper["source_tree_snapshot"](repo), before)
 
-            source.write_text("after\n", encoding="utf-8")
-            self.assertNotEqual(
-                self.helper["source_tree_snapshot"](repo),
-                before,
-            )
-            source.write_text("before\n", encoding="utf-8")
-            self.assertEqual(
-                self.helper["source_tree_snapshot"](repo),
-                before,
-            )
+                    source.write_text("after\n", encoding="utf-8")
+                    git(repo, "add", "--", name)
+                    git(repo, "commit", "-qm", "mutated")
+                    self.assertNotEqual(self.helper["source_tree_snapshot"](repo), before)
 
-            source.write_text("after\n", encoding="utf-8")
-            git(repo, "add", "source.txt")
-            git(repo, "commit", "-qm", "mutated")
-            self.assertNotEqual(
-                self.helper["source_tree_snapshot"](repo),
-                before,
-            )
-
-            (repo / "generated.txt").write_text("generated\n", encoding="utf-8")
-            self.assertNotEqual(
-                self.helper["source_tree_snapshot"](repo),
-                before,
-            )
+                    generated = repo / ("generated-" + name)
+                    generated.write_text("generated\n", encoding="utf-8")
+                    generated_before = self.helper["source_tree_snapshot"](repo)
+                    generated.write_text("changed\n", encoding="utf-8")
+                    self.assertNotEqual(self.helper["source_tree_snapshot"](repo), generated_before)
 
     def test_rejects_output_paths_inside_reviewed_repository(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:
@@ -4959,11 +4982,16 @@ with Path(__file__).with_name("scans.jsonl").open("a", encoding="utf-8") as reco
                 r"src\index.ts",
             )
 
-            report["findings"][0]["code_location"]["file_path"] = " "
-            with self.assertRaisesRegex(SystemExit, "invalid location"):
-                self.helper["validate_report"](report, repo, {"src/index.ts"}, [])
+            literal = copy.deepcopy(report)
+            literal["findings"][0]["code_location"]["file_path"] = " "
+            self.helper["validate_report"](literal, repo, {" "}, [])
+            self.assertEqual(literal["findings"][0]["code_location"]["file_path"], " ")
+            with contextlib.redirect_stderr(io.StringIO()):
+                self.helper["validate_report"](literal, repo, {"src/index.ts"}, [])
+            self.assertEqual(literal["findings"], [])
+            self.assertEqual(self.helper["review_status"](literal), "incomplete")
 
-            for invalid_path in (123, None, True):
+            for invalid_path in ("", 123, None, True):
                 with self.subTest(invalid_path=invalid_path):
                     report["findings"][0]["code_location"] = {
                         "file_path": invalid_path,


### PR DESCRIPTION
## Summary

Preserve exact Git source identity through capture and report validation, and make findings on genuinely empty sources representable.

The Git wrapper used Python text-mode subprocess output, which converts CR and CRLF to LF even inside NUL-delimited filenames and patches. That could misidentify mixed sources, miss a tracked-file mutation, or bypass the intended refusal for an ignored re-addition. Separate `.strip()` calls changed legitimate whitespace-bearing paths. A mandatory nonempty excerpt also made a finding on a present zero-byte source or an empty removed line impossible to attribute.

## Ownership and contract

`git_result` now decodes the existing `git_bytes` result with strict UTF-8. Repository-root discovery and the existing trusted global-excludes lookup share that owner; path-returning commands remove only their final LF delimiter. This deletes duplicate text-mode/decoding paths. The internal environment argument preserves the existing global-excludes exception; it adds no environment setting or broader global-Git trust. Report validation retains literal whitespace and still requires membership in the selected paths.

Python documents the newline conversion performed by text-mode subprocess pipes; binary pipes avoid it. Git for Windows configures its standard streams as binary, so trailing CR must not be discarded as an assumed platform delimiter. These are dependency-contract checks, not Windows runtime proof. [Python subprocess documentation](https://docs.python.org/3/library/subprocess.html#frequently-used-arguments), [Git for Windows initialization](https://github.com/git-for-windows/git/blob/main/compat/mingw.c#L4204-L4208).

**The reviewer JSON excerpt constraint changes deliberately:** `source_attribution.excerpt` remains a string but may be empty. Validation accepts `""` only at column 1 of an exactly empty line, or virtual line 1 of a present zero-byte source. Removed-side anchors must still identify genuinely removed lines. Record identity, target/side source identity, presence/mode, pass membership, and exact line/column checks remain mandatory. Absent sources, nonempty lines, and missing attribution do not qualify. The skill and generated review context explain this contract.

There are no new fields, target/side variants, CLI flags, environment knobs, OpenClaw configuration, RPC, or SQLite changes. Final LOC against the base: helper **+29/-50, net -21**; existing tests **+154/-79, net +75**; skill documentation **+3/-0**.

## Verification

Base: `8d34b6b48923a40d4192070c0b99b6e53fac9a7c`. Source commit: `0bd3d8194ed7e86fd5d3d3168c632310d93ea00d`. Frozen helper SHA-256: `d16c1a6a8a32099b859289ebdfcd1cf7d2a3962e9bf7faa45a9c079c269a1600`.

Before the repair, native reproductions recorded six failures among 15 Git-path checks, rejection of three legitimate whitespace-path findings among four controls, and rejection of all six valid empty-anchor cases. Focused regressions were captured failing before editing and passed after the owner repair.

| Evidence | Current result |
| --- | --- |
| Final native Git/capture/report matrix | 65 expected outcomes on the frozen helper; all raw rows and process receipts verified |
| Independent final sibling matrix | 10 native checks passed on this exact helper; lead verified the full report and receipt |
| Autoreview Python unit suite | 42 passed |
| Autoreview hardening suite | 204 run: 203 passed, one existing raw-non-UTF-8-filename platform skip; the real TruffleHog companion passed |
| Repository checks | 8 skill validations, 6 installer tests, 9 validator tests, and syntax checks passed |
| Other skill Node tests | 96 passed using local Node 24 |
| Structured review | Refreshed four-file static report is `scoped-clean`, with no actionable P0–P2 findings; lead reviewed the complete report |
| Exact-head CI | [Linux and Windows validation](https://github.com/openclaw/agent-skills/actions/runs/33621572500) passed on `0bd3d8194ed7e86fd5d3d3168c632310d93ea00d`; all CodeQL checks passed |

The [latest exact-head ClawSweeper review](https://github.com/openclaw/agent-skills/pull/220#issuecomment-5508451710) has no findings, security issues, or before-merge work. The full local rerun is green. Its first run exposed an old assertion that rejected every whitespace-only path; the corrected regression accepts an exactly captured single-space filename while still refusing it when out of scope. This regression failed against the base helper and passed against the final helper. All subprocesses from the completed native and full local runs were joined, fixtures were removed, and source identity stayed unchanged.

## Inspectable native execution proof

The path checks used real temporary Git repositories and the whole immutable helper. Empty-anchor checks used the real capture/build-pass/verification owners and TruffleHog; only the reviewer engine returned synthetic findings. No external reviewer or credentials were used. All three proof runners exited 0 under network denial.

| Native inputs | Observed result |
| --- | --- |
| `source.py`, `line\nbreak.py`, `line\rbreak.py`, `line\r\nbreak.py`, `line\tbreak.py`; each as ignored re-addition, mixed source, and tracked mutation | All 15 contracts met: ignored re-additions refused, exact staged/working paths and contents captured, tracked mutations detected |
| `source.py`, ` source.py`, `source.py `, and the single-space filename ` ` | All four synthetic findings accepted with the exact path retained |
| Empty index; empty working tree; empty line in each; genuinely removed empty line in each transition | All six valid empty anchors accepted |
| Wrong record/source/pass, wrong line/column/text, empty excerpt on nonempty lines, absent index/working sources | All 40 negative controls refused |

Representative real empty-index capture:

```json
{
  "case": "empty-index",
  "base": {"identity": "absent", "mode": null},
  "index": {
    "identity": "git:e69de29bb2d1d6434b8b29ae775ad8c2e48c5391:100644",
    "content": "",
    "bytes": 0
  },
  "workingTreeContent": "{\"working\":true}\n",
  "anchor": {"target": "index", "side": "present", "line": 1, "column": 1, "excerpt": ""},
  "validation": "findings",
  "nonemptyExcerpt": "incomplete",
  "removedNonemptyExcerpt": "incomplete",
  "missingAttribution": "incomplete"
}
```

The sanitized extract retains all 65 cases, source identities/contents, refusal reasons, runner exits, and cleanup observations. Included in the expandable raw evidence below — SHA-256 `c3d656856e95b58c00c0508f3ab62df895a831dc72beb55a8430614055bb0f55`. The lead verified all raw rows, process receipts, and log hashes.

## Scope and follow-ups

This canonical autoreview repair follows [#219](https://github.com/openclaw/agent-skills/pull/219). Source scoping, strict decoding, secret scanning, reviewer isolation, and existing file/symlink/mode guards are preserved. It adds neither another checkout nor a file-size cap.

[Global Git line-ending settings (#216)](https://github.com/openclaw/agent-skills/issues/216) and [streaming source/evidence capture (#217)](https://github.com/openclaw/agent-skills/issues/217) remain separate follow-ups. Exact subprocess transport does not resolve either. The downstream complete-directory autoreview copy must wait for the canonical merge. This PR does not close [OpenClaw #104486](https://github.com/openclaw/openclaw/issues/104486); an eventual autoreview sync addresses only that skill's portion.

<details>
<summary>Complete sanitized native execution extract (65 expected outcomes)</summary>

```json
{
  "status": "Completed behavioral runs, all raw rows and process receipts verified by lead. Not remote CI.",
  "helperSha256": "d16c1a6a8a32099b859289ebdfcd1cf7d2a3962e9bf7faa45a9c079c269a1600",
  "scope": {
    "platform": "native macOS",
    "pathAndReportCases": "Real Git repositories and whole immutable helper; no reviewer invocation.",
    "emptyAnchorCases": "Whole immutable helper, native Git capture/build-pass/verify and real TruffleHog; only run_engine returns synthetic findings. No external reviewer or credentials. Negative metadata controls call the same real validation owner.",
    "networkDenied": true,
    "providerStubCalls": 6,
    "externalReviewerInvoked": false,
    "linuxWindowsOrNode26ParityClaimed": false
  },
  "totals": {
    "expectedOutcomes": 65,
    "gitPathChecks": 15,
    "literalReportPaths": 4,
    "validEmptyAnchors": 6,
    "refusedNegativeAnchorControls": 40
  },
  "gitPathCases": [
    {
      "path": "source.py",
      "scenario": "ignored-readd",
      "nativeIndexPaths": [
        "source.py"
      ],
      "helperIndexPaths": [
        "source.py"
      ],
      "refused": true,
      "error": "mixed source source.py (working_tree): re-addition is not in validated untracked membership",
      "contractMet": true
    },
    {
      "path": "source.py",
      "scenario": "mixed-source",
      "nativeIndexPaths": [
        "source.py"
      ],
      "helperIndexPaths": [
        "source.py"
      ],
      "refused": false,
      "capturedPaths": [
        "source.py"
      ],
      "recordPath": "source.py",
      "indexContent": "staged()\n",
      "workingContent": "working()\n",
      "contractMet": true
    },
    {
      "path": "source.py",
      "scenario": "tracked-snapshot",
      "nativeIndexPaths": [
        "source.py"
      ],
      "helperIndexPaths": [
        "source.py"
      ],
      "snapshotChanged": true,
      "contractMet": true
    },
    {
      "path": "line\nbreak.py",
      "scenario": "ignored-readd",
      "nativeIndexPaths": [
        "line\nbreak.py"
      ],
      "helperIndexPaths": [
        "line\nbreak.py"
      ],
      "refused": true,
      "error": "mixed source line\\x0abreak.py (working_tree): re-addition is not in validated untracked membership",
      "contractMet": true
    },
    {
      "path": "line\nbreak.py",
      "scenario": "mixed-source",
      "nativeIndexPaths": [
        "line\nbreak.py"
      ],
      "helperIndexPaths": [
        "line\nbreak.py"
      ],
      "refused": false,
      "capturedPaths": [
        "line\nbreak.py"
      ],
      "recordPath": "line\nbreak.py",
      "indexContent": "staged()\n",
      "workingContent": "working()\n",
      "contractMet": true
    },
    {
      "path": "line\nbreak.py",
      "scenario": "tracked-snapshot",
      "nativeIndexPaths": [
        "line\nbreak.py"
      ],
      "helperIndexPaths": [
        "line\nbreak.py"
      ],
      "snapshotChanged": true,
      "contractMet": true
    },
    {
      "path": "line\rbreak.py",
      "scenario": "ignored-readd",
      "nativeIndexPaths": [
        "line\rbreak.py"
      ],
      "helperIndexPaths": [
        "line\rbreak.py"
      ],
      "refused": true,
      "error": "mixed source line\\x0dbreak.py (working_tree): re-addition is not in validated untracked membership",
      "contractMet": true
    },
    {
      "path": "line\rbreak.py",
      "scenario": "mixed-source",
      "nativeIndexPaths": [
        "line\rbreak.py"
      ],
      "helperIndexPaths": [
        "line\rbreak.py"
      ],
      "refused": false,
      "capturedPaths": [
        "line\rbreak.py"
      ],
      "recordPath": "line\rbreak.py",
      "indexContent": "staged()\n",
      "workingContent": "working()\n",
      "contractMet": true
    },
    {
      "path": "line\rbreak.py",
      "scenario": "tracked-snapshot",
      "nativeIndexPaths": [
        "line\rbreak.py"
      ],
      "helperIndexPaths": [
        "line\rbreak.py"
      ],
      "snapshotChanged": true,
      "contractMet": true
    },
    {
      "path": "line\r\nbreak.py",
      "scenario": "ignored-readd",
      "nativeIndexPaths": [
        "line\r\nbreak.py"
      ],
      "helperIndexPaths": [
        "line\r\nbreak.py"
      ],
      "refused": true,
      "error": "mixed source line\\x0d\\x0abreak.py (working_tree): re-addition is not in validated untracked membership",
      "contractMet": true
    },
    {
      "path": "line\r\nbreak.py",
      "scenario": "mixed-source",
      "nativeIndexPaths": [
        "line\r\nbreak.py"
      ],
      "helperIndexPaths": [
        "line\r\nbreak.py"
      ],
      "refused": false,
      "capturedPaths": [
        "line\r\nbreak.py"
      ],
      "recordPath": "line\r\nbreak.py",
      "indexContent": "staged()\n",
      "workingContent": "working()\n",
      "contractMet": true
    },
    {
      "path": "line\r\nbreak.py",
      "scenario": "tracked-snapshot",
      "nativeIndexPaths": [
        "line\r\nbreak.py"
      ],
      "helperIndexPaths": [
        "line\r\nbreak.py"
      ],
      "snapshotChanged": true,
      "contractMet": true
    },
    {
      "path": "line\tbreak.py",
      "scenario": "ignored-readd",
      "nativeIndexPaths": [
        "line\tbreak.py"
      ],
      "helperIndexPaths": [
        "line\tbreak.py"
      ],
      "refused": true,
      "error": "mixed source line\\x09break.py (working_tree): re-addition is not in validated untracked membership",
      "contractMet": true
    },
    {
      "path": "line\tbreak.py",
      "scenario": "mixed-source",
      "nativeIndexPaths": [
        "line\tbreak.py"
      ],
      "helperIndexPaths": [
        "line\tbreak.py"
      ],
      "refused": false,
      "capturedPaths": [
        "line\tbreak.py"
      ],
      "recordPath": "line\tbreak.py",
      "indexContent": "staged()\n",
      "workingContent": "working()\n",
      "contractMet": true
    },
    {
      "path": "line\tbreak.py",
      "scenario": "tracked-snapshot",
      "nativeIndexPaths": [
        "line\tbreak.py"
      ],
      "helperIndexPaths": [
        "line\tbreak.py"
      ],
      "snapshotChanged": true,
      "contractMet": true
    }
  ],
  "literalReportPathCases": [
    {
      "path": "source.py",
      "accepted": true,
      "reviewStatus": "findings",
      "findingPath": "source.py"
    },
    {
      "path": " source.py",
      "accepted": true,
      "reviewStatus": "findings",
      "findingPath": " source.py"
    },
    {
      "path": "source.py ",
      "accepted": true,
      "reviewStatus": "findings",
      "findingPath": "source.py "
    },
    {
      "path": " ",
      "accepted": true,
      "reviewStatus": "findings",
      "findingPath": " "
    }
  ],
  "emptyAnchorCases": [
    {
      "case": "empty-index",
      "target": "index",
      "side": "present",
      "line": 1,
      "accepted": true,
      "status": "findings",
      "reasons": [],
      "versions": {
        "base": {
          "identity": "absent",
          "mode": null,
          "content": null
        },
        "index": {
          "identity": "git:e69de29bb2d1d6434b8b29ae775ad8c2e48c5391:100644",
          "mode": "100644",
          "content": ""
        },
        "working_tree": {
          "identity": "sha256:52f0fbd120de0093c28566df75fd019c8f5eab0e81480b48b3f4685f5a803ea3:100644",
          "mode": "100644",
          "content": "{\"working\":true}\n"
        }
      },
      "removed": {
        "index": [],
        "working_tree": []
      },
      "actualGitIndexBytes": 0,
      "actualGitIndexInvalidJson": true,
      "alternatives": {
        "present-nonempty": {
          "accepted": false,
          "status": "incomplete",
          "reasons": [
            "source anchor excerpt does not match exactly at line/column"
          ]
        },
        "removed-nonempty": {
          "accepted": false,
          "status": "incomplete",
          "reasons": [
            "anchor refers to an absent source"
          ]
        },
        "null": {
          "accepted": false,
          "status": "incomplete",
          "reasons": [
            "mixed path requires explicit source attribution"
          ]
        }
      }
    },
    {
      "case": "empty-working",
      "target": "working_tree",
      "side": "present",
      "line": 1,
      "accepted": true,
      "status": "findings",
      "reasons": [],
      "versions": {
        "base": {
          "identity": "absent",
          "mode": null,
          "content": null
        },
        "index": {
          "identity": "git:13e8b8f6ca60270cefbbda89d11d53b6c6cca64d:100644",
          "mode": "100644",
          "content": "{\"staged\":true}\n"
        },
        "working_tree": {
          "identity": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:100644",
          "mode": "100644",
          "content": ""
        }
      },
      "removed": {
        "index": [],
        "working_tree": [
          [
            1,
            "{\"staged\":true}"
          ]
        ]
      }
    },
    {
      "case": "blank-index",
      "target": "index",
      "side": "present",
      "line": 2,
      "accepted": true,
      "status": "findings",
      "reasons": [],
      "versions": {
        "base": {
          "identity": "absent",
          "mode": null,
          "content": null
        },
        "index": {
          "identity": "git:96de1f93c6262488eb3ba609d7aa1568658cfc34:100644",
          "mode": "100644",
          "content": "{\"staged\":true}\n\n"
        },
        "working_tree": {
          "identity": "sha256:52f0fbd120de0093c28566df75fd019c8f5eab0e81480b48b3f4685f5a803ea3:100644",
          "mode": "100644",
          "content": "{\"working\":true}\n"
        }
      },
      "removed": {
        "index": [],
        "working_tree": [
          [
            1,
            "{\"staged\":true}"
          ],
          [
            2,
            ""
          ]
        ]
      }
    },
    {
      "case": "blank-working",
      "target": "working_tree",
      "side": "present",
      "line": 2,
      "accepted": true,
      "status": "findings",
      "reasons": [],
      "versions": {
        "base": {
          "identity": "absent",
          "mode": null,
          "content": null
        },
        "index": {
          "identity": "git:13e8b8f6ca60270cefbbda89d11d53b6c6cca64d:100644",
          "mode": "100644",
          "content": "{\"staged\":true}\n"
        },
        "working_tree": {
          "identity": "sha256:26c19060cecb4c7913b0cc08387b530a43fce34dbab1d5ec88f2f0334dcb02c1:100644",
          "mode": "100644",
          "content": "{\"working\":true}\n\n"
        }
      },
      "removed": {
        "index": [],
        "working_tree": [
          [
            1,
            "{\"staged\":true}"
          ]
        ]
      }
    },
    {
      "case": "removed-blank-index",
      "target": "index",
      "side": "removed",
      "line": 1,
      "accepted": true,
      "status": "findings",
      "reasons": [],
      "versions": {
        "base": {
          "identity": "git:8b137891791fe96927ad78e64b0aad7bded08bdc:100644",
          "mode": "100644",
          "content": "\n"
        },
        "index": {
          "identity": "git:13e8b8f6ca60270cefbbda89d11d53b6c6cca64d:100644",
          "mode": "100644",
          "content": "{\"staged\":true}\n"
        },
        "working_tree": {
          "identity": "sha256:52f0fbd120de0093c28566df75fd019c8f5eab0e81480b48b3f4685f5a803ea3:100644",
          "mode": "100644",
          "content": "{\"working\":true}\n"
        }
      },
      "removed": {
        "index": [
          [
            1,
            ""
          ]
        ],
        "working_tree": [
          [
            1,
            "{\"staged\":true}"
          ]
        ]
      }
    },
    {
      "case": "removed-blank-working",
      "target": "working_tree",
      "side": "removed",
      "line": 1,
      "accepted": true,
      "status": "findings",
      "reasons": [],
      "versions": {
        "base": {
          "identity": "absent",
          "mode": null,
          "content": null
        },
        "index": {
          "identity": "git:8b137891791fe96927ad78e64b0aad7bded08bdc:100644",
          "mode": "100644",
          "content": "\n"
        },
        "working_tree": {
          "identity": "sha256:52f0fbd120de0093c28566df75fd019c8f5eab0e81480b48b3f4685f5a803ea3:100644",
          "mode": "100644",
          "content": "{\"working\":true}\n"
        }
      },
      "removed": {
        "index": [],
        "working_tree": [
          [
            1,
            ""
          ]
        ]
      }
    }
  ],
  "negativeAnchorControls": [
    {
      "case": "empty-index",
      "control": "line",
      "accepted": false,
      "status": "incomplete",
      "reasons": [
        "source anchor line is out of range"
      ]
    },
    {
      "case": "empty-index",
      "control": "column",
      "accepted": false,
      "status": "incomplete",
      "reasons": [
        "source anchor excerpt does not match exactly at line/column"
      ]
    },
    {
      "case": "empty-index",
      "control": "text",
      "accepted": false,
      "status": "incomplete",
      "reasons": [
        "source anchor excerpt does not match exactly at line/column"
      ]
    },
    {
      "case": "empty-index",
      "control": "record",
      "accepted": false,
      "status": "incomplete",
      "reasons": [
        "mixed source record identity does not match"
      ]
    },
    {
      "case": "empty-index",
      "control": "source",
      "accepted": false,
      "status": "incomplete",
      "reasons": [
        "target/side source identity does not match"
      ]
    },
    {
      "case": "empty-index",
      "control": "unavailable",
      "accepted": false,
      "status": "incomplete",
      "reasons": [
        "mixed source record was not available in this pass"
      ]
    },
    {
      "case": "empty-working",
      "control": "line",
      "accepted": false,
      "status": "incomplete",
      "reasons": [
        "source anchor line is out of range"
      ]
    },
    {
      "case": "empty-working",
      "control": "column",
      "accepted": false,
      "status": "incomplete",
      "reasons": [
        "source anchor excerpt does not match exactly at line/column"
      ]
    },
    {
      "case": "empty-working",
      "control": "text",
      "accepted": false,
      "status": "incomplete",
      "reasons": [
        "source anchor excerpt does not match exactly at line/column"
      ]
    },
    {
      "case": "empty-working",
      "control": "record",
      "accepted": false,
      "status": "incomplete",
      "reasons": [
        "mixed source record identity does not match"
      ]
    },
    {
      "case": "empty-working",
      "control": "source",
      "accepted": false,
      "status": "incomplete",
      "reasons": [
        "target/side source identity does not match"
      ]
    },
    {
      "case": "empty-working",
      "control": "unavailable",
      "accepted": false,
      "status": "incomplete",
      "reasons": [
        "mixed source record was not available in this pass"
      ]
    },
    {
      "case": "blank-index",
      "control": "line",
      "accepted": false,
      "status": "incomplete",
      "reasons": [
        "source anchor line is out of range"
      ]
    },
    {
      "case": "blank-index",
      "control": "column",
      "accepted": false,
      "status": "incomplete",
      "reasons": [
        "source anchor excerpt does not match exactly at line/column"
      ]
    },
    {
      "case": "blank-index",
      "control": "text",
      "accepted": false,
      "status": "incomplete",
      "reasons": [
        "source anchor excerpt does not match exactly at line/column"
      ]
    },
    {
      "case": "blank-index",
      "control": "record",
      "accepted": false,
      "status": "incomplete",
      "reasons": [
        "mixed source record identity does not match"
      ]
    },
    {
      "case": "blank-index",
      "control": "source",
      "accepted": false,
      "status": "incomplete",
      "reasons": [
        "target/side source identity does not match"
      ]
    },
    {
      "case": "blank-index",
      "control": "unavailable",
      "accepted": false,
      "status": "incomplete",
      "reasons": [
        "mixed source record was not available in this pass"
      ]
    },
    {
      "case": "blank-index",
      "control": "empty-excerpt-on-nonempty-line",
      "accepted": false,
      "status": "incomplete",
      "reasons": [
        "source anchor excerpt does not match exactly at line/column"
      ]
    },
    {
      "case": "blank-working",
      "control": "line",
      "accepted": false,
      "status": "incomplete",
      "reasons": [
        "source anchor line is out of range"
      ]
    },
    {
      "case": "blank-working",
      "control": "column",
      "accepted": false,
      "status": "incomplete",
      "reasons": [
        "source anchor excerpt does not match exactly at line/column"
      ]
    },
    {
      "case": "blank-working",
      "control": "text",
      "accepted": false,
      "status": "incomplete",
      "reasons": [
        "source anchor excerpt does not match exactly at line/column"
      ]
    },
    {
      "case": "blank-working",
      "control": "record",
      "accepted": false,
      "status": "incomplete",
      "reasons": [
        "mixed source record identity does not match"
      ]
    },
    {
      "case": "blank-working",
      "control": "source",
      "accepted": false,
      "status": "incomplete",
      "reasons": [
        "target/side source identity does not match"
      ]
    },
    {
      "case": "blank-working",
      "control": "unavailable",
      "accepted": false,
      "status": "incomplete",
      "reasons": [
        "mixed source record was not available in this pass"
      ]
    },
    {
      "case": "blank-working",
      "control": "empty-excerpt-on-nonempty-line",
      "accepted": false,
      "status": "incomplete",
      "reasons": [
        "source anchor excerpt does not match exactly at line/column"
      ]
    },
    {
      "case": "removed-blank-index",
      "control": "line",
      "accepted": false,
      "status": "incomplete",
      "reasons": [
        "anchor is not a genuinely removed line of this transition"
      ]
    },
    {
      "case": "removed-blank-index",
      "control": "column",
      "accepted": false,
      "status": "incomplete",
      "reasons": [
        "source anchor excerpt does not match exactly at line/column"
      ]
    },
    {
      "case": "removed-blank-index",
      "control": "text",
      "accepted": false,
      "status": "incomplete",
      "reasons": [
        "source anchor excerpt does not match exactly at line/column"
      ]
    },
    {
      "case": "removed-blank-index",
      "control": "record",
      "accepted": false,
      "status": "incomplete",
      "reasons": [
        "mixed source record identity does not match"
      ]
    },
    {
      "case": "removed-blank-index",
      "control": "source",
      "accepted": false,
      "status": "incomplete",
      "reasons": [
        "target/side source identity does not match"
      ]
    },
    {
      "case": "removed-blank-index",
      "control": "unavailable",
      "accepted": false,
      "status": "incomplete",
      "reasons": [
        "mixed source record was not available in this pass"
      ]
    },
    {
      "case": "removed-blank-working",
      "control": "line",
      "accepted": false,
      "status": "incomplete",
      "reasons": [
        "anchor is not a genuinely removed line of this transition"
      ]
    },
    {
      "case": "removed-blank-working",
      "control": "column",
      "accepted": false,
      "status": "incomplete",
      "reasons": [
        "source anchor excerpt does not match exactly at line/column"
      ]
    },
    {
      "case": "removed-blank-working",
      "control": "text",
      "accepted": false,
      "status": "incomplete",
      "reasons": [
        "source anchor excerpt does not match exactly at line/column"
      ]
    },
    {
      "case": "removed-blank-working",
      "control": "record",
      "accepted": false,
      "status": "incomplete",
      "reasons": [
        "mixed source record identity does not match"
      ]
    },
    {
      "case": "removed-blank-working",
      "control": "source",
      "accepted": false,
      "status": "incomplete",
      "reasons": [
        "target/side source identity does not match"
      ]
    },
    {
      "case": "removed-blank-working",
      "control": "unavailable",
      "accepted": false,
      "status": "incomplete",
      "reasons": [
        "mixed source record was not available in this pass"
      ]
    },
    {
      "case": "absent-index",
      "control": "absent-present-empty-anchor",
      "accepted": false,
      "status": "incomplete",
      "reasons": [
        "anchor refers to an absent source"
      ]
    },
    {
      "case": "absent-working",
      "control": "absent-present-empty-anchor",
      "accepted": false,
      "status": "incomplete",
      "reasons": [
        "anchor refers to an absent source"
      ]
    }
  ],
  "execution": [
    {
      "name": "path-capture",
      "exitCode": 0,
      "networkDenied": true,
      "elapsedSeconds": 4.939,
      "stderrBytes": 0,
      "allChildrenJoined": true,
      "remainingProcessGroupMembers": [],
      "isolatedEnvironmentRemoved": true,
      "reportSha256": "84e3a18c8fdc06b37cc9817c5fbd3f69b2575ef4390ebcaca7a3a84525d1fc17",
      "scriptSha256": "dd1af14177f4b4c514838bd5f75a20c154764258f310b32b5df0298b9f1469f8"
    },
    {
      "name": "report-path",
      "exitCode": 0,
      "networkDenied": true,
      "elapsedSeconds": 1.593,
      "stderrBytes": 0,
      "allChildrenJoined": true,
      "remainingProcessGroupMembers": [],
      "isolatedEnvironmentRemoved": true,
      "reportSha256": "c29939efa5b5f42f66178dd41cb5755f0f153830351feee61a6ba78db6fe3871",
      "scriptSha256": "2b07f183ffe22543e5d566fd96ee26785ae7179bc1e2747b63643f6d7e31efd8"
    },
    {
      "name": "empty-anchor",
      "exitCode": 0,
      "networkDenied": true,
      "elapsedSeconds": 14.494,
      "stderrBytes": 348,
      "allChildrenJoined": true,
      "remainingProcessGroupMembers": [],
      "isolatedEnvironmentRemoved": true,
      "reportSha256": "2a91bc95491542f261d565e2eea6d7f93989844d253a8648ef1fb978f2b13f6d",
      "scriptSha256": "2cbae5d709a2eea7ea4c0e9253a07b40b95d8aee4bb228a6ba46bd0c02eea990"
    }
  ],
  "cleanup": {
    "sourceUnchanged": true,
    "allChildrenJoined": true,
    "allTaskFixturesRemoved": true
  },
  "sourceCommit": "0bd3d8194ed7e86fd5d3d3168c632310d93ea00d"
}
```

</details>
