### PR TITLE
fix(session-viewer): add opt-in bounded exports with visible warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Validate explicit index/working-tree targets for mixed local Autoreview paths, preserving source anchors, rejected-attribution audit and distinct claim variants while repeating mandatory context within existing capacity limits.
 - Restore mandatory Autoreview TruffleHog `verified,unknown` pre-send scans removed in #209, retaining reviewer P0 credential checks as defense in depth.
+- Bound session-viewer JSONL reads to 8 MiB (head and tail) before HTML embed, with a truncation warning. Thanks @SebTardif.
 - Bound agent-transcript session reads to 8 MiB and disclose partial source content in render, preview, append-body, and HTML output. Thanks @SebTardif.
 - Bound agent-transcript `find` and `html` discovery to 20,000 session files, with an integer override and correct exact-limit handling. Thanks @SebTardif.
 - Rescan the exact outgoing Autoreview pack before Codex access-fallback retries, refusing findings, scanner errors, and missing scanners before another provider invocation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Validate explicit index/working-tree targets for mixed local Autoreview paths, preserving source anchors, rejected-attribution audit and distinct claim variants while repeating mandatory context within existing capacity limits.
 - Restore mandatory Autoreview TruffleHog `verified,unknown` pre-send scans removed in #209, retaining reviewer P0 credential checks as defense in depth.
-- Bound session-viewer JSONL reads to 8 MiB (head and tail) before HTML embed, with visible truncation warnings in normalized and raw exports and an explicit byte-limit override. Thanks @SebTardif.
+- Add opt-in session-viewer head/tail reads with `--max-read-bytes`, preserving complete exports by default and showing escaped truncation warnings in normalized and raw exports; retry short reads and fail on unexpected EOF. Thanks @SebTardif.
 - Bound agent-transcript session reads to 8 MiB and disclose partial source content in render, preview, append-body, and HTML output. Thanks @SebTardif.
 - Bound agent-transcript `find` and `html` discovery to 20,000 session files, with an integer override and correct exact-limit handling. Thanks @SebTardif.
 - Rescan the exact outgoing Autoreview pack before Codex access-fallback retries, refusing findings, scanner errors, and missing scanners before another provider invocation.

--- a/skills/session-viewer/SKILL.md
+++ b/skills/session-viewer/SKILL.md
@@ -42,12 +42,13 @@ Defaults:
 - detects `codex`, `claude`, or `pi-openclaw`
 - embeds normalized session data into one HTML file
 - keeps tool input/output text in the DOM so browser search can find it
-- reads at most 8 MiB of a session file; oversized files retain the head and tail, with a visible omission warning in the CLI and exported viewer
-- `--max-read-bytes N` overrides that positive byte limit; raise it explicitly when a complete larger export is needed
-- `--raw` embeds the retained JSONL and lets the browser parse it; truncated boundary records may be omitted
+- reads the complete session file, preserving full history in both export modes
+- `--raw` embeds the original JSONL and lets the browser parse it
 - `--blank` creates a reusable file-picker viewer
 
-The read limit applies to CLI file exports, not files loaded through the browser's file picker.
+For an explicitly partial export, use `--max-read-bytes N` with a positive integer byte limit (for example, `--max-read-bytes 8388608` for 8 MiB). Oversized files retain the head and tail, with a visible omission warning in the CLI and exported viewer. Truncated boundary records may be omitted; `--raw` embeds only the retained JSONL. Files at or below the limit remain complete. Short reads are retried; an unexpected end of file fails the export instead of reporting a complete read.
+
+This opt-in read limit applies only to CLI file exports. The browser's file picker continues to load complete files.
 
 ## Where Sessions Live
 

