### PR TITLE
fix(autoreview): preserve caller home for auth helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Restore trusted caller HOME only for explicitly selected Autoreview command-auth helpers on POSIX, preserving reviewer isolation and suppressing raw provider diagnostics.
 - Make agent transcripts explicit-request-only and trim before previews or publication, retaining native hosted-session sharing and partial-source notices.
 
 - Preserve Unicode and control characters in Autoreview's Codex configuration overrides and isolated Kimi TOML configuration.

--- a/skills/autoreview/SKILL.md
+++ b/skills/autoreview/SKILL.md
@@ -109,6 +109,15 @@ wrapper; omitted or empty `auth.args` are accepted. Omitted `wire_api` and
 `requires_openai_auth` retain Codex's `responses` and `false` defaults. Optional
 auth timing and context settings keep native defaults and semantics.
 
+On POSIX, a private launcher restores the validated caller `HOME` only for the
+selected authentication executable; the engine and reviewer tools retain their
+isolated environment and filesystem access. Caller `HOME` must be an available
+absolute directory with no repository-owned path or symlink provenance. Windows
+keeps the native executable route. Command-auth runs suppress raw provider
+diagnostics and report fixed failure categories, while retaining compact progress,
+usage and assistant report streaming. An empty final report fails without exposing
+captured stdout.
+
 Catalogue and authentication working-directory paths resolve relative to the
 operator config directory and must remain outside the reviewed repository.
 A supplied catalogue is copied byte-for-byte into the private client runtime;

--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -17,6 +17,7 @@ import os
 import queue
 import re
 import secrets
+import shlex
 import shutil
 import signal
 import stat
