### PR TITLE
fix(beam): ignore persisted Codex agent messages

### DIFF
--- a/skills/beam/scripts/beam-session.js
+++ b/skills/beam/scripts/beam-session.js
@@ -748,6 +748,7 @@ function parseCodex(rows, options) {
     }
     if (row.type !== "response_item") continue;
     const type = normalizedType(payload.type);
+    if (type === "agentmessage") continue;
     if (payload.role === "user" || payload.role === "assistant") {
       if (hasEventDialogue) continue;
       pushMessage(

--- a/skills/beam/scripts/beam.test.mjs
+++ b/skills/beam/scripts/beam.test.mjs
@@ -384,6 +384,30 @@ test("standalone parser handles modern Codex items without reasoning or raw outp
   );
 });
 
+test("standalone parser ignores persisted Codex inter-agent messages", () => {
+  const session = path.join(tempDir(), "rollout.jsonl");
+  writeJsonl(session, [
+    { type: "session_meta", payload: { id: "33333333-4444-4555-8666-777777777777" } },
+    { type: "response_item", payload: { type: "function_call", name: "read_file" } },
+    {
+      type: "response_item",
+      payload: {
+        type: "agent_message",
+        author: "agent-a",
+        recipient: "agent-b",
+        content: [{ type: "input_text", text: "private inter-agent coordination" }],
+      },
+    },
+    { type: "response_item", payload: { type: "function_call", name: "exec_command" } },
+  ]);
+
+  const rendered = renderSession(session, { source: "codex" });
+  assert.deepEqual(rendered.items, [
+    { type: "other", text: "1 read, 1 execute; raw tool outputs dropped: 0" },
+  ]);
+  assert.doesNotMatch(JSON.stringify(rendered), /private inter-agent coordination/);
+});
+
 test("publish dry-run emits a sanitized versioned payload", async () => {
   const session = claudeSession();
   const result = await run([


### PR DESCRIPTION
## Summary

- ignore persisted Codex `response_item` payloads whose type is `agent_message`
- preserve `event_msg.item_completed.agent_message` as visible assistant output
- prove ignored inter-agent records add neither visible text nor a fake tool count while neighboring tool summaries remain intact

## Root cause

Persisted Codex inter-agent communication shares the `agent_message` name with a separate visible completion event. Beam treated the persisted response item as an unknown tool-like record and added a misleading `other` count.

## Validation

- `node --check skills/beam/scripts/beam-session.js`
- `node --test skills/beam/scripts/beam.test.mjs` (50 passed)
- `scripts/validate-skills`
- `git diff --check`
- mandatory autoreview: clean, no actionable findings

## CI note

Windows fails only `test_commit_review_uses_raw_parents_at_history_boundaries`. The exact same CRLF assertion failed on `main` run `33625256491` at SHA `0cdce5469d49509265333a0ef88e80a574ff8fb6` on 2026-09-02. Ubuntu, CodeQL, and Beam-local validation pass.
