### PR TITLE
docs: record Claude reviewer startup fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 **Highlights:** Isolated reviews with complete source coverage, explicit reviewer availability, and controlled session sharing.
 
+- Fix Claude reviewer startup when the CLI truncates piped help output, while retaining mandatory isolation checks. Thanks @phyrexia.
 - Add opt-in Autoreview `--status-output` to distinguish unavailable reviewers from clean, adverse, filtered, and incomplete reviews without changing existing report JSON or exit codes. Thanks @coygeek.
 - Provide shared Autoreview, Crabbox, behavior-validator, handoff, readme-standard, agent-transcript, session-viewer, and Beam workflows, with selectable symlink/copy installation and cross-platform skill validation.
 - Run explicitly requested reviews through isolated Codex, Claude, Amp, Pi, or Kimi engines, with structured findings, scoped attribution, progress, streaming diagnostics, dry-run preflight, and optional process deadlines.


### PR DESCRIPTION
Record the Claude startup fix from #238 in the consolidated Unreleased section, retaining the existing Highlights and all earlier notes. Thanks @phyrexia for the report that led to the diagnosis.

Merge this after #238. Keeping the changelog in this final PR lets the implementation branch remain independently mergeable. The dependency recheck found PyYAML and all referenced Actions current, so no dependency bump is needed. This repository is distributed through Git and has no version tags or release channel to prepare.
