### PR TITLE
fix(autoreview): preserve configured inference routes

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -36,7 +36,7 @@ jobs:
           python scripts/install-skills.test.py
           python scripts/validate-skills.test.py
       - name: Run Python tests
-        run: python -m unittest skills/autoreview/scripts/autoreview_test.py skills.autoreview.tests.test_autoreview_hardening skills.autoreview.tests.test_codex_sandbox
+        run: python -m unittest skills/autoreview/scripts/autoreview_test.py skills.autoreview.tests.test_autoreview_hardening skills.autoreview.tests.test_codex_sandbox skills.autoreview.tests.test_codex_inference_route
       - name: Check Node scripts
         run: |
           node --check skills/agent-transcript/scripts/agent-transcript

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Preserve trusted command-auth OpenAI Responses routes in Autoreview's isolated Codex client, binding catalogue and context settings without loading unrelated operator capabilities.
 - Validate explicit index/working-tree targets for mixed local Autoreview paths, preserving source anchors, rejected-attribution audit and distinct claim variants while repeating mandatory context within existing capacity limits.
 - Restore mandatory Autoreview TruffleHog `verified,unknown` pre-send scans removed in #209, retaining reviewer P0 credential checks as defense in depth.
 - Bound agent-transcript session reads to 8 MiB and disclose partial source content in render, preview, append-body, and HTML output. Thanks @SebTardif.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Preserve trusted command-auth OpenAI Responses routes in Autoreview's isolated Codex client, binding catalogue and context settings without loading unrelated operator capabilities.
+- Allow explicit trusted OpenAI Responses route projection through Autoreview's existing Codex config override, preserving default auth-only compatibility, native provider defaults, and isolated catalogue snapshots.
 - Validate explicit index/working-tree targets for mixed local Autoreview paths, preserving source anchors, rejected-attribution audit and distinct claim variants while repeating mandatory context within existing capacity limits.
 - Restore mandatory Autoreview TruffleHog `verified,unknown` pre-send scans removed in #209, retaining reviewer P0 credential checks as defense in depth.
 - Bound agent-transcript session reads to 8 MiB and disclose partial source content in render, preview, append-body, and HTML output. Thanks @SebTardif.

--- a/skills/autoreview/SKILL.md
+++ b/skills/autoreview/SKILL.md
@@ -89,6 +89,18 @@ Use `--engine`, `--model`, and `--thinking` to override the defaults.
 `--codex-speed fast` selects priority service when supported. Only Claude accepts
 `--fallback-model`. Per-engine environment overrides use `AUTOREVIEW_<ENGINE>_*`.
 
+Codex can project a named OpenAI Responses route from the operator's external
+`CODEX_HOME/config.toml` while continuing to ignore unrelated user configuration.
+The route must use `https://api.openai.com/v1` and command authentication with
+an absolute external executable. Route parsing requires Python 3.11 or `tomli`;
+ordinary auth-only configuration retains the existing fallback parser.
+Optional auth timing, context and catalogue settings keep Codex's native defaults
+and semantics. A supplied external catalogue is copied byte-for-byte into the
+private client runtime; retries use the same route and catalogue snapshot.
+Dry runs check the same external ownership and route shape without executing
+authentication. Codex owns catalogue validation, model access and context
+clamping. Other custom provider forms and split context overrides are unsupported.
+
 | Optional engine | Prerequisites                                                                                         |
 | --------------- | ----------------------------------------------------------------------------------------------------- |
 | Claude          | CLI 2.1.169+; safe mode with web-only tools                                                           |

--- a/skills/autoreview/SKILL.md
+++ b/skills/autoreview/SKILL.md
@@ -94,6 +94,7 @@ Codex can project a named OpenAI Responses route from the operator's external
 The route must use `https://api.openai.com/v1` and command authentication with
 an absolute external executable. Route parsing requires Python 3.11 or `tomli`;
 ordinary auth-only configuration retains the existing fallback parser.
+Built-in OpenAI retains its existing auth-only configuration projection.
 Optional auth timing, context and catalogue settings keep Codex's native defaults
 and semantics. A supplied external catalogue is copied byte-for-byte into the
 private client runtime; retries use the same route and catalogue snapshot.

--- a/skills/autoreview/SKILL.md
+++ b/skills/autoreview/SKILL.md
@@ -89,18 +89,33 @@ Use `--engine`, `--model`, and `--thinking` to override the defaults.
 `--codex-speed fast` selects priority service when supported. Only Claude accepts
 `--fallback-model`. Per-engine environment overrides use `AUTOREVIEW_<ENGINE>_*`.
 
-Codex can project a named OpenAI Responses route from the operator's external
-`CODEX_HOME/config.toml` while continuing to ignore unrelated user configuration.
-The route must use `https://api.openai.com/v1` and command authentication with
-an absolute external executable. Route parsing requires Python 3.11 or `tomli`;
-ordinary auth-only configuration retains the existing fallback parser.
-Built-in OpenAI retains its existing auth-only configuration projection.
-Optional auth timing, context and catalogue settings keep Codex's native defaults
-and semantics. A supplied external catalogue is copied byte-for-byte into the
-private client runtime; retries use the same route and catalogue snapshot.
-Dry runs check the same external ownership and route shape without executing
-authentication. Codex owns catalogue validation, model access and context
-clamping. Other custom provider forms and split context overrides are unsupported.
+By default, Codex preserves only authentication settings from user configuration;
+provider, profile, context and catalogue settings remain ignored. To project a
+named route, select it explicitly through the existing config override:
+
+```bash
+"$AUTOREVIEW" --mode local --codex-config 'model_provider="review_api"'
+```
+
+The selector must match `model_provider` in the operator's external
+`CODEX_HOME/config.toml`. It accepts one bare or simply quoted identifier;
+provider definitions and other capabilities cannot be supplied through overrides.
+Projection requires Python 3.11 or `tomli`; default auth-only operation retains
+its existing fallback parser.
+
+The selected route must use `https://api.openai.com/v1` and command authentication
+with an absolute external executable. Fixed arguments belong in that executable's
+wrapper; omitted or empty `auth.args` are accepted. Omitted `wire_api` and
+`requires_openai_auth` retain Codex's `responses` and `false` defaults. Optional
+auth timing and context settings keep native defaults and semantics.
+
+Catalogue and authentication working-directory paths resolve relative to the
+operator config directory and must remain outside the reviewed repository.
+A supplied catalogue is copied byte-for-byte into the private client runtime;
+retries use the same route and catalogue snapshot. Dry runs check the same
+ownership and route shape without executing authentication. Codex owns catalogue
+validation, model access and context clamping. Other custom provider forms and
+split context overrides are unsupported when projection is selected.
 
 | Optional engine | Prerequisites                                                                                         |
 | --------------- | ----------------------------------------------------------------------------------------------------- |

--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -29,7 +29,7 @@ import time
 import unicodedata
 import urllib.parse
 from pathlib import Path, PurePosixPath
-from typing import Any, BinaryIO, Callable, NamedTuple
+from typing import Any, BinaryIO, Callable, NamedTuple, Sequence
 
 
 ENGINES = ("codex", "claude", "amp", "pi", "kimi")
@@ -3810,18 +3810,33 @@ def parse_codex_auth_config_fallback(text: str) -> dict[str, Any]:
     return config
 
 
-def load_codex_auth_config(path: Path) -> dict[str, Any]:
+def load_codex_auth_config(path: Path, *, strict: bool = False) -> dict[str, Any]:
     try:
         text = path.read_text()
