### PR TITLE
fix(skills): preserve TOML values and scope transcript publication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Make agent transcripts explicit-request-only and trim before previews or publication, retaining native hosted-session sharing and partial-source notices.
+
+- Preserve Unicode and control characters in Autoreview's Codex configuration overrides and isolated Kimi TOML configuration.
 - Allow explicit trusted OpenAI Responses route projection through Autoreview's existing Codex config override, preserving default auth-only compatibility, native provider defaults, and isolated catalogue snapshots.
 - Validate explicit index/working-tree targets for mixed local Autoreview paths, preserving source anchors, rejected-attribution audit and distinct claim variants while repeating mandatory context within existing capacity limits.
 - Restore mandatory Autoreview TruffleHog `verified,unknown` pre-send scans removed in #209, retaining reviewer P0 credential checks as defense in depth.

--- a/skills/agent-transcript/SKILL.md
+++ b/skills/agent-transcript/SKILL.md
@@ -1,106 +1,81 @@
 ---
 name: agent-transcript
-description: "GitHub PR/issue agent transcripts: redact, preview, and insert safely; skip automatic use for sessions hosted on *.openclaw.ai."
+description: "Requested GitHub PR/issue agent transcripts: redact, trim, preview, and insert safely."
 ---
 
 # Agent Transcript
 
-Best-effort local-only provenance for OpenClaw PR/issue bodies. Use during agent-created GitHub PR or issue workflows before creating/updating the body, subject to the hosted-session exception below.
+Use only when the user explicitly requests a transcript or preview. Omit by
+default; never offer one or ask whether to include one during ordinary PR work.
+A preview request alone does not authorize publication.
 
-## Hosted-session exception
+For a session hosted at `*.openclaw.ai`, use native session sharing when sharing
+is requested; export a separate transcript only when the user explicitly asks
+for that copy. Identify hosting from the current session URL, not a repository
+URL or deployment/test target. Do not offer separate exports.
 
-- When the current session's hosting URL has a hostname matching `*.openclaw.ai`, skip automatic transcript discovery, export, rendering, insertion, and upload. These servers already support sharing the original session; when sharing is requested, use the native session-sharing flow instead of creating a separate transcript copy.
-- Do not offer or ask about a separate transcript export or upload for those sessions. Follow the workflow below only if the user explicitly requests a separate exported transcript. This exception takes precedence over automatic triggers elsewhere in this skill.
-- Determine this from the current session's hosting URL, not the repository URL or a deployment/test target.
+## Prepare Locally
 
-## Contract
-
-- Never use network. Session discovery reads local agent logs only.
-- Never upload raw logs. Render sanitized Markdown first.
-- Always ask the user before adding transcript logs to a GitHub PR/issue body.
-- Tell the user sanitized session logs help reviewers and can make PRs easier to prioritize.
-- Offer a local HTML preview before insertion. If the user wants preview, open it and wait for confirmation before adding the section.
-- Fail closed on unresolved secrets, private keys, browser/session/cookie details, or auth URLs.
-- Drop system/developer prompts, raw tool outputs, reasoning, env, cookies, tokens, and broad local paths.
-- Keep user prompts, assistant visible decisions, terse tool summaries, and test/proof outcomes.
-- Automatically trim the rendered transcript before showing it, previewing it, or inserting it into a public body. Never paste the raw full-session render into a PR/issue body just because `render` or `append-body` produced it.
-- Remove session turns unrelated to the PR/issue work. Use the PR/issue title, branch name, changed files, and stated goal as scope; omit earlier/later unrelated tasks even when they are in the same session log.
-- Best effort only: PR/issue creation must continue if no safe transcript is found.
-- Add the `## Agent Transcript` section only when inserting a real transcript. Never add a placeholder transcript heading or text such as "A sanitized local transcript preview was generated but not included."
-- Use a collapsed `<details>` section and update existing markers instead of duplicating sections.
-
-## Helper
-
-```bash
-skills/agent-transcript/scripts/agent-transcript --help
-```
-
-Find a likely local session:
+Default file discovery/rendering reads local Codex, Claude, Pi, and OpenClaw
+logs without network calls. Never upload raw logs.
 
 ```bash
 skills/agent-transcript/scripts/agent-transcript find \
-  --query "$PR_TITLE $BRANCH_OR_PR_URL" \
-  --cwd "$PWD" \
-  --since-days 14
+  --query "$PR_TITLE $BRANCH_OR_PR_URL" --cwd "$PWD" --since-days 14
+skills/agent-transcript/scripts/agent-transcript render \
+  --session "$SESSION_JSONL" --out /tmp/agent-transcript.md
 ```
 
