### PR TITLE
feat(autoreview): expose structured reviewer availability status

### DIFF
--- a/skills/autoreview/SKILL.md
+++ b/skills/autoreview/SKILL.md
@@ -162,18 +162,52 @@ runs. `--dry-run` checks preparation and startup without contacting a reviewer.
 
 ## Results
 
-`--output` and `--json-output` paths must be outside the reviewed repository.
+`--output`, `--json-output`, and `--status-output` paths must be outside the
+reviewed repository. When using `--status-output`, all output paths must differ;
+case-only and Unicode normalization aliases are conservatively refused on every
+platform, even when the filesystem would permit distinct files.
 
 | Exit | Meaning                                                                         |
 | ---- | ------------------------------------------------------------------------------- |
 | `0`  | `scoped-clean`, or a correct verdict with only filtered lower-priority findings |
-| `1`  | Accepted findings or an incorrect provider verdict                              |
+| `1`  | Accepted findings, an incorrect provider verdict, or a failed review attempt    |
 | `2`  | Incomplete scope/attribution, or a missing required finding                     |
 
 Treat `scoped-clean` as clean only for the selected target and requested priority.
 `filtered` is not clean; resolve `incomplete` before claiming completion.
 Verify findings against the actual code and task before changing anything.
 No extra review rounds for a nicer verdict; follow the owning workflow after fixes.
+
+Use `--status-output /outside/repo/status.json` for a separate, versioned
+machine-readable outcome. It preserves the existing exit codes and
+`--json-output` validated-report format. Completed reviews report `scoped-clean`,
+`findings`, `filtered`, `incorrect`, or `incomplete`; a launched reviewer that
+fails or returns an invalid report reports `reviewer_unavailable` with exit 1.
+A failed later pass never publishes a partial review report.
+
+```json
+{"schema_version":1,"status":"reviewer_unavailable","exit_code":1,"engine":"codex","report_produced":false,"reason":"engine_failed","reviewer_exit_code":124,"timed_out":true}
+```
+
+`reason` is `engine_failed`, `invalid_report`, or `runtime_validation_failed`
+for unavailable reviewers and null for completed reviews. The last reason means
+Amp's post-launch isolation attestation or private-result validation refused
+the result; it is not a transient-provider classification. These guards still
+run before report acceptance and retain their existing failure diagnostics.
+`reviewer_exit_code` is the last reviewer process's exit code when retained,
+including zero for rejected output, otherwise null. `timed_out` identifies the
+helper's deadline, not a reviewer that happens to exit 124. Completed envelopes
+have `report_produced: true`; this means a validated final report exists, not
+that its verdict is clean. `--expect-findings` changes exit codes as before;
+inspect `status` independently of `exit_code`.
+
+The sidecar contains no provider logs, prompts, findings, or model identifiers.
+Existing bounded, display-safe diagnostics remain on stderr; command-auth
+diagnostic suppression remains in force. Use a fresh status path per invocation:
+after argument and output-path validation, a previous sidecar is removed before
+target selection. Dry runs, preflight/scan refusals, pre-launch isolation failures, source mutations,
+interruptions, and output failures produce no new status. Absence means no
+outcome was published, never a clean review. No retry policy is added.
 
 Report material findings and status plainly. Do not add transcripts, proof
 ledgers, commits, pushes, or a new workstream unless requested.

--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -1183,6 +1183,21 @@ def emit_heartbeat(
     )
 
 
+class ReviewerUnavailable(SystemExit):
+    """A launched reviewer failed before returning a valid report."""
+
+    def __init__(self, message: str, *, reason: str = "engine_failed",
+                 result: subprocess.CompletedProcess[str] | None = None) -> None:
+        super().__init__(message)
+        self.reason = reason
+        self.returncode = result.returncode if result is not None else None
+        self.timed_out = isinstance(result, TimedOutEngineProcess)
+
+
+class TimedOutEngineProcess(subprocess.CompletedProcess[str]):
+    """Distinguish our deadline from a reviewer that itself exits 124."""
+
+
 class EngineRuntimeDeadline:
     """One absolute wall-clock deadline for an owned reviewer process."""
 
@@ -1227,7 +1242,7 @@ class EngineRuntimeDeadline:
     ) -> subprocess.CompletedProcess[str]:
         assert self.max_runtime_seconds is not None
         detail = f"{self.label} engine timed out after {self.max_runtime_seconds:g}s"