-    except OSError:
+    except FileNotFoundError:
+        if strict and path.is_symlink():
+            raise SystemExit("Codex inference configuration refused: operator TOML is unavailable")
+        return {}
+    except (OSError, UnicodeError):
+        if strict:
+            raise SystemExit("Codex inference configuration refused: operator TOML is unreadable")
         return {}
     try:
-        import tomllib
+        try:
+            import tomllib
+        except ModuleNotFoundError:
+            import tomli as tomllib
     except ModuleNotFoundError:
+        route_key = r"(?:model_provider|model_catalog_json|model_context_window|model_auto_compact_token_limit(?:_scope)?|profile|openai_base_url)"
+        route_setting = rf"(?m)^\s*(?:{route_key}|\"{route_key}\"|'{route_key}')\s*=|^\s*\[.*model_providers"
+        if strict and re.search(route_setting, text):
+            raise SystemExit("Codex inference configuration refused: reading an operator route requires Python 3.11 or tomli")
         return parse_codex_auth_config_fallback(text)
     try:
         config = tomllib.loads(text)
     except ValueError:
+        if strict:
+            raise SystemExit("Codex inference configuration refused: operator TOML is invalid")
         return {}
     return config if isinstance(config, dict) else {}
 
@@ -3840,11 +3855,14 @@ def codex_source_home(repo: Path) -> Path | None:
     )
 
 
-def codex_auth_config_flags(repo: Path, *, force_file: bool = False) -> list[str]:
+def codex_auth_config_flags(
+    repo: Path, *, force_file: bool = False, config: dict[str, Any] | None = None,
+) -> list[str]:
     codex_home = codex_source_home(repo)
     if codex_home is None:
         return ["-c", 'cli_auth_credentials_store="file"'] if force_file else []