-`find` scans the newest 400 matching local JSONL logs by default across Codex, Claude, Pi, and OpenClaw agent sessions. Use `--max-files N` for a wider local search. `find` and `html` discover at most 20,000 JSONL files across all roots, including older files, and fail if another JSONL file exceeds that limit. Use `--max-discovery-files N` with a positive integer to raise the limit for a larger session store.
-
-`render`, `preview`, `append-body`, and `html` read at most 8 MiB of each session file (head and tail) before JSONL parse. Use `--max-read-bytes N` with a positive integer to change the limit. Output includes a visible partial-transcript notice and `sourceTruncated` in its stats if the read limit or the existing 12,000-line parse limit omits source content.
-
-In a downstream repo that syncs shared skills under `.agents/skills`, replace
+In downstream repositories that sync under `.agents/skills`, replace
 `skills/agent-transcript` with `.agents/skills/agent-transcript`.
 
-Render a PR/issue body section:
+`find` scans the newest 400 matching logs by default; `--max-files N` widens
+local discovery. Treat matches as candidates, not proof of scope.
+`find` and `html` count up to 20,000 JSONL files across all roots, including old
+files, and fail when another exceeds the cap. `--max-discovery-files N` accepts
+a positive integer override; prefer narrowing roots before raising it.
 
-```bash
-skills/agent-transcript/scripts/agent-transcript render \
-  --session "$SESSION_JSONL" \
-  --out /tmp/agent-transcript.md
-```
+File rendering reads at most 8 MiB per session from its head and tail and parses
+at most 12,000 lines. `--max-read-bytes N` changes the byte limit. Preserve the
+visible partial-transcript notice and `sourceTruncated` stats through trimming,
+preview, and insertion; omitted source must never be described as complete.
+These are file-read limits, not limits on the separate app-server rendering mode.
 
-Preview one candidate session locally:
+Automatically trim the rendered Markdown **before showing, previewing, or
+inserting it**. Keep only task-relevant user prompts, visible decisions, terse
+tool summaries, and proof outcomes. Use the PR/issue goal, branch, and changed
+files to remove unrelated earlier/later turns. Drop system/developer prompts,
+reasoning, raw tool output, environment data, local paths, credentials,
+browser/session/cookie details, and auth URLs. Inspect the trimmed result;
+helper redaction is not sufficient disclosure review. Unresolved sensitive
+content means omit the transcript.
 
-```bash
-skills/agent-transcript/scripts/agent-transcript preview \
-  --session "$SESSION_JSONL" \
-  --out /tmp/agent-transcript-preview.html
-open /tmp/agent-transcript-preview.html
-```
+## Preview And Insert
 
-Append/update a body file before `gh pr create --body-file` or connector PR creation:
+Show the trimmed Markdown for a requested preview. If HTML is requested, build
+the local preview from that trimmed content. The helper's `preview`, `html`, and
+`append-body` modes render the session again; they do not consume an edited
+Markdown file and can reintroduce removed turns. Do not use their untrimmed
+output as the approved artifact.
 