@@ -3891,6 +3892,35 @@ def codex_auth_config_flags(
     return flags
 
 
+def codex_auth_helper_home(repo: Path) -> Path:
+    try:
+        home = Path(os.environ.get("HOME", ""))
+        resolved = home.resolve(strict=True)
+        if not home.is_absolute() or not resolved.is_dir():
+            raise ValueError("unavailable HOME")
+        roots = (repo.absolute(), repo.resolve())
+        pending = [home, *home.parents]
+        seen: set[Path] = set()
+        while pending:
+            path = pending.pop()
+            if path in seen:
+                continue
+            seen.add(path)
+            if any(is_within(path, root) or is_within(path.resolve(), root) for root in roots):
+                raise ValueError("repository-owned HOME")
+            if path.is_symlink():
+                # Check intermediate link targets too: a repository-owned link
+                # can lead back outside the repository before final resolution.
+                target = path.parent / os.readlink(path)
+                pending.extend((target, *target.parents))
+        return resolved
+    except (OSError, RuntimeError, ValueError):
+        raise SystemExit(
+            "Codex inference configuration refused: auth helper requires an available "
+            "absolute trusted caller HOME outside the reviewed repository"
+        ) from None
+
+
 def load_codex_inference_route(
     repo: Path, overrides: Sequence[str] = (),
 ) -> tuple[list[str], bytes | None]:
@@ -3969,6 +3999,8 @@ def load_codex_inference_route(
     command = external_path(auth.get("command"), "authentication executable", absolute=True)
     if not os.access(command, os.X_OK):
         refuse("authentication executable is not executable")
+    if os.name != "nt":
+        codex_auth_helper_home(repo)
     auth_cwd = external_path(auth.get("cwd", str(source_home)), "authentication cwd", directory=True)
     for key, minimum in (("timeout_ms", 1), ("refresh_interval_ms", 0)):
         if key in auth and (type(auth[key]) is not int or not minimum <= auth[key] <= (1 << 64) - 1):
@@ -4010,6 +4042,27 @@ def prepare_codex_inference_config(
         output.write(catalogue_bytes)
     catalogue.chmod(0o600)
     return [*flags, "-c", f"model_catalog_json={toml_string(str(catalogue.resolve()))}"]
+
+
+def stage_codex_auth_helper(repo: Path, runtime_root: Path, flags: list[str]) -> list[str]:
+    if os.name == "nt":
+        return flags
+    staged = list(flags)
+    for index, flag in enumerate(flags):
+        key, separator, value = flag.partition("=")
+        if not separator or not re.fullmatch(r"model_providers\.[A-Za-z0-9_-]+\.auth\.command", key):
+            continue
+        # Route validation owns the absolute executable. Native command auth
+        # runs outside the tool sandbox; only its launcher restores caller HOME.
+        command = json.loads(value)
+        home = codex_auth_helper_home(repo)
+        with tempfile.NamedTemporaryFile(
+            "w", prefix="provider-auth.", dir=runtime_root, delete=False, encoding="utf-8",
+        ) as wrapper:
+            wrapper.write(f"#!/bin/sh\nexport HOME={shlex.quote(str(home))}\nexec {shlex.quote(command)}\n")
+            os.fchmod(wrapper.fileno(), 0o700)
+        staged[index] = f"{key}={toml_string(wrapper.name)}"
+    return staged
 
 
 def codex_file_auth_source(repo: Path) -> Path | None:
@@ -4671,6 +4724,26 @@ def codex_model_access_failure(result: subprocess.CompletedProcess[str], model: 
     return False
 
 
+def codex_failure_category(result: subprocess.CompletedProcess[str]) -> str:
+    # Classify only; captured auth-helper diagnostics must never escape.
+    text = (result.stderr + "\n" + result.stdout).lower()
+    categories = (
+        ("provider-auth-helper", ("provider auth command", "external bearer")),
+        ("model-catalogue", ("model_catalog_json", "model catalog", "model catalogue")),
+        ("model-sandbox-policy", ("requires a sandbox", "reviewed escalations")),
+        ("cli-arguments", ("unexpected argument", "unrecognized option", "unrecognized subcommand")),
+        ("configuration", ("error loading config", "error parsing config", "failed to load config", "invalid configuration", "missing field", "unknown field")),
+        ("authentication", ("401 unauthorized", "http 401", "status code 401", "invalid api key", "missing bearer", "authentication failed")),
+        ("provider-access", ("403 forbidden", "http 403", "do not have access", "not supported when using codex")),
+        ("rate-limit", ("429 too many requests", "http 429", "rate limit", "rate_limit")),
+        ("transport", ("connection refused", "connection reset", "failed to connect", "stream disconnected", "certificate verify", "timed out")),
+    )
+    for category, markers in categories:
+        if any(marker in text for marker in markers):
+            return category
+    return "unclassified"
+
+
 def codex_command(
     args: argparse.Namespace,
     source_repo: Path,
@@ -4706,6 +4779,7 @@ def codex_command(
         auth_config = prepare_codex_inference_config(
             load_codex_inference_route(source_repo, overrides), runtime_root,
         )
+        auth_config = stage_codex_auth_helper(source_repo, runtime_root, auth_config)
     cmd.extend(auth_config)
     if force_file_auth:
         cmd.extend(["-c", 'cli_auth_credentials_store="file"'])
@@ -4762,6 +4836,8 @@ def run_codex(args: argparse.Namespace, repo: Path, prompt: str) -> str:
             runtime_codex_home = runtime_root / "codex-home"
             route = load_codex_inference_route(repo, codex_config_overrides(args))
             auth_config = prepare_codex_inference_config(route, runtime_root)
+            command_auth = any(flag.startswith("model_provider=") for flag in auth_config)
+            auth_config = stage_codex_auth_helper(repo, runtime_root, auth_config)
             file_auth_linked = prepare_codex_runtime_auth(repo, runtime_codex_home)
             for index, model in enumerate(models):
                 output_path.write_text("")
@@ -4787,7 +4863,7 @@ def run_codex(args: argparse.Namespace, repo: Path, prompt: str) -> str:
                     label="codex",
                     max_runtime_seconds=getattr(args, "engine_timeout_seconds", None),
                     stream_output=args.stream_engine_output,
-                    stream_display=CodexStreamDisplay() if args.stream_engine_output else None,
+                    stream_display=CodexStreamDisplay(suppress_diagnostics=command_auth) if args.stream_engine_output else None,
                     env=codex_runtime_env(
                         repo,
                         runtime_root,
@@ -4797,6 +4873,8 @@ def run_codex(args: argparse.Namespace, repo: Path, prompt: str) -> str:
                 )
                 output = output_path.read_text()
                 if result.returncode == 0:
+                    if command_auth and not output.strip():
+                        raise SystemExit("codex engine failed: missing-report; provider diagnostics suppressed")
                     return output or result.stdout
                 if (
                     index == 0
@@ -4810,6 +4888,10 @@ def run_codex(args: argparse.Namespace, repo: Path, prompt: str) -> str:
                         file=sys.stderr,
                     )
                     continue
+                if command_auth:
+                    raise SystemExit(
+                        f"codex engine failed: {codex_failure_category(result)}; provider diagnostics suppressed"
+                    )
                 detail = result.stderr or result.stdout
                 if primary_failure is not None:
                     primary_detail = primary_failure.stderr or primary_failure.stdout
@@ -5559,18 +5641,21 @@ def run_kimi(args: argparse.Namespace, repo: Path, prompt: str) -> str:
 
 
 class CodexStreamDisplay:
-    def __init__(self, *, activity_seconds: int = 20) -> None:
+    def __init__(self, *, activity_seconds: int = 20, suppress_diagnostics: bool = False) -> None:
         self.activity_seconds = activity_seconds
+        self.suppress_diagnostics = suppress_diagnostics
         self.hidden_events = 0
         self.last_visible = time.monotonic()
 
     def __call__(self, name: str, line: str) -> str | None:
         if name != "stdout":
-            return stream_display_escape(line)
+            return self.hidden_activity() if self.suppress_diagnostics else stream_display_escape(line)
         try:
             event = json.loads(line)
         except json.JSONDecodeError:
-            return self.visible(line)
+            return self.hidden_activity() if self.suppress_diagnostics else self.visible(line)
+        if not isinstance(event, dict):
+            return self.hidden_activity()
         event_type = event.get("type")
         if event_type == "thread.started":
             return self.visible(f"codex thread: {event.get('thread_id', '<unknown>')}\n")

--- a/skills/autoreview/tests/test_codex_inference_route.py
+++ b/skills/autoreview/tests/test_codex_inference_route.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
 import argparse
+import contextlib
 import copy
+import io
 import json
 import os
+import shlex
+import stat
 import subprocess
 import sys
 import tempfile
@@ -97,8 +101,14 @@ class CodexInferenceRouteTests(unittest.TestCase):
             observed["cwd"] = cwd
             observed["workspace"] = list(cwd.iterdir())
             observed["env"] = kwargs["env"]
+            observed["stream_display"] = kwargs["stream_display"]
             flags = [command[index + 1] for index, value in enumerate(command) if value == "-c"]
             observed["flags"] = dict(flag.split("=", 1) for flag in flags)
+            auth_command = observed["flags"].get("model_providers.review_api.auth.command")
+            if auth_command:
+                launcher = Path(tomllib.loads(f"value = {auth_command}")["value"])
+                observed["auth_command"] = launcher
+                observed["auth_launcher_text"] = launcher.read_text(encoding="utf-8")
             catalogue = observed["flags"].get("model_catalog_json")
             if catalogue:
                 file = Path(json.loads(catalogue))
@@ -123,8 +133,15 @@ class CodexInferenceRouteTests(unittest.TestCase):
         if scan is not None:
             replacements["scan_outgoing_review_pack"] = scan
         with mock.patch.dict(self.helper["run_codex"].__globals__, replacements):
-            self.helper["run_codex"](self.args, self.repo, "synthetic review")
+            observed["report"] = self.helper["run_codex"](self.args, self.repo, "synthetic review")
         return observed
+
+    def assert_auth_command(self, observed, executable):
+        if os.name == "nt":
+            self.assertEqual(observed["auth_command"], executable.resolve())
+        else:
+            self.assertNotEqual(observed["auth_command"], executable.resolve())
+            self.assertIn(f"exec {shlex.quote(str(executable.resolve()))}\n", observed["auth_launcher_text"])
 
     def test_trusted_route_reaches_client_without_workspace_or_config_capabilities(self):
         self.write_config()
@@ -132,7 +149,7 @@ class CodexInferenceRouteTests(unittest.TestCase):
         flags = observed["flags"]
         self.assertEqual(flags.get("model_provider"), '"review_api"')
         self.assertEqual(flags.get("model_providers.review_api.base_url"), '"https://api.openai.com/v1"')
-        self.assertEqual(flags.get("model_providers.review_api.auth.command"), json.dumps(str(self.runtime_helper.resolve())))
+        self.assert_auth_command(observed, self.runtime_helper)
         self.assertEqual(flags.get("model_providers.review_api.auth.cwd"), json.dumps(str(self.home.resolve())))
         self.assertEqual(flags.get("model_providers.review_api.auth.timeout_ms"), "5000")
         self.assertEqual(flags.get("model_providers.review_api.auth.refresh_interval_ms"), "300000")
@@ -152,6 +169,8 @@ class CodexInferenceRouteTests(unittest.TestCase):
         self.assertEqual(observed["command"][observed["command"].index("--ask-for-approval") + 1], "never")
         self.assertFalse(observed["cwd"].exists())
         self.assertFalse(observed["catalogue_path"].exists())
+        if os.name != "nt":
+            self.assertFalse(observed["auth_command"].exists())
 
     def available(self):
         replacements = {
@@ -185,6 +204,7 @@ class CodexInferenceRouteTests(unittest.TestCase):
         self.write_config()
         original = self.catalogue_bytes
         events = []
+        launchers = []
 
         def respond(observed):
             command = observed["command"]
@@ -192,6 +212,8 @@ class CodexInferenceRouteTests(unittest.TestCase):
             events.append(selected)
             self.assertEqual(observed["flags"].get("model_provider"), '"review_api"')
             self.assertEqual(observed["catalogue"], original)
+            self.assert_auth_command(observed, self.runtime_helper)
+            launchers.append(observed["auth_command"])
             if selected == "gpt-5.6-sol":
                 # A retry keeps the prepared route even if operator files change.
                 self.catalogue.write_bytes(b"changed after primary send")
@@ -202,6 +224,7 @@ class CodexInferenceRouteTests(unittest.TestCase):
 
         self.run_review(during_run=respond, scan=lambda *_: events.append("scan"))
         self.assertEqual(events, ["gpt-5.6-sol", "scan", "gpt-5.6-terra"])
+        self.assertEqual(launchers[0], launchers[1])
 
     def test_primary_only_catalogue_does_not_block_successful_primary(self):
         self.use_default_models()
@@ -225,7 +248,13 @@ class CodexInferenceRouteTests(unittest.TestCase):
                     self.provider["base_url"] = "https://example.invalid/custom"
                     self.write_config()
                     modules = {"tomllib": None, "tomli": None} if without_parser else {}
-                    with mock.patch.dict(sys.modules, modules):
+                    with (
+                        mock.patch.dict(sys.modules, modules),
+                        mock.patch.dict(os.environ, {"HOME": str(self.repo)}),
+                        mock.patch.dict(self.helper["run_codex"].__globals__, {
+                            "codex_auth_helper_home": mock.Mock(side_effect=AssertionError("default route must not validate helper HOME")),
+                        }),
+                    ):
                         observed = self.run_review()
                         self.assertEqual(observed["flags"]["cli_auth_credentials_store"], '"file"')
                         self.assertEqual(observed["flags"]["forced_login_method"], '"api"')
@@ -384,7 +413,7 @@ class CodexInferenceRouteTests(unittest.TestCase):
         self.auth["command"] = str(executable)
         self.write_config()
         observed = self.run_review()
-        self.assertEqual(observed["flags"]["model_providers.review_api.auth.command"], json.dumps(str(executable.resolve())))
+        self.assert_auth_command(observed, executable)
         self.auth["command"] = executable.name
         self.write_config()
         self.assert_route_refused()
@@ -396,6 +425,7 @@ class CodexInferenceRouteTests(unittest.TestCase):
         self.auth.update(command=str(executable), cwd=str(working_dir))
         self.write_config()
         observed = self.run_review()
+        self.assert_auth_command(observed, executable)
 
         runtime = self.root / "runtime-🦞"
         runtime.mkdir()
@@ -405,7 +435,7 @@ class CodexInferenceRouteTests(unittest.TestCase):
         key, value = catalogue_flags[-1].split("=", 1)
         flags = {**observed["flags"], key: value}
         expected = {
-            "model_providers.review_api.auth.command": executable,
+            "model_providers.review_api.auth.command": observed["auth_command"],
             "model_providers.review_api.auth.cwd": working_dir,
             "model_catalog_json": runtime / "model-catalog.json",
         }
@@ -465,6 +495,193 @@ class CodexInferenceRouteTests(unittest.TestCase):
         self.assertEqual(observed["flags"].get("model_provider"), '"review_api"')
         self.assertEqual(json.loads(source_auth.read_text()), {"fixture": "refreshed"})
         self.assertEqual((self.home / "config.toml").read_bytes(), config_before)
+
+    @unittest.skipIf(os.name == "nt", "POSIX auth helper launcher")
+    def test_launcher_restores_only_helper_home_with_literal_paths(self):
+        weird = " ' \" $(not-a-command) `not-a-command` ; & 🦞"
+        caller_home = self.root / ("caller" + weird)
+        caller_home.mkdir()
+        working_dir = self.home / ("working" + weird)
+        working_dir.mkdir()
+        executable = write_executable(
+            self.home / ("helper" + weird),
+            f"#!{sys.executable}\nimport json, os, sys\n"
+            "print(json.dumps({'env': dict(os.environ), 'cwd': os.getcwd(), 'args': sys.argv[1:]}))\n",
+        )
+        self.auth.update(command=str(executable), cwd=str(working_dir), args=[])
+        self.write_config()
+        originals = {path: path.read_bytes() for path in (self.home / "config.toml", self.catalogue, executable)}
+
+        def execute(observed):
+            launcher = observed["auth_command"]
+            runtime = Path(observed["env"]["HOME"]).parent
+            self.assertEqual(launcher.parent, runtime)
+            self.assertEqual(stat.S_IMODE(launcher.stat().st_mode), 0o700)
+            self.assertEqual(stat.S_IMODE(runtime.stat().st_mode), 0o700)
+            self.assertEqual(launcher.stat().st_uid, os.getuid())
+            self.assertFalse(launcher.is_relative_to(observed["cwd"]))
+            self.assertFalse(launcher.is_relative_to(self.repo))
+            before = dict(observed["env"])
+            cwd = tomllib.loads(f'value = {observed["flags"]["model_providers.review_api.auth.cwd"]}')["value"]
+            result = subprocess.run([str(launcher)], cwd=cwd, env=before, capture_output=True, text=True, check=True)
+            actual = json.loads(result.stdout)
+            self.assertEqual(actual["env"]["HOME"], str(caller_home.resolve()))
+            for key, value in before.items():
+                if key not in {"HOME", "PWD", "SHLVL", "_"}:
+                    self.assertEqual(actual["env"].get(key), value, key)
+            self.assertEqual(actual["cwd"], str(working_dir.resolve()))
+            self.assertEqual(actual["args"], [])
+            self.assertNotEqual(before["HOME"], str(caller_home.resolve()))
+            self.assertEqual(observed["env"], before)
+            self.assertEqual(list(observed["cwd"].iterdir()), [])
+            flags = observed["flags"]
+            self.assertEqual(flags["shell_environment_policy.set"], self.helper["toml_inline_string_table"](self.helper["codex_tool_git_env"]()))
+            filesystem = flags["permissions.autoreview.filesystem"]
+            for private_path in (caller_home, runtime, executable):
+                self.assertNotIn(str(private_path), filesystem)
+            self.assertEqual(flags["model_providers.review_api.auth.timeout_ms"], "5000")
+            self.assertEqual(flags["model_providers.review_api.auth.refresh_interval_ms"], "300000")
+
+        with mock.patch.dict(os.environ, {"HOME": str(caller_home)}):
+            observed = self.run_review(during_run=execute)
+        self.assert_auth_command(observed, executable)
+        self.assertEqual({path: path.read_bytes() for path in originals}, originals)
+
+    @unittest.skipIf(os.name == "nt", "POSIX auth helper launcher")
+    def test_staged_launcher_path_uses_toml_unicode_encoder(self):
+        self.write_config()
+        runtime = self.root / "runtime ' \" 🦞"
+        runtime.mkdir(mode=0o700)
+        workspace = self.root / "workspace"
+        workspace.mkdir()
+        with mock.patch.dict(self.helper["codex_command"].__globals__, {"resolve_command": lambda *_: "synthetic-codex"}):
+            command = self.helper["codex_command"](
+                self.args, self.repo, workspace, runtime, runtime / "schema", runtime / "output", self.args.model,
+            )
+        flags = [command[index + 1] for index, part in enumerate(command) if part == "-c"]
+        flag = next(value for value in flags if value.startswith("model_providers.review_api.auth.command="))
+        launcher = Path(tomllib.loads("value=" + flag.partition("=")[2])["value"])
+        self.assertEqual(launcher.parent, runtime)
+        self.assertIn(f"exec {shlex.quote(str(self.runtime_helper.resolve()))}\n", launcher.read_text())
+
+    @unittest.skipIf(os.name == "nt", "POSIX auth helper HOME validation")
+    def test_unsafe_home_refused_in_run_and_dry_run_without_auth(self):
+        self.write_config()
+        external = self.root / "external"
+        external.mkdir()
+        repo_exit = self.repo / "exit-link"
+        repo_exit.symlink_to(external, target_is_directory=True)
+        final_link = self.root / "final-link"
+        final_link.symlink_to(self.repo, target_is_directory=True)
+        chain = self.root / "chain"
+        chain.symlink_to(repo_exit, target_is_directory=True)
+        loop = self.root / "loop"
+        loop.symlink_to(loop)
+        for home in (
+            str(self.repo), str(repo_exit), str(final_link), str(final_link / "exit-link"),
+            str(chain), str(self.repo / ".." / "external"), str(loop),
+            str(self.root / "missing"), str(self.catalogue), "relative-home", "",
+        ):
+            with self.subTest(home=home), mock.patch.dict(os.environ, {"HOME": home}):
+                self.args.dry_run = True
+                self.assert_route_refused()
+
+    def test_command_auth_failures_expose_only_fixed_categories(self):
+        self.write_config()
+        cases = {
+            "provider-auth-helper": "provider auth command failed",
+            "model-catalogue": "failed reading model_catalog_json",
+            "model-sandbox-policy": "requires a sandbox with reviewed escalations",
+            "cli-arguments": "unexpected argument",
+            "configuration": "Error parsing config: missing field",
+            "authentication": "HTTP 401 Unauthorized",
+            "provider-access": "HTTP 403 Forbidden",
+            "rate-limit": "HTTP 429 Too Many Requests",
+            "transport": "connection refused",
+            "unclassified": "unrecognized synthetic failure",
+        }
+        for category, diagnostic in cases.items():
+            for stream in ("stdout", "stderr"):
+                with self.subTest(category=category, stream=stream):
+                    def fail(observed):
+                        result = subprocess.CompletedProcess(observed["command"], 1, "", "")
+                        setattr(result, stream, diagnostic + "\nsynthetic-private-diagnostic\x1b[31m")
+                        return result
+
+                    with self.assertRaises(SystemExit) as caught:
+                        self.run_review(during_run=fail)
+                    self.assertEqual(str(caught.exception), f"codex engine failed: {category}; provider diagnostics suppressed")
+
+    def test_command_auth_stream_hides_diagnostics_but_preserves_progress_and_report(self):
+        self.write_config()
+        self.args.stream_engine_output = True
+        marker = "synthetic-private-diagnostic"
+
+        def stream(observed):
+            display = observed["stream_display"]
+            for name, line in (
+                ("stderr", marker), ("stdout", marker), ("stdout", '"' + marker + '"'),
+                ("stdout", "[]"), ("stdout", "null"),
+                ("stdout", json.dumps({"type": "error", "message": marker})),
+                ("stdout", json.dumps({"type": "turn.failed", "error": {"message": marker}})),
+            ):
+                self.assertNotIn(marker, display(name, line) or "")
+            self.assertIn("turn started", display("stdout", '{"type":"turn.started"}'))
+            usage = display("stdout", '{"type":"turn.completed","usage":{"input_tokens":2,"output_tokens":1}}')
+            self.assertIn("input_tokens=2", usage)
+            report = '{"findings": []}'
+            self.assertIn(report, display("stdout", json.dumps({"type": "item.completed", "item": {"type": "agent_message", "text": report}})))
+
+        self.assertEqual(self.run_review(during_run=stream)["report"], '{"findings": []}')
+
+    def test_command_auth_missing_report_and_failed_retry_do_not_return_diagnostics(self):
+        self.write_config()
+        marker = "synthetic-private-diagnostic"
+        for stream_output in (False, True):
+            for empty in ("", " \n"):
+                with self.subTest(stream_output=stream_output, empty=empty):
+                    self.args.stream_engine_output = stream_output
+                    def no_report(observed):
+                        command = observed["command"]
+                        Path(command[command.index("--output-last-message") + 1]).write_text(empty)
+                        return subprocess.CompletedProcess(command, 0, marker, marker)
+
+                    with self.assertRaises(SystemExit) as caught:
+                        self.run_review(during_run=no_report)
+                    self.assertEqual(str(caught.exception), "codex engine failed: missing-report; provider diagnostics suppressed")
+
+        self.use_default_models()
+        attempts = []
+        def fail_retry(observed):
+            attempts.append(observed["command"])
+            diagnostic = (f"The model {self.args.model} does not exist or you do not have access to it."
+                          if len(attempts) == 1 else "provider auth command failed")
+            return subprocess.CompletedProcess(observed["command"], 1, marker, diagnostic + "\n" + marker)
+
+        console = io.StringIO()
+        with contextlib.redirect_stderr(console), self.assertRaises(SystemExit) as caught:
+            self.run_review(during_run=fail_retry)
+        self.assertEqual(len(attempts), 2)
+        self.assertNotIn(marker, console.getvalue())
+        self.assertEqual(str(caught.exception), "codex engine failed: provider-auth-helper; provider diagnostics suppressed")
+
+    def test_default_route_keeps_diagnostic_streaming_and_stdout_fallback(self):
+        self.args.codex_config = []
+        self.args.stream_engine_output = True
+        self.write_config()
+        marker = "synthetic-default-diagnostic"
+
+        def respond(observed):
+            for name in ("stdout", "stderr"):
+                self.assertIn(marker, observed["stream_display"](name, marker))
+            return subprocess.CompletedProcess(observed["command"], returncode, marker, marker)
+
+        returncode = 0
+        self.assertEqual(self.run_review(during_run=respond)["report"], marker)
+        returncode = 1
+        with self.assertRaises(SystemExit) as caught:
+            self.run_review(during_run=respond)
+        self.assertIn(marker, str(caught.exception))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

An explicitly selected command-auth provider can pass the caller's credential preflight but fail inside Autoreview: its authentication executable inherits the isolated client `HOME`, so native credential-store discovery such as macOS Keychain cannot find the caller's credential.

Stage a private, owner-only POSIX launcher that restores the validated caller `HOME` only for the trusted authentication executable, then replaces itself with that executable. The Codex engine and reviewer tools retain their isolated environment, empty workspace and restricted read-only filesystem permissions. Native authentication cwd, timeout/refresh settings and other sanitized environment variables are unchanged; the launcher is reused across retries and removed with the private runtime.

This is a focused follow-up to #232 and preserves its explicit opt-in route projection, default auth-only compatibility and frozen catalogue handling. It also preserves the TOML Unicode encoder from #233. Caller HOME validation rejects repository-owned lexical paths and symlink provenance in both real and dry runs. Windows retains the existing native executable path.

Command-auth runs suppress raw provider diagnostics because Codex may include authentication-helper stderr verbatim. Failures expose only fixed categories; compact progress, usage and assistant reports remain available, and an empty final report never falls back to captured diagnostics.

## Validation

- Full local autoreview Python suite: 278 tests completed successfully, with one Linux-only skip; the native macOS sandbox test passed.
- Independent coordinator run of the route and native sandbox suites: 28 tests passed.
- Synthetic launcher execution covers helper-only HOME restoration, unchanged client/tool environment, native auth cwd, private permissions and cleanup, retry reuse, literal shell metacharacters and supplementary Unicode, unsafe HOME provenance, redacted diagnostics and default-route compatibility.
- All 8 skills validate; Python compilation and whitespace checks pass.
- Independent Codex review of this exact four-file diff completed through the updated helper's real isolated command-auth route: exit 0, scoped-clean at the repository's default P0 threshold, with source-integrity checks passing.

No global authentication/configuration changes, service restarts, additional provider fallback, reviewer permission expansion, or credential disclosure.
