### PR TITLE
fix(autoreview): redact deleted credential diff lines

### DIFF
--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -1662,7 +1662,75 @@ def safe_trufflehog_env(repo: Path) -> dict[str, str]:
     return env
 
 
-def scan_outgoing_review_pack(repo: Path, prompt: str) -> None:
+def trufflehog_finding_line(finding: object) -> int | None:
+    """Return a verified one-based pack line number without exposing a finding."""
+    if not isinstance(finding, dict):
+        return None
+    try:
+        line = finding["SourceMetadata"]["Data"]["Filesystem"]["line"]
+    except (KeyError, TypeError):
+        return None
+    return line if isinstance(line, int) and not isinstance(line, bool) and line > 0 else None
+
+
+def trufflehog_finding_lines(output: str) -> set[int] | None:
+    """Parse scanner locations fail-closed; scanner findings never leave this helper."""
+    lines: set[int] = set()
+    for record in output.splitlines():
+        try:
+            finding = json.loads(record)
+        except json.JSONDecodeError:
+            return None
+        line = trufflehog_finding_line(finding)
+        if line is None:
+            return None
+        lines.add(line)
+    return lines or None
+
+
+def redact_deleted_diff_lines(prompt: str, finding_lines: set[int]) -> str | None:
+    """Redact only scanner-proven deleted lines inside unified-diff hunks."""
+    redacted: list[str] = []
+    in_hunk = False
+    seen: set[int] = set()
+    for number, line in enumerate(literal_lf_lines(prompt), start=1):
+        if line.startswith("diff --git "):
+            in_hunk = False
+        elif line.startswith("@@"):
+            in_hunk = True
+        if number in finding_lines:
+            if not in_hunk or not line.startswith("-") or line.startswith("--- "):
+                return None
+            ending = "\n" if line.endswith("\n") else ""
+            redacted.append("-<redacted deleted line>" + ending)
+            seen.add(number)
+        else:
+            redacted.append(line)
+    return "".join(redacted) if seen == finding_lines else None
+
+
+def trufflehog_scan(
+    trufflehog_bin: str,
+    source_args: list[str],
+    cwd: Path,
+    *,
+    stdin: object,
+    env: dict[str, str],
+) -> subprocess.CompletedProcess[str]:
+    return run(
+        [
+            trufflehog_bin, *source_args,
+            "--json", "--no-color", "--results=verified,unknown",
+            "--fail", "--fail-on-scan-errors", "--no-update",
+        ],
+        cwd,
+        stdin=stdin,
+        check=False,
+        env=env,
+    )
+
+
+def scan_outgoing_review_pack(repo: Path, prompt: str) -> str:
     trufflehog_bin = find_command("trufflehog", repo)
     if not trufflehog_bin:
         raise SystemExit(
@@ -1680,29 +1748,41 @@ def scan_outgoing_review_pack(repo: Path, prompt: str) -> None:
         # Filesystem preserves read/extraction failures; stdin does not honor
         # inline ignore tags, including decoded ones. Both must pass. A binary
         # file descriptor preserves exact bytes and avoids stdin pipe buffering.
-        with pack_path.open("rb") as pack_input:
-            for source_args, scan_input in ((["filesystem", str(pack_path)], None), (["stdin"], pack_input)):
-                result = run(
-                    [
-                        trufflehog_bin, *source_args,
-                        "--json", "--no-color", "--results=verified,unknown",
-                        "--fail", "--fail-on-scan-errors", "--no-update",
-                    ],
-                    Path(tempdir),
-                    stdin=scan_input,
-                    check=False,
+        filesystem = trufflehog_scan(
+            trufflehog_bin, ["filesystem", str(pack_path)], Path(tempdir),
+            stdin=None, env=scanner_env,
+        )
+        if filesystem.returncode == TRUFFLEHOG_FINDINGS_EXIT_CODE:
+            finding_lines = trufflehog_finding_lines(filesystem.stdout)
+            redacted = redact_deleted_diff_lines(prompt, finding_lines) if finding_lines else None
+            if redacted is None:
+                raise SystemExit(
+                    "refusing to send review pack: TruffleHog found credentials; "
+                    "remove credential material from selected changes, prompt files, and datasets, then rerun"
+                )
+            pack_path.write_bytes(redacted.encode("utf-8"))
+            prompt = redacted
+        elif filesystem.returncode != 0:
+            raise SystemExit("refusing to send review pack: TruffleHog could not complete the scan")
+
+        # The final, possibly redacted pack must pass both sources. The
+        # filesystem scan is repeated because the first run may have detected
+        # deletion-only material that was removed above.
+        for source_args in ((["filesystem", str(pack_path)]), (["stdin"])):
+            with pack_path.open("rb") as pack_input:
+                result = trufflehog_scan(
+                    trufflehog_bin, source_args, Path(tempdir),
+                    stdin=None if source_args[0] == "filesystem" else pack_input,
                     env=scanner_env,
                 )
-                if result.returncode == TRUFFLEHOG_FINDINGS_EXIT_CODE:
-                    # Input headings, filenames, and scanner metadata can themselves contain credentials.
-                    raise SystemExit(
-                        "refusing to send review pack: TruffleHog found credentials; "
-                        "remove credential material from selected changes, prompt files, and datasets, then rerun"
-                    )
-                if result.returncode != 0:
-                    raise SystemExit(
-                        "refusing to send review pack: TruffleHog could not complete the scan"
-                    )
+            if result.returncode == TRUFFLEHOG_FINDINGS_EXIT_CODE:
+                raise SystemExit(
+                    "refusing to send review pack: TruffleHog found credentials; "
+                    "remove credential material from selected changes, prompt files, and datasets, then rerun"
+                )
+            if result.returncode != 0:
+                raise SystemExit("refusing to send review pack: TruffleHog could not complete the scan")
+    return prompt
 
 
 def bounded_field(text: str, limit: int) -> str:
@@ -6440,7 +6520,11 @@ def run_reviewer(
         raise SystemExit("mixed review requires owner-built pass metadata")
     outgoing = prompt.prompt if isinstance(prompt, ReviewPass) else prompt
     with PreparationProgress("outgoing pack scan and evidence verification"):
-        scan_outgoing_review_pack(repo, outgoing)
+        scanned_outgoing = scan_outgoing_review_pack(repo, outgoing)
+        # Test and embedding callers that provide the legacy side-effect-only
+        # scanner remain safe: the real scanner always returns a string.
+        if scanned_outgoing is not None:
+            outgoing = scanned_outgoing
         verify_evidence(repo, evidence or [])
         verify_mixed_sources(repo, mixed)
     raw = run_engine(args, repo, outgoing)

--- a/skills/autoreview/tests/test_autoreview_hardening.py
+++ b/skills/autoreview/tests/test_autoreview_hardening.py
@@ -1315,8 +1315,8 @@ with Path(__file__).with_name("scans.jsonl").open("a", encoding="utf-8") as reco
                 self.helper["scan_outgoing_review_pack"](repo, prompt)
 
             records = [json.loads(line) for line in (root / "scans.jsonl").read_text(encoding="utf-8").splitlines()]
-            self.assertEqual([record["source"] for record in records], ["filesystem", "stdin"])
-            self.assertEqual([record["prompt"] for record in records], [prompt, prompt])
+            self.assertEqual([record["source"] for record in records], ["filesystem", "filesystem", "stdin"])
+            self.assertEqual([record["prompt"] for record in records], [prompt, prompt, prompt])
             self.assertFalse(Path(records[0]["pack"]).parent.exists())
 
     def test_outgoing_pack_scan_reads_exact_prompt_including_deleted_lines(self) -> None:
@@ -1356,9 +1356,10 @@ with Path(__file__).with_name("scans.jsonl").open("a", encoding="utf-8") as reco
                 },
             ):
                 self.helper["scan_outgoing_review_pack"](repo, prompt)
-            self.assertEqual(sources, ["filesystem", "stdin"])
+            self.assertEqual(sources, ["filesystem", "filesystem", "stdin"])
 
-    def test_deleted_input_scan_refusal_is_redacted_and_blocks_provider(self) -> None:
+    def test_deleted_only_scanner_finding_is_redacted_before_provider_invocation(self) -> None:
+        dangerous = "".join(chr(value) for value in (100, 101, 108, 101, 116, 101, 45, 111, 110, 108, 121, 45, 118, 97, 108, 117, 101))
         prompt = (
             "# Change Bundle\n"
             "diff --git a/config.ts b/config.ts\n"
@@ -1366,30 +1367,20 @@ with Path(__file__).with_name("scans.jsonl").open("a", encoding="utf-8") as reco
             "--- a/config.ts\n"
             "+++ /dev/null\n"
             "@@ -1 +0,0 @@\n"
-            "-const apiKey = \"removed-but-still-sensitive\";\n"
+            f"-const value = \"{dangerous}\";\n"
         )
-        finding = {
-            "SourceMetadata": {
-                "Data": {
-                    "Filesystem": {
-                        "file": "review-pack.txt",
-                        "line": 7,
-                    }
-                }
-            },
-            "Raw": "must-not-be-printed",
-        }
         with tempfile.TemporaryDirectory() as tempdir:
             repo = init_repo(Path(tempdir))
-            packs = []
-            provider = mock.Mock()
+            scans: list[tuple[str, str]] = []
+            provider_prompts: list[str] = []
 
             def run_scanner(command, cwd, **_kwargs):
-                self.assertEqual(command[1], "filesystem")
-                pack = Path(command[2])
-                self.assertEqual(pack.parent, cwd)
-                self.assertEqual(pack.read_bytes(), prompt.encode("utf-8"))
-                packs.append(pack)
+                source = command[1]
+                payload = Path(command[2]).read_text(encoding="utf-8") if source == "filesystem" else _kwargs["stdin"].read().decode("utf-8")
+                scans.append((source, payload))
+                if dangerous not in payload:
+                    return subprocess.CompletedProcess(command, 0, "", "")
+                finding = {"SourceMetadata": {"Data": {"Filesystem": {"file": "review-pack.txt", "line": 7}}}}
                 return subprocess.CompletedProcess(
                     command, self.helper["TRUFFLEHOG_FINDINGS_EXIT_CODE"], json.dumps(finding) + "\n", "",
                 )
@@ -1399,21 +1390,64 @@ with Path(__file__).with_name("scans.jsonl").open("a", encoding="utf-8") as reco
                 {
                     "find_command": lambda _name, _repo: "/trusted/trufflehog",
                     "run": run_scanner,
-                    "run_engine": provider,
+                    "run_engine": lambda _args, _repo, outgoing: provider_prompts.append(outgoing) or json.dumps({
+                        "findings": [], "overall_correctness": "patch is correct",
+                        "overall_explanation": "synthetic clean", "overall_confidence": 0.9,
+                    }),
                 },
             ), contextlib.redirect_stderr(io.StringIO()):