-```bash
-skills/agent-transcript/scripts/agent-transcript append-body \
-  --body /tmp/pr-body.md \
-  --session "$SESSION_JSONL" \
-  --out /tmp/pr-body.with-transcript.md
-```
+Insert only the inspected, scoped text when the user's authorization specifically
+covers publishing that transcript to the named PR/issue. Generating or previewing
+a transcript does not authorize publication, even when ordinary PR creation or
+editing is already approved. If that scope is missing, show the trimmed result
+and obtain publication authorization before insertion. Existing explicit
+authorization covering transcript publication needs no repeat confirmation.
+Keep the collapsed `<details>` section and replace existing transcript markers
+instead of duplicating them. No safe match means continue the PR work without
+transcript or placeholder; explain the omission when it prevents the explicitly
+requested transcript. Do not promote transcript inclusion as a review priority
+requirement.
 
-## PR/Issue Workflow
-
-1. Draft the normal PR/issue body first.
-2. Run `find` with title, branch, PR URL/number if known, and cwd.
-3. If a high-confidence session is found, ask:
-   `Include a redacted agent transcript? It helps reviewers and can make the PR easier to prioritize. I can open a local preview first.`
-4. If the user wants preview, run `preview`, open the HTML with `open`, and wait for confirmation.
-5. Render or append to a temp body, then automatically trim the `## Agent Transcript` section before showing it to the user or inserting it publicly. Keep only turns that explain this PR/issue's goal, implementation choices, files, tests, proof, blockers, and final outcome.
-6. Inspect the trimmed transcript text. If it still includes unrelated earlier/later work, trim again before proceeding.
-7. If the user approves, use the enriched trimmed body file for creation/update.
-8. If no safe session is found, say nothing and continue without transcript. If the user declines, continue without transcript and do not add any transcript placeholder section.
-
-## Validate
+## Validate Helper Changes
 
 ```bash
 node --test skills/agent-transcript/scripts/agent-transcript.test.mjs
 ```
 
-## Review Artifacts
-
-For manual audits across many PR/session candidates, create a local HTML preview from a local JSON file. This is for maintainers only and is not part of the PR/issue workflow:
-
-```bash
-skills/agent-transcript/scripts/agent-transcript html \
-  --prs /tmp/recent-prs.json \
-  --out /tmp/agent-transcript-preview.html
-```
+For a downstream `.agents/skills` copy, run that test command from `.agents/`
+so the test's relative helper path resolves. Use synthetic logs and isolated
+discovery roots; never discover real user logs just to validate this skill.

--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -3813,7 +3813,7 @@ def parse_codex_auth_config_fallback(text: str) -> dict[str, Any]:
 
 def load_codex_auth_config(path: Path, *, strict: bool = False) -> dict[str, Any]:
     try:
-        text = path.read_text()
+        text = path.read_text(encoding="utf-8")
     except FileNotFoundError:
         if strict and path.is_symlink():
             raise SystemExit("Codex inference configuration refused: operator TOML is unavailable")

--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -3710,12 +3710,13 @@ def write_json_temp(data: dict[str, Any], temp_root: Path) -> Path:
     return Path(handle.name)
 
 
-def toml_quoted_key_segment(value: str) -> str:
-    return json.dumps(value)
+def toml_string(value: str) -> str:
+    # TOML rejects JSON surrogate escapes and requires DEL to remain escaped.
+    return json.dumps(value, ensure_ascii=False).replace("\x7f", r"\u007f")
 
 
 def toml_inline_string_table(values: dict[str, str]) -> str:
-    entries = ", ".join(f"{key}={json.dumps(value)}" for key, value in sorted(values.items()))
+    entries = ", ".join(f"{toml_key(key)}={toml_string(value)}" for key, value in sorted(values.items()))
     return "{" + entries + "}"
 
 
