### PR TITLE
fix(autoreview): unconditionally quiet the claude engine's AgentBus checkin

### DIFF
--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -926,6 +926,21 @@ def safe_engine_env(
     env.update(extra or {})
     if engine == "claude":
         env["CLAUDE_CODE_DISABLE_AUTO_MEMORY"] = "1"
+        # Every claude-engine invocation here is a headless, single-shot
+        # review subprocess (this file's own isolation flags disallow tools,
+        # MCP, and session persistence) -- never an interactive session, and
+        # never a session Claude Code should register as one. Setting this
+        # unconditionally (not just passing it through when the caller sets
+        # it) matters because this function replaces the caller's entire
+        # environment with an allowlist: a caller that already exports
+        # CLAUDE_SAY_QUIET/CLAUDE_CODE_DISABLE_CRON (as autoreview-async does
+        # for its own shell) would still have them stripped here before the
+        # `claude` child ever sees them, so the global SessionStart hook
+        # would still record a checkin for a review that was never
+        # interactive work. Same failure class as PerfectPath-analysis's
+        # enrich.py and Second Brain's nightcycle llm.py (2026-09-05..08).
+        env["CLAUDE_SAY_QUIET"] = "1"
+        env["CLAUDE_CODE_DISABLE_CRON"] = "1"
     return env
 
 

--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -926,19 +926,12 @@ def safe_engine_env(
     env.update(extra or {})
     if engine == "claude":
         env["CLAUDE_CODE_DISABLE_AUTO_MEMORY"] = "1"
-        # Every claude-engine invocation here is a headless, single-shot
-        # review subprocess (this file's own isolation flags disallow tools,
-        # MCP, and session persistence) -- never an interactive session, and
-        # never a session Claude Code should register as one. Setting this
-        # unconditionally (not just passing it through when the caller sets
-        # it) matters because this function replaces the caller's entire
-        # environment with an allowlist: a caller that already exports
-        # CLAUDE_SAY_QUIET/CLAUDE_CODE_DISABLE_CRON (as autoreview-async does
-        # for its own shell) would still have them stripped here before the
-        # `claude` child ever sees them, so the global SessionStart hook
-        # would still record a checkin for a review that was never
-        # interactive work. Same failure class as PerfectPath-analysis's
-        # enrich.py and Second Brain's nightcycle llm.py (2026-09-05..08).
+        # This claude subprocess is always headless review work, never an
+        # interactive session -- force these so Claude Code's global
+        # SessionStart hook doesn't register a spurious AgentBus checkin per
+        # review. Must be forced (not passed through from the caller): this
+        # function replaces the caller's env with an allowlist, so a caller
+        # that already exported these would still lose them here otherwise.
         env["CLAUDE_SAY_QUIET"] = "1"
         env["CLAUDE_CODE_DISABLE_CRON"] = "1"
     return env


### PR DESCRIPTION
## Summary
- `safe_engine_env()` replaces the caller's entire environment with a security allowlist before spawning the review engine subprocess. For `engine == "claude"`, `CLAUDE_SAY_QUIET`/`CLAUDE_CODE_DISABLE_CRON` were not in that allowlist, so even a caller that exported them (e.g. `autoreview-async`) never got them through to the `claude` child.
- Every `claude`-engine invocation here is headless, single-shot, no-session-persistence review work (`--print --no-session-persistence --safe-mode ...`) — never interactive — so it should never register as a session. Without this fix, every push-triggered and nightly-triage review spawned a `claude` process that Claude Code's global SessionStart hook recorded as a real "session started" event on the cross-machine coordination bus (AgentBus), flooding it with checkins that had no real work behind them.
- Fix: force both vars unconditionally for `engine == "claude"`, right next to the existing unconditional `CLAUDE_CODE_DISABLE_AUTO_MEMORY` line. Unconditional (not pass-through) is required because this function *replaces* rather than extends the caller's env — a caller-set value would already be gone by the time this code runs.

## Test plan
- [x] Full existing unit suite (`python3 -m unittest autoreview_test`): 46/46 passed, unchanged.
- [x] Real (unmocked) end-to-end check: called the actual `claude` binary through the old `safe_engine_env()` with the caller pre-exporting both vars — they were stripped and Claude Code's global hook recorded a checkin. Called it again through the fixed `safe_engine_env()` with the caller *not* setting them at all — the child received them and no checkin was recorded.
- [x] Independent adversarial review (Gemini 3.1 Pro via `agy`) focused specifically on whether this weakens the allowlist's threat model: verdict APPROVE — values are fixed `"1"` literals never derived from caller env or the reviewed diff, so there is no leakage or injection path; forcing them unconditionally is strictly more defensive than pass-through. One Minor nit (comment length) addressed in a follow-up commit.

Related same-day fixes for the same failure class (batch `claude -p` pipelines not silencing the global SessionStart hook): PerfectPath-analysis's `enrich.py` and Second Brain's nightcycle `llm.py` (`_call_llm_cli`).