### PR TITLE
fix(autoreview): normalize Git diff presentation

### DIFF
--- a/skills/autoreview/SKILL.md
+++ b/skills/autoreview/SKILL.md
@@ -56,7 +56,9 @@ merge_base=$(git merge-base HEAD "origin/$pr_base")
 When a file has both staged and unstaged changes, both states are reviewed.
 A defect in the index remains actionable even if the working tree fixes it;
 the report labels it `INDEX-only`.
-Git paths and patch text retain their literal whitespace. An empty present
+Git display settings cannot suppress context markers or add patch colors;
+repository configuration is not changed. Source paths and text retain literal
+whitespace. An empty present
 source uses line 1, column 1, and an empty excerpt; empty physical lines also
 use an empty excerpt at column 1. Source identity remains mandatory.
 

--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -34,25 +34,6 @@ from typing import Any, BinaryIO, Callable, NamedTuple
 
 ENGINES = ("codex", "claude", "amp", "pi", "kimi")
 ENGINE_CHOICES = ENGINES
-SAFE_GIT_CONFIG_ARGS = (
-    "-c",
-    "core.fsmonitor=false",
-    "-c",
-    "core.pager=cat",
-    "-c",
-    "diff.external=",
-    "-c",
-    "diff.renames=false",
-    "-c",
-    "pager.diff=cat",
-    "-c",
-    "pager.log=cat",
-    "-c",
-    "pager.show=cat",
-)
-SAFE_DIFF_FLAGS = ("--no-ext-diff", "--no-textconv", "--no-renames")
-COMMIT_DIFF_FLAGS = (*SAFE_DIFF_FLAGS, "--root", "--no-commit-id", "-r")
-DIFF_HUNK_CONTENT_BOUNDARY = "\0autoreview-diff-hunk-boundary\0"
 ENGINE_GIT_CONFIG_OVERRIDES = (
     ("core.fsmonitor", "false"),
     ("core.pager", "cat"),
@@ -62,6 +43,13 @@ ENGINE_GIT_CONFIG_OVERRIDES = (
     ("pager.log", "cat"),
     ("pager.show", "cat"),
 )
+# Machine-parsed diffs require space-prefixed empty context lines.
+SAFE_GIT_CONFIG_ARGS = tuple(
+    arg for key, value in ENGINE_GIT_CONFIG_OVERRIDES for arg in ("-c", f"{key}={value}")
+) + ("-c", "diff.suppressBlankEmpty=false")
+SAFE_DIFF_FLAGS = ("--no-ext-diff", "--no-textconv", "--no-renames", "--no-color")
+COMMIT_DIFF_FLAGS = (*SAFE_DIFF_FLAGS, "--root", "--no-commit-id", "-r")
+DIFF_HUNK_CONTENT_BOUNDARY = "\0autoreview-diff-hunk-boundary\0"
 SENSITIVE_PATH_PARTS = {
     ".aws",
     ".azure",

--- a/skills/autoreview/tests/test_autoreview_hardening.py
+++ b/skills/autoreview/tests/test_autoreview_hardening.py
@@ -841,6 +841,54 @@ class AutoreviewMixedTargetTests(unittest.TestCase):
                 self.assertEqual(record.base.mode, "100644")
                 self.assertEqual(record.index.mode, "100755")
 
+    def test_git_display_settings_preserve_mixed_sources_and_chunk_coordinates(self):
+        settings = (
+            (), (("diff.suppressBlankEmpty", "false"),),
+            (("diff.suppressBlankEmpty", "true"),),
+            (("diff.suppress-blank-empty", "true"),),
+            (("color.ui", "always"),), (("color.diff", "always"),),
+            (("diff.color", "always"),),
+            (("diff.suppressBlankEmpty", "true"), ("color.diff", "always")),
+        )
+        for config in settings:
+            for pinned in (False, True):
+                with self.subTest(config=config, pinned=pinned), tempfile.TemporaryDirectory() as tempdir:
+                    repo = init_repo(Path(tempdir))
+                    git(repo, "config", "core.autocrlf", "false")
+                    for key, value in config:
+                        git(repo, "config", key, value)
+                    path = repo / "source.py"
+                    path.write_bytes(b"one\n\nbase\n")
+                    git(repo, "add", ".")
+                    git(repo, "commit", "-qm", "base")
+                    base = git(repo, "rev-parse", "HEAD").strip()
+                    if pinned:
+                        path.write_bytes(b"one\n\nhead\n")
+                        git(repo, "commit", "-qam", "advance HEAD")
+                    path.write_bytes(b"one\n\nstaged\n")
+                    git(repo, "add", ".")
+                    path.write_bytes(b"one\n\nworking\n")
+                    original_config = (repo / ".git/config").read_bytes()
+                    captured = self.helper["local_bundle"](repo, base if pinned else None)
+                    record, = captured.mixed
+                    self.assertEqual(record.base.content, "one\n\nbase\n")
+                    self.assertEqual(record.index.content, "one\n\nstaged\n")
+                    self.assertEqual(record.working_tree.content, "one\n\nworking\n")
+                    self.assertEqual(record.index_removed, ((3, "base"),))
+                    self.assertEqual(record.working_tree_removed, ((3, "staged"),))
+                    self.helper["verify_mixed_sources"](repo, captured.mixed)
+                    for patch in (record.staged, record.unstaged):
+                        self.assertNotIn("\x1b", patch)
+                        context = []
+                        new_line = old_line = None
+                        in_hunk = False
+                        for line in self.helper["literal_lf_lines"](patch):
+                            new_line, old_line, in_hunk = self.helper["update_review_chunk_context"](
+                                context, line, new_line, old_line, in_hunk,
+                            )
+                        self.assertEqual((new_line, old_line), (4, 4))
+                    self.assertEqual((repo / ".git/config").read_bytes(), original_config)
+
     def test_readded_untracked_capture_is_reused_and_evidence_stays_separate(self):
         with tempfile.TemporaryDirectory() as tempdir:
             repo = init_repo(Path(tempdir))


### PR DESCRIPTION
## Summary

Fix autoreview rejecting valid staged/unstaged changes when Git is configured to suppress blank context prefixes or force colored diffs.

`diff.suppressBlankEmpty=true` removes the leading space from empty context lines. The removal parser then reports the wrong source line, and exact source validation refuses the capture; the chunk continuation parser is affected too. Forced `color.ui`, `color.diff`, or legacy `diff.color` adds ANSI before patch headers and prevents patch ownership from being established. Both failures were reproduced with native Git before editing.

Normalize presentation at the Git producer: retain blank context markers with a per-command override and pass `--no-color` through the shared diff flags. Keep both parsers and exact source validation unchanged. Derive host Git safety arguments from the existing seven-pair policy instead of maintaining a duplicate list; the reviewer environment's policy is byte-identical.

No repository Git configuration is written. No public option, environment knob, OpenClaw configuration, RPC, report-schema field, or SQLite change is added. Git source bytes, custom prefixes, and existing external-diff/textconv protections remain intact. Production **+7/-19 (net -12)**; regression **+48**; skill documentation **+3/-1**.

## Evidence

Base: `bc3069239aed514af5924d8517a3ffa2a1867386`. Source commit: [`4ef507d51ce0ff2f20fc8899312b2771afe160b2`](https://github.com/openclaw/agent-skills/commit/4ef507d51ce0ff2f20fc8899312b2771afe160b2). Tested helper SHA-256: `6006b3eb8da8bfc1ad7398e0d1106dfb58b48c09e590622f19a77d78bdc4b118`.

| Check | Result |
| --- | --- |
| New native regression | 16 subcases in one method: default/false/true/legacy suppression, three forced-color forms, and combined suppression/color; each implicit or genuinely older pinned base. Before: 12 errors with the two expected capture failures. After: all pass. Exact base/index/working bytes, deletion line 3, continuation coordinates, and unchanged repository configuration are asserted. |
| Independent suppression reproduction | Six native captures: unset/false/true × implicit/pinned base. Before: both true cases failed and continuation coordinates were off by one. After: all six pass with correct deletion and continuation positions. |
| Independent presentation matrix | 18 native cases. Before: all three forced-color cases failed. After: all 18 capture exact identities and line-3 removals with valid review passes. No/mnemonic/custom prefixes, context/interhunk settings, algorithms, relative paths, quoting, and external-diff/textconv controls continue to pass. |
| Full canonical suite | 42 unit tests passed; 204 hardening tests passed with one existing macOS raw-non-UTF-8 filename skip; real TruffleHog companion passed. All 15 repository tests, 96 Node tests, eight-skill metadata validation, and syntax checks passed. All 13 source entries stayed unchanged; all child processes joined with no forced termination or leftovers. Local macOS, Python 3.12, Node 24; Linux/Windows coverage belongs to CI. |
| Independent structured review | Fresh three-file P0–P2 review is `scoped-clean`, with no actionable findings; static review, not a claim that the reviewer executed tests. |
| Exact-head CI | [Linux and Windows validation](https://github.com/openclaw/agent-skills/actions/runs/33624530730) passed on `4ef507d51ce0ff2f20fc8899312b2771afe160b2`; all CodeQL checks passed. The [latest ClawSweeper review](https://github.com/openclaw/agent-skills/pull/221#issuecomment-5508823791) has no findings, security issues, or before-merge work. |

The native runs used Git 2.54.0 and complete frozen helpers, with network denied and no provider/scanner invocation. External-command positive controls ran only task-owned synthetic marker programs; the protected owner ran none. Child processes were joined, fixtures were removed, and source identities remained unchanged.

Git's [documented suppression setting](https://git-scm.com/docs/git-config#Documentation/git-config.txt-diffsuppressBlankEmpty) and [diff options](https://git-scm.com/docs/git-diff) describe the presentation controls. Direct [Git 2.54 source inspection](https://github.com/git/git/blob/v2.54.0/diff.c) confirmed the legacy suppression/color spellings and LF-only context suppression. Changing only the deletion parser would leave continuation coordinates wrong; stripping ANSI from captured text could alter actual source bytes. The shared producer is the repair owner.

## Inspectable native behavior

```text
Input base/index/working: one\n\nold\n / one\n\nstaged\n / one\n\nworking\n
Before, suppressBlankEmpty=true:
  removed = [[2, "old"]]
  continuation old/new = 3/3
  capture = refused: mixed deletion source does not match patch
After, same unchanged repository configuration:
  removed = [[3, "old"]]
  index removed = [[3, "old"]]
  working removed = [[3, "staged"]]
  continuation old/new = 4/4
  capture = accepted; exact sources verified

Before, each forced-color spelling:
  patch header contains ANSI
  capture = refused: cannot establish mixed local patch ownership
After, same unchanged repository configuration:
  patch header = diff --git a/code.txt b/code.txt
  no presentation ANSI; both removed-source tuples at line 3
  capture and review-pass preparation = accepted
```

The regression's explicit-base cases advance HEAD after saving the base, so the test distinguishes the selected base from current HEAD. The native presentation matrix also proves that direct external diff/driver commands can execute its marker programs, while protected capture does not execute them.

This follows the findings from the complete downstream sync review; it is not an OpenClaw-local behavior variant. Global Git line-ending handling [#216](https://github.com/openclaw/agent-skills/issues/216) and streaming memory [#217](https://github.com/openclaw/agent-skills/issues/217) remain separate follow-ups.