@@ -3727,7 +3728,7 @@ def codex_config_isolation_flags(repo: Path, runtime_root: Path) -> list[str]:
         # Glob denies cover the root's listing as well as its descendants.
         filesystem.update({f"{root}{{,/**}}": "deny" for root in CODEX_MACOS_SCRATCH_ROOTS})
     filesystem_config = ",".join(
-        f"{json.dumps(path)}={json.dumps(access)}" for path, access in filesystem.items()
+        f"{toml_string(path)}={toml_string(access)}" for path, access in filesystem.items()
     )
     state_home = runtime_root / "state"
     log_dir = runtime_root / "log"
@@ -3737,9 +3738,9 @@ def codex_config_isolation_flags(repo: Path, runtime_root: Path) -> list[str]:
         "-c",
         "project_doc_max_bytes=0",
         "-c",
-        f"sqlite_home={json.dumps(str(state_home.resolve()))}",
+        f"sqlite_home={toml_string(str(state_home.resolve()))}",
         "-c",
-        f"log_dir={json.dumps(str(log_dir.resolve()))}",
+        f"log_dir={toml_string(str(log_dir.resolve()))}",
         "-c",
         "features.shell_snapshot=false",
         "-c",
@@ -3751,7 +3752,7 @@ def codex_config_isolation_flags(repo: Path, runtime_root: Path) -> list[str]:
         "-c",
         "skills.config=[]",
         "-c",
-        f"projects.{toml_quoted_key_segment(str(repo.resolve()))}.trust_level=\"untrusted\"",
+        f"projects.{toml_string(str(repo.resolve()))}.trust_level=\"untrusted\"",
         "-c",
         'shell_environment_policy.inherit="core"',
         "-c",
