### PR TITLE
fix(beam): keep transcript items within receiver limits

### DIFF
--- a/skills/beam/README.md
+++ b/skills/beam/README.md
@@ -154,6 +154,10 @@ Gateway HTTP authentication. Uploads require `operator.write` or
 `operator.admin`. Every `operator.read` client on that Gateway can view the
 catalog, so a separate Gateway remains the isolation boundary between teams.
 
+The receiver rejects transcript item text longer than 6,000 characters.
+Accordingly, explicit `--entry-max-chars` values above 6,000 fail locally
+before upload.
+
 The catalog has no continue, archive, terminal, tool, or node capability.
 
 For rollout compatibility, the helper also accepts the current server's exact

--- a/skills/beam/scripts/beam
+++ b/skills/beam/scripts/beam
@@ -12,6 +12,7 @@ import {
 
 const MAX_UPLOAD_BYTES = 52 * 1024;
 const MAX_UPLOAD_ITEMS = 200;
+const MAX_UPLOAD_ITEM_CHARS = 6_000;
 const DEFAULT_TIMEOUT_MS = 15_000;
 
 function usage() {
@@ -120,7 +121,7 @@ function resolveSession(options, hook) {
 
 function normalizeItems(rendered, hook, options) {
   const items = rendered.items.map((item) => ({ ...item }));
-  const entryMaxChars = positiveInteger(options["entry-max-chars"], 6_000, "--entry-max-chars");
+  const entryMaxChars = parseEntryMaxChars(options);
   const lastAssistant =
     typeof hook.last_assistant_message === "string" && hook.last_assistant_message.trim()
       ? sanitizeVisibleText(hook.last_assistant_message, { maxChars: entryMaxChars })
@@ -139,6 +140,18 @@ function positiveInteger(value, fallback, label, minimum = 1) {
     throw new Error(`${label} must be an integer of at least ${minimum}`);
   }
   return Math.floor(parsed);
+}
+
+function parseEntryMaxChars(options) {
+  const value = positiveInteger(
+    options["entry-max-chars"],
+    MAX_UPLOAD_ITEM_CHARS,
+    "--entry-max-chars",
+  );
+  if (value > MAX_UPLOAD_ITEM_CHARS) {
+    throw new Error(`--entry-max-chars must be at most ${MAX_UPLOAD_ITEM_CHARS}`);
+  }
+  return value;
 }
 
 function titleFromItems(items) {
@@ -210,7 +223,7 @@ function buildPayload(options, hook) {
   const session = resolveSession(options, hook);
   const rendered = renderSession(session.file, {
     source: session.source,
-    maxChars: positiveInteger(options["entry-max-chars"], 6_000, "--entry-max-chars"),
+    maxChars: parseEntryMaxChars(options),
   });
   const items = normalizeItems(rendered, hook, options);
   if (!items.length) throw new Error("the sanitized session contains no shareable messages");

--- a/skills/beam/scripts/beam-session.js
+++ b/skills/beam/scripts/beam-session.js
@@ -576,9 +576,16 @@ export function sanitizeVisibleText(input, options = {}) {
   text = redact(text, stats).replace(/\n{3,}/g, "\n\n").trim();
   if (unsafePatterns(text).length) throw new Error("unsafe transcript text remains after redaction");
   const maxChars = Number(options.maxChars || DEFAULT_ENTRY_MAX_CHARS);
-  return text.length > maxChars
-    ? `${text.slice(0, maxChars).trimEnd()}\n...[truncated ${text.length - maxChars} chars]`
-    : text;
+  if (text.length <= maxChars) return text;
+  let omitted = text.length - maxChars;
+  while (true) {
+    const marker = `\n...[truncated ${omitted} chars]`;
+    if (marker.length >= maxChars) return marker.slice(0, maxChars);
+    const visible = text.slice(0, maxChars - marker.length).trimEnd();
+    const nextOmitted = text.length - visible.length;
+    if (nextOmitted === omitted) return `${visible}${marker}`;
+    omitted = nextOmitted;
+  }
 }
 
 function toolFamily(name) {

--- a/skills/beam/scripts/beam-session.js
+++ b/skills/beam/scripts/beam-session.js
@@ -581,7 +581,18 @@ export function sanitizeVisibleText(input, options = {}) {
   while (true) {
     const marker = `\n...[truncated ${omitted} chars]`;
     if (marker.length >= maxChars) return marker.slice(0, maxChars);
-    const visible = text.slice(0, maxChars - marker.length).trimEnd();
+    let cutoff = maxChars - marker.length;
+    const lastCodeUnit = text.charCodeAt(cutoff - 1);
+    const nextCodeUnit = text.charCodeAt(cutoff);
+    if (
+      lastCodeUnit >= 0xd800 &&
+      lastCodeUnit <= 0xdbff &&
+      nextCodeUnit >= 0xdc00 &&
+      nextCodeUnit <= 0xdfff
+    ) {
+      cutoff--;
+    }
+    const visible = text.slice(0, cutoff).trimEnd();
     const nextOmitted = text.length - visible.length;
     if (nextOmitted === omitted) return `${visible}${marker}`;
     omitted = nextOmitted;

--- a/skills/beam/scripts/beam.test.mjs
+++ b/skills/beam/scripts/beam.test.mjs
@@ -177,6 +177,14 @@ test("standalone sanitizer keeps ordinary AGENTS.md tasks", () => {
   );
 });
 
+test("standalone sanitizer keeps its truncation marker inside the receiver item limit", () => {
+  const input = "visible ".repeat(900).trim();
+  const value = sanitizeVisibleText(input, { maxChars: 6_000 });
+
+  assert.equal(value.length, 6_000);
+  assert.match(value, /\n\.\.\.\[truncated \d+ chars\]$/);
+});
+
 test("standalone Claude discovery requires one exact session-id filename", () => {
   const configDir = tempDir();
   const projectDir = path.join(configDir, "projects", "demo");
@@ -460,7 +468,7 @@ test("publish honors the total max-chars disclosure limit", async () => {
   assert.doesNotMatch(payload.title, /^alpha/);
 });
 
-test("publish preserves a visible message when byte trimming drops tool summaries", async () => {
+test("publish keeps multibyte transcript items within receiver limits", async () => {
   const session = path.join(tempDir(), "multibyte.jsonl");
   writeJsonl(session, [
     { type: "user", message: { role: "user", content: "🦞".repeat(20_000) } },
@@ -474,8 +482,6 @@ test("publish preserves a visible message when byte trimming drops tool summarie
     session,
     "--max-chars",
     "48000",
-    "--entry-max-chars",
-    "48000",
     "--dry-run",
     "--quiet",
   ]);
@@ -483,8 +489,27 @@ test("publish preserves a visible message when byte trimming drops tool summarie
   assert.equal(result.code, 0, result.stderr);
   const payload = JSON.parse(result.stdout);
   assert.equal(payload.items.some((item) => item.type === "userMessage"), true);
-  assert.equal(payload.items.every((item) => item.type !== "other"), true);
-  assert.equal(payload.truncated, true);
+  assert.equal(payload.items.some((item) => item.type === "other"), true);
+  assert.equal(payload.items.every((item) => item.text.length <= 6_000), true);
+  assert.ok(Buffer.byteLength(JSON.stringify(payload)) <= 52 * 1024);
+});
+
+test("publish rejects an entry limit above the receiver maximum", async () => {
+  const result = await run([
+    "publish",
+    "--endpoint",
+    "http://127.0.0.1:9/api/v1/beam/sessions",
+    "--session",
+    claudeSession(),
+    "--entry-max-chars",
+    "6001",
+    "--dry-run",
+    "--quiet",
+  ]);
+
+  assert.equal(result.code, 1);
+  assert.match(result.stderr, /--entry-max-chars must be at most 6000/);
+  assert.equal(result.stdout, "");
 });
 
 test("publish accepts IPv6 loopback development endpoints", async () => {

--- a/skills/beam/scripts/beam.test.mjs
+++ b/skills/beam/scripts/beam.test.mjs
@@ -185,6 +185,15 @@ test("standalone sanitizer keeps its truncation marker inside the receiver item 
   assert.match(value, /\n\.\.\.\[truncated \d+ chars\]$/);
 });
 
+test("standalone sanitizer preserves astral characters at the truncation boundary", () => {
+  const value = sanitizeVisibleText("🦞".repeat(3_487), { maxChars: 6_000 });
+
+  assert.ok(value.length <= 6_000);
+  assert.match(value, /\n\.\.\.\[truncated \d+ chars\]$/);
+  assert.equal(Buffer.from(value, "utf8").toString("utf8"), value);
+  assert.equal(value.includes("\ufffd"), false);
+});
+
 test("standalone Claude discovery requires one exact session-id filename", () => {
   const configDir = tempDir();
   const projectDir = path.join(configDir, "projects", "demo");


### PR DESCRIPTION
## Summary

- keep Beam's truncation marker inside the receiver's 6,000-character item limit
- preserve UTF-16 surrogate pairs when truncating astral-character text
- reject explicit `--entry-max-chars` values above the receiver contract instead of silently clamping them
- document the receiver limit and local failure behavior
- replace the contradictory 48,000-character test with receiver-compatible payload coverage

## Root cause

Beam truncated visible text to the configured content limit and appended the marker afterward. The default therefore produced items longer than the OpenClaw receiver accepts, while oversized explicit limits were silently clamped. Reserving marker space also introduced a cutoff that could fall between a valid UTF-16 surrogate pair; the prefix now backs off one code unit only at that boundary.

## Maintainer decision

On September 4, 2026, the maintainer confirmed that 6,000 JavaScript string units is the universal OpenClaw Beam receiver cap and that explicit larger `--entry-max-chars` values should fail locally. `skills/beam/README.md` documents both the receiver rejection and the intentional local error.

## Validation

- pre-fix reproduction: targeted astral input emitted an unpaired surrogate
- `node --check skills/beam/scripts/beam`
- `node --check skills/beam/scripts/beam-session.js`
- `node --test skills/beam/scripts/beam.test.mjs` (52 passed)
- `uv run --with pyyaml scripts/validate-skills` (`validated 8 skills`)
- `git diff --check`
- privacy scrub: no personal paths, private hosts, tokens, or credentials in the diff
- mandatory autoreview: scoped-clean through P2; no actionable findings