--- a/skills/session-viewer/scripts/read-session.ts
+++ b/skills/session-viewer/scripts/read-session.ts
@@ -1,0 +1,43 @@
+import fs from "node:fs/promises";
+import type { FileHandle } from "node:fs/promises";
+
+async function readExactly(handle: FileHandle, length: number, position: number): Promise<Buffer> {
+  const buffer = Buffer.alloc(length);
+  let offset = 0;
+  while (offset < length) {
+    const { bytesRead } = await handle.read(buffer, offset, length - offset, position + offset);
+    if (bytesRead === 0) {
+      throw new Error("session file ended before the expected read completed; retry the export");
+    }
+    offset += bytesRead;
+  }
+  return buffer;
+}
+
+export async function readSessionText(
+  file: string,
+  maxBytes?: number,
+): Promise<{ size: number; text: string; truncated: boolean }> {
+  if (maxBytes === undefined) {
+    const buffer = await fs.readFile(file);
+    return { size: buffer.length, text: buffer.toString("utf8"), truncated: false };
+  }
+  const handle = await fs.open(file, "r");
+  try {
+    const { size } = await handle.stat();
+    if (size <= maxBytes) {
+      return { size, text: (await readExactly(handle, size, 0)).toString("utf8"), truncated: false };
+    }
+    const headLength = Math.ceil(maxBytes / 2);
+    const tailLength = maxBytes - headLength;
+    const head = await readExactly(handle, headLength, 0);
+    const tail = await readExactly(handle, tailLength, size - tailLength);
+    return {
+      size,
+      text: `${head.toString("utf8")}\n[...middle omitted for scan...]\n${tail.toString("utf8")}`,
+      truncated: true,
+    };
+  } finally {
+    await handle.close();
+  }
+}

--- a/skills/session-viewer/scripts/session-viewer.test.ts
+++ b/skills/session-viewer/scripts/session-viewer.test.ts
@@ -831,3 +831,79 @@ test("CLI writes a one-file HTML export", async () => {
   assert.ok(payload);
   assert.equal(JSON.parse(payload).kind, "normalized");
 });
+
+function oversizedSessionJsonl(): string {
+  const pad = JSON.stringify({
+    timestamp: "2026-05-25T10:00:01Z",
+    type: "response_item",
+    payload: {
+      type: "message",
+      role: "user",
+      content: [{ type: "input_text", text: `pad-${"x".repeat(80)}` }],
+    },
+  });
+  return [
+    JSON.stringify({
+      timestamp: "2026-05-25T10:00:00Z",
+      type: "session_meta",
+      payload: { id: "HEAD_READ_BOUND_MARKER" },
+    }),
+    ...Array.from({ length: 40 }, () => pad),
+    JSON.stringify({
+      timestamp: "2026-05-25T10:00:02Z",
+      type: "response_item",
+      payload: {
+        type: "message",
+        role: "user",
+        content: [{ type: "input_text", text: "MIDDLE_READ_BOUND_MARKER" }],
+      },
+    }),
+    ...Array.from({ length: 40 }, () => pad),
+    JSON.stringify({
+      timestamp: "2026-05-25T10:00:03Z",
+      type: "response_item",
+      payload: {
+        type: "message",
+        role: "user",
+        content: [{ type: "input_text", text: "TAIL_READ_BOUND_MARKER" }],
+      },
+    }),
+  ].join("\n");
+}
+
+function embeddedViewerText(html: string): string {
+  const payload = /<script id="viewer-payload" type="application\/json">([^<]*)<\/script>/u.exec(
+    html,
+  )?.[1];
+  assert.ok(payload);
+  const parsed = JSON.parse(payload) as { kind: string; data: string };
+  return Buffer.from(parsed.data, "base64").toString("utf8");
+}
+
+test("CLI bounds oversized JSONL reads before HTML embed", async () => {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "session-viewer-bound-"));
+  const input = path.join(dir, "session.jsonl");
+  const output = path.join(dir, "session.html");
+  const text = oversizedSessionJsonl();
+  await fs.writeFile(input, `${text}\n`, "utf8");
+  const size = (await fs.stat(input)).size;
+  assert.ok(size > 400);
+  assert.match(text, /MIDDLE_READ_BOUND_MARKER/);
+
+  const { stdout } = await execFileAsync(process.execPath, [
+    "skills/session-viewer/scripts/session-viewer.ts",
+    input,
+    "--out",
+    output,
+    "--raw",
+    "--max-read-bytes",
+    "400",
+  ]);
+  const html = await fs.readFile(output, "utf8");
+  const embedded = embeddedViewerText(html);
+  assert.match(html, /Session Viewer/);
+  assert.doesNotMatch(html, /MIDDLE_READ_BOUND_MARKER/);
+  assert.doesNotMatch(embedded, /MIDDLE_READ_BOUND_MARKER/);
+  assert.match(embedded, /HEAD_READ_BOUND_MARKER|TAIL_READ_BOUND_MARKER/);
+  assert.match(`${stdout}\n${html}\n${embedded}`, /truncat|omitted middle/i);
+});

