### PR TITLE
fix(autoreview): allow disabling account-access fallback

### DIFF
--- a/skills/autoreview/SKILL.md
+++ b/skills/autoreview/SKILL.md
@@ -84,6 +84,8 @@ parent-relative patch; otherwise leave the attribution unknown.
 Codex is the default: `gpt-5.6-sol`, high reasoning, with a `gpt-5.6-terra` retry
 only for an account-access failure. Honor explicit engine/model choices; do not
 switch because a review is slow or rate-limited.
+Pass `--no-access-fallback` when the workflow requires the selected Codex model
+only; an account-access failure then stops without trying another model.
 
 Use `--engine`, `--model`, and `--thinking` to override the defaults.
 `--codex-speed fast` selects priority service when supported. Only Claude accepts

--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -6034,6 +6034,11 @@ def parse_args() -> argparse.Namespace:
         help="Claude fallback model chain or claude=a,b. Repeatable.",
     )
     parser.add_argument(
+        "--no-access-fallback",
+        action="store_true",
+        help="Keep the selected Codex model on account-access failure; do not retry another model.",
+    )
+    parser.add_argument(
         "--engine-timeout-seconds",
         type=positive_float,
         default=os.environ.get("AUTOREVIEW_ENGINE_TIMEOUT_SECONDS"),
@@ -6168,6 +6173,8 @@ def reviewer_args(args: argparse.Namespace) -> list[argparse.Namespace]:
         raise SystemExit("--codex-config is only supported for codex; no codex reviewer selected")
     if getattr(args, "codex_speed", None) and engine != "codex":
         raise SystemExit("--codex-speed is only supported for codex; no codex reviewer selected")
+    if getattr(args, "no_access_fallback", False) and engine != "codex":
+        raise SystemExit("--no-access-fallback is only supported for codex; no codex reviewer selected")
     model = (
         model_by_engine.get(engine)
         or global_model
@@ -6189,7 +6196,11 @@ def reviewer_args(args: argparse.Namespace) -> list[argparse.Namespace]:
             or env_fallback_by_engine.get(engine)
             or env_global_fallback
         )
-    elif engine == "codex" and model == DEFAULT_MODEL_BY_ENGINE["codex"]:
+    elif (
+        engine == "codex"
+        and model == DEFAULT_MODEL_BY_ENGINE["codex"]
+        and not getattr(args, "no_access_fallback", False)
+    ):
         fallback_model = DEFAULT_CODEX_ACCESS_FALLBACK_MODEL
     else:
         fallback_model = None

--- a/skills/autoreview/scripts/autoreview_test.py
+++ b/skills/autoreview/scripts/autoreview_test.py
@@ -1260,6 +1260,42 @@ class AutoreviewCompatibilityTests(unittest.TestCase):
         args = argparse.Namespace(codex_config=['model_verbosity="low"'])
         self.assertEqual(AUTOREVIEW.codex_config_keys(args), ["model_verbosity"])
 
+    def test_codex_no_access_fallback_stops_after_primary_error(self) -> None:
+        with mock.patch.object(
+            sys, "argv",
+            ["autoreview", "--engine", "codex", "--model", "gpt-5.6-sol", "--no-access-fallback"],
+        ):
+            args = AUTOREVIEW.reviewer_args(AUTOREVIEW.parse_args())[0]
+        models: list[str] = []
+
+        def fake_run(command, _cwd, **kwargs):
+            self.assertEqual(kwargs["input_text"], "complete review input")
+            models.append(command[command.index("--model") + 1])
+            return subprocess.CompletedProcess(
+                command, 1, "",
+                "The model `gpt-5.6-sol` does not exist or you do not have access to it.",
+            )
+
+        with tempfile.TemporaryDirectory(prefix="autoreview-no-access-fallback.") as tmpdir, \
+                mock.patch.object(AUTOREVIEW, "resolve_command", return_value="/usr/bin/codex"), \
+                mock.patch.object(AUTOREVIEW, "ensure_codex_isolation_supported"), \
+                mock.patch.object(AUTOREVIEW, "codex_auth_config_flags", return_value=[]), \
+                mock.patch.object(AUTOREVIEW, "prepare_codex_runtime_auth", return_value=None), \
+                mock.patch.object(AUTOREVIEW, "run_with_heartbeat", side_effect=fake_run):
+            with self.assertRaisesRegex(SystemExit, "does not exist or you do not have access"):
+                AUTOREVIEW.run_codex(args, Path(tmpdir), "complete review input")
+
+        self.assertEqual(models, ["gpt-5.6-sol"])
+        self.assertIsNone(args.fallback_model)
+
+    def test_no_access_fallback_rejects_other_engines(self) -> None:
+        with mock.patch.object(
+            sys, "argv", ["autoreview", "--engine", "claude", "--no-access-fallback"],
+        ):
+            args = AUTOREVIEW.parse_args()
+        with self.assertRaisesRegex(SystemExit, "only supported for codex"):
+            AUTOREVIEW.reviewer_args(args)
+
     def test_codex_retries_terra_after_sol_access_failure(self) -> None:
         args = argparse.Namespace(
             engine="codex",


### PR DESCRIPTION
## Summary

- Add `--no-access-fallback` for workflows that require the selected review model.
- Stop on account-access errors when selected; retain existing fallback behavior otherwise.
- Reject the option for engines that do not use this fallback.

## Validation

- New parser/engine regressions failed before implementation.
- All 44 compatibility tests pass.
- Skill validation passes for all eight skills.
- Real helper preparation with the new flag passes.
- Fresh independent P0–P2 review found no actionable findings.

## Runtime proof and limitation

The changed canonical helper also completed real isolated review invocations with:

```sh
skills/autoreview/scripts/autoreview --mode local --no-access-fallback --max-priority P2
```

The latest run completed in26seconds with exit0 and a validated structured `patch is correct` result. Source scanning, normal authentication, isolation, engine execution and final-source verification all ran. This proves the supported option reaches the real runtime; preparation alone was not the only check.

The current authorized account can access its selected model, so these runs did not produce a genuine account-access refusal. I cannot safely force that external account condition without changing credentials or account permissions. The refusal branch is therefore covered by the parser-to-runner regression with a controlled child-process access error: the explicit option makes one attempt; the existing default-path regression makes the fallback attempt. All44 compatibility tests pass.

ClawSweeper's requested real-refusal/default comparison is not claimed as executed. This is the concrete infeasibility for that extra proof; no runtime, authentication or review safeguard was bypassed to manufacture it.