-                with self.assertRaisesRegex(SystemExit, "TruffleHog found credentials") as error:
-                    self.helper["run_reviewer"](
-                        argparse.Namespace(engine="codex", max_priority="P0"), repo, prompt, set(), [],
-                    )
-            self.assertEqual(len(packs), 1)
-            self.assertFalse(packs[0].parent.exists())
-            provider.assert_not_called()
-        self.assertEqual(
-            str(error.exception),
-            "refusing to send review pack: TruffleHog found credentials; "
-            "remove credential material from selected changes, prompt files, and datasets, then rerun",
+                self.helper["run_reviewer"](
+                    argparse.Namespace(engine="codex", max_priority="P0"), repo, prompt, set(), [],
+                )
+            self.assertEqual([source for source, _payload in scans], ["filesystem", "filesystem", "stdin"])
+            self.assertIn(dangerous, scans[0][1])
+            self.assertTrue(all(dangerous not in payload for _source, payload in scans[1:]))
+            self.assertEqual(len(provider_prompts), 1)
+            self.assertNotIn(dangerous, provider_prompts[0])
+            self.assertIn("-<redacted deleted line>", provider_prompts[0])
+
+    def test_added_or_mixed_scanner_findings_block_before_provider_invocation(self) -> None:
+        dangerous = "".join(chr(value) for value in (97, 100, 100, 101, 100, 45, 111, 110, 108, 121, 45, 118, 97, 108, 117, 101))
+        base = (
+            "# Change Bundle\n"
+            "diff --git a/config.ts b/config.ts\n"
+            "--- a/config.ts\n"
+            "+++ b/config.ts\n"
+            "@@ -1 +1 @@\n"
         )
+        for changed, finding_lines in ((f"+const value = \"{dangerous}\";\n", (6,)), (f"-const old = \"{dangerous}\";\n+const new = \"{dangerous}\";\n", (6, 7))):
+            with self.subTest(finding_lines=finding_lines), tempfile.TemporaryDirectory() as tempdir:
+                repo = init_repo(Path(tempdir))
+                calls: list[str] = []
+
+                def run_scanner(command, _cwd, **_kwargs):
+                    calls.append(command[1])
+                    findings = [
+                        {"SourceMetadata": {"Data": {"Filesystem": {"file": "review-pack.txt", "line": line}}}}
+                        for line in finding_lines
+                    ]
+                    return subprocess.CompletedProcess(
+                        command, self.helper["TRUFFLEHOG_FINDINGS_EXIT_CODE"],
+                        "".join(json.dumps(finding) + "\n" for finding in findings), "",
+                    )
+
+                with mock.patch.dict(self.helper["scan_outgoing_review_pack"].__globals__, {
+                    "find_command": lambda _name, _repo: "/trusted/trufflehog", "run": run_scanner,
+                }):
+                    with self.assertRaisesRegex(SystemExit, "TruffleHog found credentials"):
+                        self.helper["scan_outgoing_review_pack"](repo, base + changed)
+                self.assertEqual(calls, ["filesystem"])
+
+    def test_scanner_error_blocks_deleted_only_redaction(self) -> None:
+        prompt = "# Change Bundle\n"
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo = init_repo(Path(tempdir))
+            with mock.patch.dict(self.helper["scan_outgoing_review_pack"].__globals__, {
+                "find_command": lambda _name, _repo: "/trusted/trufflehog",
+                "run": lambda command, _cwd, **_kwargs: subprocess.CompletedProcess(command, 1, "", ""),
+            }):
+                with self.assertRaisesRegex(SystemExit, "TruffleHog could not complete"):
+                    self.helper["scan_outgoing_review_pack"](repo, prompt)
 
     def test_outgoing_pack_scan_fails_closed_when_scanner_is_missing(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:
@@ -2029,15 +2063,15 @@ with Path(__file__).with_name("scans.jsonl").open("a", encoding="utf-8") as reco
                         self.assertEqual(source_kind, "stdin")
                         outgoing = Path(kwargs["stdin"].name)
                         payload = kwargs["stdin"].read()
-                    self.assertEqual(payload, pack.encode("utf-8"))
+                    self.assertIn(payload, (pack.encode("utf-8"), pack.replace("-// DELETED_SCAN_MARKER", "-<redacted deleted line>").encode("utf-8")))
                     if os.name != "nt":
                         self.assertEqual(stat.S_IMODE(outgoing.stat().st_mode), 0o600)
                     self.assertIn("--results=verified,unknown", command)
                     self.assertIn("--no-update", command)
-                    for token in ("-// DELETED_SCAN_MARKER", "+// STAGED_SCAN_MARKER", "UNTRACKED_SCAN_MARKER", "PROMPT_SCAN_MARKER", "# Dataset:", "# Prompt file:"):
-                        self.assertIn(token, pack)
+                    for token in ("+// STAGED_SCAN_MARKER", "UNTRACKED_SCAN_MARKER", "PROMPT_SCAN_MARKER", "# Dataset:", "# Prompt file:"):
+                        self.assertIn(token, payload.decode("utf-8"))
                     events.append(source_kind)
-                    if marker:
+                    if marker and (marker != "DELETED_SCAN_MARKER" or payload == pack.encode("utf-8")):
                         line = next(i for i, text in enumerate(pack.splitlines(), 1) if marker in text)
                         detected = {"SourceMetadata": {"Data": {"Filesystem": {"file": str(outgoing), "line": line}}}}
                         return subprocess.CompletedProcess(command, self.helper["TRUFFLEHOG_FINDINGS_EXIT_CODE"], json.dumps(detected), "")
@@ -2049,13 +2083,19 @@ with Path(__file__).with_name("scans.jsonl").open("a", encoding="utf-8") as reco
                 }):
                     args = argparse.Namespace(engine="codex", max_priority="P2")
                     if marker:
