### PR TITLE
fix(autoreview): confine macOS reviewer scratch access

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -36,7 +36,7 @@ jobs:
           python scripts/install-skills.test.py
           python scripts/validate-skills.test.py
       - name: Run Python tests
-        run: python -m unittest skills/autoreview/scripts/autoreview_test.py skills.autoreview.tests.test_autoreview_hardening
+        run: python -m unittest skills/autoreview/scripts/autoreview_test.py skills.autoreview.tests.test_autoreview_hardening skills.autoreview.tests.test_codex_sandbox
       - name: Check Node scripts
         run: |
           node --check skills/agent-transcript/scripts/agent-transcript

--- a/skills/autoreview/SKILL.md
+++ b/skills/autoreview/SKILL.md
@@ -107,8 +107,9 @@ echo input headings or finding payloads; remove credentials locally and rerun.
 Never reproduce credentials in findings or work around an isolation failure.
 
 On macOS, reviewer tools cannot access the shared `/tmp` and `/var/tmp` trees
-(including their `/private` aliases). The review workspace must remain outside
-those trees; unset a shared `TMPDIR`/`TMP`/`TEMP` override to use macOS's private
+(including their `/private` aliases). Codex preflight rejects those temporary
+roots before workspace, runtime, or authentication setup; unset a shared
+`TMPDIR`/`TMP`/`TEMP` override to use macOS's private
 temporary directory. Other engines and platforms retain their normal isolation.
 Tools installed in shared scratch or requiring writes there will be denied too.
 

--- a/skills/autoreview/SKILL.md
+++ b/skills/autoreview/SKILL.md
@@ -106,6 +106,12 @@ Source-controlled ignore tags cannot suppress this gate. Scanner refusals never
 echo input headings or finding payloads; remove credentials locally and rerun.
 Never reproduce credentials in findings or work around an isolation failure.
 
+On macOS, reviewer tools cannot access the shared `/tmp` and `/var/tmp` trees
+(including their `/private` aliases). The review workspace must remain outside
+those trees; unset a shared `TMPDIR`/`TMP`/`TEMP` override to use macOS's private
+temporary directory. Other engines and platforms retain their normal isolation.
+Tools installed in shared scratch or requiring writes there will be denied too.
+
 Review files have no size/count cap and are never truncated. Large diffs and
 datasets are partitioned automatically. Intact instructions and required mixed
 source context must still fit the per-pass prompt budget. A failed pass does not

--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -3712,6 +3712,20 @@ def toml_inline_string_table(values: dict[str, str]) -> str:
 
 def codex_config_isolation_flags(repo: Path, runtime_root: Path) -> list[str]:
     tool_env = toml_inline_string_table(codex_tool_git_env())
+    filesystem = {":minimal": "read", ":workspace_roots": "read"}
+    if sys.platform == "darwin":
+        # Codex's macOS process defaults otherwise grant shared scratch access.
+        # Glob denies override those defaults but cannot reopen a nested workspace.
+        scratch_roots = ("/tmp", "/private/tmp", "/var/tmp", "/private/var/tmp")
+        if any(is_within(repo.resolve(), Path(root)) for root in scratch_roots):
+            raise SystemExit(
+                "Codex review workspace must be outside shared scratch directories; "
+                "unset TMPDIR/TMP/TEMP to use the macOS private temporary directory"
+            )
+        filesystem.update({f"{root}{{,/**}}": "deny" for root in scratch_roots})
+    filesystem_config = ",".join(
+        f"{json.dumps(path)}={json.dumps(access)}" for path, access in filesystem.items()
+    )
     state_home = runtime_root / "state"
     log_dir = runtime_root / "log"
     state_home.mkdir(parents=True, exist_ok=True)
@@ -3748,7 +3762,7 @@ def codex_config_isolation_flags(repo: Path, runtime_root: Path) -> list[str]:
         "-c",
         'default_permissions="autoreview"',
         "-c",
-        'permissions.autoreview.filesystem={":minimal"="read",":workspace_roots"="read"}',
+        f"permissions.autoreview.filesystem={{{filesystem_config}}}",
     ]
 
 

--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -360,6 +360,7 @@ CODEX_TRUST_PATH_ENV_KEYS = {
     "SSL_CERT_DIR",
     "SSL_CERT_FILE",
 }
