### PR TITLE
docs: consolidate unreleased skill changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,22 +2,23 @@
 
 ## Unreleased
 
-- Restore trusted caller HOME only for explicitly selected Autoreview command-auth helpers on POSIX, preserving reviewer isolation and suppressing raw provider diagnostics.
-- Make agent transcripts explicit-request-only and trim before previews or publication, retaining native hosted-session sharing and partial-source notices.
+**Highlights:** Isolated reviews with complete source coverage, explicit reviewer availability, and controlled session sharing.
 
+- Add opt-in Autoreview `--status-output` to distinguish unavailable reviewers from clean, adverse, filtered, and incomplete reviews without changing existing report JSON or exit codes. Thanks @coygeek.
+- Provide shared Autoreview, Crabbox, behavior-validator, handoff, readme-standard, agent-transcript, session-viewer, and Beam workflows, with selectable symlink/copy installation and cross-platform skill validation.
+- Run explicitly requested reviews through isolated Codex, Claude, Amp, Pi, or Kimi engines, with structured findings, scoped attribution, progress, streaming diagnostics, dry-run preflight, and optional process deadlines.
+- Preserve complete Autoreview source and evidence without file or count caps, partitioning oversized inputs across review passes without truncation or partial-clean success.
+- Preserve base/index/working-tree source identity, literal paths, empty-source anchors, raw Git parents, and directory transitions; honor explicit local bases and normalize Git diff presentation.
+- Restore mandatory TruffleHog scans of complete frozen inputs and every outgoing review pack, including account-access retries, while supporting root-owned scanner installations and exact Windows scan bytes.
+- Keep reviewer input, authentication, temporary files, and tools isolated; protect captured evidence against mutation and topology changes, and confine macOS reviewer scratch access.
+- Allow explicit trusted OpenAI Responses route projection through Autoreview's existing Codex config override, retaining native provider defaults, isolated catalogue snapshots, and trusted caller HOME only for selected POSIX authentication helpers.
 - Preserve Unicode and control characters in Autoreview's Codex configuration overrides and isolated Kimi TOML configuration.
-- Allow explicit trusted OpenAI Responses route projection through Autoreview's existing Codex config override, preserving default auth-only compatibility, native provider defaults, and isolated catalogue snapshots.
-- Validate explicit index/working-tree targets for mixed local Autoreview paths, preserving source anchors, rejected-attribution audit and distinct claim variants while repeating mandatory context within existing capacity limits.
-- Restore mandatory Autoreview TruffleHog `verified,unknown` pre-send scans removed in #209, retaining reviewer P0 credential checks as defense in depth.
-- Add opt-in session-viewer head/tail reads with `--max-read-bytes`, preserving complete exports by default and showing escaped truncation warnings in normalized and raw exports; retry short reads and fail on unexpected EOF. Thanks @SebTardif.
+- Preserve provider conclusions, rejected findings, and distinct mixed-source claim variants; distinguish filtered and incomplete reviews from a scoped-clean result.
+- Publish redacted coding sessions through Beam's authenticated read-only catalog; accept readable and named share URLs, ignore persisted agent messages, and keep transcript items within receiver limits.
+- Make agent transcripts explicit-request-only and trim before previews or publication, retaining native hosted-session sharing and partial-source notices.
 - Bound agent-transcript session reads to 8 MiB and disclose partial source content in render, preview, append-body, and HTML output. Thanks @SebTardif.
 - Bound agent-transcript `find` and `html` discovery to 20,000 session files, with an integer override and correct exact-limit handling. Thanks @SebTardif.
-- Rescan the exact outgoing Autoreview pack before Codex access-fallback retries, refusing findings, scanner errors, and missing scanners before another provider invocation.
-- Show Autoreview preparation progress, reuse captured bundle membership, and guard explicit evidence against content and path changes while preserving full-tree integrity checks.
-- Verify raw Git parents in Autoreview commit bundles, preserving true roots and refusing unsupported attribution from shallow boundaries, grafts, or misleading metadata.
-- Partition oversized Autoreview evidence without dropping change context, keeping complete-input and per-pass credential scans within existing engine limits.
-- Preserve exact outgoing autoreview scan bytes on Windows instead of translating line endings.
-- Fix autoreview credential-source inclusion and scope-filtered results, preserving provider verdicts and rejected findings while documenting complete PR-plus-dirty review.
-- Honor explicit review bases in local Autoreview runs, preserving complete staged and unstaged changes without re-reviewing unchanged upstream files.
-- Update the validation workflow to Node.js 26.
-- Fix autoreview scans with root-owned TruffleHog installations by disabling scanner self-updates while preserving credential detection and fail-closed behavior.
+- Add opt-in session-viewer head/tail reads with `--max-read-bytes`, preserving complete exports by default and showing escaped truncation warnings; retry short reads and fail on unexpected EOF. Thanks @SebTardif.
+- Normalize session-viewer metadata and timestamps, improve searchable local HTML exports, and avoid the Windows shell when opening an export.
+- Make Crabbox guidance portable and provider-neutral while preserving source-trust, remote-proof, and cleanup ownership boundaries.
+- Update validation to Node.js 26 and current setup actions, restrict workflow permissions, and maintain Python and Node regression coverage across Linux and Windows.


### PR DESCRIPTION
Consolidate the unversioned Unreleased notes into a user-focused summary with a Highlights lead-in. This includes the reviewer-status feature in the independent implementation PR #235, the complete shared skill catalog, and current review, transcript, session-viewer, Beam, and portability improvements.

Merge this notes PR after #235. It contains no code or dependency changes. The dependency sweep found PyYAML and the workflow action references current.

No numbered release is proposed: the repository has no tags or GitHub releases, and commit 283f069 explicitly removed accidental numbered release metadata. Distribution remains the Git source and skill installer.

Rendered preview at the exact reviewed head: https://github.com/openclaw/agent-skills/blob/b75da14cf2e15797fb2e873a0ed1934ae7b0b9eb/CHANGELOG.md . The GitHub GFM renderer was checked for the title, Unreleased heading, Highlights lead-in, and all 18 entries.
