### PR TITLE
fix(autoreview): remove restored TruffleHog dependency

### DIFF
--- a/skills/autoreview/AGENTS.md
+++ b/skills/autoreview/AGENTS.md
@@ -4,3 +4,5 @@
 - Before editing any copy, fast-forward a checkout of `openclaw/agent-skills` from `origin/main`.
 - Make and validate shared changes in canonical `skills/autoreview` first, then sync the complete directory into downstream repos.
 - Never create repo-local behavior variants; downstream differences belong in repo-level validation, not the skill.
+
+- When changing review preparation, provider calls, or credential handling, read and preserve the intentional scanner-free policy in [SKILL.md](SKILL.md#intentional-scanner-free-policy).

--- a/skills/autoreview/AGENTS.md
+++ b/skills/autoreview/AGENTS.md
@@ -4,5 +4,3 @@
 - Before editing any copy, fast-forward a checkout of `openclaw/agent-skills` from `origin/main`.
 - Make and validate shared changes in canonical `skills/autoreview` first, then sync the complete directory into downstream repos.
 - Never create repo-local behavior variants; downstream differences belong in repo-level validation, not the skill.
-
-- When changing review preparation, provider calls, or credential handling, read and preserve the intentional scanner-free policy in [SKILL.md](SKILL.md#intentional-scanner-free-policy).

--- a/skills/autoreview/SKILL.md
+++ b/skills/autoreview/SKILL.md
@@ -144,18 +144,10 @@ or invoke an external secret scanner. Never work around an isolation failure.
 
 ### Intentional scanner-free policy
 
-Keep autoreview usable without installing or executing TruffleHog. This is an
-intentional enterprise-compatibility decision, not a missing security step:
-maintainers report that enterprise security teams flag or restrict the tool,
-blocking developers from using autoreview when it is a required dependency.
-[Truffle Security documents attackers using TruffleHog in Shai-Hulud](https://trufflesecurity.com/blog/the-rise-of-api-worms);
-that documents abuse of the tool, not a breach of TruffleHog itself.
-
-Reviewer credential findings happen after transmission and do not provide a
-pre-send secret gate. Organizations can enforce their approved scanning controls
-outside autoreview. Reintroducing a scanner requires an explicit maintainer
-policy decision; routine hardening, review fixes, and downstream syncs must
-preserve scanner-free operation. Decision and history: [agent-skills #240](https://github.com/openclaw/agent-skills/pull/240).
+TruffleHog is intentionally excluded because enterprise security teams may flag
+or restrict it. Keep approved scanning outside autoreview; reviewer findings
+happen after transmission. Reintroducing a scanner requires an explicit maintainer
+decision. See [#240](https://github.com/openclaw/agent-skills/pull/240) for rationale and history.
 
 ### Reviewer isolation
 

--- a/skills/autoreview/SKILL.md
+++ b/skills/autoreview/SKILL.md
@@ -41,7 +41,7 @@ PR base or `origin/main`. Clean main has no implicit review target.
 
 Registered nested linked checkouts from the same repository are outside the
 current review scope. Their presence or edits do not make the parent dirty;
-ordinary adjacent files remain included and scanned. Worktree boundaries are
+ordinary adjacent files remain included in the review. Worktree boundaries are
 revalidated without changing Git ignore rules.
 
 For a complete PR candidate **including dirty rewrites**, use local mode with
@@ -137,11 +137,10 @@ split context overrides are unsupported when projection is selected.
 
 The helper owns reviewer isolation, sanitized authentication, process cleanup,
 Git scope, and structured result validation. Keep those controls enabled.
-TruffleHog must scan the complete frozen input for partitioned reviews and each
-exact outgoing pack before it is sent; missing or failed scanning stops the run.
-Source-controlled ignore tags cannot suppress this gate. Scanner refusals never
-echo input headings or finding payloads; remove credentials locally and rerun.
-Never reproduce credentials in findings or work around an isolation failure.
+Every reviewer pass must inspect its bundle for real credentials and report
+suspected credentials as P0 findings without reproducing their values. Harmless
+placeholders and test fixtures are not credentials. Autoreview does not require
+or invoke an external secret scanner. Never work around an isolation failure.
 
 On macOS, reviewer tools cannot access the shared `/tmp` and `/var/tmp` trees
 (including their `/private` aliases). Codex preflight rejects those temporary
@@ -205,7 +204,7 @@ The sidecar contains no provider logs, prompts, findings, or model identifiers.
 Existing bounded, display-safe diagnostics remain on stderr; command-auth
 diagnostic suppression remains in force. Use a fresh status path per invocation:
 after argument and output-path validation, a previous sidecar is removed before
-target selection. Dry runs, preflight/scan refusals, pre-launch isolation failures, source mutations,
+target selection. Dry runs, preflight refusals, pre-launch isolation failures, source mutations,
 interruptions, and output failures produce no new status. Absence means no
 outcome was published, never a clean review. No retry policy is added.
 

--- a/skills/autoreview/SKILL.md
+++ b/skills/autoreview/SKILL.md
@@ -142,6 +142,23 @@ suspected credentials as P0 findings without reproducing their values. Harmless
 placeholders and test fixtures are not credentials. Autoreview does not require
 or invoke an external secret scanner. Never work around an isolation failure.
 
+### Intentional scanner-free policy
+
+Keep autoreview usable without installing or executing TruffleHog. This is an
+intentional enterprise-compatibility decision, not a missing security step:
+maintainers report that enterprise security teams flag or restrict the tool,
+blocking developers from using autoreview when it is a required dependency.
+[Truffle Security documents attackers using TruffleHog in Shai-Hulud](https://trufflesecurity.com/blog/the-rise-of-api-worms);
+that documents abuse of the tool, not a breach of TruffleHog itself.
+
+Reviewer credential findings happen after transmission and do not provide a
+pre-send secret gate. Organizations can enforce their approved scanning controls
+outside autoreview. Reintroducing a scanner requires an explicit maintainer
+policy decision; routine hardening, review fixes, and downstream syncs must
+preserve scanner-free operation. Decision and history: [agent-skills #240](https://github.com/openclaw/agent-skills/pull/240).
+
+### Reviewer isolation
+
 On macOS, reviewer tools cannot access the shared `/tmp` and `/var/tmp` trees
 (including their `/private` aliases). Codex preflight rejects those temporary
 roots before workspace, runtime, or authentication setup; unset a shared

--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -6653,6 +6653,8 @@ def run_reviewer(
     with PreparationProgress("evidence verification"):
         verify_evidence(repo, evidence or [])
         verify_mixed_sources(repo, mixed)
+    # Scanner-free operation is intentional for enterprise compatibility.
+    # Preserve SKILL.md's "Intentional scanner-free policy" when changing this path.
     raw = run_engine(args, repo, outgoing)
     try:
         report = extract_json(raw)

--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -1633,10 +1633,6 @@ def validate_git_ref(repo: Path, ref: str, label: str, *, pin: bool = False) -> 
     return result.strip() if pin else ref
 
 
-TRUFFLEHOG_INSTALL_URL = "https://github.com/trufflesecurity/trufflehog#installation"
-TRUFFLEHOG_FINDINGS_EXIT_CODE = 183
-
-
 def git_bytes(
     repo: Path,
     *args: str,
@@ -1665,73 +1661,6 @@ def git_bytes(
             f"{display_escape(detail, 1000, multiline=True)}"
         )
     return result
-
-
-def safe_trufflehog_env(repo: Path) -> dict[str, str]:
-    env = safe_git_env(repo)
-    for key in (
-        "ALL_PROXY",
-        "HTTP_PROXY",
-        "HTTPS_PROXY",
-        "NO_PROXY",
-        "all_proxy",
-        "http_proxy",
-        "https_proxy",
-        "no_proxy",
-    ):
-        value = os.environ.get(key)
-        if not value:
-            continue
-        if key.casefold() != "no_proxy" and not safe_proxy_url(value):
-            raise SystemExit(
-                f"unsafe credentialed or malformed proxy URL in {key}; "
-                "configure a credential-free proxy URL before running autoreview"
-            )
-        env[key] = value
-    return env
-
-
-def scan_outgoing_review_pack(repo: Path, prompt: str) -> None:
-    trufflehog_bin = find_command("trufflehog", repo)
-    if not trufflehog_bin:
-        raise SystemExit(
-            "refusing to send review pack: TruffleHog is required but was not found. "
-            f"Install it using the official instructions, then rerun autoreview: {TRUFFLEHOG_INSTALL_URL}"
-        )
-    with tempfile.TemporaryDirectory(
-        prefix="autoreview-pack-scan.",
-        dir=safe_temp_root(repo),
-    ) as tempdir:
-        pack_path = Path(tempdir) / "review-pack.txt"
-        pack_path.write_bytes(prompt.encode("utf-8"))
-        pack_path.chmod(0o600)
-        scanner_env = safe_trufflehog_env(repo)
-        # Filesystem preserves read/extraction failures; stdin does not honor
-        # inline ignore tags, including decoded ones. Both must pass. A binary
-        # file descriptor preserves exact bytes and avoids stdin pipe buffering.
-        with pack_path.open("rb") as pack_input:
-            for source_args, scan_input in ((["filesystem", str(pack_path)], None), (["stdin"], pack_input)):
-                result = run(
-                    [
-                        trufflehog_bin, *source_args,
-                        "--json", "--no-color", "--results=verified,unknown",
-                        "--fail", "--fail-on-scan-errors", "--no-update",
-                    ],
-                    Path(tempdir),
-                    stdin=scan_input,
-                    check=False,
-                    env=scanner_env,
-                )
-                if result.returncode == TRUFFLEHOG_FINDINGS_EXIT_CODE:
-                    # Input headings, filenames, and scanner metadata can themselves contain credentials.
-                    raise SystemExit(
-                        "refusing to send review pack: TruffleHog found credentials; "
-                        "remove credential material from selected changes, prompt files, and datasets, then rerun"
-                    )
-                if result.returncode != 0:
-                    raise SystemExit(
-                        "refusing to send review pack: TruffleHog could not complete the scan"
-                    )
 
 
 def bounded_field(text: str, limit: int) -> str:
@@ -3713,18 +3642,9 @@ def prepare_review_prompts(
     datasets: list[ReviewDataset],
     max_prompt_bytes: int,
 ) -> list[str] | list[ReviewPass]:
-    prompts = build_review_prompts(
+    return build_review_prompts(
         repo, target, target_ref, bundle, extra_prompt, datasets, max_prompt_bytes,
     )
-    if len(prompts) > 1:
-        # A credential can span a partition boundary. Scan the complete frozen
-        # input before any send, in addition to each exact outgoing pack.
-        chunk = mixed_bundle_chunk(bundle) if isinstance(bundle, CapturedBundle) else ReviewChunk(bundle)
-        scan_outgoing_review_pack(repo, render_review_prompt(
-            current_branch(repo), target, target_ref, chunk,
-            extra_prompt, render_datasets(datasets),
-        ))
-    return prompts
 
 
 def write_json_temp(data: dict[str, Any], temp_root: Path) -> Path:
@@ -4885,10 +4805,6 @@ def run_codex(args: argparse.Namespace, repo: Path, prompt: str) -> str:
                     force_file_auth=file_auth_linked,
                     auth_config=auth_config,
                 )
-                if index:
-                    # The initial send was scanned by run_reviewer; a retry is
-                    # a new provider invocation even with the same frozen pack.
-                    scan_outgoing_review_pack(repo, prompt)
                 result = run_with_heartbeat(
                     cmd,
                     review_root,
@@ -6688,14 +6604,12 @@ def dry_run_preflight(
     # pass's capacity once combined with intact instructions/source context.
     if bundle_ok and inputs_ok:
         try:
-            with PreparationProgress("bundle/evidence preparation and scan"):
+            with PreparationProgress("bundle/evidence preparation"):
                 threshold_extra_prompt = apply_finding_threshold_prompt(args, evidence.prompt)
-                prompts = prepare_review_prompts(
+                prepare_review_prompts(
                     repo, target, target_ref, captured, threshold_extra_prompt,
                     evidence.datasets, max_prompt_bytes_for_reviewers(reviewers),
                 )
-                for prompt in prompts:
-                    scan_outgoing_review_pack(repo, prompt.prompt if isinstance(prompt, ReviewPass) else prompt)
             with PreparationProgress("evidence verification"):
                 verify_evidence(repo, evidence.files)
                 verify_mixed_sources(repo, captured.mixed)
@@ -6736,8 +6650,7 @@ def run_reviewer(
     if mixed and not isinstance(prompt, ReviewPass):
         raise SystemExit("mixed review requires owner-built pass metadata")
     outgoing = prompt.prompt if isinstance(prompt, ReviewPass) else prompt
-    with PreparationProgress("outgoing pack scan and evidence verification"):
-        scan_outgoing_review_pack(repo, outgoing)
+    with PreparationProgress("evidence verification"):
         verify_evidence(repo, evidence or [])
         verify_mixed_sources(repo, mixed)
     raw = run_engine(args, repo, outgoing)
@@ -6981,7 +6894,7 @@ def main_impl() -> int:
         evidence = capture_evidence_inputs(args, repo)
     with PreparationProgress("initial source snapshot") as progress:
         review_source_snapshot = source_tree_snapshot(repo, progress)
-    with PreparationProgress("bundle/evidence preparation and scan"):
+    with PreparationProgress("bundle/evidence preparation"):
         captured = build_bundle(repo, target, target_ref, args.commit)
         if target == "commit":
             target_ref = args.commit

--- a/skills/autoreview/scripts/autoreview_test.py
+++ b/skills/autoreview/scripts/autoreview_test.py
@@ -57,7 +57,7 @@ class AutoreviewCursorTests(unittest.TestCase):
         for raw in ("[" * 2000 + "]" * 2000, '{"findings":[],"number":' + "9" * 10000 + "}"):
             with self.subTest(length=len(raw)), mock.patch.object(
                 AUTOREVIEW, "run_engine", return_value=raw,
-            ), mock.patch.object(AUTOREVIEW, "scan_outgoing_review_pack"):
+            ):
                 with self.assertRaises(AUTOREVIEW.ReviewerUnavailable) as caught:
                     AUTOREVIEW.run_reviewer(args, Path.cwd(), "synthetic", set(), [])
                 self.assertEqual(caught.exception.reason, "invalid_report")
@@ -79,7 +79,7 @@ class AutoreviewCursorTests(unittest.TestCase):
                 owner[field] = value
                 with self.subTest(field=field, value=value), mock.patch.object(
                     AUTOREVIEW, "run_engine", return_value=json.dumps(report),
-                ), mock.patch.object(AUTOREVIEW, "scan_outgoing_review_pack"):
+                ):
                     with self.assertRaises(AUTOREVIEW.ReviewerUnavailable) as caught:
                         AUTOREVIEW.run_reviewer(args, Path.cwd(), "synthetic", {"draft.js"}, [])
                     self.assertEqual(caught.exception.reason, "invalid_report")
@@ -190,9 +190,7 @@ class AutoreviewResultScopeTests(unittest.TestCase):
     def test_required_finding_must_survive_priority_filter_for_every_pass_count(self) -> None:
         args = argparse.Namespace(engine="codex", max_priority="P0", require_finding=["Draft finding"])
         for count in (1, 2):
-            with self.subTest(count=count), mock.patch.object(
-                AUTOREVIEW, "scan_outgoing_review_pack"
-            ), mock.patch.object(AUTOREVIEW, "run_engine", return_value=json.dumps(DRAFT_REPORT)):
+            with self.subTest(count=count), mock.patch.object(AUTOREVIEW, "run_engine", return_value=json.dumps(DRAFT_REPORT)):
                 reports = AUTOREVIEW.run_review_passes(
                     args, [args], Path.cwd(), ["pack"] * count, {"draft.js"}
                 )
@@ -389,7 +387,6 @@ class AutoreviewTargetResultTests(unittest.TestCase):
                     "overall_correctness": "patch is incorrect", "overall_confidence": 0.43}
         for engine in AUTOREVIEW.ENGINES:
             with self.subTest(engine=engine), mock.patch.object(AUTOREVIEW, "run_engine", return_value=json.dumps(provider)), \
-                    mock.patch.object(AUTOREVIEW, "scan_outgoing_review_pack"), \
                     mock.patch.object(AUTOREVIEW, "verify_mixed_sources"), contextlib.redirect_stderr(io.StringIO()):
                 report = AUTOREVIEW.run_reviewer(argparse.Namespace(engine=engine, max_priority="P0"),
                                                  Path.cwd(), prompt, captured, [])
@@ -987,56 +984,21 @@ class AutoreviewAmpTests(unittest.TestCase):
                     AUTOREVIEW.run_amp(args, repo, "review")
 
 
-class AutoreviewTruffleHogTests(unittest.TestCase):
-    def test_refusal_does_not_echo_input_headings_or_scanner_fields(self) -> None:
-        marker = "SYNTHETIC_SCAN_SENTINEL_NOT_A_CREDENTIAL"
-        headings = [
-            f"# Dataset: {marker}",
-            f"# Prompt file: {marker}",
-            'Source snapshot: ' + json.dumps({"path": marker, "line_count": 0}),
-            'Removed source: ' + json.dumps({"path": marker}),
-            '# Untracked File\npath: ' + json.dumps(marker),
-            f"+++ b/{marker}",
-            f"diff --git a/old.txt b/{marker}\n--- a/old.txt\n+++ b/{marker}\n@@ -1 +1 @@\n+example",
-        ]
-        for heading in headings:
-            with self.subTest(heading=heading), tempfile.TemporaryDirectory() as tempdir:
-                prompt = "# Dataset: safe-evidence.txt\n" + heading
-                lines = [number for number, line in enumerate(prompt.splitlines(), 1) if marker in line]
-                output = json.dumps({"SourceMetadata": {"Data": {"Filesystem": {"line": lines[-1]}}},
-                                     "Raw": marker, "RawV2": marker})
-                with mock.patch.object(AUTOREVIEW, "find_command", return_value="/trusted/trufflehog"), \
-                        mock.patch.object(AUTOREVIEW, "run", return_value=subprocess.CompletedProcess(
-                            [], AUTOREVIEW.TRUFFLEHOG_FINDINGS_EXIT_CODE, output, marker,
-                        )), mock.patch.object(AUTOREVIEW, "run_engine") as provider:
-                    with self.assertRaises(SystemExit) as error:
-                        AUTOREVIEW.run_reviewer(argparse.Namespace(engine="codex", max_priority="P0"),
-                                                 Path(tempdir), prompt, {"change.txt"}, [])
-                self.assertNotIn(marker, str(error.exception))
-                self.assertIn("remove credential material", str(error.exception))
-                provider.assert_not_called()
+class AutoreviewInputTests(unittest.TestCase):
 
-    def test_scanner_checks_stdin_without_literal_ignore_markers(self) -> None:
-        prompt = "unicode \u03c0\r\nsource without suppression instructions\n"
-        commands = []
-        with tempfile.TemporaryDirectory() as tempdir:
-            def scanner(command, cwd, **kwargs):
-                commands.append(command[1])
-                if command[1] == "filesystem":
-                    self.assertEqual(Path(command[2]).read_bytes(), prompt.encode("utf-8"))
-                    return subprocess.CompletedProcess(command, 0, "", "")
-                self.assertEqual(command[1], "stdin")
-                self.assertEqual(kwargs["stdin"].read(), prompt.encode("utf-8"))
-                return subprocess.CompletedProcess(command, AUTOREVIEW.TRUFFLEHOG_FINDINGS_EXIT_CODE, "", "")
 
-            with mock.patch.object(AUTOREVIEW, "find_command", return_value="/trusted/trufflehog"), \
-                    mock.patch.object(AUTOREVIEW, "run", side_effect=scanner), \
-                    mock.patch.object(AUTOREVIEW, "run_engine", return_value=json.dumps(FINAL_REPORT)) as provider:
-                with self.assertRaisesRegex(SystemExit, "refusing to send review pack"):
-                    AUTOREVIEW.run_reviewer(argparse.Namespace(engine="codex", max_priority="P0"),
-                                             Path(tempdir), prompt, {"change.txt"}, [])
-            self.assertEqual(commands, ["filesystem", "stdin"])
-            provider.assert_not_called()
+    def test_every_provider_reviews_each_pack_without_a_scanner(self) -> None:
+        for engine in ("codex", "claude", "amp", "pi", "kimi"):
+            with self.subTest(engine=engine), tempfile.TemporaryDirectory() as tempdir:
+                args = argparse.Namespace(engine=engine, max_priority="P0")
+                prompts = [f"complete pack {index}: unicode π\r\n-context\n+change\n" for index in range(2)]
+                with mock.patch.object(AUTOREVIEW, "find_command", side_effect=AssertionError("unexpected scanner lookup")), \
+                        mock.patch.object(AUTOREVIEW, "run", side_effect=AssertionError("unexpected scanner process")), \
+                        mock.patch.object(AUTOREVIEW, f"run_{engine}", return_value=json.dumps(FINAL_REPORT)) as provider:
+                    for prompt in prompts:
+                        report = AUTOREVIEW.run_reviewer(args, Path(tempdir), prompt, set(), [])
+                        self.assertEqual(report["findings"], [])
+                self.assertEqual([call.args[2] for call in provider.call_args_list], prompts)
 
     def test_binary_stdin_preserves_utf8_and_crlf_bytes(self) -> None:
         payload = "unicode \u03c0\r\nnext\n".encode("utf-8")
@@ -1048,100 +1010,6 @@ class AutoreviewTruffleHogTests(unittest.TestCase):
                 Path(tempdir), stdin=source,
             )
         self.assertEqual(result.stdout.strip(), payload.hex())
-
-    def test_every_provider_scans_each_pack_and_refuses_scanner_failures(self) -> None:
-        for engine in ("codex", "claude", "amp", "pi", "kimi"):
-            for failed_source, failure in ((None, None), (None, "missing"),
-                                           ("filesystem", "finding"), ("filesystem", "error"),
-                                           ("stdin", "finding"), ("stdin", "error")):
-                with self.subTest(engine=engine, source=failed_source, failure=failure), tempfile.TemporaryDirectory() as tempdir:
-                    repo = Path(tempdir)
-                    args = argparse.Namespace(engine=engine, max_priority="P0")
-                    prompts = [f"complete pack {index}: unicode \u03c0\r\n-context\n+change\n" for index in range(2)]
-                    events: list[tuple[str, str]] = []
-                    packs: list[Path] = []
-
-                    def scanner(command, cwd, **kwargs):
-                        source = command[1]
-                        pack = Path(command[2]) if source == "filesystem" else Path(kwargs["stdin"].name)
-                        data = pack.read_bytes() if source == "filesystem" else kwargs["stdin"].read()
-                        packs.append(pack)
-                        prompt = data.decode("utf-8")
-                        self.assertIn(prompt, prompts)
-                        self.assertEqual(cwd, pack.parent)
-                        if os.name != "nt":
-                            self.assertEqual(stat.S_IMODE(pack.stat().st_mode), 0o600)
-                            self.assertEqual(stat.S_IMODE(pack.parent.stat().st_mode), 0o700)
-                        events.append((source, prompt))
-                        code = 0
-                        if prompt == prompts[1] and source == failed_source:
-                            code = {"finding": AUTOREVIEW.TRUFFLEHOG_FINDINGS_EXIT_CODE, "error": 1}.get(failure, 0)
-                        return subprocess.CompletedProcess(command, code, "", "")
-
-                    def provider(_args, _repo, prompt):
-                        events.append(("send", prompt))
-                        return json.dumps(FINAL_REPORT)
-
-                    with mock.patch.object(AUTOREVIEW, "find_command", return_value="/trusted/trufflehog") as find, \
-                            mock.patch.object(AUTOREVIEW, "run", side_effect=scanner), contextlib.ExitStack() as stack:
-                        providers = {
-                            name: stack.enter_context(mock.patch.object(AUTOREVIEW, f"run_{name}", side_effect=provider))
-                            for name in ("codex", "claude", "amp", "pi", "kimi")
-                        }
-                        AUTOREVIEW.run_reviewer(args, repo, prompts[0], set(), [])
-                        if failure == "missing":
-                            find.return_value = None
-                        if failure:
-                            with self.assertRaisesRegex(SystemExit, "refusing to send review pack"):
-                                AUTOREVIEW.run_reviewer(args, repo, prompts[1], set(), [])
-                        else:
-                            AUTOREVIEW.run_reviewer(args, repo, prompts[1], set(), [])
-                        for name, call in providers.items():
-                            self.assertEqual(call.call_count, (1 if failure else 2) if name == engine else 0)
-                    expected = [("filesystem", prompts[0]), ("stdin", prompts[0]), ("send", prompts[0])]
-                    if failure != "missing":
-                        expected.append(("filesystem", prompts[1]))
-                        if failed_source != "filesystem":
-                            expected.append(("stdin", prompts[1]))
-                    if not failure:
-                        expected.append(("send", prompts[1]))
-                    self.assertEqual(events, expected)
-                    self.assertTrue(all(not pack.parent.exists() for pack in packs))
-
-    def test_scanner_command_requests_verified_and_unknown_results(self) -> None:
-        prompt = "review pack with redacted examples only"
-        with tempfile.TemporaryDirectory() as tempdir:
-            repo = Path(tempdir)
-
-            def run_scanner(
-                command: list[str],
-                cwd: Path,
-                **kwargs: object,
-            ) -> subprocess.CompletedProcess[str]:
-                pack = Path(command[2]) if command[1] == "filesystem" else Path(kwargs["stdin"].name)
-                self.assertEqual(cwd, pack.parent)
-                data = pack.read_bytes() if command[1] == "filesystem" else kwargs["stdin"].read()
-                self.assertEqual(data, prompt.encode("utf-8"))
-                self.assertEqual(
-                    command[3:] if command[1] == "filesystem" else command[2:],
-                    [
-                        "--json",
-                        "--no-color",
-                        "--results=verified,unknown",
-                        "--fail",
-                        "--fail-on-scan-errors",
-                        "--no-update",
-                    ],
-                )
-                self.assertEqual(kwargs["check"], False)
-                return subprocess.CompletedProcess(command, 0, "", "")
-
-            with mock.patch.object(
-                AUTOREVIEW,
-                "find_command",
-                return_value="/trusted/trufflehog",
-            ), mock.patch.object(AUTOREVIEW, "run", side_effect=run_scanner):
-                AUTOREVIEW.scan_outgoing_review_pack(repo, prompt)
 
 
 class AutoreviewCompatibilityTests(unittest.TestCase):
@@ -1245,7 +1113,7 @@ class AutoreviewCompatibilityTests(unittest.TestCase):
                     AUTOREVIEW, "load_kimi_review_config", return_value=({"telemetry": False}, None),
                 ), mock.patch.object(
                     AUTOREVIEW, "run_with_heartbeat", return_value=subprocess.CompletedProcess([], 0, stream, ""),
-                ), mock.patch.object(AUTOREVIEW, "scan_outgoing_review_pack"):
+                ):
                     with self.assertRaises(AUTOREVIEW.ReviewerUnavailable) as caught:
                         AUTOREVIEW.run_reviewer(args, repo, "synthetic pack", set(), [])
                     self.assertEqual(caught.exception.reason, "invalid_report")
@@ -1346,62 +1214,31 @@ class AutoreviewCompatibilityTests(unittest.TestCase):
             web_search=False,
         )
         prompt = "complete retry pack: unicode \u03c0\r\n-deleted line\n unchanged context\n"
-        for failed_source, failure in ((None, None), (None, "missing"),
-                                       ("filesystem", "finding"), ("filesystem", "error"),
-                                       ("stdin", "finding"), ("stdin", "error")):
-            with self.subTest(source=failed_source, failure=failure), tempfile.TemporaryDirectory(prefix="autoreview-codex-fallback.") as tmpdir:
-                events: list[str] = []
-                packs: list[Path] = []
+        with tempfile.TemporaryDirectory(prefix="autoreview-codex-fallback.") as tmpdir:
+            events = []
 
-                def scanner(command, _cwd, **kwargs):
-                    source = command[1]
-                    pack = Path(command[2]) if source == "filesystem" else Path(kwargs["stdin"].name)
-                    data = pack.read_bytes() if source == "filesystem" else kwargs["stdin"].read()
-                    packs.append(pack)
-                    self.assertEqual(data, prompt.encode("utf-8"))
-                    events.append(source)
-                    code = 0
-                    if "gpt-5.6-sol" in events and source == failed_source:
-                        code = {"finding": AUTOREVIEW.TRUFFLEHOG_FINDINGS_EXIT_CODE, "error": 1}.get(failure, 0)
-                    return subprocess.CompletedProcess(command, code, "", "")
+            def fake_run(command, _cwd, **kwargs):
+                self.assertEqual(kwargs["input_text"], prompt)
+                model = command[command.index("--model") + 1]
+                events.append(model)
+                if model == "gpt-5.6-sol":
+                    return subprocess.CompletedProcess(
+                        command, 1, "",
+                        "The model `gpt-5.6-sol` does not exist or you do not have access to it.",
+                    )
+                output_path = Path(command[command.index("--output-last-message") + 1])
+                output_path.write_text(json.dumps(FINAL_REPORT))
+                return subprocess.CompletedProcess(command, 0, "", "")
 
-                def fake_run(command, _cwd, **kwargs):
-                    self.assertEqual(kwargs["input_text"], prompt)
-                    model = command[command.index("--model") + 1]
-                    events.append(model)
-                    if model == "gpt-5.6-sol":
-                        if failure == "missing":
-                            find.return_value = None
-                        return subprocess.CompletedProcess(
-                            command, 1, "",
-                            "The model `gpt-5.6-sol` does not exist or you do not have access to it.",
-                        )
-                    output_path = Path(command[command.index("--output-last-message") + 1])
-                    output_path.write_text(json.dumps(FINAL_REPORT))
-                    return subprocess.CompletedProcess(command, 0, "", "")
-
-                with mock.patch.object(AUTOREVIEW, "resolve_command", return_value="/usr/bin/codex"), \
-                        mock.patch.object(AUTOREVIEW, "ensure_codex_isolation_supported", return_value="/usr/bin/codex"), \
-                        mock.patch.object(AUTOREVIEW, "codex_auth_config_flags", return_value=[]), \
-                        mock.patch.object(AUTOREVIEW, "prepare_codex_runtime_auth", return_value=None), \
-                        mock.patch.object(AUTOREVIEW, "find_command", return_value="/trusted/trufflehog") as find, \
-                        mock.patch.object(AUTOREVIEW, "run", side_effect=scanner), \
-                        mock.patch.object(AUTOREVIEW, "run_with_heartbeat", side_effect=fake_run):
-                    if failure:
-                        with self.assertRaisesRegex(SystemExit, "refusing to send review pack"):
-                            AUTOREVIEW.run_reviewer(args, Path(tmpdir), prompt, set(), [])
-                    else:
-                        report = AUTOREVIEW.run_reviewer(args, Path(tmpdir), prompt, set(), [])
-                        self.assertEqual(report["findings"], [])
-                expected = ["filesystem", "stdin", "gpt-5.6-sol"]
-                if failure != "missing":
-                    expected.append("filesystem")
-                    if failed_source != "filesystem":
-                        expected.append("stdin")
-                if not failure:
-                    expected.append("gpt-5.6-terra")
-                self.assertEqual(events, expected)
-                self.assertTrue(all(not pack.parent.exists() for pack in packs))
+            with mock.patch.object(AUTOREVIEW, "resolve_command", return_value="/usr/bin/codex"), \
+                    mock.patch.object(AUTOREVIEW, "ensure_codex_isolation_supported", return_value="/usr/bin/codex"), \
+                    mock.patch.object(AUTOREVIEW, "codex_auth_config_flags", return_value=[]), \
+                    mock.patch.object(AUTOREVIEW, "prepare_codex_runtime_auth", return_value=None), \
+                    mock.patch.object(AUTOREVIEW, "find_command", side_effect=AssertionError("unexpected scanner lookup")), \
+                    mock.patch.object(AUTOREVIEW, "run_with_heartbeat", side_effect=fake_run):
+                report = AUTOREVIEW.run_reviewer(args, Path(tmpdir), prompt, set(), [])
+                self.assertEqual(report["findings"], [])
+            self.assertEqual(events, ["gpt-5.6-sol", "gpt-5.6-terra"])
 
     def test_codex_runs_outside_repo_with_bundle_only_workspace(self) -> None:
         args = argparse.Namespace(

--- a/skills/autoreview/tests/test_autoreview_hardening.py
+++ b/skills/autoreview/tests/test_autoreview_hardening.py
@@ -267,18 +267,6 @@ def installed_java() -> str | None:
     return java if probe.returncode == 0 else None
 
 
-def add_fake_trufflehog(
-    helper: dict[str, object],
-    root: Path,
-    env: dict[str, str],
-) -> None:
-    write_executable(
-        root / "trufflehog",
-        "#!/usr/bin/env python3\nraise SystemExit(0)\n",
-    )
-    env["PATH"] = f"{root}{os.pathsep}{env.get('PATH', '')}"
-
-
 def path_excluding_command(name: str) -> str:
     """Build a PATH value with every directory that resolves ``name``
     removed, so a subprocess launched with it cannot find that command
@@ -700,7 +688,7 @@ class AutoreviewMixedTargetTests(unittest.TestCase):
                     path.unlink()
                 provider = mock.Mock()
                 with mock.patch.dict(self.helper["run_reviewer"].__globals__, {
-                    "scan_outgoing_review_pack": lambda *_: None, "run_engine": provider,
+                    "run_engine": provider,
                 }), contextlib.redirect_stderr(io.StringIO()):
                     refusal = "unsafe mixed source mode" if mutation.startswith("index ") else "mixed source changed|symlinked mixed source"
                     with self.assertRaisesRegex(SystemExit, refusal):
@@ -708,16 +696,14 @@ class AutoreviewMixedTargetTests(unittest.TestCase):
                                                      repo, passes[0], captured, [])
                 provider.assert_not_called()
 
-    def test_complete_and_per_pass_scans_include_new_authoritative_context(self):
+    def test_every_pass_sends_complete_authoritative_context(self):
         with self.migration(scan_sentinel=True) as (repo, *_):
-            # This unchanged line is outside every diff hunk, but now sent as
-            # authoritative source and therefore part of the frozen-input scan.
+            # Unchanged authoritative source outside diff hunks reaches the reviewer.
             captured = self.helper["local_bundle"](repo)
             self.assertNotIn("SOURCE_ONLY_SCAN_SENTINEL", captured.text)
             evidence = [self.helper["ReviewDataset"]("evidence.txt", "evidence\n" * 6000)]
-            scans, sends = [], []
+            sends = []
             with mock.patch.dict(self.helper["prepare_review_prompts"].__globals__, {
-                "scan_outgoing_review_pack": lambda _repo, prompt: scans.append(prompt),
                 "run_engine": lambda _args, _repo, prompt: sends.append(prompt) or json.dumps({
                     "findings": [], "overall_correctness": "patch is correct",
                     "overall_explanation": "Synthetic clean.", "overall_confidence": 0.9,
@@ -725,24 +711,21 @@ class AutoreviewMixedTargetTests(unittest.TestCase):
             }), contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(io.StringIO()):
                 passes = self.helper["prepare_review_prompts"](repo, "local", None, captured, "", evidence, 30_000)
                 self.assertGreater(len(passes), 1)
-                self.assertEqual(len(scans), 1)
-                self.assertIn("SOURCE_ONLY_SCAN_SENTINEL\nMULTILINE_SCAN_CONTINUATION\n", scans[0])
-                self.assertIn(evidence[0].content, scans[0])
                 args = argparse.Namespace(engine="codex", max_priority="P0")
                 self.helper["run_review_passes"](args, [args], repo, passes, captured)
-            self.assertEqual(scans[1:], sends)
-            for item, scanned in zip(passes, scans[1:]):
-                self.assertEqual(item.prompt, scanned)
+            self.assertEqual(len(passes), len(sends))
+            for item, sent in zip(passes, sends):
+                self.assertEqual(item.prompt, sent)
                 for record in item.chunk.sources:
-                    self.assertIn(record.index.content, scanned)
-                    self.assertIn(record.working_tree.content, scanned)
+                    self.assertIn(record.index.content, sent)
+                    self.assertIn(record.working_tree.content, sent)
 
     def test_honest_capacity_refusal_and_no_legacy_metadata_bypass(self):
         with self.migration() as (repo, *_):
             captured = self.helper["local_bundle"](repo)
-            scan, provider = mock.Mock(), mock.Mock()
+            provider = mock.Mock()
             with mock.patch.dict(self.helper["prepare_review_prompts"].__globals__, {
-                "scan_outgoing_review_pack": scan, "run_engine": provider,
+                "run_engine": provider,
             }):
                 with self.assertRaisesRegex(SystemExit, r"mixed source src/migrate-0.py .*index=.*working_tree=.*prompt limit 1000"):
                     self.helper["prepare_review_prompts"](repo, "local", None, captured, "", [], 1000)
@@ -755,7 +738,6 @@ class AutoreviewMixedTargetTests(unittest.TestCase):
                 datasets = [self.helper["ReviewDataset"]("e" * 4000 + ".txt", "evidence")]
                 with self.assertRaisesRegex(SystemExit, r"mixed source src/migrate-\d.py .*prompt limit"):
                     self.helper["prepare_review_prompts"](repo, "local", None, captured, "", datasets, budget)
-            scan.assert_not_called()
             provider.assert_not_called()
 
 
@@ -802,7 +784,6 @@ class AutoreviewMixedTargetTests(unittest.TestCase):
                         with mock.patch.dict(self.helper["main_impl"].__globals__, {
                             "repo_root": lambda: repo,
                             "prepare_review_prompts": lambda *args: original_prepare(*args) * count,
-                            "scan_outgoing_review_pack": lambda *_: None,
                             "run_engine": lambda *_: json.dumps(provider),
                         }), mock.patch.object(sys, "argv", argv), contextlib.redirect_stdout(text), \
                                 contextlib.redirect_stderr(io.StringIO()):
@@ -923,7 +904,7 @@ class AutoreviewMixedTargetTests(unittest.TestCase):
             self.assertEqual(self.helper["source_tree_snapshot"](repo), before)
             provider = mock.Mock()
             with mock.patch.dict(self.helper["run_reviewer"].__globals__, {
-                "scan_outgoing_review_pack": lambda *_: None, "run_engine": provider,
+                "run_engine": provider,
             }), contextlib.redirect_stderr(io.StringIO()):
                 with self.assertRaisesRegex(SystemExit, "evidence changed"):
                     self.helper["run_reviewer"](argparse.Namespace(engine="codex"), repo, passes[0], captured, [],
@@ -982,7 +963,7 @@ class AutoreviewHardeningTests(unittest.TestCase):
             (repo / "source.md").write_text("after\n")
             (repo / "evidence").mkdir()
             (repo / "evidence/note.md").write_text("frozen evidence\r\n")
-            sends, scans = [], []
+            sends = []
             stdout, stderr = io.StringIO(), io.StringIO()
 
             def engine(_args, _repo, prompt):
@@ -997,16 +978,15 @@ class AutoreviewHardeningTests(unittest.TestCase):
             with mock.patch.dict(self.helper["main_impl"].__globals__, {
                 "repo_root": lambda: repo,
                 "run_engine": engine,
-                "scan_outgoing_review_pack": lambda _repo, prompt: scans.append(prompt),
                 "resolve_engine_binary": lambda *_args: (True, None),
             }), mock.patch.object(sys, "argv", [str(SCRIPT), "--mode", "local", *options]), \
                     contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
-                yield repo, sends, scans, stdout, stderr
+                yield repo, sends, stdout, stderr
 
     def test_preparation_reuses_untracked_capture_and_keeps_three_full_snapshots(self):
         for explicit in (False, True):
             options = ("--dataset", "note.md") if explicit else ()
-            with self.subTest(explicit=explicit), self.preparation_fixture(*options) as (repo, sends, scans, _out, err):
+            with self.subTest(explicit=explicit), self.preparation_fixture(*options) as (repo, sends, _out, err):
                 (repo / "note.md").write_text("untracked evidence\n")
                 read = mock.Mock(wraps=self.helper["file_bundle_snapshot"])
                 fingerprint = mock.Mock(wraps=self.helper["source_file_fingerprint"])
@@ -1014,7 +994,6 @@ class AutoreviewHardeningTests(unittest.TestCase):
                     "file_bundle_snapshot": read, "source_file_fingerprint": fingerprint,
                 }):
                     self.assertEqual(self.helper["main_impl"](), 0)
-                self.assertEqual(scans, sends)
                 # Explicit evidence has its own initial capture and three fresh
                 # checks; finding membership never adds another content read.
                 self.assertEqual(read.call_count, 5 if explicit else 1)
@@ -1040,7 +1019,7 @@ class AutoreviewHardeningTests(unittest.TestCase):
             self.assertFalse(sends)
 
     def test_preparation_progress_precedes_snapshot(self):
-        with self.preparation_fixture() as (_repo, sends, _scans, _out, err):
+        with self.preparation_fixture() as (_repo, sends, _out, err):
             def snapshot(*_args, **_kwargs):
                 self.assertIn("preparation: initial source snapshot", err.getvalue())
                 self.assertFalse(sends)
@@ -1051,20 +1030,19 @@ class AutoreviewHardeningTests(unittest.TestCase):
                     self.helper["main_impl"]()
 
     def test_dry_run_reuses_capture_without_whole_tree_snapshots(self):
-        with self.preparation_fixture("--dry-run", "--dataset", "evidence/note.md") as (_repo, sends, scans, *_):
+        with self.preparation_fixture("--dry-run", "--dataset", "evidence/note.md") as (_repo, sends, *_):
             snapshot = mock.Mock(side_effect=AssertionError("dry run must not sweep the checkout"))
             with mock.patch.dict(self.helper["main_impl"].__globals__, {"source_tree_snapshot": snapshot}):
                 self.assertEqual(self.helper["main_impl"](), 0)
             snapshot.assert_not_called()
-            self.assertTrue(scans)
             self.assertFalse(sends)
 
     def test_evidence_mutations_refuse_stale_publication_and_later_passes(self):
         for tracked in (False, True):
-            for timing in ("construction", "scan", "review", "between passes"):
+            for timing in ("construction", "preparation", "review", "between passes"):
                 with self.subTest(tracked=tracked, timing=timing), self.preparation_fixture(
                     "--prompt-file", "evidence/note.md", "--dataset", "evidence/note.md",
-                ) as (repo, sends, _scans, out, _err):
+                ) as (repo, sends, out, _err):
                     evidence = repo / "evidence/note.md"
                     if tracked:
                         git(repo, "add", "-f", "evidence/note.md")
@@ -1092,8 +1070,13 @@ class AutoreviewHardeningTests(unittest.TestCase):
                         return result
 
                     patches = {"run_engine": engine, "build_bundle": build}
-                    if timing == "scan":
-                        patches["scan_outgoing_review_pack"] = lambda *_args: mutate()
+                    if timing == "preparation":
+                        original_prepare = self.helper["prepare_review_prompts"]
+                        def prepare(*args):
+                            result = original_prepare(*args)
+                            mutate()
+                            return result
+                        patches["prepare_review_prompts"] = prepare
                     if timing == "between passes":
                         original_prepare = self.helper["prepare_review_prompts"]
                         patches["prepare_review_prompts"] = lambda *args: original_prepare(*args) * 2
@@ -1148,7 +1131,7 @@ class AutoreviewHardeningTests(unittest.TestCase):
         with self.preparation_fixture(
             "--prompt-file", "evidence/note.md", "--dataset", "evidence/note.md",
             "--dataset", "evidence/note.md",
-        ) as (repo, sends, scans, *_):
+        ) as (repo, sends, *_):
             evidence = (repo / "evidence/note.md").read_bytes().decode()
             original = self.helper["prepare_review_prompts"]
             with mock.patch.dict(self.helper["main_impl"].__globals__, {
@@ -1156,7 +1139,6 @@ class AutoreviewHardeningTests(unittest.TestCase):
             }):
                 self.assertEqual(self.helper["main_impl"](), 0)
             self.assertEqual(len(sends), 2)
-            self.assertEqual(scans, sends)
             for prompt in sends:
                 self.assertEqual(prompt.count(evidence), 3)
 
@@ -1280,155 +1262,6 @@ class AutoreviewHardeningTests(unittest.TestCase):
                 self.assertEqual(captured.paths, {"task.md"})
                 self.assertIn("+task change", captured.text)
 
-    def test_outgoing_pack_scan_disables_installed_scanner_updates(self) -> None:
-        prompt = "harmless review pack\npreserved CRLF\r\nfinal line\r"
-        with tempfile.TemporaryDirectory() as tempdir:
-            root = Path(tempdir)
-            repo = root / "repo"
-            repo.mkdir()
-            write_executable(
-                root / "trufflehog",
-                r'''#!/usr/bin/env python3
-import json
-from pathlib import Path
-import sys
-
-args = sys.argv[1:]
-if "--no-update" not in args:
-    print("updater: cannot move binary: permission denied", file=sys.stderr)
-    raise SystemExit(1)
-source = args[0]
-assert source in {"filesystem", "stdin"}
-pack = Path(args[1]) if source == "filesystem" else None
-assert set(args[2:] if pack else args[1:]) == {
-    "--json", "--no-color", "--results=verified,unknown",
-    "--fail", "--fail-on-scan-errors", "--no-update",
-}
-payload = pack.read_bytes() if pack else sys.stdin.buffer.read()
-with Path(__file__).with_name("scans.jsonl").open("a", encoding="utf-8") as records:
-    records.write(json.dumps({
-        "source": source,
-        "pack": str(pack) if pack else None,
-        "prompt": payload.decode("utf-8"),
-    }) + "\n")
-''',
-            )
-            with mock.patch.dict(
-                os.environ,
-                {"PATH": f"{root}{os.pathsep}{os.environ.get('PATH', '')}"},
-            ):
-                self.helper["scan_outgoing_review_pack"](repo, prompt)
-
-            records = [json.loads(line) for line in (root / "scans.jsonl").read_text(encoding="utf-8").splitlines()]
-            self.assertEqual([record["source"] for record in records], ["filesystem", "stdin"])
-            self.assertEqual([record["prompt"] for record in records], [prompt, prompt])
-            self.assertFalse(Path(records[0]["pack"]).parent.exists())
-
-    def test_outgoing_pack_scan_reads_exact_prompt_including_deleted_lines(self) -> None:
-        prompt = (
-            "# Change Bundle\n"
-            "diff --git a/config.ts b/config.ts\n"
-            "deleted file mode 100644\n"
-            "--- a/config.ts\n"
-            "+++ /dev/null\n"
-            "@@ -1 +0,0 @@\n"
-            "-const apiKey = \"removed-but-still-sensitive\";\n"
-        )
-        with tempfile.TemporaryDirectory() as tempdir:
-            repo = init_repo(Path(tempdir))
-            sources = []
-
-            def run_scanner(
-                command: list[str],
-                cwd: Path,
-                **kwargs: object,
-            ) -> subprocess.CompletedProcess[str]:
-                sources.append(command[1])
-                if command[1] == "filesystem":
-                    payload = Path(command[2]).read_bytes()
-                else:
-                    self.assertEqual(command[1], "stdin")
-                    payload = kwargs["stdin"].read()
-                self.assertEqual(payload, prompt.encode("utf-8"))
-                self.assertIn("-const apiKey", prompt)
-                return subprocess.CompletedProcess(command, 0, "", "")
-
-            with mock.patch.dict(
-                self.helper["scan_outgoing_review_pack"].__globals__,
-                {
-                    "find_command": lambda _name, _repo: "/trusted/trufflehog",
-                    "run": run_scanner,
-                },
-            ):
-                self.helper["scan_outgoing_review_pack"](repo, prompt)
-            self.assertEqual(sources, ["filesystem", "stdin"])
-
-    def test_deleted_input_scan_refusal_is_redacted_and_blocks_provider(self) -> None:
-        prompt = (
-            "# Change Bundle\n"
-            "diff --git a/config.ts b/config.ts\n"
-            "deleted file mode 100644\n"
-            "--- a/config.ts\n"
-            "+++ /dev/null\n"
-            "@@ -1 +0,0 @@\n"
-            "-const apiKey = \"removed-but-still-sensitive\";\n"
-        )
-        finding = {
-            "SourceMetadata": {
-                "Data": {
-                    "Filesystem": {
-                        "file": "review-pack.txt",
-                        "line": 7,
-                    }
-                }
-            },
-            "Raw": "must-not-be-printed",
-        }
-        with tempfile.TemporaryDirectory() as tempdir:
-            repo = init_repo(Path(tempdir))
-            packs = []
-            provider = mock.Mock()
-
-            def run_scanner(command, cwd, **_kwargs):
-                self.assertEqual(command[1], "filesystem")
-                pack = Path(command[2])
-                self.assertEqual(pack.parent, cwd)
-                self.assertEqual(pack.read_bytes(), prompt.encode("utf-8"))
-                packs.append(pack)
-                return subprocess.CompletedProcess(
-                    command, self.helper["TRUFFLEHOG_FINDINGS_EXIT_CODE"], json.dumps(finding) + "\n", "",
-                )
-
-            with mock.patch.dict(
-                self.helper["run_reviewer"].__globals__,
-                {
-                    "find_command": lambda _name, _repo: "/trusted/trufflehog",
-                    "run": run_scanner,
-                    "run_engine": provider,
-                },
-            ), contextlib.redirect_stderr(io.StringIO()):
-                with self.assertRaisesRegex(SystemExit, "TruffleHog found credentials") as error:
-                    self.helper["run_reviewer"](
-                        argparse.Namespace(engine="codex", max_priority="P0"), repo, prompt, set(), [],
-                    )
-            self.assertEqual(len(packs), 1)
-            self.assertFalse(packs[0].parent.exists())
-            provider.assert_not_called()
-        self.assertEqual(
-            str(error.exception),
-            "refusing to send review pack: TruffleHog found credentials; "
-            "remove credential material from selected changes, prompt files, and datasets, then rerun",
-        )
-
-    def test_outgoing_pack_scan_fails_closed_when_scanner_is_missing(self) -> None:
-        with tempfile.TemporaryDirectory() as tempdir:
-            repo = init_repo(Path(tempdir))
-            with mock.patch.dict(
-                self.helper["scan_outgoing_review_pack"].__globals__,
-                {"find_command": lambda _name, _repo: None},
-            ):
-                with self.assertRaisesRegex(SystemExit, "refusing to send review pack"):
-                    self.helper["scan_outgoing_review_pack"](repo, "prompt")
 
     def test_local_bundle_preserves_boundary_when_sensitive_diff_is_omitted(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:
@@ -1517,7 +1350,7 @@ with Path(__file__).with_name("scans.jsonl").open("a", encoding="utf-8") as reco
 
     @contextlib.contextmanager
     def nested_worktree_fixture(self, *, linked_root=False, name="scratch/review branch"):
-        with self.preparation_fixture() as (main, sends, scans, out, err):
+        with self.preparation_fixture() as (main, sends, out, err):
             repo = main
             if linked_root:
                 repo = main.parent / "reviewed checkout"
@@ -1525,15 +1358,15 @@ with Path(__file__).with_name("scans.jsonl").open("a", encoding="utf-8") as reco
                 (repo / "source.md").write_text("outer linked change\n", encoding="utf-8")
             child = repo / name
             git(main, "worktree", "add", "--detach", str(child), "HEAD")
-            yield repo, child, sends, scans, out, err
+            yield repo, child, sends, out, err
 
-    def test_nested_worktree_keeps_neighboring_untracked_files_in_outgoing_scans(self):
+    def test_nested_worktree_keeps_neighboring_untracked_files_in_review(self):
         names = ["scratch/review branch"]
         if os.name != "nt":
             names.append("scratch/review\nbranch")
         for name in names:
             with self.subTest(name=name), self.nested_worktree_fixture(name=name) as (
-                repo, child, sends, scans, _out, _err,
+                repo, child, sends, _out, _err,
             ):
                 ordinary = {
                     ".worktrees/notes.md": "OUTER_WORKTREE_DIRECTORY_NOTE\n",
@@ -1549,9 +1382,7 @@ with Path(__file__).with_name("scans.jsonl").open("a", encoding="utf-8") as reco
                 captured = self.helper["local_bundle"](repo)
                 self.assertEqual(captured.paths, {"source.md", *ordinary})
                 self.assertEqual(self.helper["main_impl"](), 0)
-                self.assertEqual(scans, sends)
-                self.assertTrue(scans)
-                for pack in scans:
+                for pack in sends:
                     for marker in ordinary.values():
                         self.assertIn(marker.strip(), pack)
                     self.assertNotIn("CHILD_SOURCE_NOT_REVIEWED", pack)
@@ -1730,7 +1561,6 @@ with Path(__file__).with_name("scans.jsonl").open("a", encoding="utf-8") as reco
             # Expected patches must use the same protected Git policy.
             staged = self.helper["git"](repo, "diff", *self.helper["SAFE_DIFF_FLAGS"], "--cached", incoming)
             unstaged = self.helper["git"](repo, "diff", *self.helper["SAFE_DIFF_FLAGS"])
-            scanned: list[str] = []
             sent: list[str] = []
             report = {
                 "findings": [{
@@ -1753,7 +1583,6 @@ with Path(__file__).with_name("scans.jsonl").open("a", encoding="utf-8") as reco
             main = self.helper["main_impl"]
             with mock.patch.dict(main.__globals__, {
                 "repo_root": lambda: repo,
-                "scan_outgoing_review_pack": lambda _repo, prompt: scanned.append(prompt),
                 "run_engine": run_engine,
                 "resolve_engine_binary": lambda _reviewer, _repo: (True, None),
             }):
@@ -1765,7 +1594,6 @@ with Path(__file__).with_name("scans.jsonl").open("a", encoding="utf-8") as reco
                         self.assertEqual(main(), 0 if dry_run else 1)
 
             self.assertEqual(len(sent), 1)
-            self.assertEqual(scanned, [sent[0], sent[0]])
             self.assertIn(f"# Staged Diff\nbase: {incoming}", sent[0])
             self.assertIn(staged.rstrip(), sent[0])
             self.assertIn(unstaged.rstrip(), sent[0])
@@ -1893,7 +1721,7 @@ with Path(__file__).with_name("scans.jsonl").open("a", encoding="utf-8") as reco
             for engine in ("codex", "claude", "amp", "pi", "kimi"):
                 for mode, ref, accepted, expected_exit in cases:
                     with self.subTest(engine=engine, mode=mode, ref=bool(ref)):
-                        scans, sends = [], []
+                        sends = []
 
                         def run_engine(_args, _repo, prompt):
                             sends.append(prompt)
@@ -1907,7 +1735,6 @@ with Path(__file__).with_name("scans.jsonl").open("a", encoding="utf-8") as reco
                         output = io.StringIO()
                         with mock.patch.dict(self.helper["main_impl"].__globals__, {
                             "repo_root": lambda: repo, "run_engine": run_engine,
-                            "scan_outgoing_review_pack": lambda _repo, prompt: scans.append(prompt),
                         }), mock.patch.object(sys, "argv", argv), contextlib.redirect_stdout(output), contextlib.redirect_stderr(io.StringIO()):
                             self.assertEqual(self.helper["main_impl"](), expected_exit)
                         result = json.loads((root / "result.json").read_text())
@@ -1922,7 +1749,6 @@ with Path(__file__).with_name("scans.jsonl").open("a", encoding="utf-8") as reco
                         self.assertNotIn("clean:", text)
                         rejected = result.get("scope_rejected_findings", [])
                         self.assertEqual(len(rejected), 2 - len(accepted))
-                        self.assertEqual(scans, sends)
                         self.assertIn("# Dataset: " + str(Path(e2e)), sends[0])
                         self.assertNotIn("OMIT_STAGED_STORE", sends[0])
                         self.assertNotIn("OMIT_UNTRACKED_ENV", sends[0])
@@ -1980,7 +1806,6 @@ with Path(__file__).with_name("scans.jsonl").open("a", encoding="utf-8") as reco
                         with mock.patch.dict(self.helper["main_impl"].__globals__, {
                             "repo_root": lambda: repo,
                             "build_review_prompts": lambda *_args: ["synthetic pack"] * count,
-                            "scan_outgoing_review_pack": lambda *_args: None,
                             "run_engine": lambda *_args: json.dumps(provider),
                         }), mock.patch.object(sys, "argv", argv), contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(io.StringIO()):
                             self.assertEqual(self.helper["main_impl"](), exit_code)
@@ -2036,7 +1861,6 @@ with Path(__file__).with_name("scans.jsonl").open("a", encoding="utf-8") as reco
                         with mock.patch.dict(self.helper["main_impl"].__globals__, {
                             "repo_root": lambda: repo,
                             "build_review_prompts": lambda *_args: ["synthetic pack"] * count,
-                            "scan_outgoing_review_pack": lambda *_args: None,
                             "run_engine": engine,
                         }), mock.patch.object(sys, "argv", argv), contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(io.StringIO()):
                             with self.assertRaises((SystemExit, OSError)):
@@ -2102,7 +1926,6 @@ with Path(__file__).with_name("scans.jsonl").open("a", encoding="utf-8") as reco
             git(repo, "commit", "-q", "--allow-empty", "-m", "base")
             (repo / "source.txt").write_text("review me\n")
             env = os.environ.copy()
-            add_fake_trufflehog(self.helper, root, env)
             env.update({"HOME": str(root), "USERPROFILE": str(root)})
             for engine, source in (("codex", fake_codex_script()), ("claude", fake_claude_script())):
                 for timeout in (False, True):
@@ -2128,70 +1951,6 @@ with Path(__file__).with_name("scans.jsonl").open("a", encoding="utf-8") as reco
                         self.assertNotIn("DIAGNOSTIC_SENTINEL", sidecar.read_text())
                         self.assertNotIn("\x1b", result.stderr)
 
-    def test_credential_source_exception_still_scans_every_outgoing_input(self) -> None:
-        source = "Sources/Configuration/CredentialFile.swift"
-        with tempfile.TemporaryDirectory() as tempdir:
-            repo = init_repo(Path(tempdir))
-            path = repo / source
-            path.parent.mkdir(parents=True)
-            path.write_text("// DELETED_SCAN_MARKER\n", encoding="utf-8")
-            git(repo, "add", source)
-            git(repo, "commit", "-q", "-m", "base")
-            path.write_text("// STAGED_SCAN_MARKER\n", encoding="utf-8")
-            git(repo, "add", source)
-            untracked = repo / "Runtime/CredentialFile.swift"
-            untracked.parent.mkdir()
-            untracked.write_text("// UNTRACKED_SCAN_MARKER\n", encoding="utf-8")
-            evidence = self.helper["capture_evidence_inputs"](argparse.Namespace(
-                prompt=["PROMPT_SCAN_MARKER"], prompt_file=[source],
-                dataset=[str(untracked.relative_to(repo))],
-            ), repo)
-            extra, datasets = evidence.prompt, evidence.datasets
-            bundle, _paths, _mixed, _spans = self.helper["local_bundle"](repo)
-            pack, = self.helper["build_review_prompts"](repo, "local", None, bundle, extra, datasets)
-            provider = mock.Mock(return_value=json.dumps({
-                "findings": [], "overall_correctness": "patch is correct",
-                "overall_explanation": "Synthetic review.", "overall_confidence": 0.8,
-            }))
-            for marker in (None, "DELETED_SCAN_MARKER", "STAGED_SCAN_MARKER", "UNTRACKED_SCAN_MARKER", "PROMPT_SCAN_MARKER"):
-                events = []
-
-                def scanner(command, _repo, **kwargs):
-                    source_kind = command[1]
-                    if source_kind == "filesystem":
-                        outgoing = Path(command[2])
-                        payload = outgoing.read_bytes()
-                    else:
-                        self.assertEqual(source_kind, "stdin")
-                        outgoing = Path(kwargs["stdin"].name)
-                        payload = kwargs["stdin"].read()
-                    self.assertEqual(payload, pack.encode("utf-8"))
-                    if os.name != "nt":
-                        self.assertEqual(stat.S_IMODE(outgoing.stat().st_mode), 0o600)
-                    self.assertIn("--results=verified,unknown", command)
-                    self.assertIn("--no-update", command)
-                    for token in ("-// DELETED_SCAN_MARKER", "+// STAGED_SCAN_MARKER", "UNTRACKED_SCAN_MARKER", "PROMPT_SCAN_MARKER", "# Dataset:", "# Prompt file:"):
-                        self.assertIn(token, pack)
-                    events.append(source_kind)
-                    if marker:
-                        line = next(i for i, text in enumerate(pack.splitlines(), 1) if marker in text)
-                        detected = {"SourceMetadata": {"Data": {"Filesystem": {"file": str(outgoing), "line": line}}}}
-                        return subprocess.CompletedProcess(command, self.helper["TRUFFLEHOG_FINDINGS_EXIT_CODE"], json.dumps(detected), "")
-                    return subprocess.CompletedProcess(command, 0, "", "")
-
-                provider.reset_mock()
-                with self.subTest(marker=marker), mock.patch.dict(self.helper["run_reviewer"].__globals__, {
-                    "find_command": lambda *_args: "/trusted/trufflehog", "run": scanner, "run_engine": provider,
-                }):
-                    args = argparse.Namespace(engine="codex", max_priority="P2")
-                    if marker:
-                        with self.assertRaisesRegex(SystemExit, "refusing to send review pack"):
-                            self.helper["run_reviewer"](args, repo, pack, {source}, [])
-                        provider.assert_not_called()
-                    else:
-                        self.helper["run_reviewer"](args, repo, pack, {source}, [])
-                        provider.assert_called_once_with(args, repo, pack)
-                    self.assertEqual(events, ["filesystem"] if marker else ["filesystem", "stdin"])
 
     def test_tracked_binary_changes_are_blocked_in_all_modes(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:
@@ -2952,12 +2711,9 @@ with Path(__file__).with_name("scans.jsonl").open("a", encoding="utf-8") as reco
         with tempfile.TemporaryDirectory() as tempdir:
             repo = init_repo(Path(tempdir))
             bundle = "diff --git a/code.py b/code.py\n" + "+review me\n" * 20_000
-            with mock.patch.dict(self.helper["prepare_review_prompts"].__globals__, {
-                "scan_outgoing_review_pack": mock.Mock(),
-            }):
-                prompts = self.helper["prepare_review_prompts"](
-                    repo, "local", None, bundle, "", [], 120_000
-                )
+            prompts = self.helper["prepare_review_prompts"](
+                repo, "local", None, bundle, "", [], 120_000
+            )
             self.assertGreater(len(prompts), 1)
             for prompt in prompts:
                 self.assertIn(
@@ -2965,38 +2721,6 @@ with Path(__file__).with_name("scans.jsonl").open("a", encoding="utf-8") as reco
                     prompt,
                 )
 
-    def test_partitioned_input_scans_complete_content_before_any_send(self) -> None:
-        with tempfile.TemporaryDirectory() as tempdir:
-            repo = init_repo(Path(tempdir))
-            sentinel = "synthetic scanner boundary " + "x" * 160_000 + " end sentinel"
-            for source in ("diff", "dataset"):
-                with self.subTest(source=source):
-                    bundle = "+" + (sentinel if source == "diff" else "safe") + "\n" * 30_000
-                    datasets = (
-                        [self.helper["ReviewDataset"]("evidence.txt", sentinel)]
-                        if source == "dataset" else []
-                    )
-                    prompts = self.helper["build_review_prompts"](
-                        repo, "local", None, bundle, "", datasets, 120_000
-                    )
-                    self.assertGreater(len(prompts), 1)
-                    self.assertFalse(any(sentinel in prompt for prompt in prompts))
-                    scanned = []
-
-                    def scan(_repo, prompt):
-                        scanned.append(prompt)
-                        if sentinel in prompt:
-                            raise SystemExit("complete input scanner rejection")
-
-                    with mock.patch.dict(
-                        self.helper["prepare_review_prompts"].__globals__,
-                        {"scan_outgoing_review_pack": scan},
-                    ), self.assertRaisesRegex(SystemExit, "complete input scanner rejection"):
-                        self.helper["prepare_review_prompts"](
-                            repo, "local", None, bundle, "", datasets, 120_000
-                        )
-                    self.assertEqual(len(scanned), 1)
-                    self.assertIn(sentinel, scanned[0])
 
     def test_review_prompt_preserves_bundle_ending_whitespace(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:
@@ -3030,15 +2754,11 @@ with Path(__file__).with_name("scans.jsonl").open("a", encoding="utf-8") as reco
             "category": "bug",
             "code_location": {"file_path": "source.txt", "line": 1},
         }
-        for failure in (None, "scan", "engine"):
+        for failure in (None, "engine"):
             with self.subTest(failure=failure), tempfile.TemporaryDirectory() as tempdir:
                 repo = init_repo(Path(tempdir))
                 events = []
 
-                def scan(_repo, prompt):
-                    events.append(("scan", prompt))
-                    if failure == "scan" and prompt == prompts[8]:
-                        raise SystemExit("late scan failure")
 
                 def engine(_args, _repo, prompt):
                     events.append(("engine", prompt))
@@ -3058,7 +2778,7 @@ with Path(__file__).with_name("scans.jsonl").open("a", encoding="utf-8") as reco
 
                 with mock.patch.dict(
                     self.helper["run_review_passes"].__globals__,
-                    {"scan_outgoing_review_pack": scan, "run_engine": engine},
+                    {"run_engine": engine},
                 ), contextlib.redirect_stdout(io.StringIO()):
                     if failure:
                         with self.assertRaisesRegex(SystemExit, f"late {failure} failure"):
@@ -3076,10 +2796,10 @@ with Path(__file__).with_name("scans.jsonl").open("a", encoding="utf-8") as reco
                             [item["title"] for item in report["findings"]], [finding["title"]]
                         )
                 expected = [
-                    (stage, prompt) for prompt in prompts for stage in ("scan", "engine")
+                    ("engine", prompt) for prompt in prompts
                 ]
                 if failure:
-                    expected = expected[:17 if failure == "scan" else 18]
+                    expected = expected[:9]
                 self.assertEqual(events, expected)
 
     def test_review_patch_does_not_disclose_controls_in_omitted_paths(self) -> None:
@@ -3429,28 +3149,6 @@ with Path(__file__).with_name("scans.jsonl").open("a", encoding="utf-8") as reco
             patch,
         )
 
-    @unittest.skipUnless(
-        shutil.which("trufflehog"), "TruffleHog binary not installed"
-    )
-    def test_outgoing_pack_scan_accepts_deleted_swift_status_literals(self) -> None:
-        # Live-scanner companion to the regression above: TruffleHog must not
-        # flag the benign "ok-token" status literal in a deleted-file bundle.
-        source = (FIXTURES / "swift-benign-status-literals.swift").read_text(
-            encoding="utf-8"
-        )
-        prompt = (
-            "# Change Bundle\n"
-            "diff --git a/apps/macos/MenuContentView.swift "
-            "b/apps/macos/MenuContentView.swift\n"
-            "deleted file mode 100644\n"
-            "--- a/apps/macos/MenuContentView.swift\n"
-            "+++ /dev/null\n"
-            f"@@ -1,{len(source.splitlines())} +0,0 @@\n"
-            + "".join(f"-{line}\n" for line in source.splitlines())
-        )
-        with tempfile.TemporaryDirectory() as tempdir:
-            repo = init_repo(Path(tempdir))
-            self.helper["scan_outgoing_review_pack"](repo, prompt)
 
     def test_review_bundle_preserves_typescript_config_paths(self) -> None:
         source = (FIXTURES / "typescript-benign-config-path-references.ts").read_text(
@@ -4378,7 +4076,6 @@ with Path(__file__).with_name("scans.jsonl").open("a", encoding="utf-8") as reco
             )
             record_path = root / "record.json"
             env = os.environ.copy()
-            add_fake_trufflehog(self.helper, root, env)
             env.update(
                 {
                     "AUTOREVIEW_FAKE_MUTATE": str(source),
@@ -5791,7 +5488,6 @@ os.execv(target, [str(target), *sys.argv[1:]])
 ''',
             )
             env = os.environ.copy()
-            add_fake_trufflehog(self.helper, root, env)
             env.update(
                 {
                     "CODEX_HOME": str(source_home),
@@ -5888,7 +5584,6 @@ os.execv(target, [str(target), *sys.argv[1:]])
             invocations = root / "codex-invocations.jsonl"
             record = root / "codex-record.json"
             env = os.environ.copy()
-            add_fake_trufflehog(self.helper, root, env)
             env.update(
                 {
                     "AUTOREVIEW_FAKE_CODEX_INVOCATIONS": str(invocations),
@@ -6000,10 +5695,7 @@ os.execv(target, [str(target), *sys.argv[1:]])
                 root / "codex",
                 fake_codex_script(),
             )
-            # Dry run scans the exact prompt too, so use a deterministic
-            # scanner instead of relying on the host installation.
             env = {**os.environ, "CODEX_HOME": str(root)}
-            add_fake_trufflehog(self.helper, root, env)
 
             result = subprocess.run(
                 [
@@ -6043,7 +5735,6 @@ os.execv(target, [str(target), *sys.argv[1:]])
                 fake_codex_script(),
             )
             env = os.environ.copy()
-            add_fake_trufflehog(self.helper, root, env)
             repo_temp = repo / "tmp"
             repo_temp.mkdir()
             env.update(
@@ -6074,7 +5765,7 @@ os.execv(target, [str(target), *sys.argv[1:]])
             )
 
             self.assertEqual(result.returncode, 1, result.stdout + result.stderr)
-            self.assertIn("prompt: FAILED", result.stdout)
+            self.assertIn("prompt: OK", result.stdout)
             self.assertIn("must be outside the reviewed repository", result.stdout)
             self.assertRegex(
                 result.stdout,
@@ -6082,8 +5773,8 @@ os.execv(target, [str(target), *sys.argv[1:]])
             )
 
     @unittest.skipIf(os.name == "nt", "the fake executable is POSIX-only")
-    def test_dry_run_flag_exits_nonzero_when_trufflehog_missing(self) -> None:
-        # Dry run applies the same exact-pack scan as a real provider call.
+    def test_dry_run_succeeds_without_trufflehog(self) -> None:
+        # Dry run needs only the reviewer CLI, with no external scanner.
         with tempfile.TemporaryDirectory() as tempdir:
             root = Path(tempdir)
             repo = init_repo(root)
@@ -6116,11 +5807,8 @@ os.execv(target, [str(target), *sys.argv[1:]])
                 check=False,
             )
 
-            self.assertEqual(result.returncode, 1, result.stdout + result.stderr)
-            self.assertIn("prompt: FAILED", result.stdout)
-            self.assertIn("TruffleHog is required but was not found", result.stdout)
-            self.assertIn(self.helper["TRUFFLEHOG_INSTALL_URL"], result.stdout)
-            # The engine itself still resolves; only trufflehog should fail.
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            self.assertIn("prompt: OK", result.stdout)
             self.assertRegex(result.stdout, r"engine check: codex[^\n]* OK\b")
 
     def test_dry_run_flag_exits_nonzero_when_codex_no_tools(self) -> None:
@@ -6235,7 +5923,6 @@ os.execv(target, [str(target), *sys.argv[1:]])
                 preflight.__globals__,
                 {
                     "build_review_prompts": capturing,
-                    "scan_outgoing_review_pack": lambda _repo, _prompt: None,
                 },
             ):
                 with contextlib.redirect_stdout(stdout):
@@ -6258,7 +5945,6 @@ os.execv(target, [str(target), *sys.argv[1:]])
                 fake_codex_script(),
             )
             env = {**os.environ, "CODEX_HOME": str(root)}
-            add_fake_trufflehog(self.helper, root, env)
 
             result = subprocess.run(
                 [
@@ -6300,7 +5986,6 @@ os.execv(target, [str(target), *sys.argv[1:]])
                 fake_pi_script(),
             )
             env = os.environ.copy()
-            add_fake_trufflehog(self.helper, root, env)
             env["AUTOREVIEW_FAKE_PI_VERSION"] = "0.50.0"
 
             result = subprocess.run(
@@ -6339,7 +6024,6 @@ os.execv(target, [str(target), *sys.argv[1:]])
                 fake_pi_script(),
             )
             env = os.environ.copy()
-            add_fake_trufflehog(self.helper, root, env)
 
             result = subprocess.run(
                 [
@@ -6378,7 +6062,6 @@ os.execv(target, [str(target), *sys.argv[1:]])
                 fake_kimi_script(),
             )
             env = os.environ.copy()
-            add_fake_trufflehog(self.helper, root, env)
             env["AUTOREVIEW_FAKE_KIMI_VERSION"] = "0.10.0"
 
             result = subprocess.run(
@@ -6417,7 +6100,6 @@ os.execv(target, [str(target), *sys.argv[1:]])
                 fake_kimi_script(),
             )
             env = os.environ.copy()
-            add_fake_trufflehog(self.helper, root, env)
             # Isolate KIMI_CODE_HOME to an empty, hermetic directory instead
             # of leaking the host's real ~/.kimi-code (which may or may not
             # exist) into this test; an empty source share has no
@@ -6465,7 +6147,6 @@ os.execv(target, [str(target), *sys.argv[1:]])
                 fake_kimi_script(),
             )
             env = os.environ.copy()
-            add_fake_trufflehog(self.helper, root, env)
             env["KIMI_CODE_HOME"] = str(repo / ".kimi-code")
 
             result = subprocess.run(
@@ -6520,7 +6201,6 @@ os.execv(target, [str(target), *sys.argv[1:]])
             source_share.mkdir()
             (source_share / "device_id").write_text("not-a-valid-id!!", encoding="utf-8")
             env = os.environ.copy()
-            add_fake_trufflehog(self.helper, root, env)
             env["KIMI_CODE_HOME"] = str(source_share)
 
             result = subprocess.run(
@@ -6573,7 +6253,6 @@ os.execv(target, [str(target), *sys.argv[1:]])
             source_share.mkdir()
             (source_share / "credentials").write_text("not-a-directory", encoding="utf-8")
             env = os.environ.copy()
-            add_fake_trufflehog(self.helper, root, env)
             env["KIMI_CODE_HOME"] = str(source_share)
 
             result = subprocess.run(
@@ -6625,7 +6304,6 @@ os.execv(target, [str(target), *sys.argv[1:]])
             )
             (source_share / "credentials").mkdir()
             env = os.environ.copy()
-            add_fake_trufflehog(self.helper, root, env)
             env["KIMI_CODE_HOME"] = str(source_share)
 
             result = subprocess.run(
@@ -6670,7 +6348,6 @@ os.execv(target, [str(target), *sys.argv[1:]])
                 fake_claude_script(),
             )
             env = os.environ.copy()
-            add_fake_trufflehog(self.helper, root, env)
 
             result = subprocess.run(
                 [
@@ -6713,7 +6390,6 @@ os.execv(target, [str(target), *sys.argv[1:]])
                 fake_kimi_script(),
             )
             env = os.environ.copy()
-            add_fake_trufflehog(self.helper, root, env)
             # Prompt limits must not depend on the host's Kimi configuration.
             env["KIMI_CODE_HOME"] = str(root / "kimi-empty-home")
             (root / "kimi-empty-home").mkdir()
@@ -6771,7 +6447,6 @@ os.execv(target, [str(target), *sys.argv[1:]])
                 fake_codex_script(),
             )
             env = {**os.environ, "CODEX_HOME": str(root)}
-            add_fake_trufflehog(self.helper, root, env)
 
             result = subprocess.run(
                 [
@@ -6816,7 +6491,6 @@ os.execv(target, [str(target), *sys.argv[1:]])
                 fake_codex_script(),
             )
             env = {**os.environ, "CODEX_HOME": str(root)}
-            add_fake_trufflehog(self.helper, root, env)
 
             result = subprocess.run(
                 [
@@ -6857,7 +6531,6 @@ os.execv(target, [str(target), *sys.argv[1:]])
                 fake_codex_script(),
             )
             env = os.environ.copy()
-            add_fake_trufflehog(self.helper, root, env)
 
             result = subprocess.run(
                 [

--- a/skills/autoreview/tests/test_codex_inference_route.py
+++ b/skills/autoreview/tests/test_codex_inference_route.py
@@ -93,7 +93,7 @@ class CodexInferenceRouteTests(unittest.TestCase):
         text += '\n[mcp_servers.unrelated]\ncommand = "must-not-execute"\n'
         (self.home / "config.toml").write_text(text, encoding="utf-8")
 
-    def run_review(self, *, prepare_auth=None, during_run=None, scan=None):
+    def run_review(self, *, prepare_auth=None, during_run=None):
         observed = {}
 
         def fake_run(command, cwd, **kwargs):
@@ -126,12 +126,9 @@ class CodexInferenceRouteTests(unittest.TestCase):
             "ensure_codex_isolation_supported": mock.Mock(return_value="synthetic-codex"),
             "resolve_command": mock.Mock(return_value="synthetic-codex"),
             "run_with_heartbeat": fake_run,
-            "scan_outgoing_review_pack": mock.Mock(),
         }
         if prepare_auth is not None:
             replacements["prepare_codex_runtime_auth"] = prepare_auth
-        if scan is not None:
-            replacements["scan_outgoing_review_pack"] = scan
         with mock.patch.dict(self.helper["run_codex"].__globals__, replacements):
             observed["report"] = self.helper["run_codex"](self.args, self.repo, "synthetic review")
         return observed
@@ -222,8 +219,8 @@ class CodexInferenceRouteTests(unittest.TestCase):
                     command, 1, "", "The model gpt-5.6-sol does not exist or you do not have access to it.",
                 )
 
-        self.run_review(during_run=respond, scan=lambda *_: events.append("scan"))
-        self.assertEqual(events, ["gpt-5.6-sol", "scan", "gpt-5.6-terra"])
+        self.run_review(during_run=respond)
+        self.assertEqual(events, ["gpt-5.6-sol", "gpt-5.6-terra"])
         self.assertEqual(launchers[0], launchers[1])
 
     def test_primary_only_catalogue_does_not_block_successful_primary(self):


### PR DESCRIPTION
Remove the TruffleHog dependency from canonical autoreview, restoring the behavior requested in [#209](https://github.com/openclaw/agent-skills/pull/209) and synced to [openclaw/openclaw#133626](https://github.com/openclaw/openclaw/pull/133626). [#212](https://github.com/openclaw/agent-skills/pull/212) subsequently restored the scanner.

Provider calls, partitioned prompt preparation, Codex fallback, and dry-run preflight no longer invoke or require TruffleHog. Every reviewer pass retains the instruction to report suspected real credentials as P0 without reproducing values. Source/evidence integrity checks, sensitive-path exclusions, reviewer isolation, mixed-source attribution, and review-result validation remain in place.

The scanner-free policy is intentional for enterprise compatibility: maintainers report enterprise security teams flagging or restricting TruffleHog, making a mandatory dependency prevent developer adoption. [Truffle Security confirms attackers used TruffleHog in Shai-Hulud](https://trufflesecurity.com/blog/the-rise-of-api-worms); this is evidence of tool abuse, not a claim that TruffleHog itself was breached.

The canonical skill now records this rationale and requires an explicit maintainer policy decision before reintroducing a scanner. A comment at the provider call points to that policy. Before, the skill stated the behavior without its rationale; now it explains the enterprise constraint, transmission tradeoff, and decision history.

Validation:
- Before: the dry-run regression against current upstream fails with `TruffleHog is required but was not found`.
- After: the same regression succeeds with TruffleHog absent from PATH.
- Provider regressions cover all five engines and Codex fallback without scanner lookup or invocation.
- Full autoreview suite: 277 cases, with 275 passing and one platform skip; the remaining stale scanner-stage assertion was updated and passes in the focused rerun (2/2).
- Skill validation, Python compilation, installer tests (6), validator tests (9), and whitespace checks pass.
- The unsafe-temporary-root regression still refuses execution at reviewer-isolation preflight; its updated assertion and the no-TruffleHog dry-run regression both pass.

Review tradeoff: independent Codex autoreview raised one P1 about removing pre-transmission credential screening. That is the explicitly requested policy change; reviewer findings occur after transmission and are not a substitute for a pre-send gate. This PR does not claim a clean independent-review verdict.