-                        with self.assertRaisesRegex(SystemExit, "refusing to send review pack"):
+                        if marker == "DELETED_SCAN_MARKER":
                             self.helper["run_reviewer"](args, repo, pack, {source}, [])
-                        provider.assert_not_called()
+                            provider.assert_called_once()
+                            self.assertNotIn(marker, provider.call_args.args[2])
+                        else:
+                            with self.assertRaisesRegex(SystemExit, "refusing to send review pack"):
+                                self.helper["run_reviewer"](args, repo, pack, {source}, [])
+                            provider.assert_not_called()
                     else:
                         self.helper["run_reviewer"](args, repo, pack, {source}, [])
                         provider.assert_called_once_with(args, repo, pack)
-                    self.assertEqual(events, ["filesystem"] if marker else ["filesystem", "stdin"])
+                    expected = ["filesystem", "filesystem", "stdin"] if marker in (None, "DELETED_SCAN_MARKER") else ["filesystem"]
+                    self.assertEqual(events, expected)
 
     def test_tracked_binary_changes_are_blocked_in_all_modes(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:


### PR DESCRIPTION
Redact TruffleHog findings only when every finding is provably confined to removed unified-diff lines, then rescan the redacted review pack before reviewer invocation.\n\nAdded/current/context and ambiguous findings remain fail-closed. Tests cover deletion-only redaction, added/mixed blocking, and scanner errors.\n\nValidation: 208 hardening tests (1 platform skip), py_compile, validate-skills, diff-check, and a scanned Codex autoreview.