+CODEX_MACOS_SCRATCH_ROOTS = ("/tmp", "/private/tmp", "/var/tmp", "/private/var/tmp")
 PROVIDER_CREDENTIAL_PATH_ENV_KEYS = {
     "AWS_CONFIG_FILE",
     "AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE",
@@ -644,7 +645,7 @@ def safe_dbus_session_address(repo: Path, value: str) -> bool:
     return Path(path).is_absolute() and external_env_path(repo, path)
 
 
-def safe_temp_root(repo: Path) -> Path:
+def safe_temp_root(repo: Path, *, engine: str | None = None) -> Path:
     try:
         root = Path(tempfile.gettempdir()).resolve(strict=True)
     except OSError as exc:
@@ -653,6 +654,14 @@ def safe_temp_root(repo: Path) -> Path:
         raise SystemExit(
             "temporary directory must be outside the reviewed repository; "
             "unset or relocate TMPDIR/TMP/TEMP"
+        )
+    # Reject before Codex's probe or runtime can put file auth in shared scratch.
+    if engine == "codex" and sys.platform == "darwin" and any(
+        is_within(root, Path(scratch)) for scratch in CODEX_MACOS_SCRATCH_ROOTS
+    ):
+        raise SystemExit(
+            "Codex temporary directory must be outside shared scratch directories; "
+            "unset TMPDIR/TMP/TEMP to use the macOS private temporary directory"
         )
     return root
 
@@ -3715,14 +3724,8 @@ def codex_config_isolation_flags(repo: Path, runtime_root: Path) -> list[str]:
     filesystem = {":minimal": "read", ":workspace_roots": "read"}
     if sys.platform == "darwin":
         # Codex's macOS process defaults otherwise grant shared scratch access.
-        # Glob denies override those defaults but cannot reopen a nested workspace.
-        scratch_roots = ("/tmp", "/private/tmp", "/var/tmp", "/private/var/tmp")
-        if any(is_within(repo.resolve(), Path(root)) for root in scratch_roots):
-            raise SystemExit(
-                "Codex review workspace must be outside shared scratch directories; "
-                "unset TMPDIR/TMP/TEMP to use the macOS private temporary directory"
-            )
-        filesystem.update({f"{root}{{,/**}}": "deny" for root in scratch_roots})
+        # Glob denies cover the root's listing as well as its descendants.
+        filesystem.update({f"{root}{{,/**}}": "deny" for root in CODEX_MACOS_SCRATCH_ROOTS})
     filesystem_config = ",".join(
         f"{json.dumps(path)}={json.dumps(access)}" for path, access in filesystem.items()
     )
@@ -3973,7 +3976,7 @@ def ensure_codex_isolation_supported(
 ) -> str:
     selected_bin = args.codex_bin
     codex_bin = resolve_command(selected_bin, repo)
-    temp_root = safe_temp_root(repo)
+    temp_root = safe_temp_root(repo, engine="codex")
     with tempfile.TemporaryDirectory(
         prefix="autoreview-codex-probe-workspace.",
         dir=temp_root,
@@ -4580,7 +4583,7 @@ def run_codex(args: argparse.Namespace, repo: Path, prompt: str) -> str:
     if not args.tools:
         raise SystemExit("--no-tools is not supported by the Codex engine; use --engine claude --no-tools for a no-tools run")
     ensure_codex_isolation_supported(args, repo)
-    temp_root = safe_temp_root(repo)
+    temp_root = safe_temp_root(repo, engine="codex")
     schema_path = write_json_temp(SCHEMA, temp_root)
     with tempfile.NamedTemporaryFile(
         "w",

--- a/skills/autoreview/tests/test_autoreview_hardening.py
+++ b/skills/autoreview/tests/test_autoreview_hardening.py
@@ -4910,6 +4910,55 @@ with Path(__file__).with_name("scans.jsonl").open("a", encoding="utf-8") as reco
                 os.environ.clear()
                 os.environ.update(old)
 
+    @unittest.skipIf(os.name == "nt", "POSIX shared scratch roots")
+    def test_codex_rejects_shared_scratch_before_runtime_setup(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            root = Path(tempdir)
+            repo = init_repo(root)
+            binary = write_executable(root / "codex", fake_codex_script())
+            source_home = root / "synthetic-auth-home"
+            source_home.mkdir()
+            source_auth = source_home / "auth.json"
+            source_auth.write_text('{"fixture":"synthetic"}')
+            auth_before = source_auth.read_bytes()
+            links_before = source_auth.stat().st_nlink
+            args = argparse.Namespace(
+                codex_bin=str(binary), model=None, tools=True, web_search=False,
+                thinking=None, codex_config=[], codex_speed=None,
+                stream_engine_output=False,
+            )
+            for scratch_root in ("/tmp", "/var/tmp"):
+                for entry in ("ensure_codex_isolation_supported", "run_codex"):
+                    with self.subTest(root=scratch_root, entry=entry), tempfile.TemporaryDirectory(
+                        prefix="autoreview-scratch-order.", dir=scratch_root,
+                    ) as scratch:
+                        runtime_auth = mock.Mock(wraps=self.helper["prepare_codex_runtime_auth"])
+                        with (
+                            mock.patch.dict(os.environ, {
+                                "PATH": os.environ["PATH"], "CODEX_HOME": str(source_home),
+                                "HOME": str(root),
+                            }, clear=True),
+                            mock.patch.object(sys, "platform", "darwin"),
+                            mock.patch.object(tempfile, "gettempdir", return_value=scratch),
+                            mock.patch.object(tempfile, "TemporaryDirectory", wraps=tempfile.TemporaryDirectory) as directories,
+                            mock.patch.object(tempfile, "NamedTemporaryFile", wraps=tempfile.NamedTemporaryFile) as files,
+                            mock.patch.dict(self.helper[entry].__globals__, {
+                                "prepare_codex_runtime_auth": runtime_auth,
+                            }),
+                        ):
+                            self.assertEqual(self.helper["safe_temp_root"](repo), Path(scratch).resolve())
+                            with self.assertRaisesRegex(SystemExit, "outside shared scratch"):
+                                if entry == "run_codex":
+                                    self.helper[entry](args, repo, "synthetic review input")
+                                else:
+                                    self.helper[entry](args, repo)
+                            runtime_auth.assert_not_called()
+                            directories.assert_not_called()
+                            files.assert_not_called()
+                        self.assertEqual(list(Path(scratch).iterdir()), [])
+                        self.assertEqual(source_auth.read_bytes(), auth_before)
+                        self.assertEqual(source_auth.stat().st_nlink, links_before)
+
     def test_codex_isolation_restricts_tool_environment(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:
             root = Path(tempdir)

--- a/skills/autoreview/tests/test_autoreview_hardening.py
+++ b/skills/autoreview/tests/test_autoreview_hardening.py
@@ -4933,9 +4933,12 @@ with Path(__file__).with_name("scans.jsonl").open("a", encoding="utf-8") as reco
             "shell_environment_policy.experimental_use_profile=false",
             "allow_login_shell=false",
             'default_permissions="autoreview"',
-            'permissions.autoreview.filesystem={":minimal"="read",":workspace_roots"="read"}',
         ):
             self.assertIn(required, flags)
+        filesystem = '":minimal"="read",":workspace_roots"="read"'
+        if sys.platform == "darwin":
+            filesystem += ',"/tmp{,/**}"="deny","/private/tmp{,/**}"="deny","/var/tmp{,/**}"="deny","/private/var/tmp{,/**}"="deny"'
+        self.assertIn(f"permissions.autoreview.filesystem={{{filesystem}}}", flags)
         set_flag = next(
             flag for flag in flags if flag.startswith("shell_environment_policy.set=")
         )

--- a/skills/autoreview/tests/test_codex_sandbox.py
+++ b/skills/autoreview/tests/test_codex_sandbox.py
@@ -15,18 +15,6 @@ HELPER = Path(__file__).resolve().parents[1] / "scripts" / "autoreview"
 
 @unittest.skipUnless(sys.platform == "darwin" and shutil.which("codex"), "requires macOS and Codex")
 class CodexSandboxTests(unittest.TestCase):
-    def test_workspace_in_shared_scratch_is_rejected_before_runtime_setup(self):
-        helper = runpy.run_path(str(HELPER), run_name="autoreview_under_test")
-        for scratch_root in ("/private/tmp", "/private/var/tmp"):
-            with self.subTest(root=scratch_root), tempfile.TemporaryDirectory(
-                prefix="autoreview-scratch-test.", dir=scratch_root,
-            ) as scratch:
-                for spelling in (scratch, scratch.removeprefix("/private")):
-                    root = Path(spelling)
-                    with self.assertRaisesRegex(SystemExit, "outside shared scratch"):
-                        helper["codex_config_isolation_flags"](root, root / "runtime")
-                    self.assertFalse((root / "runtime").exists())
-
     def test_shared_scratch_is_denied_but_workspace_remains_read_only(self):
         helper = runpy.run_path(str(HELPER), run_name="autoreview_under_test")
         private_temp_root = Path(tempfile.gettempdir()).resolve()

--- a/skills/autoreview/tests/test_codex_sandbox.py
+++ b/skills/autoreview/tests/test_codex_sandbox.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Exercise the real macOS tool sandbox, not a mocked Codex verdict."""
+
+import runpy
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+HELPER = Path(__file__).resolve().parents[1] / "scripts" / "autoreview"
+
+
+@unittest.skipUnless(sys.platform == "darwin" and shutil.which("codex"), "requires macOS and Codex")
+class CodexSandboxTests(unittest.TestCase):
+    def test_workspace_in_shared_scratch_is_rejected_before_runtime_setup(self):
+        helper = runpy.run_path(str(HELPER), run_name="autoreview_under_test")
+        for scratch_root in ("/private/tmp", "/private/var/tmp"):
+            with self.subTest(root=scratch_root), tempfile.TemporaryDirectory(
+                prefix="autoreview-scratch-test.", dir=scratch_root,
+            ) as scratch:
+                for spelling in (scratch, scratch.removeprefix("/private")):
+                    root = Path(spelling)
+                    with self.assertRaisesRegex(SystemExit, "outside shared scratch"):
+                        helper["codex_config_isolation_flags"](root, root / "runtime")
+                    self.assertFalse((root / "runtime").exists())
+
+    def test_shared_scratch_is_denied_but_workspace_remains_read_only(self):
+        helper = runpy.run_path(str(HELPER), run_name="autoreview_under_test")
+        private_temp_root = Path(tempfile.gettempdir()).resolve()
+        for scratch_root in ("/private/tmp", "/private/var/tmp"):
+            self.assertFalse(
+                private_temp_root.is_relative_to(scratch_root),
+                "sandbox positive control requires the macOS private temporary directory",
+            )
+        for scratch_root in ("/private/tmp", "/private/var/tmp"):
+            with (
+                self.subTest(root=scratch_root),
+                tempfile.TemporaryDirectory(
+                    prefix="autoreview-sandbox-test.", dir=private_temp_root,
+                ) as private_temp,
+                tempfile.TemporaryDirectory(
+                    prefix="autoreview-scratch-test.", dir=scratch_root,
+                ) as scratch,
+            ):
+                root = Path(private_temp).resolve()
+                workspace = root / "workspace"
+                workspace.mkdir()
+                inside = workspace / "inside.txt"
+                outside = Path(scratch) / "outside.txt"
+                inside.write_text("owned inside\n")
+                outside.write_text("owned outside\n")
+                flags = helper["codex_config_isolation_flags"](workspace, root / "runtime")
+                runtime_file = root / "runtime" / "synthetic-auth.txt"
+                runtime_file.write_text("synthetic runtime sentinel\n")
+                scratch_link = workspace / "scratch-link"
+                scratch_link.symlink_to(outside)
+                runtime_link = workspace / "runtime-link"
+                runtime_link.symlink_to(runtime_file)
+                alias = Path(str(outside).removeprefix("/private"))
+                for path in (outside, alias, scratch_link):
+                    self.assertEqual(path.read_text(), "owned outside\n")
+                self.assertEqual(runtime_link.read_text(), "synthetic runtime sentinel\n")
+                subprocess.run(
+                    ["/bin/ls", "-f", scratch_root], check=True,
+                    stdout=subprocess.DEVNULL, stderr=subprocess.PIPE,
+                )
+                result = subprocess.run(
+                    [
+                        shutil.which("codex"), "sandbox", "--include-managed-config",
+                        "--permission-profile", "autoreview", *flags, "-C", str(workspace),
+                        "--", "/bin/sh", "-c",
+                        '''
+                        fail=0
+                        test "$(cat "$1")" = "owned inside" || fail=1
+                        if cat "$2" >/dev/null; then echo outside-read-allowed; fail=1; fi
+                        if cat "$3" >/dev/null; then echo alias-read-allowed; fail=1; fi
+                        if ls -f "$4" >/dev/null; then echo root-list-allowed; fail=1; fi
+                        if (printf unexpected >> "$2"); then echo outside-write-allowed; fail=1; fi
+                        if (printf unexpected >> "$1"); then echo inside-write-allowed; fail=1; fi
+                        if touch "$5"; then echo outside-create-allowed; fail=1; fi
+                        if cat "$6" >/dev/null; then echo scratch-link-read-allowed; fail=1; fi
+                        if cat "$7" >/dev/null; then echo runtime-link-read-allowed; fail=1; fi
+                        exit "$fail"
+                        ''',
+                        "sandbox-test", str(inside), str(outside), str(alias), scratch_root,
+                        str(Path(scratch) / "created"), str(scratch_link), str(runtime_link),
+                    ],
+                    capture_output=True, text=True, timeout=60,
+                )
+                self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+                self.assertEqual(inside.read_text(), "owned inside\n")
+                self.assertEqual(outside.read_text(), "owned outside\n")
+                self.assertEqual(runtime_file.read_text(), "synthetic runtime sentinel\n")
+                self.assertFalse((Path(scratch) / "created").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Keep macOS Codex review tools inside the intended read-only review boundary. The minimal filesystem profile still received Codex's ordinary-process read/write allowances for shared temporary directories, so an empty review workspace alone did not isolate those paths.

The existing profile now adds explicit root-and-descendant denies for `/tmp`, `/var/tmp`, and their `/private` aliases. The canonical temporary-root selector rejects those trees before Codex preflight or execution can create a workspace, create runtime files, or prepare authentication. Both selections are checked; there is no late deny-and-reopen exception. Authentication stays with the parent process. No reviewer control is disabled; global configuration and other engines/platforms are unchanged.

The new regression exercises the installed macOS sandbox rather than a mocked verdict. It covers both scratch trees, aliases, root listing, scratch/runtime symlinks, allowed workspace reads, and denied writes/creation. Every negative path first resolves to a readable synthetic sentinel, and directory-listing contents are discarded. The test is included in the normal suite and skips where macOS/Codex are unavailable.

## Verification

- Exact baseline helper: four expected failing sandbox/rejection subcases. Shared scratch reads, listing, writes, creation, and a scratch symlink were allowed; the private runtime sibling and workspace writes were already denied.
- The first candidate's setup-order regression fails in four intended cells: both shared roots reached preflight setup, and the normal execution path prepared synthetic authentication before rejecting them. The revised production-entry regression verifies rejection before any temporary constructor or authentication preparation, with unchanged synthetic auth bytes and link count. Other engines retain their generic temporary-root behavior.
- Repaired helper: the production-entry ordering regression, real sandbox case, and existing profile-config case pass. Verified with Codex CLI 0.151.0 on macOS; no claim about other binary versions.
- Normal authenticated benign review harness: scoped-clean, with the restricted reviewer profile retained.
- Complete revised Python suite: 248 passed, one platform skip (249 total), in 171.966 seconds; source hashes unchanged.
- Repository script tests: 6 installer + 9 validator tests pass. Node tests: 97 pass. Skill validation and Python/shell/Node syntax checks pass.
- The initial P0 reviews did not cover the later P1 setup-order finding. That finding is accepted and corrected in `c12920c4bf534605a1df65d3ceddcf1afc20ce89`; fresh complete staged P1 review and separate committed full-branch read-only P1 review are both scoped-clean with no accepted findings. Independent source/contract review found no remaining setup-order defect. The owner separately verified exact commit/tree/source identities; the reviewers did not execute project tests.

Dependency inspection: `openai/codex` revision `41e22fee981a63b3698df7ed36bad393cda24715`, `codex-rs/sandboxing/src/seatbelt.rs` (process defaults, glob deny generation, brace parsing) and `codex-rs/protocol/src/permissions.rs` (minimal defaults and unreadable globs). This is a pinned source-contract reference, not a source-to-installed-binary equivalence claim; the real sandbox tests establish the observed binary behavior.

## Compatibility and scope

Tools installed in shared scratch or requiring writes there now fail closed. A shared `TMPDIR`/`TMP`/`TEMP` override must be removed so the reviewer workspace uses macOS's private temporary directory. Linux/Windows policy and other review engines are unchanged. Hosted validation currently runs Linux/Windows; the actual macOS enforcement proof is local.

This adds 17 net helper lines (+21/-4) for the missing platform-specific isolation boundary and pre-authentication root validation. Tests, documentation, and CI wiring are separate. Only synthetic files were used for the confinement probes; no real credential data was inspected.