@@ -3871,14 +3872,14 @@ def codex_auth_config_flags(
     if not force_file:
         value = config.get("cli_auth_credentials_store")
         if isinstance(value, str) and value in {"file", "keyring", "auto", "ephemeral"}:
-            flags.extend(["-c", f"cli_auth_credentials_store={json.dumps(value)}"])
+            flags.extend(["-c", f"cli_auth_credentials_store={toml_string(value)}"])
     for key, allowed in allowed_values.items():
         value = config.get(key)
         if isinstance(value, str) and value in allowed:
-            flags.extend(["-c", f"{key}={json.dumps(value)}"])
+            flags.extend(["-c", f"{key}={toml_string(value)}"])
     workspace_ids = config.get("forced_chatgpt_workspace_id")
     if isinstance(workspace_ids, str) and workspace_ids.strip():
-        flags.extend(["-c", f"forced_chatgpt_workspace_id={json.dumps(workspace_ids.strip())}"])
+        flags.extend(["-c", f"forced_chatgpt_workspace_id={toml_string(workspace_ids.strip())}"])
     elif isinstance(workspace_ids, list):
         normalized_workspace_ids = [
             value.strip()
@@ -3886,7 +3887,7 @@ def codex_auth_config_flags(
             if isinstance(value, str) and value.strip()
         ]
         if normalized_workspace_ids:
-            flags.extend(["-c", f"forced_chatgpt_workspace_id={json.dumps(normalized_workspace_ids)}"])
+            flags.extend(["-c", f"forced_chatgpt_workspace_id={toml_value(normalized_workspace_ids)}"])
     return flags
 
 
@@ -3993,7 +3994,7 @@ def load_codex_inference_route(
         **{f"model_providers.{provider_id}.auth.{key}": auth[key]
            for key in ("timeout_ms", "refresh_interval_ms") if key in auth},
     }
-    return flags + [part for key, value in settings.items() for part in ("-c", f"{key}={json.dumps(value)}")], catalogue_bytes
+    return flags + [part for key, value in settings.items() for part in ("-c", f"{key}={toml_value(value)}")], catalogue_bytes
 
 
 def prepare_codex_inference_config(
@@ -4008,7 +4009,7 @@ def prepare_codex_inference_config(
     with catalogue.open("xb") as output:
         output.write(catalogue_bytes)
     catalogue.chmod(0o600)
-    return [*flags, "-c", f"model_catalog_json={json.dumps(str(catalogue.resolve()))}"]
+    return [*flags, "-c", f"model_catalog_json={toml_string(str(catalogue.resolve()))}"]
 
 
 def codex_file_auth_source(repo: Path) -> Path | None:
@@ -4503,7 +4504,7 @@ def prepare_kimi_runtime_auth(
 def toml_key(key: str) -> str:
     if re.fullmatch(r"[A-Za-z0-9_-]+", key):
         return key
-    return json.dumps(key)
+    return toml_string(key)
 
 
 def toml_value(value: Any) -> str:
@@ -4512,10 +4513,10 @@ def toml_value(value: Any) -> str:
     if isinstance(value, (int, float)):
         return repr(value)
     if isinstance(value, str):
-        return json.dumps(value)
+        return toml_string(value)
     if isinstance(value, list):
         return "[" + ", ".join(toml_value(item) for item in value) + "]"
-    raise SystemExit(f"kimi config contains a value autoreview cannot serialize: {value!r}")
+    raise SystemExit(f"TOML config contains a value autoreview cannot serialize: {value!r}")
 
 
 def dump_toml(data: dict[str, Any]) -> str:

--- a/skills/autoreview/tests/test_autoreview_hardening.py
+++ b/skills/autoreview/tests/test_autoreview_hardening.py
@@ -21,6 +21,11 @@ import unittest
 from unittest import mock
 from pathlib import Path, PureWindowsPath
 
+try:
+    import tomllib
+except ModuleNotFoundError:
+    import tomli as tomllib
+
 
 SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "autoreview"
 FIXTURES = Path(__file__).with_name("fixtures")
@@ -3619,6 +3624,19 @@ with Path(__file__).with_name("scans.jsonl").open("a", encoding="utf-8") as reco
         self.assertNotIn("thinking", config)
         self.assertNotIn("hooks", config)
 
+    def test_kimi_written_config_round_trips_unicode_and_scalar_types(self) -> None:
+        config = {
+            "default_model": "review-🦞",
+            "models": {"review-🦞": {"provider": "provider-🦞", "max_context_size": 100000}},
+            "providers": {"provider-🦞": {
+                "label.🦞\x7f": 'Unicode 🦞 with "quotes", backslash \\, newline\n and DEL\x7f',
+                "values": [True, False, 42, 1.5, "🦞"],
+            }},
+        }
+        with tempfile.TemporaryDirectory() as tempdir:
+            config_path, _ = self.helper["write_kimi_review_files"](Path(tempdir), config)
+            self.assertEqual(tomllib.loads(config_path.read_text(encoding="utf-8")), config)
+
     def test_kimi_oauth_credentials_are_linked_outside_runtime_state(self) -> None:
         if os.name == "nt":
             self.skipTest("directory symlink privileges vary on Windows")
@@ -4993,6 +5011,27 @@ with Path(__file__).with_name("scans.jsonl").open("a", encoding="utf-8") as reco
         )
         for key, value in self.helper["codex_tool_git_env"]().items():
             self.assertIn(f"{key}={json.dumps(value)}", set_flag)
+
+    def test_codex_isolation_overrides_round_trip_unicode_paths(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            root = Path(tempdir)
+            repo = root / "repo-🦞"
+            repo.mkdir()
+            runtime = root / "runtime-🦞"
+            tool_env = {"GIT_CONFIG_VALUE_0": "value-🦞\x7f"}
+            with mock.patch.dict(self.helper["codex_config_isolation_flags"].__globals__, {
+                "codex_tool_git_env": lambda: tool_env,
+            }):
+                flags = self.helper["codex_config_isolation_flags"](repo, runtime)
+            parsed = tomllib.loads("\n".join(flags[1::2]))
+            self.assertEqual(parsed["sqlite_home"], str((runtime / "state").resolve()))
+            self.assertEqual(parsed["log_dir"], str((runtime / "log").resolve()))
+            self.assertEqual(parsed["projects"], {str(repo.resolve()): {"trust_level": "untrusted"}})
+            self.assertEqual(parsed["shell_environment_policy"]["set"], tool_env)
+            expected = {":minimal": "read", ":workspace_roots": "read"}
+            if sys.platform == "darwin":
+                expected.update({f"{path}{{,/**}}": "deny" for path in self.helper["CODEX_MACOS_SCRATCH_ROOTS"]})
+            self.assertEqual(parsed["permissions"]["autoreview"]["filesystem"], expected)
 
     def test_safe_engine_env_excludes_repo_local_path_entries(self) -> None:
         old_path = os.environ.get("PATH", "")

--- a/skills/autoreview/tests/test_autoreview_hardening.py
+++ b/skills/autoreview/tests/test_autoreview_hardening.py
@@ -2272,16 +2272,19 @@ with Path(__file__).with_name("scans.jsonl").open("a", encoding="utf-8") as reco
         with tempfile.TemporaryDirectory() as tempdir:
             root = Path(tempdir).resolve()
             repo = init_repo(root)
+            git(repo, "config", "core.autocrlf", "false")
             (repo / "behavior.py").write_text("def behavior(): return 'preexisting'\n", encoding="utf-8")
             git(repo, "add", "behavior.py")
             git(repo, "commit", "-qm", "initial behavior")
             initial = git(repo, "rev-parse", "HEAD").strip()
-            for value in ("before", "after"):
-                (repo / "unrelated.txt").write_text(value + "\n", encoding="utf-8")
+            for content in (b"before\n", b"after\r\n"):
+                (repo / "unrelated.txt").write_bytes(content)
                 git(repo, "add", "unrelated.txt")
                 git(repo, "commit", "-qm", "unrelated maintenance")
             expected_parent = git(repo, "rev-parse", "HEAD^").strip()
-            expected_patch = git(repo, "diff", *self.helper["SAFE_DIFF_FLAGS"], "HEAD^", "HEAD")
+            expected_patch = subprocess.check_output(
+                ["git", "diff", *self.helper["SAFE_DIFF_FLAGS"], "HEAD^", "HEAD"], cwd=repo,
+            ).decode("utf-8")
             for state, depth in (("missing", 1), ("available", 2), ("retained", None)):
                 with self.subTest(state=state):
                     checkout = root / state

--- a/skills/autoreview/tests/test_codex_inference_route.py
+++ b/skills/autoreview/tests/test_codex_inference_route.py
@@ -87,7 +87,7 @@ class CodexInferenceRouteTests(unittest.TestCase):
         text += "\n[model_providers.review_api.auth]\n" + table(self.auth)
         # These unrelated operator capabilities must never enter the review runtime.
         text += '\n[mcp_servers.unrelated]\ncommand = "must-not-execute"\n'
-        (self.home / "config.toml").write_text(text)
+        (self.home / "config.toml").write_text(text, encoding="utf-8")
 
     def run_review(self, *, prepare_auth=None, during_run=None, scan=None):
         observed = {}

--- a/skills/autoreview/tests/test_codex_inference_route.py
+++ b/skills/autoreview/tests/test_codex_inference_route.py
@@ -11,6 +11,11 @@ import unittest
 from pathlib import Path
 from unittest import mock
 
+try:
+    import tomllib
+except ModuleNotFoundError:
+    import tomli as tomllib
+
 from .test_autoreview_hardening import init_repo, load_helper, write_executable
 
 
@@ -72,7 +77,7 @@ class CodexInferenceRouteTests(unittest.TestCase):
         def value(item):
             if isinstance(item, dict):
                 return "{" + ", ".join(f"{json.dumps(key)}={value(part)}" for key, part in item.items()) + "}"
-            return json.dumps(item)
+            return json.dumps(item, ensure_ascii=False)
 
         def table(values):
             return "\n".join(f"{key} = {value(item)}" for key, item in values.items())
@@ -383,6 +388,32 @@ class CodexInferenceRouteTests(unittest.TestCase):
         self.auth["command"] = executable.name
         self.write_config()
         self.assert_route_refused()
+
+    def test_non_bmp_route_paths_round_trip_through_toml_overrides(self):
+        executable = write_executable(self.home / "credential-🦞", "#!/bin/sh\nexit 99\n")
+        working_dir = self.home / "working-🦞"
+        working_dir.mkdir()
+        self.auth.update(command=str(executable), cwd=str(working_dir))
+        self.write_config()
+        observed = self.run_review()
+
+        runtime = self.root / "runtime-🦞"
+        runtime.mkdir()
+        catalogue_flags = self.helper["prepare_codex_inference_config"](
+            ([], self.catalogue_bytes), runtime,
+        )
+        key, value = catalogue_flags[-1].split("=", 1)
+        flags = {**observed["flags"], key: value}
+        expected = {
+            "model_providers.review_api.auth.command": executable,
+            "model_providers.review_api.auth.cwd": working_dir,
+            "model_catalog_json": runtime / "model-catalog.json",
+        }
+        for key, path in expected.items():
+            with self.subTest(key=key):
+                parsed = tomllib.loads(f"value = {flags[key]}")["value"]
+                self.assertEqual(parsed, str(path.resolve()))
+        self.assertEqual((runtime / "model-catalog.json").read_bytes(), self.catalogue_bytes)
 
     def test_repository_owned_route_files_refuse_before_authentication(self):
         for name in ("config.toml", "models.json", self.runtime_helper.name):


### PR DESCRIPTION
## Summary

Autoreview emitted JSON string escapes into TOML configuration. Non-BMP characters in authentication/runtime paths became surrogate pairs that TOML rejects; Codex then treated the invalid override as a literal string and used the wrong path.

Use one TOML string encoder for Codex overrides and isolated Kimi config. Preserve Unicode, keep DEL escaped as TOML requires, and retain existing quote/control escaping and scalar behavior. Unrelated JSON output is unchanged.

Also align the canonical transcript instructions with explicit-request-only discovery, scoped publication authorization, trimming before preview, hosted native sharing, and honest partial-source notices. Transcript helper code is unchanged; consumers retain their reviewed file-based implementations rather than importing an unrequested protocol feature.

## Validation

- Three parser-based regressions failed before the fix: emitted inference paths, Codex isolation/runtime configuration, and the written Kimi file.
- All 72 focused tests pass, including existing route, configuration, and real macOS sandbox checks.
- All eight skill frontmatters and `git diff --check` pass. The unchanged canonical transcript helper passes 17 existing synthetic file-workflow tests without reading real user logs.
- Native Codex override parsing inspected at `codex-rs/utils/cli/src/config_override.rs:70–79`: TOML parsing precedes literal fallback. The tests use an independent TOML parser instead of asserting the implementation's strings.
- Independent Codex review found no actionable P0–P2 issue in the serializer repair. Exact-head CI is checked before landing.

Windows CI initially exposed locale-dependent fixture/config handling and a raw-diff test that normalized line endings in its expected value. TOML reads and fixture writes now explicitly use UTF-8; the history test captures Git bytes and exercises an LF-to-CRLF change without weakening assertions. The route suite passes under a simulated CP1252 default. Independent review of this correction is clean; exact-head Windows CI is rerun.

The installed native Kimi config loader (1.48.0, tomlkit 0.14.0) also accepted the generated configuration in an offline synthetic check, preserving supplementary Unicode, dotted keys, control escaping, and scalar values. No authentication or inference ran. Native Codex execution was not performed; its pinned parser contract and independent TOML round-trip tests provide the evidence for this serialization-only repair. This is not a claim of an end-to-end inference run.
