### PR TITLE
fix(autoreview): capture complete Claude capability output

### DIFF
--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -489,19 +489,32 @@ def run(
     check: bool = True,
     env: dict[str, str] | None = None,
     text_errors: str = SUBPROCESS_TEXT_ERRORS,
+    capture_dir: Path | None = None,
 ) -> subprocess.CompletedProcess[str]:
-    result = subprocess.run(
-        args,
-        cwd=cwd,
-        input=input_text,
-        stdin=stdin,
-        text=True,
-        encoding=SUBPROCESS_TEXT_ENCODING,
-        errors=text_errors,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        env=env,
-    )
+    with contextlib.ExitStack() as stack:
+        captures = [
+            stack.enter_context(tempfile.TemporaryFile(
+                mode="w+", encoding=SUBPROCESS_TEXT_ENCODING,
+                errors=text_errors, dir=capture_dir,
+            ))
+            for _ in range(2)
+        ] if capture_dir is not None else []
+        result = subprocess.run(
+            args,
+            cwd=cwd,
+            input=input_text,
+            stdin=stdin,
+            text=True,
+            encoding=SUBPROCESS_TEXT_ENCODING,
+            errors=text_errors,
+            stdout=captures[0] if captures else subprocess.PIPE,
+            stderr=captures[1] if captures else subprocess.PIPE,
+            env=env,
+        )
+        if captures:
+            for capture in captures:
+                capture.seek(0)
+            result.stdout, result.stderr = (capture.read() for capture in captures)
     if check and result.returncode != 0:
         cmd = " ".join(args)
         raise SystemExit(f"command failed ({result.returncode}): {cmd}\n{result.stderr or result.stdout}")
@@ -4289,7 +4302,12 @@ def ensure_claude_isolation_supported(args: argparse.Namespace, repo: Path) -> N
             f"claude engine requires Claude Code >= {format_version(minimum_version)} "
             f"{version_reason} (found {format_version(version)})"
         )
-    help_result = run([claude_bin, "--help"], temp_root, check=False, env=engine_env)
+    # Claude can exit before flushing piped help; regular files preserve the
+    # complete capability list without weakening any required isolation flag.
+    help_result = run(
+        [claude_bin, "--help"], temp_root, check=False, env=engine_env,
+        capture_dir=temp_root,
+    )
     help_text = f"{help_result.stdout}\n{help_result.stderr}"
     required_flags = ["--safe-mode", "--setting-sources", "--strict-mcp-config", "--disallowedTools", "--tools"]
     missing = [flag for flag in required_flags if flag not in help_text]

--- a/skills/autoreview/tests/test_autoreview_hardening.py
+++ b/skills/autoreview/tests/test_autoreview_hardening.py
@@ -4582,6 +4582,31 @@ with Path(__file__).with_name("scans.jsonl").open("a", encoding="utf-8") as reco
             ):
                 self.helper["ensure_claude_isolation_supported"](args, repo)
 
+    @unittest.skipIf(os.name == "nt", "POSIX executable fixture")
+    def test_claude_probe_captures_help_from_pipe_sensitive_cli(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            root = Path(tempdir)
+            repo = init_repo(root)
+            cli = write_executable(root / "claude", r'''#!/usr/bin/env python3
+import os
+import stat
+import sys
+
+if "--version" in sys.argv:
+    print("2.1.226 (Claude Code)")
+else:
+    text = "Usage: claude\n" + " " * 16384
+    text += "--safe-mode --setting-sources --strict-mcp-config --disallowedTools --tools\n"
+    if stat.S_ISFIFO(os.fstat(1).st_mode):
+        text = text[:512]
+    sys.stdout.write(text)
+''')
+            args = argparse.Namespace(claude_bin=str(cli), model=None, fallback_model=None)
+            self.helper["ensure_claude_isolation_supported"](args, repo)
+            cli.write_text(cli.read_text().replace("--safe-mode", "--unsafe-mode"))
+            with self.assertRaisesRegex(SystemExit, "missing from --help: --safe-mode"):
+                self.helper["ensure_claude_isolation_supported"](args, repo)
+
     def test_claude_canonical_fable_model_uses_portable_cli_selector(self) -> None:
         self.assertEqual(
             self.helper["claude_cli_model_selector"]("claude-fable-5"),


### PR DESCRIPTION
Claude 2.1.226 can return only the first 512 bytes of `--help` when stdout is a pipe. Autoreview then rejects an installed, supported CLI because the required isolation flags occur in the missing tail. Capturing the same native command to a regular file returned all 16,890 bytes.

Capture Claude's help probe through private temporary files and read both streams before closing them. Keep the existing version, required-flag, environment, and exit-status checks. The regression runs a pipe-sensitive executable and also checks that a genuinely missing `--safe-mode` still fails closed.

Validation:

- The regression failed with the reported missing-flags error before the fix and passes afterward.
- The actual Claude 2.1.226 binary now passes production preflight and completes `run_claude`, returning the requested structured review JSON through the existing isolated path.
- Full local validation passed: 287 Python tests (one platform skip), 107 Node tests, 15 repository-script tests, and eight validated skills. Copy installation and the installed helper CLI were exercised.
- Both the local-change and committed-branch isolated Codex Autoreview passes are scoped-clean through P2.
- The installed Autoreview CLI completed an authenticated Claude review of a synthetic fixture with exit 0 and a scoped-clean structured result. The initial full-change Claude proof used a 60-second deadline and timed out; the small CLI fixture completed within its 180-second deadline.

Found while investigating #237. Thanks @phyrexia for the report that led to this diagnosis. The changelog entry is carried in #239 so the branches remain independently mergeable.

Observable native output (real installed binary; the harness invokes `subprocess.run([claude, "--help"])` through both capture modes, then calls production `ensure_claude_isolation_supported` from main and the proposed commit):

```text
2.1.226 (Claude Code)
native piped help [1]: exit=0 bytes=512 safe_mode_flag=False
native piped help [2]: exit=0 bytes=512 safe_mode_flag=False
native piped help [3]: exit=0 bytes=512 safe_mode_flag=False
native file help: exit=0 bytes=16890 safe_mode_flag=True
main production preflight: FAIL: claude engine requires Claude Code isolation flags missing from --help: --safe-mode, --setting-sources, --strict-mcp-config, --disallowedTools, --tools
c05f1c3 production preflight: PASS
```

The complete file contains 16,890 UTF-8 bytes (16,886 characters).

Copied output from the installed helper reviewing the disposable fixture with real Claude:

```text
autoreview scoped-clean: no accepted/actionable findings in the selected Git scope and priority
overall: patch is correct (1)
The change is a straightforward modification to message.txt that updates the text from "hello" to "hello world". No actionable defects were identified. The patch involves a simple text append with no security implications, logical errors, regressions, or maintainability concerns.
```