-        return subprocess.CompletedProcess(
+        return TimedOutEngineProcess(
             args,
             124,
             stdout,
@@ -4874,7 +4889,8 @@ def run_codex(args: argparse.Namespace, repo: Path, prompt: str) -> str:
                 output = output_path.read_text()
                 if result.returncode == 0:
                     if command_auth and not output.strip():
-                        raise SystemExit("codex engine failed: missing-report; provider diagnostics suppressed")
+                        raise ReviewerUnavailable("codex engine failed: missing-report; provider diagnostics suppressed",
+                                                  reason="invalid_report", result=result)
                     return output or result.stdout
                 if (
                     index == 0
@@ -4889,17 +4905,18 @@ def run_codex(args: argparse.Namespace, repo: Path, prompt: str) -> str:
                     )
                     continue
                 if command_auth:
-                    raise SystemExit(
-                        f"codex engine failed: {codex_failure_category(result)}; provider diagnostics suppressed"
+                    raise ReviewerUnavailable(
+                        f"codex engine failed: {codex_failure_category(result)}; provider diagnostics suppressed",
+                        result=result,
                     )
                 detail = result.stderr or result.stdout
                 if primary_failure is not None:
                     primary_detail = primary_failure.stderr or primary_failure.stdout
-                    raise SystemExit(
+                    raise ReviewerUnavailable(
                         f"codex engine failed with primary model ({primary_failure.returncode})\n{primary_detail}\n"
-                        f"codex fallback model failed ({result.returncode})\n{detail}"
+                        f"codex fallback model failed ({result.returncode})\n{detail}", result=result,
                     )
-                raise SystemExit(f"codex engine failed ({result.returncode})\n{detail}")
+                raise ReviewerUnavailable(f"codex engine failed ({result.returncode})\n{detail}", result=result)
     finally:
         schema_path.unlink(missing_ok=True)
         output_path.unlink(missing_ok=True)
@@ -4952,7 +4969,7 @@ def run_claude(args: argparse.Namespace, repo: Path, prompt: str) -> str:
             ),
         )
     if result.returncode != 0:
-        raise SystemExit(f"claude engine failed ({result.returncode})\n{result.stderr or result.stdout}")
+        raise ReviewerUnavailable(f"claude engine failed ({result.returncode})\n{result.stderr or result.stdout}", result=result)
     return result.stdout
 
 
@@ -5464,14 +5481,23 @@ def run_amp(args: argparse.Namespace, repo: Path, prompt: str) -> str:
             stream_output=args.stream_engine_output,
             env=engine_env,
         )
+        return amp_review_result(result, review_root, error_path, result_path)
+
+
+def amp_review_result(result: subprocess.CompletedProcess[str], review_root: Path,
+                      error_path: Path, result_path: Path) -> str:
+    # This boundary is post-launch only. Attestation and private-file guards
+    # still run before report acceptance and retain their original diagnostics.
+    try:
         if result.returncode == 124:
             detail = result.stderr or result.stdout
-            raise SystemExit(
+            raise ReviewerUnavailable(
                 f"amp engine failed ({result.returncode})\n"
-                + display_escape(detail, 4000, multiline=True)
+                + display_escape(detail, 4000, multiline=True), result=result,
             )
         if len(result.stdout) > AMP_MAX_OUTPUT_CHARS:
-            raise SystemExit("amp engine stream exceeds the output limit")
+            raise ReviewerUnavailable("amp engine stream exceeds the output limit",
+                                      reason="invalid_report", result=result)
         tool_succeeded = attest_amp_stream(result.stdout, review_root)
         if error_path.exists():
             detail = read_amp_private_file(
@@ -5479,23 +5505,27 @@ def run_amp(args: argparse.Namespace, repo: Path, prompt: str) -> str:
                 label="error",
                 max_chars=4000,
             )
-            raise SystemExit(
+            raise ReviewerUnavailable(
                 "amp direct generation failed: "
-                + display_escape(detail, 4000, multiline=True)
+                + display_escape(detail, 4000, multiline=True), result=result,
             )
         if not tool_succeeded:
-            raise SystemExit("amp adapter tool failed without producing an error file")
+            raise ReviewerUnavailable("amp adapter tool failed without producing an error file", result=result)
         if result.returncode != 0:
             detail = result.stderr or result.stdout
-            raise SystemExit(
+            raise ReviewerUnavailable(
                 f"amp engine failed ({result.returncode})\n"
-                + display_escape(detail, 4000, multiline=True)
+                + display_escape(detail, 4000, multiline=True), result=result,
             )
         return read_amp_private_file(
             result_path,
             label="result",
             max_chars=AMP_MAX_OUTPUT_CHARS,
         )
+    except ReviewerUnavailable:
+        raise
+    except SystemExit as exc:
+        raise ReviewerUnavailable(str(exc), reason="runtime_validation_failed", result=result) from None
 
 
 def json_file_declares_hooks(path: Path) -> bool:
@@ -5547,7 +5577,7 @@ def run_pi(args: argparse.Namespace, repo: Path, prompt: str) -> str:
             ),
         )
     if result.returncode != 0:
-        raise SystemExit(f"pi engine failed ({result.returncode})\n{result.stderr or result.stdout}")
+        raise ReviewerUnavailable(f"pi engine failed ({result.returncode})\n{result.stderr or result.stdout}", result=result)
     return result.stdout
 
 
@@ -5614,8 +5644,8 @@ def run_kimi(args: argparse.Namespace, repo: Path, prompt: str) -> str:
             ),
         )
     if result.returncode != 0:
-        raise SystemExit(
-            f"kimi engine failed ({result.returncode})\n{result.stderr or result.stdout}"
+        raise ReviewerUnavailable(
+            f"kimi engine failed ({result.returncode})\n{result.stderr or result.stdout}", result=result,
         )
     # stream-json: one JSON object per line; assistant content carries the
     # reply, tool/meta lines are progress noise (there are no tools anyway).
@@ -5634,8 +5664,9 @@ def run_kimi(args: argparse.Namespace, repo: Path, prompt: str) -> str:
             if isinstance(content, str):
                 texts.append(content)
     if not texts:
-        raise SystemExit(
-            f"kimi engine returned no assistant output\n{result.stdout[:2000]}"
+        raise ReviewerUnavailable(
+            f"kimi engine returned no assistant output\n{result.stdout[:2000]}",
+            reason="invalid_report", result=result,
         )
     return "\n".join(texts)
 
@@ -6311,6 +6342,7 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument("--output", help="Write human output to a file as well as stdout.")
     parser.add_argument("--json-output", help="Write validated structured review JSON.")
+    parser.add_argument("--status-output", help="Write a versioned status sidecar, including reviewer_unavailable; does not change report JSON or exit codes.")
     parser.add_argument(
         "--stream-engine-output",
         action="store_true",
@@ -6682,9 +6714,14 @@ def run_reviewer(
         verify_evidence(repo, evidence or [])
         verify_mixed_sources(repo, mixed)
     raw = run_engine(args, repo, outgoing)
-    report = extract_json(raw)
-    provider_report = copy.deepcopy(report)
-    validate_report(report, repo, paths, [], mixed, available)
+    try:
+        report = extract_json(raw)
+        provider_report = copy.deepcopy(report)
+        validate_report(report, repo, paths, [], mixed, available)
+    except SystemExit as exc:
+        # Only parsing/schema validation is inside this boundary. Scanner,
+        # isolation, attribution refusals, and required-finding gates stay distinct.
+        raise ReviewerUnavailable(str(exc), reason="invalid_report") from None
     filter_findings_by_priority(report, args.max_priority)
     report["provider_report"] = provider_report
     if mixed:
@@ -6791,9 +6828,11 @@ def run_review_passes(
 
 def reject_repo_output_paths(args: argparse.Namespace, repo: Path) -> None:
     repo_root_path = repo.resolve()
+    outputs: list[tuple[str, Path]] = []
     for option, value in (
         ("--json-output", getattr(args, "json_output", None)),
         ("--output", getattr(args, "output", None)),
+        ("--status-output", getattr(args, "status_output", None)),
     ):
         if not value:
             continue
@@ -6801,6 +6840,21 @@ def reject_repo_output_paths(args: argparse.Namespace, repo: Path) -> None:
         resolved = (
             path if path.is_absolute() else Path.cwd() / path
         ).resolve()
+        if getattr(args, "status_output", None):
+            for previous_option, previous in outputs:
+                # Refuse spelling aliases even before files exist, including
+                # macOS case/decomposition aliases and Windows case aliases.
+                same = (unicodedata.normalize("NFD", str(resolved)).casefold()
+                        == unicodedata.normalize("NFD", str(previous)).casefold())
+                if (not same and resolved.parent.exists() and previous.parent.exists()
+                        and unicodedata.normalize("NFD", resolved.name).casefold()
+                        == unicodedata.normalize("NFD", previous.name).casefold()):
+                    same = os.path.samefile(resolved.parent, previous.parent)
+                if not same and resolved.exists() and previous.exists():
+                    same = os.path.samefile(resolved, previous)
+                if same:
+                    raise SystemExit(f"{option} must use a different path from {previous_option}")
+            outputs.append((option, resolved))
         inside_repo = resolved.is_relative_to(repo_root_path)
         if not inside_repo:
             for ancestor in (resolved, *resolved.parents):
@@ -6833,6 +6887,23 @@ def atomic_write_text(path: Path, content: str) -> None:
         temporary_path.unlink(missing_ok=True)
 
 
+def write_review_status(args: argparse.Namespace, status: str, exit_code: int,
+                        failure: ReviewerUnavailable | None = None) -> None:
+    if not getattr(args, "status_output", None):
+        return
+    envelope = {
+        "schema_version": 1,
+        "status": status,
+        "exit_code": exit_code,
+        "engine": args.engine,
+        "report_produced": failure is None,
+        "reason": failure.reason if failure else None,
+        "reviewer_exit_code": failure.returncode if failure else None,
+        "timed_out": failure.timed_out if failure else False,
+    }
+    atomic_write_text(Path(args.status_output).expanduser(), json.dumps(envelope, indent=2) + "\n")
+
+
 def main() -> int:
     with OwnedProcessSignalHandlers():
         try:
@@ -6850,6 +6921,8 @@ def main_impl() -> int:
     with PreparationProgress("target selection"):
         repo = repo_root()
         reject_repo_output_paths(args, repo)
+        if getattr(args, "status_output", None):
+            Path(args.status_output).expanduser().unlink(missing_ok=True)
         target, target_ref = choose_target(repo, args.mode, args.base)
         branch = current_branch(repo)
     print(f"autoreview target: {target}", flush=True)
@@ -6900,14 +6973,18 @@ def main_impl() -> int:
                 "source changed while the review bundle was being created; "
                 "rerun autoreview against the updated tree"
             )
-    chunk_reports = run_review_passes(
-        args,
-        reviewers,
-        repo,
-        prompts,
-        captured,
-        evidence.files,
-    )
+    try:
+        chunk_reports = run_review_passes(
+            args,
+            reviewers,
+            repo,
+            prompts,
+            captured,
+            evidence.files,
+        )
+    except ReviewerUnavailable as exc:
+        write_review_status(args, "reviewer_unavailable", 1, exc)
+        raise
     if len(chunk_reports) == 1 and not captured.mixed:
         report = chunk_reports[0][1]
     else:
@@ -6955,10 +7032,13 @@ def main_impl() -> int:
     has_findings = bool(report["findings"])
     overall_incorrect = report["overall_correctness"] == "patch is incorrect"
     if report["review_status"] == "incomplete":
-        return 2
-    if args.expect_findings:
-        return 0 if has_findings else 1
-    return 1 if has_findings or overall_incorrect else 0
+        exit_code = 2
+    elif args.expect_findings:
+        exit_code = 0 if has_findings else 1
+    else:
+        exit_code = 1 if has_findings or overall_incorrect else 0
+    write_review_status(args, report["review_status"], exit_code)
+    return exit_code
 
 
 def sanitized_main() -> int:

--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -4886,7 +4886,11 @@ def run_codex(args: argparse.Namespace, repo: Path, prompt: str) -> str:
                         file_auth_linked=file_auth_linked,
                     ),
                 )
-                output = output_path.read_text()
+                try:
+                    output = output_path.read_text(encoding="utf-8")
+                except UnicodeDecodeError:
+                    raise ReviewerUnavailable("codex engine returned non-UTF-8 report",
+                                              reason="invalid_report", result=result) from None
                 if result.returncode == 0:
                     if command_auth and not output.strip():
                         raise ReviewerUnavailable("codex engine failed: missing-report; provider diagnostics suppressed",
@@ -5083,7 +5087,7 @@ def attest_amp_stream(output: str, review_root: Path) -> bool:
             raise SystemExit(
                 f"amp isolation attestation failed: stream line {line_number} is not an object"
             )
-        if event.get("type") not in {"system", "user", "assistant", "result"}:
+        if not isinstance(event.get("type"), str) or event["type"] not in {"system", "user", "assistant", "result"}:
             raise SystemExit(
                 "amp isolation attestation failed: unexpected stream event type "
                 f"{event.get('type')!r}"
@@ -5153,7 +5157,7 @@ def attest_amp_stream(output: str, review_root: Path) -> bool:
             if not isinstance(block, dict):
                 raise SystemExit("amp isolation attestation failed: message block was malformed")
             block_type = block.get("type")
-            if block_type not in {"text", "thinking", "tool_use", "tool_result"}:
+            if not isinstance(block_type, str) or block_type not in {"text", "thinking", "tool_use", "tool_result"}:
                 raise SystemExit(
                     f"amp isolation attestation failed: unexpected message block {block_type!r}"
                 )
@@ -5187,10 +5191,13 @@ def attest_amp_stream(output: str, review_root: Path) -> bool:
     tool_succeeded = tool_result.get("is_error") is False
     if tool_succeeded and tool_result.get("content") != "Adapter completed.":
         raise SystemExit("amp isolation attestation failed: adapter success result was malformed")
-    if not tool_succeeded and tool_result.get("content") not in {
-        "Autoreview generation failed.",
-        "Error: Autoreview generation failed.",
-    }:
+    if not tool_succeeded and (
+        not isinstance(tool_result.get("content"), str)
+        or tool_result["content"] not in {
+            "Autoreview generation failed.",
+            "Error: Autoreview generation failed.",
+        }
+    ):
         raise SystemExit("amp isolation attestation failed: adapter failure result was not sanitized")
 
     result_events = [event for event in events if event.get("type") == "result"]
@@ -5524,7 +5531,7 @@ def amp_review_result(result: subprocess.CompletedProcess[str], review_root: Pat
         )
     except ReviewerUnavailable:
         raise
-    except SystemExit as exc:
+    except (SystemExit, ValueError, RecursionError) as exc:
         raise ReviewerUnavailable(str(exc), reason="runtime_validation_failed", result=result) from None
 
 
@@ -5901,9 +5908,11 @@ def _report_from_events(events: list[Any]) -> dict[str, Any] | None:
             candidates.append(data["content"])
         message = event.get("message")
         if isinstance(message, dict):
-            for item in message.get("content", []):
-                if isinstance(item, dict) and item.get("type") == "text" and isinstance(item.get("text"), str):
-                    assistant_candidates.append(item["text"])
+            content = message.get("content", [])
+            if isinstance(content, list):
+                for item in content:
+                    if isinstance(item, dict) and item.get("type") == "text" and isinstance(item.get("text"), str):
+                        assistant_candidates.append(item["text"])
         if isinstance(event.get("result"), str):
             terminal_candidates.append(event["result"])
         if isinstance(event.get("result"), dict):
@@ -5980,9 +5989,9 @@ def validate_attribution_shape(value: Any, index: int) -> None:
     keys = {"target", "record_id", "source_id", "side", "column", "excerpt"}
     if not isinstance(value, dict) or set(value) != keys:
         raise SystemExit(f"finding {index} has invalid source_attribution keys")
-    if (value["target"] not in {"index", "working_tree"}
+    if (not all(isinstance(value[key], str) for key in ("target", "side", "record_id", "source_id", "excerpt"))
+            or value["target"] not in {"index", "working_tree"}
             or value["side"] not in {"present", "removed"}
-            or not all(isinstance(value[key], str) for key in ("record_id", "source_id", "excerpt"))
             or not isinstance(value["column"], int) or isinstance(value["column"], bool)
             or value["column"] < 1):
         raise SystemExit(f"finding {index} has invalid source_attribution")
@@ -6042,7 +6051,7 @@ def _validate_report(
             raise SystemExit(f"review JSON missing required key: {key}")
     if not isinstance(report["findings"], list):
         raise SystemExit("review JSON findings must be an array")
-    if report.get("overall_correctness") not in {"patch is correct", "patch is incorrect"}:
+    if not isinstance(report.get("overall_correctness"), str) or report["overall_correctness"] not in {"patch is correct", "patch is incorrect"}:
         raise SystemExit(f"review JSON has invalid overall_correctness: {report.get('overall_correctness')}")
     if not isinstance(report.get("overall_explanation"), str) or not report["overall_explanation"]:
         raise SystemExit("review JSON overall_explanation must be a non-empty string")
@@ -6072,12 +6081,12 @@ def _validate_report(
         if not isinstance(body, str) or not body or len(body) > 2000:
             raise SystemExit(f"finding {index} has invalid body")
         priority = finding.get("priority")
-        if priority not in {"P0", "P1", "P2", "P3"}:
+        if not isinstance(priority, str) or priority not in {"P0", "P1", "P2", "P3"}:
             raise SystemExit(f"finding {index} has invalid priority: {priority}")
         if not number_in_range(finding.get("confidence")):
             raise SystemExit(f"finding {index} has invalid confidence")
         category = finding.get("category")
-        if category not in {"bug", "security", "regression", "test_gap", "maintainability"}:
+        if not isinstance(category, str) or category not in {"bug", "security", "regression", "test_gap", "maintainability"}:
             raise SystemExit(f"finding {index} has invalid category: {category}")
         location = finding.get("code_location")
         if not isinstance(location, dict):
@@ -6718,7 +6727,7 @@ def run_reviewer(
         report = extract_json(raw)
         provider_report = copy.deepcopy(report)
         validate_report(report, repo, paths, [], mixed, available)
-    except SystemExit as exc:
+    except (SystemExit, ValueError, RecursionError) as exc:
         # Only parsing/schema validation is inside this boundary. Scanner,
         # isolation, attribution refusals, and required-finding gates stay distinct.
         raise ReviewerUnavailable(str(exc), reason="invalid_report") from None

--- a/skills/autoreview/scripts/autoreview_test.py
+++ b/skills/autoreview/scripts/autoreview_test.py
@@ -845,6 +845,22 @@ class AutoreviewAmpTests(unittest.TestCase):
         self.assertIn("amp engine timed out after 0.01s", message)
         attest.assert_not_called()
 
+    def test_amp_failed_process_and_invalid_artifact_keep_runtime_guards(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            cases = (
+                (subprocess.CompletedProcess([], 7, "", "provider failed"), "expected exactly one leading"),
+                (subprocess.CompletedProcess([], 7, '{"type":"system","subtype":"init"}\n', ""), "unexpected adapter event sequence"),
+                (subprocess.CompletedProcess([], 0, amp_test_stream(root, tools=["shell_command"]), ""), "exposed tools"),
+                (subprocess.CompletedProcess([], 0, amp_test_stream(root), ""), "produced no result file"),
+            )
+            for result, diagnostic in cases:
+                with self.subTest(diagnostic=diagnostic), self.assertRaises(AUTOREVIEW.ReviewerUnavailable) as caught:
+                    AUTOREVIEW.amp_review_result(result, root, root / "error", root / "result")
+                self.assertEqual(caught.exception.reason, "runtime_validation_failed")
+                self.assertIn(diagnostic, str(caught.exception))
+                self.assertEqual(caught.exception.returncode, result.returncode)
+
     def test_amp_plugin_inventory_attestation_fails_closed(self) -> None:
         cwd = Path("/tmp/amp-review-empty")
         plugin_path = cwd.parent / "config" / "amp" / "plugins" / "autoreview-token.ts"
@@ -1178,6 +1194,24 @@ class AutoreviewCompatibilityTests(unittest.TestCase):
                 AUTOREVIEW.ensure_kimi_isolation_supported(args, Path(tmpdir)),
                 "/usr/bin/kimi",
             )
+
+    def test_kimi_invalid_streams_are_unavailable_after_launch(self) -> None:
+        args = argparse.Namespace(engine="kimi", kimi_bin="kimi", model="kimi-model",
+                                  stream_engine_output=False, thinking="on", max_priority="P2")
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo = Path(tmpdir) / "repo"
+            repo.mkdir()
+            for stream in ("malformed JSON", '{"role":"meta"}\n', '{"role":"assistant","content":"{}"}'):
+                with self.subTest(stream=stream), mock.patch.object(
+                    AUTOREVIEW, "ensure_kimi_isolation_supported", return_value="/usr/bin/kimi",
+                ), mock.patch.object(
+                    AUTOREVIEW, "load_kimi_review_config", return_value=({"telemetry": False}, None),
+                ), mock.patch.object(
+                    AUTOREVIEW, "run_with_heartbeat", return_value=subprocess.CompletedProcess([], 0, stream, ""),
+                ), mock.patch.object(AUTOREVIEW, "scan_outgoing_review_pack"):
+                    with self.assertRaises(AUTOREVIEW.ReviewerUnavailable) as caught:
+                        AUTOREVIEW.run_reviewer(args, repo, "synthetic pack", set(), [])
+                    self.assertEqual(caught.exception.reason, "invalid_report")
 
     def test_kimi_runs_with_empty_tools_skills_and_mcp(self) -> None:
         args = argparse.Namespace(

--- a/skills/autoreview/scripts/autoreview_test.py
+++ b/skills/autoreview/scripts/autoreview_test.py
@@ -52,6 +52,38 @@ DRAFT_REPORT = {
 
 
 class AutoreviewCursorTests(unittest.TestCase):
+    def test_parser_resource_errors_are_invalid_reports(self) -> None:
+        args = argparse.Namespace(engine="codex", max_priority="P2")
+        for raw in ("[" * 2000 + "]" * 2000, '{"findings":[],"number":' + "9" * 10000 + "}"):
+            with self.subTest(length=len(raw)), mock.patch.object(
+                AUTOREVIEW, "run_engine", return_value=raw,
+            ), mock.patch.object(AUTOREVIEW, "scan_outgoing_review_pack"):
+                with self.assertRaises(AUTOREVIEW.ReviewerUnavailable) as caught:
+                    AUTOREVIEW.run_reviewer(args, Path.cwd(), "synthetic", set(), [])
+                self.assertEqual(caught.exception.reason, "invalid_report")
+
+    def test_container_valued_report_enums_are_invalid_reports(self) -> None:
+        args = argparse.Namespace(engine="codex", max_priority="P2")
+        finding = copy.deepcopy(DRAFT_REPORT["findings"][0])
+        finding["source_attribution"] = {
+            "target": "index", "record_id": "record", "source_id": "source",
+            "side": "present", "column": 1, "excerpt": "text",
+        }
+        for field in ("overall_correctness", "priority", "category", "target", "side"):
+            for value in ([], {}, None, 42, False):
+                report = copy.deepcopy(FINAL_REPORT)
+                report["findings"] = [copy.deepcopy(finding)]
+                owner = report if field == "overall_correctness" else report["findings"][0]
+                if field in {"target", "side"}:
+                    owner = owner["source_attribution"]
+                owner[field] = value
+                with self.subTest(field=field, value=value), mock.patch.object(
+                    AUTOREVIEW, "run_engine", return_value=json.dumps(report),
+                ), mock.patch.object(AUTOREVIEW, "scan_outgoing_review_pack"):
+                    with self.assertRaises(AUTOREVIEW.ReviewerUnavailable) as caught:
+                        AUTOREVIEW.run_reviewer(args, Path.cwd(), "synthetic", {"draft.js"}, [])
+                    self.assertEqual(caught.exception.reason, "invalid_report")
+
     def test_extract_json_prefers_terminal_result_event(self) -> None:
         stream = "\n".join(
             [
@@ -853,6 +885,7 @@ class AutoreviewAmpTests(unittest.TestCase):
                 (subprocess.CompletedProcess([], 7, '{"type":"system","subtype":"init"}\n', ""), "unexpected adapter event sequence"),
                 (subprocess.CompletedProcess([], 0, amp_test_stream(root, tools=["shell_command"]), ""), "exposed tools"),
                 (subprocess.CompletedProcess([], 0, amp_test_stream(root), ""), "produced no result file"),
+                (subprocess.CompletedProcess([], 0, '{"type":[]}\n', ""), "unexpected stream event type"),
             )
             for result, diagnostic in cases:
                 with self.subTest(diagnostic=diagnostic), self.assertRaises(AUTOREVIEW.ReviewerUnavailable) as caught:
@@ -860,6 +893,10 @@ class AutoreviewAmpTests(unittest.TestCase):
                 self.assertEqual(caught.exception.reason, "runtime_validation_failed")
                 self.assertIn(diagnostic, str(caught.exception))
                 self.assertEqual(caught.exception.returncode, result.returncode)
+            for raw in ("[" * 2000 + "]" * 2000, '{"number":' + "9" * 10000 + "}"):
+                with self.subTest(length=len(raw)), self.assertRaises(AUTOREVIEW.ReviewerUnavailable) as caught:
+                    AUTOREVIEW.amp_review_result(subprocess.CompletedProcess([], 0, raw, ""), root, root / "error", root / "result")
+                self.assertEqual(caught.exception.reason, "runtime_validation_failed")
 
     def test_amp_plugin_inventory_attestation_fails_closed(self) -> None:
         cwd = Path("/tmp/amp-review-empty")

--- a/skills/autoreview/tests/test_autoreview_hardening.py
+++ b/skills/autoreview/tests/test_autoreview_hardening.py
@@ -2013,6 +2013,9 @@ with Path(__file__).with_name("scans.jsonl").open("a", encoding="utf-8") as reco
             ("timeout", unavailable("DIAGNOSTIC_SENTINEL", result=self.helper["TimedOutEngineProcess"]([], 124, "", "")), "engine_failed"),
             ("invalid-json", "not JSON", "invalid_report"),
             ("invalid-schema", '{"findings": []}', "invalid_report"),
+            ("invalid-field-type", json.dumps({"findings": [], "overall_correctness": [],
+                                               "overall_explanation": "Invalid enum", "overall_confidence": 0.9}), "invalid_report"),
+            ("invalid-event-type", '[{"type":"assistant","message":{"content":null}}]', "invalid_report"),
             ("isolation", SystemExit("isolation refused"), None),
             ("spawn", OSError("cannot execute reviewer"), None),
         )

--- a/skills/autoreview/tests/test_autoreview_hardening.py
+++ b/skills/autoreview/tests/test_autoreview_hardening.py
@@ -1971,7 +1971,8 @@ with Path(__file__).with_name("scans.jsonl").open("a", encoding="utf-8") as reco
                             "overall_explanation": "Synthetic provider explanation.", "overall_confidence": 0.61,
                         }
                         argv = [str(SCRIPT), "--engine", "codex", "--mode", "local", "--max-priority", priority,
-                                "--output", str(root / "result.txt"), "--json-output", str(root / "result.json")]
+                                "--output", str(root / "result.txt"), "--json-output", str(root / "result.json"),
+                                "--status-output", str(root / "status.json")]
                         for needle in required:
                             argv.extend(["--require-finding", needle])
                         if expect:
@@ -1984,6 +1985,12 @@ with Path(__file__).with_name("scans.jsonl").open("a", encoding="utf-8") as reco
                         }), mock.patch.object(sys, "argv", argv), contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(io.StringIO()):
                             self.assertEqual(self.helper["main_impl"](), exit_code)
                         result = json.loads((root / "result.json").read_text())
+                        outcome = json.loads((root / "status.json").read_text())
+                        self.assertEqual(outcome, {
+                            "schema_version": 1, "status": expected_status, "exit_code": exit_code,
+                            "engine": "codex", "report_produced": True, "reason": None,
+                            "reviewer_exit_code": None, "timed_out": False,
+                        })
                         text = (root / "result.txt").read_text()
                         self.assertEqual(result["review_status"], expected_status)
                         self.assertEqual(result["overall_correctness"], verdict)
@@ -1996,6 +2003,127 @@ with Path(__file__).with_name("scans.jsonl").open("a", encoding="utf-8") as reco
                             self.assertIn("incomplete:", text)
                         if required and expected_status == "incomplete":
                             self.assertEqual(result["missing_required_findings"], required)
+
+    def test_status_unavailable_and_local_refusals_remain_distinct(self) -> None:
+        clean = json.dumps({"findings": [], "overall_correctness": "patch is correct",
+                            "overall_explanation": "Synthetic review.", "overall_confidence": 0.9})
+        unavailable = self.helper["ReviewerUnavailable"]
+        cases = (
+            ("engine", unavailable("DIAGNOSTIC_SENTINEL", result=subprocess.CompletedProcess([], 7, "", "")), "engine_failed"),
+            ("timeout", unavailable("DIAGNOSTIC_SENTINEL", result=self.helper["TimedOutEngineProcess"]([], 124, "", "")), "engine_failed"),
+            ("invalid-json", "not JSON", "invalid_report"),
+            ("invalid-schema", '{"findings": []}', "invalid_report"),
+            ("isolation", SystemExit("isolation refused"), None),
+            ("spawn", OSError("cannot execute reviewer"), None),
+        )
+        with tempfile.TemporaryDirectory() as tempdir:
+            root = Path(tempdir)
+            repo = init_repo(root)
+            git(repo, "commit", "-q", "--allow-empty", "-m", "base")
+            (repo / "source.txt").write_text("changed\n")
+            for count in (1, 2):
+                for label, failure, reason in cases:
+                    with self.subTest(count=count, label=label):
+                        sidecar = root / "status.json"
+                        report = root / "result.json"
+                        sidecar.write_text('{"status":"scoped-clean"}')
+                        argv = [str(SCRIPT), "--mode", "local", "--engine", "codex",
+                                "--status-output", str(sidecar), "--json-output", str(report)]
+                        engine = mock.Mock(side_effect=[clean] * (count - 1) + [failure])
+                        with mock.patch.dict(self.helper["main_impl"].__globals__, {
+                            "repo_root": lambda: repo,
+                            "build_review_prompts": lambda *_args: ["synthetic pack"] * count,
+                            "scan_outgoing_review_pack": lambda *_args: None,
+                            "run_engine": engine,
+                        }), mock.patch.object(sys, "argv", argv), contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(io.StringIO()):
+                            with self.assertRaises((SystemExit, OSError)):
+                                self.helper["main_impl"]()
+                        self.assertFalse(report.exists())
+                        self.assertEqual(sidecar.exists(), reason is not None)
+                        if reason:
+                            text = sidecar.read_text()
+                            outcome = json.loads(text)
+                            self.assertEqual(outcome["status"], "reviewer_unavailable")
+                            self.assertEqual(outcome["reason"], reason)
+                            self.assertFalse(outcome["report_produced"])
+                            self.assertEqual(outcome["timed_out"], label == "timeout")
+                            self.assertEqual(outcome["reviewer_exit_code"], {"engine": 7, "timeout": 124}.get(label))
+                            self.assertNotIn("DIAGNOSTIC_SENTINEL", text)
+
+    def test_status_paths_reject_repo_and_aliases_before_removing_files(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            root = Path(tempdir)
+            repo = init_repo(root)
+            existing = root / "status.json"
+            existing.write_text("keep existing output")
+            for first, second in (("result.json", "RESULT.json"), ("caf\u00e9.json", "cafe\u0301.json")):
+                args = argparse.Namespace(status_output=str(root / first), output=None, json_output=str(root / second))
+                with self.assertRaises(SystemExit):
+                    self.helper["reject_repo_output_paths"](args, repo)
+                self.assertFalse((root / first).exists())
+            for value in (str(repo / "result.json"), str(existing)):
+                args = argparse.Namespace(status_output=value, output=None, json_output=str(existing))
+                with self.assertRaises(SystemExit):
+                    self.helper["reject_repo_output_paths"](args, repo)
+                self.assertEqual(existing.read_text(), "keep existing output")
+            if os.name != "nt":
+                alias = root / "alias.json"
+                alias.symlink_to(existing)
+                args.status_output = str(alias)
+                with self.assertRaises(SystemExit):
+                    self.helper["reject_repo_output_paths"](args, repo)
+                alias.unlink()
+                os.link(existing, alias)
+                with self.assertRaises(SystemExit):
+                    self.helper["reject_repo_output_paths"](args, repo)
+
+    @unittest.skipUnless(sys.platform == "darwin", "macOS firmlink alias")
+    def test_status_rejects_absent_outputs_under_same_parent_inode(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            root = Path(tempdir).resolve()
+            alias = Path("/System/Volumes/Data") / root.relative_to("/")
+            if not alias.exists() or not os.path.samefile(root, alias):
+                self.skipTest("temporary directory has no data-volume alias")
+            repo = init_repo(root)
+            args = argparse.Namespace(status_output=str(root / "result.json"),
+                                      json_output=str(alias / "result.json"), output=None)
+            with self.assertRaises(SystemExit):
+                self.helper["reject_repo_output_paths"](args, repo)
+            self.assertFalse((root / "result.json").exists())
+
+    @unittest.skipIf(os.name == "nt", "the executable fixtures are POSIX-only")
+    def test_cli_status_for_launched_codex_and_claude_failures(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            root = Path(tempdir)
+            repo = init_repo(root)
+            git(repo, "commit", "-q", "--allow-empty", "-m", "base")
+            (repo / "source.txt").write_text("review me\n")
+            env = os.environ.copy()
+            add_fake_trufflehog(self.helper, root, env)
+            env.update({"HOME": str(root), "USERPROFILE": str(root)})
+            for engine, source in (("codex", fake_codex_script()), ("claude", fake_claude_script())):
+                for timeout in (False, True):
+                    with self.subTest(engine=engine, timeout=timeout):
+                        # Help/version preflights succeed; only the launched review fails.
+                        injected = "import time; sys.stdin.read(); time.sleep(30)" if timeout else "print('DIAGNOSTIC_SENTINEL\\x1b[31m', file=sys.stderr); raise SystemExit(17)"
+                        executable = write_executable(root / engine, source.replace('record = os.environ["AUTOREVIEW_FAKE_RECORD"]', injected + '\nrecord = os.environ["AUTOREVIEW_FAKE_RECORD"]'))
+                        sidecar = root / "status.json"
+                        report = root / "result.json"
+                        argv = [sys.executable, str(SCRIPT), "--mode", "local", "--engine", engine,
+                                f"--{engine}-bin", str(executable), "--status-output", str(sidecar),
+                                "--json-output", str(report)]
+                        if timeout:
+                            argv += ["--engine-timeout-seconds", "0.2"]
+                        result = subprocess.run(argv, cwd=repo, env=env, text=True, capture_output=True, timeout=30)
+                        self.assertEqual(result.returncode, 1, result.stderr)
+                        outcome = json.loads(sidecar.read_text())
+                        self.assertEqual(outcome["status"], "reviewer_unavailable")
+                        self.assertEqual(outcome["engine"], engine)
+                        self.assertEqual(outcome["reviewer_exit_code"], 124 if timeout else 17)
+                        self.assertEqual(outcome["timed_out"], timeout)
+                        self.assertFalse(report.exists())
+                        self.assertNotIn("DIAGNOSTIC_SENTINEL", sidecar.read_text())
+                        self.assertNotIn("\x1b", result.stderr)
 
     def test_credential_source_exception_still_scans_every_outgoing_input(self) -> None:
         source = "Sources/Configuration/CredentialFile.swift"


### PR DESCRIPTION
Automation currently receives exit 1 for both completed adverse reviews and reviewers that fail before producing a valid report. Add an opt-in `--status-output` sidecar so callers can classify those outcomes without parsing provider stderr.

The versioned sidecar preserves existing report JSON and exit codes, including `--expect-findings`. Completed results retain the existing scoped-clean/findings/filtered/incorrect/incomplete vocabulary; post-launch failures produce `reviewer_unavailable`. Amp runtime-validation refusals have a distinct reason and retain their original attestation/file checks and diagnostics. Pre-launch failures and source-integrity failures remain separate, and a failed later pass never publishes a partial report.

The envelope contains fixed status metadata only. Output aliases, including case and Unicode normalization aliases, are rejected; prior sidecars are cleared before target preparation. Changelog coverage is in the separate consolidated notes PR #236, to be merged last.

Fixes #187.

Validation: the final-head CLI proof and malformed-output regression results are recorded in the proof comments. The full Linux/Windows validation run is https://github.com/openclaw/agent-skills/actions/runs/34102198997 .