-    config = load_codex_auth_config(codex_home / "config.toml")
+    if config is None:
+        config = load_codex_auth_config(codex_home / "config.toml")
 
     allowed_values = {
         "forced_login_method": {"chatgpt", "api"},
@@ -3872,6 +3890,115 @@ def codex_auth_config_flags(repo: Path, *, force_file: bool = False) -> list[str
         if normalized_workspace_ids:
             flags.extend(["-c", f"forced_chatgpt_workspace_id={json.dumps(normalized_workspace_ids)}"])
     return flags
+
+
+def load_codex_inference_route(
+    repo: Path, overrides: Sequence[str] = (),
+) -> tuple[list[str], bytes | None]:
+    """Read the trusted client route without loading operator tool capabilities."""
+    def refuse(detail: str) -> None:
+        raise SystemExit(f"Codex inference configuration refused: {detail}")
+
+    def external_path(value: Any, label: str, *, directory: bool = False) -> Path:
+        if not isinstance(value, str) or not Path(value).is_absolute():
+            refuse(f"{label} must be an absolute external path")
+        try:
+            path = Path(value).resolve(strict=True)
+        except (OSError, ValueError, RuntimeError):
+            refuse(f"{label} is unavailable")
+        if not external_env_path(repo, str(path)) or not (
+            path.is_dir() if directory else path.is_file()
+        ):
+            refuse(f"{label} must be outside the reviewed repository")
+        return path
+
+    source_home = codex_source_home(repo)
+    if source_home is None:
+        if os.environ.get("CODEX_HOME", "").strip():
+            refuse("CODEX_HOME must be an available external directory")
+        return [], None
+    config_path = source_home / "config.toml"
+    if not external_env_path(repo, str(config_path)):
+        refuse("operator config must be outside the reviewed repository")
+    config = load_codex_auth_config(config_path, strict=True)
+    flags = codex_auth_config_flags(repo, config=config)
+    context_keys = (
+        "model_context_window", "model_auto_compact_token_limit",
+        "model_auto_compact_token_limit_scope",
+    )
+    if any(key in config for key in ("profile", "openai_base_url")):
+        refuse("profile or base URL overrides cannot be projected as one inference route")
+    provider_id = config.get("model_provider", "openai")
+    if provider_id == "openai":
+        if any(key in config for key in (*context_keys, "model_catalog_json")):
+            refuse("catalogue/context settings require a supported explicit inference route")
+        return flags, None
+    if not isinstance(provider_id, str) or not re.fullmatch(r"[A-Za-z0-9_-]+", provider_id):
+        refuse("invalid provider selector")
+    if provider_id in {"ollama", "lmstudio", "amazon-bedrock", "amazon-bedrock-runtime"}:
+        refuse("command authentication requires a distinct named provider")
+    providers = config.get("model_providers", {})
+    provider = providers.get(provider_id) if isinstance(providers, dict) else None
+    if not isinstance(provider, dict) or set(provider) - {
+        "name", "base_url", "wire_api", "requires_openai_auth", "auth",
+    }:
+        refuse("unsupported provider fields")
+    if (
+        provider.get("base_url") != "https://api.openai.com/v1"
+        or provider.get("wire_api") != "responses"
+        or provider.get("requires_openai_auth") is not False
+        or not isinstance(provider.get("name", ""), str)
+    ):
+        refuse("only command-auth OpenAI Responses routes are supported")
+    auth = provider.get("auth")
+    if not isinstance(auth, dict) or set(auth) - {
+        "command", "cwd", "timeout_ms", "refresh_interval_ms",
+    }:
+        refuse("unsupported provider authentication fields")
+    command = external_path(auth.get("command"), "authentication executable")
+    if not os.access(command, os.X_OK):
+        refuse("authentication executable is not executable")
+    auth_cwd = external_path(auth.get("cwd", str(source_home)), "authentication cwd", directory=True)
+    for key, minimum in (("timeout_ms", 1), ("refresh_interval_ms", 0)):
+        if key in auth and (type(auth[key]) is not int or not minimum <= auth[key] <= (1 << 64) - 1):
+            refuse(f"invalid authentication {key}")
+    if any(override.partition("=")[0].strip() in context_keys for override in overrides):
+        refuse("context overrides would split the operator inference route")
+
+    catalogue_bytes = None
+    if "model_catalog_json" in config:
+        catalogue = external_path(config["model_catalog_json"], "model catalogue")
+        try:
+            catalogue_bytes = catalogue.read_bytes()
+        except OSError:
+            refuse("model catalogue is unreadable")
+    # Codex owns catalogue parsing, optional defaults, model fallback and context
+    # clamping. Preserve the operator's bytes instead of rebuilding its metadata.
+    settings = {
+        "model_provider": provider_id,
+        **{key: config[key] for key in context_keys if key in config},
+        **{f"model_providers.{provider_id}.{key}": value for key, value in provider.items() if key != "auth"},
+        f"model_providers.{provider_id}.auth.command": str(command),
+        f"model_providers.{provider_id}.auth.cwd": str(auth_cwd),
+        **{f"model_providers.{provider_id}.auth.{key}": auth[key]
+           for key in ("timeout_ms", "refresh_interval_ms") if key in auth},
+    }
+    return flags + [part for key, value in settings.items() for part in ("-c", f"{key}={json.dumps(value)}")], catalogue_bytes
+
+
+def prepare_codex_inference_config(
+    route: tuple[list[str], bytes | None], runtime_root: Path,
+) -> list[str]:
+    flags, catalogue_bytes = route
+    if catalogue_bytes is None:
+        return flags
+    # Client metadata stays outside the model's readable workspace and remains
+    # the same snapshot across the existing model-access retry.
+    catalogue = runtime_root / "model-catalog.json"
+    with catalogue.open("xb") as output:
+        output.write(catalogue_bytes)
+    catalogue.chmod(0o600)
+    return [*flags, "-c", f"model_catalog_json={json.dumps(str(catalogue.resolve()))}"]
 
 
 def codex_file_auth_source(repo: Path) -> Path | None:
@@ -4542,6 +4669,7 @@ def codex_command(
     model: str | None,
     *,
     force_file_auth: bool = False,
+    auth_config: list[str] | None = None,
 ) -> list[str]:
     cmd = [resolve_command(args.codex_bin, source_repo), "--ask-for-approval", "never"]
     if args.web_search:
@@ -4559,7 +4687,9 @@ def codex_command(
     if speed_override is not None:
         cmd.extend(["-c", speed_override])
     cmd.extend(codex_config_isolation_flags(review_root, runtime_root))
-    cmd.extend(codex_auth_config_flags(source_repo, force_file=force_file_auth))
+    cmd.extend(auth_config if auth_config is not None else codex_auth_config_flags(source_repo))
+    if force_file_auth:
+        cmd.extend(["-c", 'cli_auth_credentials_store="file"'])
     cmd.append("exec")
     if args.stream_engine_output:
         cmd.append("--json")
@@ -4611,6 +4741,8 @@ def run_codex(args: argparse.Namespace, repo: Path, prompt: str) -> str:
             review_root = Path(workspace_dir)
             runtime_root = Path(runtime_dir)
             runtime_codex_home = runtime_root / "codex-home"
+            route = load_codex_inference_route(repo, codex_config_overrides(args))
+            auth_config = prepare_codex_inference_config(route, runtime_root)
             file_auth_linked = prepare_codex_runtime_auth(repo, runtime_codex_home)
             for index, model in enumerate(models):
                 output_path.write_text("")
@@ -4623,6 +4755,7 @@ def run_codex(args: argparse.Namespace, repo: Path, prompt: str) -> str:
                     output_path,
                     model,
                     force_file_auth=file_auth_linked,
+                    auth_config=auth_config,
                 )
                 if index:
                     # The initial send was scanned by run_reviewer; a retry is
@@ -6310,6 +6443,7 @@ def resolve_engine_binary(reviewer: argparse.Namespace, repo: Path) -> tuple[boo
         try:
             codex_config_keys(reviewer)
             codex_speed_override(reviewer)
+            load_codex_inference_route(repo, codex_config_overrides(reviewer))
         except SystemExit as exc:
             return False, str(exc.code)
     if engine == "claude" and getattr(reviewer, "tools", True):

--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -3827,9 +3827,7 @@ def load_codex_auth_config(path: Path, *, strict: bool = False) -> dict[str, Any
         except ModuleNotFoundError:
             import tomli as tomllib
     except ModuleNotFoundError:
-        route_key = r"(?:model_provider|model_catalog_json|model_context_window|model_auto_compact_token_limit(?:_scope)?|profile|openai_base_url)"
-        route_setting = rf"(?m)^\s*(?:{route_key}|\"{route_key}\"|'{route_key}')\s*=|^\s*\[.*model_providers"
-        if strict and re.search(route_setting, text):
+        if strict:
             raise SystemExit("Codex inference configuration refused: reading an operator route requires Python 3.11 or tomli")
         return parse_codex_auth_config_fallback(text)
     try:
@@ -3899,11 +3897,30 @@ def load_codex_inference_route(
     def refuse(detail: str) -> None:
         raise SystemExit(f"Codex inference configuration refused: {detail}")
 
-    def external_path(value: Any, label: str, *, directory: bool = False) -> Path:
-        if not isinstance(value, str) or not Path(value).is_absolute():
-            refuse(f"{label} must be an absolute external path")
+    selectors = [
+        value.strip()
+        for key, _, value in (item.partition("=") for item in overrides)
+        if key.strip() == "model_provider"
+    ]
+    if not selectors:
+        # Unselected provider/profile/tuning settings keep their historical
+        # auth-only behavior, including on hosts without a TOML parser.
+        return codex_auth_config_flags(repo), None
+    if len(selectors) != 1:
+        refuse("select exactly one model_provider")
+    match = re.fullmatch(r'''(["']?)([A-Za-z0-9_-]+)\1''', selectors[0])
+    if match is None:
+        refuse("model_provider must be a bare or quoted provider identifier")
+    provider_id = match[2]
+
+    def external_path(
+        value: Any, label: str, *, directory: bool = False, absolute: bool = False,
+    ) -> Path:
+        if not isinstance(value, str) or not value or (absolute and not Path(value).is_absolute()):
+            refuse(f"{label} must be {'an absolute ' if absolute else 'an '}external path")
         try:
-            path = Path(value).resolve(strict=True)
+            # Codex resolves path settings relative to their owning config file.
+            path = (source_home / Path(value).expanduser()).resolve(strict=True)
         except (OSError, ValueError, RuntimeError):
             refuse(f"{label} is unavailable")
         if not external_env_path(repo, str(path)) or not (
@@ -3914,9 +3931,7 @@ def load_codex_inference_route(
 
     source_home = codex_source_home(repo)
     if source_home is None:
-        if os.environ.get("CODEX_HOME", "").strip():
-            refuse("CODEX_HOME must be an available external directory")
-        return [], None
+        refuse("CODEX_HOME must be an available external directory")
     config_path = source_home / "config.toml"
     if not external_env_path(repo, str(config_path)):
         refuse("operator config must be outside the reviewed repository")
@@ -3926,14 +3941,11 @@ def load_codex_inference_route(
         "model_context_window", "model_auto_compact_token_limit",
         "model_auto_compact_token_limit_scope",
     )
-    provider_id = config.get("model_provider", "openai")
-    if provider_id == "openai":
-        return flags, None
+    if config.get("model_provider") != provider_id:
+        refuse("selected model_provider must match the operator config")
     if any(key in config for key in ("profile", "openai_base_url")):
         refuse("profile or base URL overrides cannot be projected as one inference route")
-    if not isinstance(provider_id, str) or not re.fullmatch(r"[A-Za-z0-9_-]+", provider_id):
-        refuse("invalid provider selector")
-    if provider_id in {"ollama", "lmstudio", "amazon-bedrock", "amazon-bedrock-runtime"}:
+    if provider_id in {"openai", "ollama", "lmstudio", "amazon-bedrock", "amazon-bedrock-runtime"}:
         refuse("command authentication requires a distinct named provider")
     providers = config.get("model_providers", {})
     provider = providers.get(provider_id) if isinstance(providers, dict) else None
@@ -3943,17 +3955,17 @@ def load_codex_inference_route(
         refuse("unsupported provider fields")
     if (
         provider.get("base_url") != "https://api.openai.com/v1"
-        or provider.get("wire_api") != "responses"
-        or provider.get("requires_openai_auth") is not False
+        or provider.get("wire_api", "responses") != "responses"
+        or provider.get("requires_openai_auth", False) is not False
         or not isinstance(provider.get("name", ""), str)
     ):
         refuse("only command-auth OpenAI Responses routes are supported")
     auth = provider.get("auth")
     if not isinstance(auth, dict) or set(auth) - {
-        "command", "cwd", "timeout_ms", "refresh_interval_ms",
-    }:
+        "command", "args", "cwd", "timeout_ms", "refresh_interval_ms",
+    } or auth.get("args", []) != []:
         refuse("unsupported provider authentication fields")
-    command = external_path(auth.get("command"), "authentication executable")
+    command = external_path(auth.get("command"), "authentication executable", absolute=True)
     if not os.access(command, os.X_OK):
         refuse("authentication executable is not executable")
     auth_cwd = external_path(auth.get("cwd", str(source_home)), "authentication cwd", directory=True)
@@ -4554,6 +4566,7 @@ def format_version(version: tuple[int, int, int]) -> str:
 
 SAFE_CODEX_CONFIG_KEYS = {
     "hide_agent_reasoning",
+    "model_provider",
     "model_auto_compact_token_limit",
     "model_auto_compact_token_limit_scope",
     "model_context_window",
@@ -4584,7 +4597,7 @@ def codex_config_overrides(args: argparse.Namespace) -> list[str]:
         if key not in SAFE_CODEX_CONFIG_KEYS:
             raise SystemExit(
                 f"unsafe Codex config override refused: {key}; "
-                "only model and response tuning keys are allowed"
+                "only model/response tuning and validated provider selection are allowed"
             )
         overrides.append(item)
     return overrides
@@ -4675,8 +4688,11 @@ def codex_command(
     if model:
         cmd.extend(["--model", model])
     # User overrides go before the isolation flags so isolation stays authoritative on conflicts.
-    for override in codex_config_overrides(args):
-        cmd.extend(["-c", override])
+    overrides = codex_config_overrides(args)
+    for override in overrides:
+        # Provider selection is emitted only by the validated route owner.
+        if override.partition("=")[0].strip() != "model_provider":
+            cmd.extend(["-c", override])
     # Dedicated settings win over the generic config escape hatch.
     if args.thinking:
         cmd.extend(["-c", f'model_reasoning_effort="{args.thinking}"'])
@@ -4685,7 +4701,11 @@ def codex_command(
     if speed_override is not None:
         cmd.extend(["-c", speed_override])
     cmd.extend(codex_config_isolation_flags(review_root, runtime_root))
-    cmd.extend(auth_config if auth_config is not None else codex_auth_config_flags(source_repo))
+    if auth_config is None:
+        auth_config = prepare_codex_inference_config(
+            load_codex_inference_route(source_repo, overrides), runtime_root,
+        )
+    cmd.extend(auth_config)
     if force_file_auth:
         cmd.extend(["-c", 'cli_auth_credentials_store="file"'])
     cmd.append("exec")
@@ -6174,7 +6194,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--codex-config",
         action="append",
-        help='Safe Codex model/response tuning "-c key=value" override (TOML value), codex reviewer only. Repeatable. Capability-, command-, and path-bearing keys are refused. Env default: AUTOREVIEW_CODEX_CONFIG (semicolon-separated), e.g. service_tier="fast".',
+        help='Codex "-c key=value" tuning override (TOML value). Select model_provider=<id> to project the matching trusted external route. Repeatable; one provider selector. Command-, path-, and provider-definition keys are refused. Env default: AUTOREVIEW_CODEX_CONFIG (semicolon-separated).',
     )
     parser.add_argument(
         "--codex-speed",

--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -3926,13 +3926,11 @@ def load_codex_inference_route(
         "model_context_window", "model_auto_compact_token_limit",
         "model_auto_compact_token_limit_scope",
     )
-    if any(key in config for key in ("profile", "openai_base_url")):
-        refuse("profile or base URL overrides cannot be projected as one inference route")
     provider_id = config.get("model_provider", "openai")
     if provider_id == "openai":
-        if any(key in config for key in (*context_keys, "model_catalog_json")):
-            refuse("catalogue/context settings require a supported explicit inference route")
         return flags, None
+    if any(key in config for key in ("profile", "openai_base_url")):
+        refuse("profile or base URL overrides cannot be projected as one inference route")
     if not isinstance(provider_id, str) or not re.fullmatch(r"[A-Za-z0-9_-]+", provider_id):
         refuse("invalid provider selector")
     if provider_id in {"ollama", "lmstudio", "amazon-bedrock", "amazon-bedrock-runtime"}:

--- a/skills/autoreview/tests/test_autoreview_hardening.py
+++ b/skills/autoreview/tests/test_autoreview_hardening.py
@@ -2125,7 +2125,7 @@ with Path(__file__).with_name("scans.jsonl").open("a", encoding="utf-8") as reco
             'mcp_servers.review.command="touch /tmp/owned"',
             'notify=["sh", "-c", "touch /tmp/owned"]',
             'model_instructions_file="/tmp/hostile.md"',
-            'model_provider="credential-sink"',
+            'model_providers.review_api.auth.command="/tmp/credential-sink"',
             'hooks.PreToolUse.command="touch /tmp/owned"',
         ):
             with self.subTest(override=override), self.assertRaisesRegex(

--- a/skills/autoreview/tests/test_autoreview_hardening.py
+++ b/skills/autoreview/tests/test_autoreview_hardening.py
@@ -5534,7 +5534,7 @@ with Path(__file__).with_name("scans.jsonl").open("a", encoding="utf-8") as reco
             found = argparse.Namespace(engine="codex", codex_bin="codex")
             with mock.patch.dict(
                 os.environ,
-                {"PATH": f"{fake_bin_dir}{os.pathsep}{os.environ.get('PATH', '')}"},
+                {"PATH": f"{fake_bin_dir}{os.pathsep}{os.environ.get('PATH', '')}", "CODEX_HOME": str(root)},
             ):
                 available, reason = resolve_engine_binary(found, repo)
             self.assertTrue(available, reason)
@@ -5804,7 +5804,7 @@ os.execv(target, [str(target), *sys.argv[1:]])
             )
             # Dry run scans the exact prompt too, so use a deterministic
             # scanner instead of relying on the host installation.
-            env = os.environ.copy()
+            env = {**os.environ, "CODEX_HOME": str(root)}
             add_fake_trufflehog(self.helper, root, env)
 
             result = subprocess.run(
@@ -5896,7 +5896,7 @@ os.execv(target, [str(target), *sys.argv[1:]])
                 root / "codex",
                 fake_codex_script(),
             )
-            env = os.environ.copy()
+            env = {**os.environ, "CODEX_HOME": str(root)}
             env["PATH"] = path_excluding_command("trufflehog")
 
             result = subprocess.run(
@@ -6059,7 +6059,7 @@ os.execv(target, [str(target), *sys.argv[1:]])
                 root / "codex",
                 fake_codex_script(),
             )
-            env = os.environ.copy()
+            env = {**os.environ, "CODEX_HOME": str(root)}
             add_fake_trufflehog(self.helper, root, env)
 
             result = subprocess.run(
@@ -6572,7 +6572,7 @@ os.execv(target, [str(target), *sys.argv[1:]])
                 root / "codex",
                 fake_codex_script(),
             )
-            env = os.environ.copy()
+            env = {**os.environ, "CODEX_HOME": str(root)}
             add_fake_trufflehog(self.helper, root, env)
 
             result = subprocess.run(
@@ -6617,7 +6617,7 @@ os.execv(target, [str(target), *sys.argv[1:]])
                 root / "codex",
                 fake_codex_script(),
             )
-            env = os.environ.copy()
+            env = {**os.environ, "CODEX_HOME": str(root)}
             add_fake_trufflehog(self.helper, root, env)
 
             result = subprocess.run(

--- a/skills/autoreview/tests/test_codex_inference_route.py
+++ b/skills/autoreview/tests/test_codex_inference_route.py
@@ -57,7 +57,7 @@ class CodexInferenceRouteTests(unittest.TestCase):
         }
         self.helper = load_helper()
         self.args = argparse.Namespace(
-            engine="codex", codex_bin="synthetic-codex", codex_config=[], codex_speed=None,
+            engine="codex", codex_bin="synthetic-codex", codex_config=['model_provider="review_api"'], codex_speed=None,
             fallback_model=None, model="gpt-5.6-sol", stream_engine_output=False,
             thinking="high", tools=True, web_search=False,
         )
@@ -162,7 +162,7 @@ class CodexInferenceRouteTests(unittest.TestCase):
 
     def assert_route_refused(self):
         prepare_auth = mock.Mock()
-        with self.assertRaisesRegex(SystemExit, "inference") as caught:
+        with self.assertRaisesRegex(SystemExit, "inference|Codex config") as caught:
             self.run_review(prepare_auth=prepare_auth)
         prepare_auth.assert_not_called()
         self.assertEqual(self.available(), (False, str(caught.exception.code)))
@@ -207,36 +207,86 @@ class CodexInferenceRouteTests(unittest.TestCase):
         self.assertEqual(attempts[0][attempts[0].index("--model") + 1], "gpt-5.6-sol")
         self.assertEqual(self.available(), (True, None))
 
-    def test_builtin_route_preserves_auth_only_isolation(self):
-        self.config.update({
-            "model_provider": "openai", "profile": "operator-profile",
-            "openai_base_url": "https://example.invalid/operator",
-        })
+    def test_default_keeps_legacy_auth_only_behavior_with_unrelated_routes(self):
+        self.args.codex_config = []
+        for provider in ("openai", "review_api", "unsupported-provider"):
+            for without_parser in (False, True):
+                with self.subTest(provider=provider, without_parser=without_parser):
+                    self.config.update({
+                        "model_provider": provider, "profile": "operator-profile",
+                        "openai_base_url": "https://example.invalid/operator",
+                        "forced_login_method": "api",
+                    })
+                    self.provider["base_url"] = "https://example.invalid/custom"
+                    self.write_config()
+                    modules = {"tomllib": None, "tomli": None} if without_parser else {}
+                    with mock.patch.dict(sys.modules, modules):
+                        observed = self.run_review()
+                        self.assertEqual(observed["flags"]["cli_auth_credentials_store"], '"file"')
+                        self.assertEqual(observed["flags"]["forced_login_method"], '"api"')
+                        for key in (
+                            "model_provider", "model_catalog_json", "model_context_window",
+                            "model_auto_compact_token_limit", "model_auto_compact_token_limit_scope",
+                            "profile", "openai_base_url", "model_providers.review_api.auth.command",
+                        ):
+                            self.assertNotIn(key, observed["flags"])
+                        self.assertEqual(self.available(), (True, None))
+
+    def test_tuning_override_alone_does_not_select_operator_route(self):
+        self.args.codex_config = ["model_context_window=240000"]
         self.write_config()
         observed = self.run_review()
-        self.assertEqual(observed["flags"]["cli_auth_credentials_store"], '"file"')
-        for key in (
-            "model_provider", "model_catalog_json", "model_context_window",
-            "model_auto_compact_token_limit", "model_auto_compact_token_limit_scope",
-            "profile", "openai_base_url",
-        ):
-            self.assertNotIn(key, observed["flags"])
+        self.assertEqual(observed["flags"]["model_context_window"], "240000")
+        self.assertNotIn("model_provider", observed["flags"])
+        self.assertNotIn("model_catalog_json", observed["flags"])
         self.assertEqual(self.available(), (True, None))
+
+    def test_projection_requires_explicit_matching_provider_selector(self):
+        self.write_config()
+        for selector in ('review_api', '"review_api"', "'review_api'"):
+            with self.subTest(selector=selector):
+                self.args.codex_config = [f"model_provider = {selector}"]
+                observed = self.run_review()
+                provider_flags = [part for part in observed["command"] if part.startswith("model_provider=")]
+                self.assertEqual(provider_flags, ['model_provider="review_api"'])
+                self.assertEqual(observed["catalogue"], self.catalogue_bytes)
+                self.assertEqual(self.available(), (True, None))
+
+    def test_provider_selector_rejects_mismatch_and_nonliteral_values(self):
+        self.write_config()
+        for selector in (
+            '"other"', '["review_api"]', '{id="review_api"}',
+            '"review_api"\nfeatures.hooks=true', '"review_api" # comment',
+            '"review\\u005fapi"', '""',
+        ):
+            with self.subTest(selector=selector):
+                self.args.codex_config = [f"model_provider={selector}"]
+                self.assert_route_refused()
+        self.args.codex_config = ['model_provider="review_api"', 'model_provider="other"']
+        self.assert_route_refused()
+        self.args.codex_config = ['model_provider="review_api"']
+        del self.config["model_provider"]
+        self.write_config()
+        self.assert_route_refused()
 
     def test_optional_route_fields_keep_native_defaults_when_omitted(self):
         context = ("model_context_window", "model_auto_compact_token_limit", "model_auto_compact_token_limit_scope")
-        original_config, original_auth = copy.deepcopy(self.config), copy.deepcopy(self.auth)
-        for absent in (("timeout_ms", "refresh_interval_ms"), context, (*context, "model_catalog_json", "timeout_ms", "refresh_interval_ms")):
+        original_config, original_auth, original_provider = copy.deepcopy(self.config), copy.deepcopy(self.auth), copy.deepcopy(self.provider)
+        for absent in (("timeout_ms", "refresh_interval_ms"), ("name", "wire_api", "requires_openai_auth"), context, (*context, "model_catalog_json", "timeout_ms", "refresh_interval_ms")):
             with self.subTest(absent=absent):
-                self.config, self.auth = copy.deepcopy(original_config), copy.deepcopy(original_auth)
+                self.config, self.auth, self.provider = copy.deepcopy(original_config), copy.deepcopy(original_auth), copy.deepcopy(original_provider)
+                self.auth["args"] = []
                 for key in absent:
                     self.config.pop(key, None)
                     self.auth.pop(key, None)
+                    self.provider.pop(key, None)
                 self.write_config()
                 observed = self.run_review()
                 self.assertEqual(observed["flags"]["model_provider"], '"review_api"')
                 for key in absent:
-                    flag = f"model_providers.review_api.auth.{key}" if key in {"timeout_ms", "refresh_interval_ms"} else key
+                    flag = (f"model_providers.review_api.auth.{key}" if key in {"timeout_ms", "refresh_interval_ms"}
+                            else f"model_providers.review_api.{key}" if key in {"name", "wire_api", "requires_openai_auth"}
+                            else key)
                     self.assertNotIn(flag, observed["flags"])
                 self.assertEqual(self.available(), (True, None))
 
@@ -261,9 +311,13 @@ class CodexInferenceRouteTests(unittest.TestCase):
         cases = [
             ("provider", {**provider, "base_url": "https://example.invalid/v1"}),
             ("provider", {**provider, "http_headers": {"Authorization": "synthetic"}}),
+            ("provider", {**provider, "requires_openai_auth": True}),
+            ("provider", {**provider, "requires_openai_auth": "false"}),
+            ("provider", {**provider, "wire_api": "chat"}),
             ("auth", {**auth, "command": "credential-helper"}),
             ("auth", {**auth, "args": ["synthetic-credential"]}),
             ("auth", {**auth, "cwd": str(self.repo)}),
+            ("auth", {**auth, "cwd": "../repo"}),
             ("auth", {**auth, "timeout_ms": True}),
             ("auth", {**auth, "refresh_interval_ms": -1}),
         ]
@@ -297,18 +351,38 @@ class CodexInferenceRouteTests(unittest.TestCase):
         self.write_config()
         self.assert_route_refused()
 
-    def test_auth_only_config_remains_supported_without_optional_toml_parser(self):
-        (self.home / "config.toml").write_text(
-            'cli_auth_credentials_store = "file"\nforced_login_method = "api"\n'
-        )
+    def test_explicit_projection_requires_toml_parser(self):
+        self.write_config()
         with mock.patch.dict(sys.modules, {"tomllib": None, "tomli": None}):
-            observed = self.run_review()
-            self.assertEqual(observed["flags"]["cli_auth_credentials_store"], '"file"')
-            self.assertEqual(observed["flags"]["forced_login_method"], '"api"')
-            self.assertNotIn("model_provider", observed["flags"])
-            self.assertEqual(self.available(), (True, None))
-            self.write_config()
             self.assert_route_refused()
+
+    def test_relative_catalogue_and_auth_cwd_use_the_operator_config_directory(self):
+        working_dir = self.home / "credential files"
+        working_dir.mkdir()
+        self.config["model_catalog_json"] = "models.json"
+        for cwd, expected in ((".", self.home), (working_dir.name, working_dir)):
+            with self.subTest(cwd=cwd):
+                self.auth["cwd"] = cwd
+                self.write_config()
+                observed = self.run_review()
+                self.assertEqual(observed["flags"]["model_providers.review_api.auth.cwd"], json.dumps(str(expected.resolve())))
+                self.assertEqual(observed["catalogue"], self.catalogue_bytes)
+                self.assertEqual(self.available(), (True, None))
+        repo_catalogue = self.repo / "models.json"
+        repo_catalogue.write_bytes(self.catalogue_bytes)
+        self.config["model_catalog_json"] = "../repo/models.json"
+        self.write_config()
+        self.assert_route_refused()
+
+    def test_configured_executable_is_preserved_including_platform_wrapper(self):
+        executable = write_executable(self.home / "credential tool", "#!/usr/bin/env python3\nraise SystemExit(99)\n")
+        self.auth["command"] = str(executable)
+        self.write_config()
+        observed = self.run_review()
+        self.assertEqual(observed["flags"]["model_providers.review_api.auth.command"], json.dumps(str(executable.resolve())))
+        self.auth["command"] = executable.name
+        self.write_config()
+        self.assert_route_refused()
 
     def test_repository_owned_route_files_refuse_before_authentication(self):
         for name in ("config.toml", "models.json", self.runtime_helper.name):
@@ -332,16 +406,17 @@ class CodexInferenceRouteTests(unittest.TestCase):
             self.assert_route_refused()
 
     def test_context_override_cannot_split_projected_route(self):
-        self.args.codex_config = ["model_context_window=240000"]
+        self.args.codex_config.append("model_context_window=240000")
         self.write_config()
         self.assert_route_refused()
 
     def test_builtin_provider_collision_does_not_silently_change_route(self):
-        for provider in ("ollama", "lmstudio", "amazon-bedrock", "amazon-bedrock-runtime"):
+        for provider in ("openai", "ollama", "lmstudio", "amazon-bedrock", "amazon-bedrock-runtime"):
             with self.subTest(provider=provider):
                 self.write_config()
                 config = self.home / "config.toml"
                 config.write_text(config.read_text().replace("review_api", provider))
+                self.args.codex_config = [f'model_provider="{provider}"']
                 self.assert_route_refused()
 
     def test_route_preserves_linked_auth_refresh_and_original_configuration(self):

--- a/skills/autoreview/tests/test_codex_inference_route.py
+++ b/skills/autoreview/tests/test_codex_inference_route.py
@@ -207,6 +207,22 @@ class CodexInferenceRouteTests(unittest.TestCase):
         self.assertEqual(attempts[0][attempts[0].index("--model") + 1], "gpt-5.6-sol")
         self.assertEqual(self.available(), (True, None))
 
+    def test_builtin_route_preserves_auth_only_isolation(self):
+        self.config.update({
+            "model_provider": "openai", "profile": "operator-profile",
+            "openai_base_url": "https://example.invalid/operator",
+        })
+        self.write_config()
+        observed = self.run_review()
+        self.assertEqual(observed["flags"]["cli_auth_credentials_store"], '"file"')
+        for key in (
+            "model_provider", "model_catalog_json", "model_context_window",
+            "model_auto_compact_token_limit", "model_auto_compact_token_limit_scope",
+            "profile", "openai_base_url",
+        ):
+            self.assertNotIn(key, observed["flags"])
+        self.assertEqual(self.available(), (True, None))
+
     def test_optional_route_fields_keep_native_defaults_when_omitted(self):
         context = ("model_context_window", "model_auto_compact_token_limit", "model_auto_compact_token_limit_scope")
         original_config, original_auth = copy.deepcopy(self.config), copy.deepcopy(self.auth)
@@ -295,7 +311,7 @@ class CodexInferenceRouteTests(unittest.TestCase):
             self.assert_route_refused()
 
     def test_repository_owned_route_files_refuse_before_authentication(self):
-        for name in ("config.toml", "models.json", "credential-helper"):
+        for name in ("config.toml", "models.json", self.runtime_helper.name):
             with self.subTest(name=name):
                 self.write_config()
                 source = self.home / name

--- a/skills/autoreview/tests/test_codex_inference_route.py
+++ b/skills/autoreview/tests/test_codex_inference_route.py
@@ -1,0 +1,349 @@
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from .test_autoreview_hardening import init_repo, load_helper, write_executable
+
+
+class CodexInferenceRouteTests(unittest.TestCase):
+    def setUp(self):
+        self.temporary = tempfile.TemporaryDirectory(prefix="autoreview-route-test.")
+        self.addCleanup(self.temporary.cleanup)
+        self.root = Path(self.temporary.name)
+        self.repo = init_repo(self.root)
+        self.home = self.root / "operator-home"
+        self.home.mkdir()
+        self.runtime_helper = write_executable(
+            self.home / "credential-helper", "#!/bin/sh\nexit 99\n"
+        )
+        self.catalogue = self.home / "models.json"
+        self.catalogue_bytes = json.dumps({
+            "models": [{
+                "slug": "gpt-5.6-sol", "context_window": 120000,
+                "max_context_window": 120000, "auto_compact_token_limit": 90000,
+                "display_name": "Synthetic model", "supported_reasoning_levels": [],
+                "shell_type": "unified_exec", "visibility": "list",
+                "supported_in_api": True, "priority": 0, "support_verbosity": False,
+                "truncation_policy": {"mode": "tokens", "limit": 10000},
+                "experimental_supported_tools": [],
+                "model_messages": {"instructions_template": "synthetic instructions"},
+            }],
+        }).encode()
+        self.catalogue.write_bytes(self.catalogue_bytes)
+        self.config = {
+            "model_provider": "review_api",
+            "model_catalog_json": str(self.catalogue),
+            "model_context_window": 120000,
+            "model_auto_compact_token_limit": 90000,
+            "model_auto_compact_token_limit_scope": "total",
+            "cli_auth_credentials_store": "file",
+        }
+        self.provider = {
+            "name": "Synthetic review API", "base_url": "https://api.openai.com/v1",
+            "wire_api": "responses", "requires_openai_auth": False,
+        }
+        self.auth = {
+            "command": str(self.runtime_helper), "timeout_ms": 5000,
+            "refresh_interval_ms": 300000,
+        }
+        self.helper = load_helper()
+        self.args = argparse.Namespace(
+            engine="codex", codex_bin="synthetic-codex", codex_config=[], codex_speed=None,
+            fallback_model=None, model="gpt-5.6-sol", stream_engine_output=False,
+            thinking="high", tools=True, web_search=False,
+        )
+        self.environment = mock.patch.dict(os.environ, {
+            "CODEX_HOME": str(self.home), "HOME": str(self.root),
+            "AUTOREVIEW_CODEX_CONFIG": "", "AUTOREVIEW_CODEX_SPEED": "",
+        })
+        self.environment.start()
+        self.addCleanup(self.environment.stop)
+
+    def write_config(self):
+        def value(item):
+            if isinstance(item, dict):
+                return "{" + ", ".join(f"{json.dumps(key)}={value(part)}" for key, part in item.items()) + "}"
+            return json.dumps(item)
+
+        def table(values):
+            return "\n".join(f"{key} = {value(item)}" for key, item in values.items())
+
+        text = table(self.config)
+        text += "\n[model_providers.review_api]\n" + table(self.provider)
+        text += "\n[model_providers.review_api.auth]\n" + table(self.auth)
+        # These unrelated operator capabilities must never enter the review runtime.
+        text += '\n[mcp_servers.unrelated]\ncommand = "must-not-execute"\n'
+        (self.home / "config.toml").write_text(text)
+
+    def run_review(self, *, prepare_auth=None, during_run=None, scan=None):
+        observed = {}
+
+        def fake_run(command, cwd, **kwargs):
+            observed["command"] = command
+            observed["cwd"] = cwd
+            observed["workspace"] = list(cwd.iterdir())
+            observed["env"] = kwargs["env"]
+            flags = [command[index + 1] for index, value in enumerate(command) if value == "-c"]
+            observed["flags"] = dict(flag.split("=", 1) for flag in flags)
+            catalogue = observed["flags"].get("model_catalog_json")
+            if catalogue:
+                file = Path(json.loads(catalogue))
+                observed["catalogue"] = file.read_bytes()
+                observed["catalogue_path"] = file
+            if during_run:
+                result = during_run(observed)
+                if result is not None:
+                    return result
+            output = Path(command[command.index("--output-last-message") + 1])
+            output.write_text('{"findings": []}')
+            return subprocess.CompletedProcess(command, 0, "", "")
+
+        replacements = {
+            "ensure_codex_isolation_supported": mock.Mock(return_value="synthetic-codex"),
+            "resolve_command": mock.Mock(return_value="synthetic-codex"),
+            "run_with_heartbeat": fake_run,
+            "scan_outgoing_review_pack": mock.Mock(),
+        }
+        if prepare_auth is not None:
+            replacements["prepare_codex_runtime_auth"] = prepare_auth
+        if scan is not None:
+            replacements["scan_outgoing_review_pack"] = scan
+        with mock.patch.dict(self.helper["run_codex"].__globals__, replacements):
+            self.helper["run_codex"](self.args, self.repo, "synthetic review")
+        return observed
+
+    def test_trusted_route_reaches_client_without_workspace_or_config_capabilities(self):
+        self.write_config()
+        observed = self.run_review()
+        flags = observed["flags"]
+        self.assertEqual(flags.get("model_provider"), '"review_api"')
+        self.assertEqual(flags.get("model_providers.review_api.base_url"), '"https://api.openai.com/v1"')
+        self.assertEqual(flags.get("model_providers.review_api.auth.command"), json.dumps(str(self.runtime_helper.resolve())))
+        self.assertEqual(flags.get("model_providers.review_api.auth.cwd"), json.dumps(str(self.home.resolve())))
+        self.assertEqual(flags.get("model_providers.review_api.auth.timeout_ms"), "5000")
+        self.assertEqual(flags.get("model_providers.review_api.auth.refresh_interval_ms"), "300000")
+        self.assertEqual(flags.get("model_context_window"), "120000")
+        self.assertEqual(flags.get("model_auto_compact_token_limit"), "90000")
+        self.assertEqual(observed["catalogue"], self.catalogue_bytes)
+        self.assertNotEqual(observed["catalogue_path"], self.catalogue)
+        self.assertFalse(observed["catalogue_path"].is_relative_to(observed["cwd"]))
+        self.assertEqual(observed["workspace"], [])
+        self.assertIn("--ignore-user-config", observed["command"])
+        self.assertIn("--ignore-rules", observed["command"])
+        self.assertNotIn("mcp_servers.unrelated.command", flags)
+        self.assertEqual(flags["features.hooks"], "false")
+        self.assertEqual(flags["features.plugins"], "false")
+        self.assertEqual(flags["default_permissions"], '"autoreview"')
+        self.assertEqual(observed["command"][observed["command"].index("--model") + 1], self.args.model)
+        self.assertEqual(observed["command"][observed["command"].index("--ask-for-approval") + 1], "never")
+        self.assertFalse(observed["cwd"].exists())
+        self.assertFalse(observed["catalogue_path"].exists())
+
+    def available(self):
+        replacements = {
+            "find_command": mock.Mock(return_value="synthetic-codex"),
+            "ENGINE_ISOLATION_PROBES": {"codex": mock.Mock()},
+        }
+        with (
+            mock.patch.dict(self.helper["resolve_engine_binary"].__globals__, replacements),
+            mock.patch("tempfile.TemporaryDirectory", side_effect=AssertionError("preflight must not create runtime state")),
+            mock.patch("subprocess.run", side_effect=AssertionError("preflight must not execute credentials or reviewer")),
+        ):
+            return self.helper["resolve_engine_binary"](self.args, self.repo)
+
+    def assert_route_refused(self):
+        prepare_auth = mock.Mock()
+        with self.assertRaisesRegex(SystemExit, "inference") as caught:
+            self.run_review(prepare_auth=prepare_auth)
+        prepare_auth.assert_not_called()
+        self.assertEqual(self.available(), (False, str(caught.exception.code)))
+
+    def use_default_models(self):
+        args = copy.copy(self.args)
+        args.model, args.thinking, args.fallback_model = [], [], []
+        with mock.patch.dict(self.helper["reviewer_args"].__globals__, {
+            "env_defaults_for": lambda _: (None, {}),
+        }):
+            self.args = self.helper["reviewer_args"](args)[0]
+
+    def test_primary_only_catalogue_keeps_normal_fallback_and_frozen_route(self):
+        self.use_default_models()
+        self.write_config()
+        original = self.catalogue_bytes
+        events = []
+
+        def respond(observed):
+            command = observed["command"]
+            selected = command[command.index("--model") + 1]
+            events.append(selected)
+            self.assertEqual(observed["flags"].get("model_provider"), '"review_api"')
+            self.assertEqual(observed["catalogue"], original)
+            if selected == "gpt-5.6-sol":
+                # A retry keeps the prepared route even if operator files change.
+                self.catalogue.write_bytes(b"changed after primary send")
+                (self.home / "config.toml").write_text('model_provider = "another-route"')
+                return subprocess.CompletedProcess(
+                    command, 1, "", "The model gpt-5.6-sol does not exist or you do not have access to it.",
+                )
+
+        self.run_review(during_run=respond, scan=lambda *_: events.append("scan"))
+        self.assertEqual(events, ["gpt-5.6-sol", "scan", "gpt-5.6-terra"])
+
+    def test_primary_only_catalogue_does_not_block_successful_primary(self):
+        self.use_default_models()
+        self.write_config()
+        attempts = []
+        self.run_review(during_run=lambda observed: attempts.append(observed["command"]))
+        self.assertEqual(len(attempts), 1)
+        self.assertEqual(attempts[0][attempts[0].index("--model") + 1], "gpt-5.6-sol")
+        self.assertEqual(self.available(), (True, None))
+
+    def test_optional_route_fields_keep_native_defaults_when_omitted(self):
+        context = ("model_context_window", "model_auto_compact_token_limit", "model_auto_compact_token_limit_scope")
+        original_config, original_auth = copy.deepcopy(self.config), copy.deepcopy(self.auth)
+        for absent in (("timeout_ms", "refresh_interval_ms"), context, (*context, "model_catalog_json", "timeout_ms", "refresh_interval_ms")):
+            with self.subTest(absent=absent):
+                self.config, self.auth = copy.deepcopy(original_config), copy.deepcopy(original_auth)
+                for key in absent:
+                    self.config.pop(key, None)
+                    self.auth.pop(key, None)
+                self.write_config()
+                observed = self.run_review()
+                self.assertEqual(observed["flags"]["model_provider"], '"review_api"')
+                for key in absent:
+                    flag = f"model_providers.review_api.auth.{key}" if key in {"timeout_ms", "refresh_interval_ms"} else key
+                    self.assertNotIn(flag, observed["flags"])
+                self.assertEqual(self.available(), (True, None))
+
+    def test_conflicting_or_malformed_operator_route_refuses_in_run_and_preflight(self):
+        original = copy.deepcopy(self.config)
+        for config in (
+            {**original, "profile": "another-route"},
+            {**original, "openai_base_url": "https://example.invalid/v1"},
+        ):
+            with self.subTest(config=config):
+                self.config = config
+                self.write_config()
+                self.assert_route_refused()
+        for contents in (b"model_provider = [", b"\xff"):
+            with self.subTest(contents=contents):
+                (self.home / "config.toml").write_bytes(contents)
+                self.assert_route_refused()
+
+    def test_unsafe_route_descriptor_is_never_forwarded(self):
+        provider = copy.deepcopy(self.provider)
+        auth = copy.deepcopy(self.auth)
+        cases = [
+            ("provider", {**provider, "base_url": "https://example.invalid/v1"}),
+            ("provider", {**provider, "http_headers": {"Authorization": "synthetic"}}),
+            ("auth", {**auth, "command": "credential-helper"}),
+            ("auth", {**auth, "args": ["synthetic-credential"]}),
+            ("auth", {**auth, "cwd": str(self.repo)}),
+            ("auth", {**auth, "timeout_ms": True}),
+            ("auth", {**auth, "refresh_interval_ms": -1}),
+        ]
+        for target, values in cases:
+            with self.subTest(target=target, values=values):
+                self.provider, self.auth = copy.deepcopy(provider), copy.deepcopy(auth)
+                setattr(self, target, values)
+                self.write_config()
+                self.assert_route_refused()
+
+    def test_catalogue_preserves_native_metadata_and_context_semantics(self):
+        document = json.loads(self.catalogue_bytes)
+        model = document["models"][0]
+        model["max_context_window"] = 240000
+        del model["auto_compact_token_limit"]
+        model["base_instructions"] = model.pop("model_messages")["instructions_template"]
+        # Codex supports a larger maximum and legacy instruction metadata.
+        # The helper must forward these bytes without applying another schema.
+        self.catalogue_bytes = json.dumps(document, indent=2).encode() + b"\n"
+        self.catalogue.write_bytes(self.catalogue_bytes)
+        self.write_config()
+        observed = self.run_review()
+        self.assertEqual(observed["catalogue"], self.catalogue_bytes)
+        self.assertEqual(observed["flags"]["model_context_window"], "120000")
+        self.assertEqual(self.available(), (True, None))
+
+    def test_catalogue_path_must_be_external(self):
+        repo_catalogue = self.repo / "models.json"
+        repo_catalogue.write_bytes(self.catalogue_bytes)
+        self.config["model_catalog_json"] = str(repo_catalogue)
+        self.write_config()
+        self.assert_route_refused()
+
+    def test_auth_only_config_remains_supported_without_optional_toml_parser(self):
+        (self.home / "config.toml").write_text(
+            'cli_auth_credentials_store = "file"\nforced_login_method = "api"\n'
+        )
+        with mock.patch.dict(sys.modules, {"tomllib": None, "tomli": None}):
+            observed = self.run_review()
+            self.assertEqual(observed["flags"]["cli_auth_credentials_store"], '"file"')
+            self.assertEqual(observed["flags"]["forced_login_method"], '"api"')
+            self.assertNotIn("model_provider", observed["flags"])
+            self.assertEqual(self.available(), (True, None))
+            self.write_config()
+            self.assert_route_refused()
+
+    def test_repository_owned_route_files_refuse_before_authentication(self):
+        for name in ("config.toml", "models.json", "credential-helper"):
+            with self.subTest(name=name):
+                self.write_config()
+                source = self.home / name
+                original = source.read_bytes()
+                repo_file = self.repo / name
+                repo_file.write_bytes(original)
+                repo_file.chmod(0o755)
+                source.unlink()
+                source.symlink_to(repo_file)
+                try:
+                    self.assert_route_refused()
+                finally:
+                    source.unlink()
+                    source.write_bytes(original)
+                    source.chmod(0o755)
+
+        with mock.patch.dict(os.environ, {"CODEX_HOME": str(self.repo)}):
+            self.assert_route_refused()
+
+    def test_context_override_cannot_split_projected_route(self):
+        self.args.codex_config = ["model_context_window=240000"]
+        self.write_config()
+        self.assert_route_refused()
+
+    def test_builtin_provider_collision_does_not_silently_change_route(self):
+        for provider in ("ollama", "lmstudio", "amazon-bedrock", "amazon-bedrock-runtime"):
+            with self.subTest(provider=provider):
+                self.write_config()
+                config = self.home / "config.toml"
+                config.write_text(config.read_text().replace("review_api", provider))
+                self.assert_route_refused()
+
+    def test_route_preserves_linked_auth_refresh_and_original_configuration(self):
+        self.write_config()
+        source_auth = self.home / "auth.json"
+        source_auth.write_text('{"fixture": "before"}')
+        config_before = (self.home / "config.toml").read_bytes()
+
+        def refresh(observed):
+            linked = Path(observed["env"]["CODEX_HOME"]) / "auth.json"
+            self.assertTrue(os.path.samefile(linked, source_auth))
+            linked.write_text('{"fixture": "refreshed"}')
+
+        observed = self.run_review(during_run=refresh)
+        self.assertEqual(observed["flags"].get("model_provider"), '"review_api"')
+        self.assertEqual(json.loads(source_auth.read_text()), {"fixture": "refreshed"})
+        self.assertEqual((self.home / "config.toml").read_bytes(), config_before)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Autoreview isolates its Codex reviewer by ignoring user configuration. That also discarded an explicitly configured command-auth OpenAI Responses route, which could send a review through a different provider/account.

Use the existing `--codex-config 'model_provider="review_api"'` override to opt into projecting the matching external operator route. Without a selector, preserve the previous auth-only behavior for all provider/profile/tuning configurations, including Python installations without a TOML parser. Explicit selection validates the supported descriptor and external path ownership before emitting any provider settings.

The projection preserves native optional defaults, resolves catalogue and authentication working-directory paths against their owning config directory, and freezes catalogue bytes once across retries. It deliberately supports absolute external authentication executables with omitted/empty arguments; unsupported routes remain unavailable only when explicitly selected. Reviewer permissions, credential scanning, authentication ownership and the existing model-access fallback remain unchanged.

Validation:

- The opt-in compatibility controls failed before this follow-up. The full Python suite now passes 268 tests with one skip; 19 focused route/sandbox cases pass after the final help-only wording correction. Skill validation, compilation, shell syntax and whitespace checks pass.
- Managed Codex review of the final five-file follow-up completed through P2 with no actionable findings, using the matching explicit selector and a real isolated command-auth API request. Source hashes remained unchanged.
- Direct Codex source inspection covers provider defaults, authentication defaults and config-relative path ownership at commit `459a79eb85400af759e9220c7bafb4429ae07516`. Codex continues to own catalogue parsing, model metadata, access and context clamping.
- The previous head passed both Linux and Windows CI after correcting a Windows fixture to target the executable returned by its factory. Fresh hosted CI is required for this follow-up; those earlier results are not relabeled as new-head proof.

The [earlier redacted native-runtime observation](https://github.com/openclaw/agent-skills/pull/232#issuecomment-5553745253) retains the executable/version and isolation evidence. No global configuration, installed helper or credential value was changed. The latest review's parser/default-compatibility findings are addressed by explicit opt-in, unchanged default auth-only handling and native omitted-field defaults.
