### PR TITLE
fix(autoreview): default Codex reviews to gpt-6-astra

### DIFF
--- a/skills/autoreview/SKILL.md
+++ b/skills/autoreview/SKILL.md
@@ -81,9 +81,15 @@ parent-relative patch; otherwise leave the attribution unknown.
 
 ## Engines
 
-Codex is the default: `gpt-6-astra`, high reasoning, with no automatic model
-fallback. Honor explicit engine/model choices; do not switch because a review is
-slow or rate-limited.
+Codex is the default: `gpt-6-astra`, high reasoning. When no model override is
+set, retry `gpt-5.6-terra` only for an Astra account-access failure. Explicit
+CLI or environment model choices disable this fallback. Do not switch because
+a review is slow or rate-limited.
+
+Astra supports `low`, `medium`, `high`, `xhigh`, and `max`. Inherited `none`
+or `minimal` reasoning settings are rejected before review preparation; choose
+`--thinking low` or explicitly select a model that supports those settings.
+See the [Astra model reference](https://developers.openai.com/api/docs/models/gpt-6-astra).
 
 Use `--engine`, `--model`, and `--thinking` to override the defaults.
 `--codex-speed fast` selects priority service when supported. Only Claude accepts

--- a/skills/autoreview/SKILL.md
+++ b/skills/autoreview/SKILL.md
@@ -19,7 +19,7 @@ it leaves review judgment to Codex. For an OpenClaw checkout:
 
 ```bash
 AUTOREVIEW=".agents/skills/autoreview/scripts/autoreview"
-"$AUTOREVIEW" --mode local
+"$AUTOREVIEW" --mode local --model gpt-6-astra
 ```
 
 In the canonical agent-skills repo, the path is
@@ -81,9 +81,11 @@ parent-relative patch; otherwise leave the attribution unknown.
 
 ## Engines
 
-Codex is the default: `gpt-5.6-sol`, high reasoning, with a `gpt-5.6-terra` retry
-only for an account-access failure. Honor explicit engine/model choices; do not
-switch because a review is slow or rate-limited.
+Codex is the default engine. Use `--model gpt-6-astra` with high reasoning for
+Codex reviews unless the caller explicitly chooses another model. Pass the model
+explicitly on every Codex invocation to override the helper's built-in default.
+Honor explicit engine/model choices; do not switch because a review is slow or
+rate-limited.
 
 Use `--engine`, `--model`, and `--thinking` to override the defaults.
 `--codex-speed fast` selects priority service when supported. Only Claude accepts

--- a/skills/autoreview/SKILL.md
+++ b/skills/autoreview/SKILL.md
@@ -19,7 +19,7 @@ it leaves review judgment to Codex. For an OpenClaw checkout:
 
 ```bash
 AUTOREVIEW=".agents/skills/autoreview/scripts/autoreview"
-"$AUTOREVIEW" --mode local --model gpt-6-astra
+"$AUTOREVIEW" --mode local
 ```
 
 In the canonical agent-skills repo, the path is
@@ -81,11 +81,9 @@ parent-relative patch; otherwise leave the attribution unknown.
 
 ## Engines
 
-Codex is the default engine. Use `--model gpt-6-astra` with high reasoning for
-Codex reviews unless the caller explicitly chooses another model. Pass the model
-explicitly on every Codex invocation to override the helper's built-in default.
-Honor explicit engine/model choices; do not switch because a review is slow or
-rate-limited.
+Codex is the default: `gpt-6-astra`, high reasoning, with no automatic model
+fallback. Honor explicit engine/model choices; do not switch because a review is
+slow or rate-limited.
 
 Use `--engine`, `--model`, and `--thinking` to override the defaults.
 `--codex-speed fast` selects priority service when supported. Only Claude accepts

--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -373,10 +373,9 @@ PROVIDER_CREDENTIAL_PATH_ENV_KEYS = {
 }
 DEFAULT_MODEL_BY_ENGINE = {
     "amp": "openai/gpt-5.6-sol",
-    "codex": "gpt-5.6-sol",
+    "codex": "gpt-6-astra",
     "claude": "claude-fable-5",
 }
-DEFAULT_CODEX_ACCESS_FALLBACK_MODEL = "gpt-5.6-terra"
 AMP_THINKING_VALUES = frozenset({"none", "low", "medium", "high", "xhigh", "max"})
 DEFAULT_THINKING_BY_ENGINE = {
     "amp": "high",
@@ -6025,7 +6024,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--model",
         action="append",
-        help="Model override or engine=model. Repeatable. Defaults: codex=gpt-5.6-sol with an access-only gpt-5.6-terra retry, claude=claude-fable-5, amp=openai/gpt-5.6-sol.",
+        help="Model override or engine=model. Repeatable. Defaults: codex=gpt-6-astra, claude=claude-fable-5, amp=openai/gpt-5.6-sol.",
     )
     parser.add_argument("--thinking", action="append", help="Thinking/effort override or engine=level. Repeatable. Codex: none, minimal, low, medium, high, xhigh, max. Claude: low, medium, high, xhigh, max. Amp: none, low, medium, high, xhigh, max. Pi: off, minimal, low, medium, high, xhigh. Kimi: off, on.")
     parser.add_argument(
@@ -6189,8 +6188,6 @@ def reviewer_args(args: argparse.Namespace) -> list[argparse.Namespace]:
             or env_fallback_by_engine.get(engine)
             or env_global_fallback
         )
-    elif engine == "codex" and model == DEFAULT_MODEL_BY_ENGINE["codex"]:
-        fallback_model = DEFAULT_CODEX_ACCESS_FALLBACK_MODEL
     else:
         fallback_model = None
     if thinking and thinking not in THINKING_LEVELS_BY_ENGINE[engine]:

--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -376,6 +376,7 @@ DEFAULT_MODEL_BY_ENGINE = {
     "codex": "gpt-6-astra",
     "claude": "claude-fable-5",
 }
+DEFAULT_CODEX_ACCESS_FALLBACK_MODEL = "gpt-5.6-terra"
 AMP_THINKING_VALUES = frozenset({"none", "low", "medium", "high", "xhigh", "max"})
 DEFAULT_THINKING_BY_ENGINE = {
     "amp": "high",
@@ -6024,9 +6025,9 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--model",
         action="append",
-        help="Model override or engine=model. Repeatable. Defaults: codex=gpt-6-astra, claude=claude-fable-5, amp=openai/gpt-5.6-sol.",
+        help="Model override or engine=model. Repeatable. Defaults: codex=gpt-6-astra with an access-only gpt-5.6-terra retry when no model override is set, claude=claude-fable-5, amp=openai/gpt-5.6-sol.",
     )
-    parser.add_argument("--thinking", action="append", help="Thinking/effort override or engine=level. Repeatable. Codex: none, minimal, low, medium, high, xhigh, max. Claude: low, medium, high, xhigh, max. Amp: none, low, medium, high, xhigh, max. Pi: off, minimal, low, medium, high, xhigh. Kimi: off, on.")
+    parser.add_argument("--thinking", action="append", help="Thinking/effort override or engine=level. Repeatable. Codex: none, minimal, low, medium, high, xhigh, max; gpt-6-astra requires low through max. Claude: low, medium, high, xhigh, max. Amp: none, low, medium, high, xhigh, max. Pi: off, minimal, low, medium, high, xhigh. Kimi: off, on.")
     parser.add_argument(
         "--fallback-model",
         action="append",
@@ -6167,13 +6168,13 @@ def reviewer_args(args: argparse.Namespace) -> list[argparse.Namespace]:
         raise SystemExit("--codex-config is only supported for codex; no codex reviewer selected")
     if getattr(args, "codex_speed", None) and engine != "codex":
         raise SystemExit("--codex-speed is only supported for codex; no codex reviewer selected")
-    model = (
+    model_override = (
         model_by_engine.get(engine)
         or global_model
         or env_model_by_engine.get(engine)
         or env_global_model
-        or DEFAULT_MODEL_BY_ENGINE.get(engine)
     )
+    model = model_override or DEFAULT_MODEL_BY_ENGINE.get(engine)
     thinking = (
         thinking_by_engine.get(engine)
         or global_thinking
@@ -6188,11 +6189,18 @@ def reviewer_args(args: argparse.Namespace) -> list[argparse.Namespace]:
             or env_fallback_by_engine.get(engine)
             or env_global_fallback
         )
+    elif engine == "codex" and not model_override:
+        fallback_model = DEFAULT_CODEX_ACCESS_FALLBACK_MODEL
     else:
         fallback_model = None
-    if thinking and thinking not in THINKING_LEVELS_BY_ENGINE[engine]:
-        valid = ", ".join(sorted(THINKING_LEVELS_BY_ENGINE[engine])) or "none"
-        raise SystemExit(f"invalid thinking level for {engine}: {thinking} (valid: {valid})")
+    thinking_levels = THINKING_LEVELS_BY_ENGINE[engine]
+    thinking_target = engine
+    if engine == "codex" and model == "gpt-6-astra":
+        thinking_levels = thinking_levels - {"none", "minimal"}
+        thinking_target = f"{engine} model {model}"
+    if thinking and thinking not in thinking_levels:
+        valid = ", ".join(sorted(thinking_levels)) or "none"
+        raise SystemExit(f"invalid thinking level for {thinking_target}: {thinking} (valid: {valid})")
     clone = copy.copy(args)
     clone.model = model
     clone.thinking = thinking

--- a/skills/autoreview/scripts/autoreview_test.py
+++ b/skills/autoreview/scripts/autoreview_test.py
@@ -1092,7 +1092,56 @@ class AutoreviewTruffleHogTests(unittest.TestCase):
 
 
 class AutoreviewCompatibilityTests(unittest.TestCase):
-    def test_codex_defaults_to_astra_without_fallback(self) -> None:
+    def test_astra_rejects_unsupported_effort_before_preparation(self) -> None:
+        for effort in ("none", "minimal"):
+            for source in ("cli", "cli-keyed", "env", "env-keyed"):
+                with self.subTest(effort=effort, source=source):
+                    argv = [sys.executable, str(SCRIPT_PATH), "--mode", "local"]
+                    env = {key: value for key, value in os.environ.items() if not key.startswith("AUTOREVIEW_")}
+                    if source.startswith("cli"):
+                        argv += ["--thinking", f"codex={effort}" if source == "cli-keyed" else effort]
+                    else:
+                        env["AUTOREVIEW_CODEX_THINKING" if source == "env-keyed" else "AUTOREVIEW_THINKING"] = effort
+                    with tempfile.TemporaryDirectory(prefix="autoreview-astra-effort.") as directory:
+                        result = subprocess.run(argv, cwd=directory, env=env, capture_output=True, text=True)
+                    self.assertNotEqual(result.returncode, 0)
+                    self.assertIn("invalid thinking level for codex model gpt-6-astra", result.stderr)
+                    self.assertIn("high, low, max, medium, xhigh", result.stderr)
+                    self.assertNotIn("preparation:", result.stderr)
+
+    def test_astra_preserves_supported_efforts(self) -> None:
+        for effort in ("low", "medium", "high", "xhigh", "max"):
+            with self.subTest(effort=effort), mock.patch.dict(os.environ, {}, clear=True), mock.patch.object(
+                sys, "argv", ["autoreview", "--thinking", effort]
+            ):
+                reviewer = AUTOREVIEW.reviewer_args(AUTOREVIEW.parse_args())[0]
+                self.assertEqual(reviewer.model, "gpt-6-astra")
+                self.assertEqual(reviewer.thinking, effort)
+                self.assertEqual(reviewer.fallback_model, "gpt-5.6-terra")
+
+    def test_explicit_astra_selection_has_no_fallback(self) -> None:
+        for source in ("cli", "cli-keyed", "env", "env-keyed"):
+            argv = ["autoreview"]
+            env = {}
+            if source.startswith("cli"):
+                argv += ["--model", "codex=gpt-6-astra" if source == "cli-keyed" else "gpt-6-astra"]
+            else:
+                env["AUTOREVIEW_CODEX_MODEL" if source == "env-keyed" else "AUTOREVIEW_MODEL"] = "gpt-6-astra"
+            with self.subTest(source=source), mock.patch.dict(os.environ, env, clear=True), mock.patch.object(sys, "argv", argv):
+                reviewer = AUTOREVIEW.reviewer_args(AUTOREVIEW.parse_args())[0]
+                self.assertEqual(reviewer.model, "gpt-6-astra")
+                self.assertIsNone(reviewer.fallback_model)
+
+    def test_legacy_codex_models_keep_their_supported_efforts(self) -> None:
+        for effort in ("none", "minimal"):
+            with self.subTest(effort=effort), mock.patch.dict(os.environ, {}, clear=True), mock.patch.object(
+                sys, "argv", ["autoreview", "--model", "gpt-5.6-sol", "--thinking", effort]
+            ):
+                reviewer = AUTOREVIEW.reviewer_args(AUTOREVIEW.parse_args())[0]
+                self.assertEqual(reviewer.model, "gpt-5.6-sol")
+                self.assertEqual(reviewer.thinking, effort)
+
+    def test_codex_defaults_to_astra_with_access_fallback(self) -> None:
         with mock.patch.dict(os.environ, {}, clear=True), mock.patch.object(
             sys, "argv", ["autoreview"]
         ):
@@ -1100,7 +1149,7 @@ class AutoreviewCompatibilityTests(unittest.TestCase):
         self.assertEqual(reviewer.engine, "codex")
         self.assertEqual(reviewer.model, "gpt-6-astra")
         self.assertEqual(reviewer.thinking, "high")
-        self.assertIsNone(reviewer.fallback_model)
+        self.assertEqual(reviewer.fallback_model, "gpt-5.6-terra")
 
     @classmethod
     def setUpClass(cls) -> None:
@@ -1270,20 +1319,11 @@ class AutoreviewCompatibilityTests(unittest.TestCase):
         args = argparse.Namespace(codex_config=['model_verbosity="low"'])
         self.assertEqual(AUTOREVIEW.codex_config_keys(args), ["model_verbosity"])
 
-    def test_codex_retries_terra_after_sol_access_failure(self) -> None:
-        args = argparse.Namespace(
-            engine="codex",
-            max_priority="P0",
-            codex_bin="codex",
-            codex_config=None,
-            codex_speed=None,
-            fallback_model="gpt-5.6-terra",
-            model="gpt-5.6-sol",
-            stream_engine_output=False,
-            thinking="high",
-            tools=True,
-            web_search=False,
-        )
+    def test_codex_retries_terra_after_astra_access_failure(self) -> None:
+        with mock.patch.dict(os.environ, {}, clear=True), mock.patch.object(
+            sys, "argv", ["autoreview"]
+        ):
+            args = AUTOREVIEW.reviewer_args(AUTOREVIEW.parse_args())[0]
         prompt = "complete retry pack: unicode \u03c0\r\n-deleted line\n unchanged context\n"
         for failed_source, failure in ((None, None), (None, "missing"),
                                        ("filesystem", "finding"), ("filesystem", "error"),
@@ -1300,7 +1340,7 @@ class AutoreviewCompatibilityTests(unittest.TestCase):
                     self.assertEqual(data, prompt.encode("utf-8"))
                     events.append(source)
                     code = 0
-                    if "gpt-5.6-sol" in events and source == failed_source:
+                    if "gpt-6-astra" in events and source == failed_source:
                         code = {"finding": AUTOREVIEW.TRUFFLEHOG_FINDINGS_EXIT_CODE, "error": 1}.get(failure, 0)
                     return subprocess.CompletedProcess(command, code, "", "")
 
@@ -1308,12 +1348,12 @@ class AutoreviewCompatibilityTests(unittest.TestCase):
                     self.assertEqual(kwargs["input_text"], prompt)
                     model = command[command.index("--model") + 1]
                     events.append(model)
-                    if model == "gpt-5.6-sol":
+                    if model == "gpt-6-astra":
                         if failure == "missing":
                             find.return_value = None
                         return subprocess.CompletedProcess(
                             command, 1, "",
-                            "The model `gpt-5.6-sol` does not exist or you do not have access to it.",
+                            "The model `gpt-6-astra` does not exist or you do not have access to it.",
                         )
                     output_path = Path(command[command.index("--output-last-message") + 1])
                     output_path.write_text(json.dumps(FINAL_REPORT))
@@ -1332,7 +1372,7 @@ class AutoreviewCompatibilityTests(unittest.TestCase):
                     else:
                         report = AUTOREVIEW.run_reviewer(args, Path(tmpdir), prompt, set(), [])
                         self.assertEqual(report["findings"], [])
-                expected = ["filesystem", "stdin", "gpt-5.6-sol"]
+                expected = ["filesystem", "stdin", "gpt-6-astra"]
                 if failure != "missing":
                     expected.append("filesystem")
                     if failed_source != "filesystem":

--- a/skills/autoreview/scripts/autoreview_test.py
+++ b/skills/autoreview/scripts/autoreview_test.py
@@ -1092,6 +1092,16 @@ class AutoreviewTruffleHogTests(unittest.TestCase):
 
 
 class AutoreviewCompatibilityTests(unittest.TestCase):
+    def test_codex_defaults_to_astra_without_fallback(self) -> None:
+        with mock.patch.dict(os.environ, {}, clear=True), mock.patch.object(
+            sys, "argv", ["autoreview"]
+        ):
+            reviewer = AUTOREVIEW.reviewer_args(AUTOREVIEW.parse_args())[0]
+        self.assertEqual(reviewer.engine, "codex")
+        self.assertEqual(reviewer.model, "gpt-6-astra")
+        self.assertEqual(reviewer.thinking, "high")
+        self.assertIsNone(reviewer.fallback_model)
+
     @classmethod
     def setUpClass(cls) -> None:
         cls.home_dir = tempfile.TemporaryDirectory(prefix="autoreview-test-home.")


### PR DESCRIPTION
GPT-6 Astra is now available, so make `gpt-6-astra` the default Codex review model with the existing high reasoning setting. Amp's default stays unchanged.

Preserve the existing Terra recovery path for default runs: retry only when Codex reports that Astra is unavailable to the account. Explicit CLI or environment model selections disable fallback. Reject Astra's unsupported `none` and `minimal` reasoning settings before preparation, with an error listing supported values; explicit legacy models retain those settings.

The model-specific effort validation follows the approach proposed in #228. That PR also covers separate prompt and documentation changes.

### Validation

- Regression proof on the previous PR head: inherited invalid efforts reached preparation, and an unavailable-Astra response failed instead of retrying. Both paths pass after the fix.
- Subprocess tests cover global and per-engine CLI/environment effort settings. Tests also cover supported efforts, explicit model overrides, and default Astra-to-Terra recovery with the outgoing pack rescanned before retry.
- Full autoreview Python suite: 254 tests, one skipped; all executed tests passed.
- `scripts/validate-skills`, Python compilation, and `git diff --check` passed.

### Real default-run proof

Ran Codex CLI 0.153.1 against the repository harness's benign fixture, created with `create_fixture_repo(..., "benign")`. Removed all `AUTOREVIEW_*` environment overrides, then invoked the patched helper from that fixture without engine, model, reasoning, or prompt flags:

```sh
python3 "$AUTOREVIEW" --mode local --json-output "$PROOF_DIR/result.json"
```

Terminal excerpt (local paths omitted):

```text
engine: codex
model: gpt-6-astra
fallback_model: gpt-5.6-terra
thinking: high
tools: on
web_search: on
bundle: 1480 bytes; review passes: 1
preparation: pre-review verification
preparation: outgoing pack scan and evidence verification
preparation: final source verification
autoreview scoped-clean: no accepted/actionable findings in the selected Git scope and priority
overall: patch is correct (0.99)
```

Exit code: `0`. The JSON report contained no findings and reported `scoped-clean`. No fallback was needed. This proves the default invocation completes on an account with Astra access at the default P0 threshold; access-denial recovery is covered by simulated provider responses, not a live access-denied account.
