### PR TITLE
revert(autoreview): remove account-access fallback control

### DIFF
--- a/skills/autoreview/SKILL.md
+++ b/skills/autoreview/SKILL.md
@@ -84,8 +84,6 @@ parent-relative patch; otherwise leave the attribution unknown.
 Codex is the default: `gpt-5.6-sol`, high reasoning, with a `gpt-5.6-terra` retry
 only for an account-access failure. Honor explicit engine/model choices; do not
 switch because a review is slow or rate-limited.
-Pass `--no-access-fallback` when the workflow requires the selected Codex model
-only; an account-access failure then stops without trying another model.
 
 Use `--engine`, `--model`, and `--thinking` to override the defaults.
 `--codex-speed fast` selects priority service when supported. Only Claude accepts

--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -6034,11 +6034,6 @@ def parse_args() -> argparse.Namespace:
         help="Claude fallback model chain or claude=a,b. Repeatable.",
     )
     parser.add_argument(
-        "--no-access-fallback",
-        action="store_true",
-        help="Keep the selected Codex model on account-access failure; do not retry another model.",
-    )
-    parser.add_argument(
         "--engine-timeout-seconds",
         type=positive_float,
         default=os.environ.get("AUTOREVIEW_ENGINE_TIMEOUT_SECONDS"),
@@ -6173,8 +6168,6 @@ def reviewer_args(args: argparse.Namespace) -> list[argparse.Namespace]:
         raise SystemExit("--codex-config is only supported for codex; no codex reviewer selected")
     if getattr(args, "codex_speed", None) and engine != "codex":
         raise SystemExit("--codex-speed is only supported for codex; no codex reviewer selected")
-    if getattr(args, "no_access_fallback", False) and engine != "codex":
-        raise SystemExit("--no-access-fallback is only supported for codex; no codex reviewer selected")
     model = (
         model_by_engine.get(engine)
         or global_model
@@ -6196,11 +6189,7 @@ def reviewer_args(args: argparse.Namespace) -> list[argparse.Namespace]:
             or env_fallback_by_engine.get(engine)
             or env_global_fallback
         )
-    elif (
-        engine == "codex"
-        and model == DEFAULT_MODEL_BY_ENGINE["codex"]
-        and not getattr(args, "no_access_fallback", False)
-    ):
+    elif engine == "codex" and model == DEFAULT_MODEL_BY_ENGINE["codex"]:
         fallback_model = DEFAULT_CODEX_ACCESS_FALLBACK_MODEL
     else:
         fallback_model = None

--- a/skills/autoreview/scripts/autoreview_test.py
+++ b/skills/autoreview/scripts/autoreview_test.py
@@ -1260,42 +1260,6 @@ class AutoreviewCompatibilityTests(unittest.TestCase):
         args = argparse.Namespace(codex_config=['model_verbosity="low"'])
         self.assertEqual(AUTOREVIEW.codex_config_keys(args), ["model_verbosity"])
 
-    def test_codex_no_access_fallback_stops_after_primary_error(self) -> None:
-        with mock.patch.object(
-            sys, "argv",
-            ["autoreview", "--engine", "codex", "--model", "gpt-5.6-sol", "--no-access-fallback"],
-        ):
-            args = AUTOREVIEW.reviewer_args(AUTOREVIEW.parse_args())[0]
-        models: list[str] = []
-
-        def fake_run(command, _cwd, **kwargs):
-            self.assertEqual(kwargs["input_text"], "complete review input")
-            models.append(command[command.index("--model") + 1])
-            return subprocess.CompletedProcess(
-                command, 1, "",
-                "The model `gpt-5.6-sol` does not exist or you do not have access to it.",
-            )
-
-        with tempfile.TemporaryDirectory(prefix="autoreview-no-access-fallback.") as tmpdir, \
-                mock.patch.object(AUTOREVIEW, "resolve_command", return_value="/usr/bin/codex"), \
-                mock.patch.object(AUTOREVIEW, "ensure_codex_isolation_supported"), \
-                mock.patch.object(AUTOREVIEW, "codex_auth_config_flags", return_value=[]), \
-                mock.patch.object(AUTOREVIEW, "prepare_codex_runtime_auth", return_value=None), \
-                mock.patch.object(AUTOREVIEW, "run_with_heartbeat", side_effect=fake_run):
-            with self.assertRaisesRegex(SystemExit, "does not exist or you do not have access"):
-                AUTOREVIEW.run_codex(args, Path(tmpdir), "complete review input")
-
-        self.assertEqual(models, ["gpt-5.6-sol"])
-        self.assertIsNone(args.fallback_model)
-
-    def test_no_access_fallback_rejects_other_engines(self) -> None:
-        with mock.patch.object(
-            sys, "argv", ["autoreview", "--engine", "claude", "--no-access-fallback"],
-        ):
-            args = AUTOREVIEW.parse_args()
-        with self.assertRaisesRegex(SystemExit, "only supported for codex"):
-            AUTOREVIEW.reviewer_args(args)
-
     def test_codex_retries_terra_after_sol_access_failure(self) -> None:
         args = argparse.Namespace(
             engine="codex",


### PR DESCRIPTION
## Summary

- Revert PR #230 at the owner’s request.
- Remove `--no-access-fallback`, its documentation, and its two tests.
- Restore the exact repository tree from before commit `f022bb339b0c6c66e9a86576a83e81b3cf61a430`.

## Validation

- All 249 Python tests completed successfully; one platform-specific test was skipped.
- Skill validation passed for all eight skills.
- The removed option is rejected by the command-line parser.
- `git diff --check` passed.
- No tree differences remain against the parent of the reverted commit.