--- a/skills/session-viewer/scripts/session-viewer.test.ts
+++ b/skills/session-viewer/scripts/session-viewer.test.ts
@@ -10,6 +10,7 @@ import { parseSessionDocument } from "./core/detect.ts";
 import { parseJsonl } from "./core/jsonl.ts";
 import { resolveOpenBrowserCommand } from "./open-browser.ts";
 import { buildSessionViewerHtml } from "./html.ts";
+import { readSessionText } from "./read-session.ts";
 
 const execFileAsync = promisify(execFile);
 
@@ -834,14 +835,14 @@ test("CLI writes a one-file HTML export", async () => {
   assert.equal(JSON.parse(payload).kind, "normalized");
 });
 
-function oversizedSessionJsonl(): string {
+function oversizedSessionJsonl(padLength = 80): string {
   const pad = JSON.stringify({
     timestamp: "2026-05-25T10:00:01Z",
     type: "response_item",
     payload: {
       type: "message",
       role: "user",
-      content: [{ type: "input_text", text: `pad-${"x".repeat(80)}` }],
+      content: [{ type: "input_text", text: `pad-${"x".repeat(padLength)}` }],
     },
   });
   return [
@@ -929,13 +930,112 @@ test("CLI bounds oversized JSONL reads and displays warnings in both exports", a
     const html = await fs.readFile(output, "utf8");
     const embedded = Buffer.from(embeddedViewerPayload(html).data, "base64").toString("utf8");
     assert.doesNotMatch(embedded, /MIDDLE_READ_BOUND_MARKER/);
-    assert.match(embedded, /HEAD_READ_BOUND_MARKER|TAIL_READ_BOUND_MARKER/);
+    assert.match(embedded, /HEAD_READ_BOUND_MARKER/);
+    assert.match(embedded, /TAIL_READ_BOUND_MARKER/);
     assert.match(stdout, /source truncated: omitted middle/);
     const warning = renderViewer(html).get("warnings")!;
     assert.equal(warning.hidden, false);
     assert.match(warning.innerHTML, /source truncated: omitted middle/);
     assert.match(warning.innerHTML, /read cap 400 bytes/);
   }
+});
+
+test("CLI preserves full sessions over 8 MiB by default in both export modes", async (t) => {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "session-viewer-full-"));
+  t.after(() => fs.rm(dir, { recursive: true, force: true }));
+  const input = path.join(dir, "session.jsonl");
+  const output = path.join(dir, "session.html");
+  const text = oversizedSessionJsonl(128 * 1024);
+  assert.ok(Buffer.byteLength(text) > 8 * 1024 * 1024);
+  await fs.writeFile(input, text);
+  for (const mode of [[], ["--raw"]]) {
+    const { stdout } = await execFileAsync(process.execPath, [
+      "skills/session-viewer/scripts/session-viewer.ts", input, "--out", output, ...mode,
+    ]);
+    assert.doesNotMatch(stdout, /truncated|warnings:/);
+    const payload = embeddedViewerPayload(await fs.readFile(output, "utf8"));
+    const embedded = Buffer.from(payload.data, "base64");
+    if (payload.kind === "raw") {
+      assert.deepEqual(embedded, Buffer.from(text));
+      assert.deepEqual(payload.warnings, []);
+    } else {
+      const document = JSON.parse(embedded.toString("utf8"));
+      assert.equal(document.events.length, parse(text).events.length);
+      assert.ok(document.events.some((event: { text: string }) => event.text === "MIDDLE_READ_BOUND_MARKER"));
+      assert.deepEqual(document.warnings, []);
+    }
+  }
+});
+
+test("bounded reads retry short reads and close the file", async (t) => {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "session-viewer-short-"));
+  t.after(() => fs.rm(dir, { recursive: true, force: true }));
+  const input = path.join(dir, "session.jsonl");
+  const text = "HEAD-0123456789-TAIL";
+  await fs.writeFile(input, text);
+  const open = fs.open.bind(fs);
+  const handles: Awaited<ReturnType<typeof fs.open>>[] = [];
+  t.mock.method(fs, "open", async (...args: Parameters<typeof fs.open>) => {
+    const handle = await open(...args);
+    handles.push(handle);
+    const read = handle.read.bind(handle);
+    t.mock.method(handle, "read", (buffer: Buffer, offset: number, length: number, position: number) =>
+      read(buffer, offset, Math.min(length, 2), position));
+    return handle;
+  });
+  for (const limit of [text.length, text.length + 1, 9, 1]) {
+    const result = await readSessionText(input, limit);
+    assert.equal(result.size, text.length);
+    if (limit >= text.length) {
+      assert.equal(result.text, text);
+      assert.equal(result.truncated, false);
+    } else {
+      const head = Math.ceil(limit / 2);
+      const tail = limit - head;
+      assert.equal(result.text, `${text.slice(0, head)}\n[...middle omitted for scan...]\n${text.slice(text.length - tail)}`);
+      assert.equal(result.truncated, true);
+    }
+  }
+  assert.equal(handles.length, 4);
+  for (const handle of handles) assert.equal(handle.fd, -1);
+});
+
+test("bounded reads reject unexpected EOF and close the file", async (t) => {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "session-viewer-eof-"));
+  t.after(() => fs.rm(dir, { recursive: true, force: true }));
+  const input = path.join(dir, "session.jsonl");
+  const text = "HEAD-0123456789-TAIL";
+  await fs.writeFile(input, text);
+  const open = fs.open.bind(fs);
+  const handles: Awaited<ReturnType<typeof fs.open>>[] = [];
+  t.mock.method(fs, "open", async (...args: Parameters<typeof fs.open>) => {
+    const handle = await open(...args);
+    handles.push(handle);
+    const read = handle.read.bind(handle);
+    t.mock.method(handle, "read", async (buffer: Buffer, offset: number, length: number, position: number) => {
+      if (position >= 3) return { buffer, bytesRead: 0 };
+      return read(buffer, offset, Math.min(length, 3 - position), position);
+    });
+    return handle;
+  });
+  for (const limit of [text.length, 4, 10]) {
+    await assert.rejects(readSessionText(input, limit), /ended before the expected read completed/);
+  }
+  assert.equal(handles.length, 3);
+  for (const handle of handles) assert.equal(handle.fd, -1);
+});
+
+test("CLI rejects invalid explicit byte limits without writing an export", async (t) => {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "session-viewer-invalid-"));
+  t.after(() => fs.rm(dir, { recursive: true, force: true }));
+  const output = path.join(dir, "session.html");
+  for (const value of ["0", "-1", "1.5", "NaN", "Infinity", "9007199254740992"]) {
+    await assert.rejects(execFileAsync(process.execPath, [
+      "skills/session-viewer/scripts/session-viewer.ts", "unused.jsonl", "--out", output,
+      "--max-read-bytes", value,
+    ]), /must be a positive integer/);
+  }
+  await assert.rejects(fs.stat(output), { code: "ENOENT" });
 });
 
 test("CLI preserves exact-limit raw input without truncation", async (t) => {

--- a/skills/session-viewer/scripts/session-viewer.ts
+++ b/skills/session-viewer/scripts/session-viewer.ts
@@ -6,9 +6,12 @@ import { parseJsonl } from "./core/jsonl.ts";
 import { buildSessionViewerHtml } from "./html.ts";
 import { resolveOpenBrowserCommand } from "./open-browser.ts";
 
+const MAX_SESSION_BYTES = 8 * 1024 * 1024;
+
 type Options = {
   blank: boolean;
   inputPath?: string;
+  maxReadBytes: number;
   open: boolean;
   outPath?: string;
   raw: boolean;
@@ -17,20 +20,34 @@ type Options = {
 function usage(): string {
   return [
     "Usage:",
-    "  node session-viewer.ts <session.jsonl> --out session.html [--open] [--raw]",
+    "  node session-viewer.ts <session.jsonl> --out session.html [--open] [--raw] [--max-read-bytes N]",
     "  node session-viewer.ts --blank --out viewer.html [--open]",
     "",
     "Options:",
-    "  --blank        Write reusable file-picker viewer",
-    "  --out PATH     Output HTML path",
-    "  --open         Open output path in the browser",
-    "  --raw          Embed raw JSONL instead of normalized data",
-    "  -h, --help     Show help",
+    "  --blank             Write reusable file-picker viewer",
+    "  --out PATH          Output HTML path",
+    "  --open              Open output path in the browser",
+    "  --raw               Embed raw JSONL instead of normalized data",
+    "  --max-read-bytes N  Max session bytes to read (default 8388608)",
+    "  -h, --help          Show help",
   ].join("\n");
 }
 
+function parsePositiveInteger(value: string, flag: string): number {
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed < 1) {
+    throw new Error(`${flag} must be a positive integer`);
+  }
+  return parsed;
+}
+
 function parseArgs(argv: string[]): Options {
-  const options: Options = { blank: false, open: false, raw: false };
+  const options: Options = {
+    blank: false,
+    maxReadBytes: MAX_SESSION_BYTES,
+    open: false,
+    raw: false,
+  };
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index];
     if (arg === "-h" || arg === "--help") {
@@ -58,6 +75,15 @@ function parseArgs(argv: string[]): Options {
       index += 1;
       continue;
     }
+    if (arg === "--max-read-bytes") {
+      const value = argv[index + 1];
+      if (!value) {
+        throw new Error("missing value after --max-read-bytes");
+      }
+      options.maxReadBytes = parsePositiveInteger(value, "--max-read-bytes");
+      index += 1;
+      continue;
+    }
     if (arg.startsWith("-")) {
       throw new Error(`unknown option: ${arg}`);
     }
@@ -70,6 +96,42 @@ function parseArgs(argv: string[]): Options {
     throw new Error("missing input session path");
   }
   return options;
+}
+
+async function readBoundedText(
+  file: string,
+  maxBytes = MAX_SESSION_BYTES,
+): Promise<{ size: number; text: string; truncated: boolean }> {
+  const handle = await fs.open(file, "r");
+  try {
+    const stat = await handle.stat();
+    if (stat.size <= maxBytes) {
+      const buffer = Buffer.alloc(stat.size);
+      const { bytesRead } = await handle.read(buffer, 0, stat.size, 0);
+      return {
+        size: stat.size,
+        text: buffer.subarray(0, bytesRead).toString("utf8"),
+        truncated: false,
+      };
+    }
+    const half = Math.floor(maxBytes / 2);
+    const head = Buffer.alloc(half);
+    const tail = Buffer.alloc(half);
+    const { bytesRead: headBytes } = await handle.read(head, 0, half, 0);
+    const { bytesRead: tailBytes } = await handle.read(
+      tail,
+      0,
+      half,
+      Math.max(0, stat.size - half),
+    );
+    return {
+      size: stat.size,
+      text: `${head.subarray(0, headBytes).toString("utf8")}\n[...middle omitted for scan...]\n${tail.subarray(0, tailBytes).toString("utf8")}`,
+      truncated: true,
+    };
+  } finally {
+    await handle.close();
+  }
 }
 
 function defaultOutputPath(inputPath: string | undefined, blank: boolean): string {
@@ -103,10 +165,16 @@ async function main(): Promise<void> {
   }
 
   const inputPath = path.resolve(options.inputPath ?? "");
-  const rawText = await fs.readFile(inputPath, "utf8");
+  const bounded = await readBoundedText(inputPath, options.maxReadBytes);
+  const rawText = bounded.text;
   const { records, warnings } = parseJsonl(rawText);
   const document = parseSessionDocument(records, inputPath);
   document.warnings.unshift(...warnings);
+  if (bounded.truncated) {
+    const warning = `source truncated: omitted middle of ${inputPath} (${bounded.size} bytes, read cap ${options.maxReadBytes} bytes)`;
+    document.warnings.unshift(warning);
+    console.log(warning);
+  }
   const html = buildSessionViewerHtml(document, {
     embedMode: options.raw ? "raw" : "normalized",
     rawText,

--- a/skills/session-viewer/scripts/session-viewer.ts
+++ b/skills/session-viewer/scripts/session-viewer.ts
@@ -5,13 +5,12 @@ import { parseSessionDocument } from "./core/detect.ts";
 import { parseJsonl } from "./core/jsonl.ts";
 import { buildSessionViewerHtml } from "./html.ts";
 import { resolveOpenBrowserCommand } from "./open-browser.ts";
-
-const MAX_SESSION_BYTES = 8 * 1024 * 1024;
+import { readSessionText } from "./read-session.ts";
 
 type Options = {
   blank: boolean;
   inputPath?: string;
-  maxReadBytes: number;
+  maxReadBytes?: number;
   open: boolean;
   outPath?: string;
   raw: boolean;
@@ -28,7 +27,7 @@ function usage(): string {
     "  --out PATH          Output HTML path",
     "  --open              Open output path in the browser",
     "  --raw               Embed raw JSONL instead of normalized data",
-    "  --max-read-bytes N   Max session bytes to read (default 8388608)",
+    "  --max-read-bytes N   Opt into head/tail truncation (default: full file)",
     "  -h, --help          Show help",
   ].join("\n");
 }
@@ -44,7 +43,6 @@ function parsePositiveInteger(value: string, flag: string): number {
 function parseArgs(argv: string[]): Options {
   const options: Options = {
     blank: false,
-    maxReadBytes: MAX_SESSION_BYTES,
     open: false,
     raw: false,
   };
@@ -98,42 +96,6 @@ function parseArgs(argv: string[]): Options {
   return options;
 }
 
-async function readBoundedText(
-  file: string,
-  maxBytes = MAX_SESSION_BYTES,
-): Promise<{ size: number; text: string; truncated: boolean }> {
-  const handle = await fs.open(file, "r");
-  try {
-    const stat = await handle.stat();
-    if (stat.size <= maxBytes) {
-      const buffer = Buffer.alloc(stat.size);
-      const { bytesRead } = await handle.read(buffer, 0, stat.size, 0);
-      return {
-        size: stat.size,
-        text: buffer.subarray(0, bytesRead).toString("utf8"),
-        truncated: false,
-      };
-    }
-    const half = Math.floor(maxBytes / 2);
-    const head = Buffer.alloc(half);
-    const tail = Buffer.alloc(half);
-    const { bytesRead: headBytes } = await handle.read(head, 0, half, 0);
-    const { bytesRead: tailBytes } = await handle.read(
-      tail,
-      0,
-      half,
-      Math.max(0, stat.size - half),
-    );
-    return {
-      size: stat.size,
-      text: `${head.subarray(0, headBytes).toString("utf8")}\n[...middle omitted for scan...]\n${tail.subarray(0, tailBytes).toString("utf8")}`,
-      truncated: true,
-    };
-  } finally {
-    await handle.close();
-  }
-}
-
 function defaultOutputPath(inputPath: string | undefined, blank: boolean): string {
   if (blank || !inputPath) {
     return path.resolve("session-viewer.html");
@@ -165,7 +127,7 @@ async function main(): Promise<void> {
   }
 
   const inputPath = path.resolve(options.inputPath ?? "");
-  const bounded = await readBoundedText(inputPath, options.maxReadBytes);
+  const bounded = await readSessionText(inputPath, options.maxReadBytes);
   const rawText = bounded.text;
   const { records, warnings } = parseJsonl(rawText);
   const document = parseSessionDocument(records, inputPath);


### PR DESCRIPTION
Large session exports need an explicit way to limit the input without changing the existing complete-history default. This adds `--max-read-bytes N` as an opt-in head/tail read limit for both normalized and raw HTML exports. With no limit, the CLI still exports the complete file.

Partial exports carry their warnings through raw serialization and display escaped warning text above events in both modes. Files at or below an explicit limit remain complete. The bounded reader retries short reads and fails on unexpected EOF while closing the file. The browser file picker continues to read complete files. Documentation and the changelog describe these boundaries.

The original contribution by @SebTardif is retained. The maintainer corrections are additive commits that preserve contributor history and credit.

Validation:

- 37 session-viewer tests cover default full exports over 8 MiB, explicit bounds, both endpoint markers, exact-limit reads, short reads and EOF cleanup, positive-integer validation, raw warning propagation, escaped hostile warning text, and legacy raw payloads.
- A real 10,495,156-byte synthetic JSONL exports byte-for-byte in default raw mode and retains all 83 events, including a middle marker, in normalized mode. Explicit `--max-read-bytes 8388608` retains the head/tail, embeds 8,388,641 raw bytes including the omission marker, and preserves truncation warnings in both modes.
- Full repository checks and native TypeScript checking pass. Independent full-candidate Codex review through P2 found no actionable issues.

Live-browser appearance and before/after screenshots remain unverified because browser access was blocked in the maintenance environment. Generated local HTML artifacts and execution of the emitted JavaScript with DOM stubs provide supporting evidence; they are not a live-browser check. The full-file default retains its existing memory costs; users must explicitly choose a partial export to limit input bytes.
