### PR TITLE
fix(transcript): tokenize local paths before redaction

### DIFF
--- a/skills/agent-transcript/scripts/agent-transcript
+++ b/skills/agent-transcript/scripts/agent-transcript
@@ -382,11 +382,14 @@ function transformWithoutHttpUrls(text, transform, stats) {
   const urls = [];
   const protectedText = text.replace(/\bhttps?:\/\/[^\s`"'<>]+/gi, (url) => {
     const punctuation = /[\])},.;!?]+$/.exec(url)?.[0] ?? "";
-    const coreUrl = punctuation ? url.slice(0, -punctuation.length) : url;
+    let coreUrl = punctuation ? url.slice(0, -punctuation.length) : url;
+    const adjacentField = /,[A-Za-z_][\w]*=/.exec(coreUrl);
+    const remainder = adjacentField ? coreUrl.slice(adjacentField.index) : "";
+    if (adjacentField) coreUrl = coreUrl.slice(0, adjacentField.index);
     const key = `BEAMNETWORKURL${urls.length}END`;
     const sanitized = stats ? sanitizeNetworkUrl(coreUrl, stats) : coreUrl;
     urls.push(`${sanitized}${punctuation}`);
-    return key;
+    return `${key}${remainder}`;
   });
   const transformed = transform(protectedText);
   if (typeof transformed !== "string") return transformed;
@@ -412,7 +415,7 @@ function redactLocalPaths(text, stats) {
   );
   next = transformWithoutHttpUrls(next, (value) => {
     let transformed = value;
-    const prefix = "(^|[\\s\\[\\{:`\"'(=,>|;&]|-[A-Za-z][A-Za-z0-9]*)";
+    const prefix = "(^|[\\s\\[\\{:`\"'(=,>|;&@]|-[A-Za-z][A-Za-z0-9]*)";
     transformed = replaceTracked(
       transformed,
       new RegExp(`${prefix}(\\.\\.?[\\\\/][^\\s\`"'<>),;]+)`, "gm"),

--- a/skills/agent-transcript/scripts/agent-transcript
+++ b/skills/agent-transcript/scripts/agent-transcript
@@ -380,13 +380,14 @@ function sanitizeNetworkUrl(url, stats) {
 
 function transformWithoutHttpUrls(text, transform, stats) {
   const urls = [];
+  const tokenId = process.hrtime.bigint().toString(36);
   const protectedText = text.replace(/\bhttps?:\/\/[^\s`"'<>]+/gi, (url) => {
     const punctuation = /[\])},.;!?]+$/.exec(url)?.[0] ?? "";
     let coreUrl = punctuation ? url.slice(0, -punctuation.length) : url;
-    const adjacentField = /,[A-Za-z_][\w]*=/.exec(coreUrl);
+    const adjacentField = /[,;][A-Za-z_][\w-]*=/.exec(coreUrl);
     const remainder = adjacentField ? coreUrl.slice(adjacentField.index) : "";
     if (adjacentField) coreUrl = coreUrl.slice(0, adjacentField.index);
-    const key = `BEAMNETWORKURL${urls.length}END`;
+    const key = `BEAMNETWORKURL${tokenId}N${urls.length}END`;
     const sanitized = stats ? sanitizeNetworkUrl(coreUrl, stats) : coreUrl;
     urls.push(`${sanitized}${punctuation}`);
     return `${key}${remainder}`;
@@ -394,8 +395,8 @@ function transformWithoutHttpUrls(text, transform, stats) {
   const transformed = transform(protectedText);
   if (typeof transformed !== "string") return transformed;
   return transformed.replace(
-    /BEAMNETWORKURL(\d+)END/g,
-    (_match, index) => urls[Number(index)],
+    new RegExp(`BEAMNETWORKURL${tokenId}N(\\d+)END`, "g"),
+    (_match, index) => urls[Number(index)] ?? _match,
   );
 }
 

--- a/skills/agent-transcript/scripts/agent-transcript
+++ b/skills/agent-transcript/scripts/agent-transcript
@@ -412,27 +412,37 @@ function redactLocalPaths(text, stats) {
   );
   next = transformWithoutHttpUrls(next, (value) => {
     let transformed = value;
+    const prefix = "(^|[\\s\\[\\{:`\"'(=,>|;&]|-[A-Za-z][A-Za-z0-9]*)";
     transformed = replaceTracked(
       transformed,
-      /(^|[\s\[\{:`"'(=,>|;&])(\.\.?[\\/][^\s`"'<>),;]+)/gm,
+      new RegExp(`${prefix}(\\.\\.?[\\\\/][^\\s\`"'<>),;]+)`, "gm"),
       "$1[LOCAL_PATH]",
       stats,
     );
     transformed = replaceTracked(
       transformed,
-      /(^|[\s\[\{:`"'(=,>|;&])([A-Za-z]:[\\/](?:(?:[^\\/\r\n,;`"'<>]+[\\/])+[^\\/\s\r\n,;`"'<>]+|[^\\/\s\r\n,;`"'<>]+))/gm,
+      new RegExp(
+        `${prefix}([A-Za-z]:[\\\\/](?:(?:[^\\\\/\\s\\r\\n,;\`"'<>]+[\\\\/])+[^\\\\/\\s\\r\\n,;\`"'<>]+|[^\\\\/\\s\\r\\n,;\`"'<>]+))`,
+        "gm",
+      ),
       "$1[LOCAL_PATH]",
       stats,
     );
     transformed = replaceTracked(
       transformed,
-      /(^|[\s\[\{:`"'(=,>|;&])(\/(?:(?:[^/\r\n,;`"'<>]+\/)+[^/\s\r\n,;`"'<>]+|[^/\s\r\n,;`"'<>]+))/gm,
+      new RegExp(
+        `${prefix}(\\/(?:(?:[^/\\s\\r\\n,;\`"'<>]+\\/)+[^/\\s\\r\\n,;\`"'<>]+|[^/\\s\\r\\n,;\`"'<>]+))`,
+        "gm",
+      ),
       "$1[LOCAL_PATH]",
       stats,
     );
     transformed = replaceTracked(
       transformed,
-      /(^|[\s\[\{:`"'(=,>|;&])(\\\\[^\\\r\n,;`"'<>]+\\(?:[^\\\r\n,;`"'<>]+\\)*[^\\\s\r\n,;`"'<>]+)/gm,
+      new RegExp(
+        `${prefix}(\\\\\\\\[^\\\\\\s\\r\\n,;\`"'<>]+\\\\(?:[^\\\\\\s\\r\\n,;\`"'<>]+\\\\)*[^\\\\\\s\\r\\n,;\`"'<>]+)`,
+        "gm",
+      ),
       "$1[LOCAL_PATH]",
       stats,
     );

--- a/skills/agent-transcript/scripts/agent-transcript
+++ b/skills/agent-transcript/scripts/agent-transcript
@@ -400,65 +400,109 @@ function transformWithoutHttpUrls(text, transform, stats) {
   );
 }
 
+function startsLocalPath(text, index) {
+  const slice = text.slice(index);
+  if (/^file:/i.test(slice)) return slice.match(/^file:(?:\/\/)?/i)?.[0] ?? "file:";
+  if (slice.startsWith("~/")) return "~/";
+  if (slice.startsWith("../")) return "../";
+  if (slice.startsWith("./")) return "./";
+  if (slice.startsWith("\\\\")) return "\\\\";
+  if (/^[A-Za-z]:[\\/]/.test(slice)) return slice.slice(0, 3);
+  if (slice.startsWith("/") && !slice.startsWith("//")) return "/";
+  return "";
+}
+
+function isAdjacentFieldSeparator(text, index) {
+  return /[,;][A-Za-z_][\w-]*=/.test(text.slice(index));
+}
+
+function looksLikeLocalPathToken(value) {
+  const trimmed = String(value).trim();
+  if (!trimmed) return false;
+  return Boolean(startsLocalPath(trimmed, 0)) || isLocalPathText(trimmed);
+}
+
+function pathLabel(value) {
+  return String(value).trim().startsWith("~/") ? "[HOME_PATH]" : "[LOCAL_PATH]";
+}
+
+function tryQuotedLocalPath(text, index) {
+  const quote = text[index];
+  if (quote !== '"' && quote !== "'") return null;
+  const end = text.indexOf(quote, index + 1);
+  if (end === -1) return null;
+  const inner = text.slice(index + 1, end);
+  if (!looksLikeLocalPathToken(inner)) return null;
+  return { end: end + 1, replacement: pathLabel(inner) };
+}
+
+function tryDelimitedLocalPath(text, index, open, close) {
+  if (!text.startsWith(open, index)) return null;
+  const end = text.indexOf(close, index + open.length);
+  if (end === -1) return null;
+  const inner = text.slice(index + open.length, end);
+  if (!looksLikeLocalPathToken(inner)) return null;
+  return { end: end + close.length, replacement: `${open}${pathLabel(inner)}${close}` };
+}
+
+function consumeUnquotedLocalPath(text, start) {
+  const kind = startsLocalPath(text, start);
+  if (!kind) return start;
+  let index = start + kind.length;
+  while (index < text.length) {
+    const ch = text[index];
+    if (/[\s`"'<>)\]}]/.test(ch)) break;
+    if ((ch === "," || ch === ";") && isAdjacentFieldSeparator(text, index)) break;
+    index += 1;
+  }
+  if (index <= start + kind.length) return start;
+  return index;
+}
+
+function redactPathTokens(text, stats) {
+  let out = "";
+  let index = 0;
+  let hits = 0;
+  while (index < text.length) {
+    const quoted = tryQuotedLocalPath(text, index);
+    if (quoted) {
+      out += quoted.replacement;
+      index = quoted.end;
+      hits += 1;
+      continue;
+    }
+    let delimited = tryDelimitedLocalPath(text, index, "```", "```");
+    if (!delimited) delimited = tryDelimitedLocalPath(text, index, "**", "**");
+    if (!delimited) delimited = tryDelimitedLocalPath(text, index, "__", "__");
+    if (!delimited) delimited = tryDelimitedLocalPath(text, index, "`", "`");
+    if (!delimited) delimited = tryDelimitedLocalPath(text, index, "*", "*");
+    if (!delimited) delimited = tryDelimitedLocalPath(text, index, "_", "_");
+    if (delimited) {
+      out += delimited.replacement;
+      index = delimited.end;
+      hits += 1;
+      continue;
+    }
+    const pathEnd = consumeUnquotedLocalPath(text, index);
+    if (pathEnd > index) {
+      out += pathLabel(text.slice(index, pathEnd));
+      index = pathEnd;
+      hits += 1;
+      continue;
+    }
+    out += text[index];
+    index += 1;
+  }
+  if (hits) stats.redactions += hits;
+  return out;
+}
+
 function redactLocalPaths(text, stats) {
-  let next = text;
-  next = replaceTracked(
-    next,
-    /(["'])(?:file:(?:\/\/)?|\.\.?[\\/]|\/(?!\/)|[A-Za-z]:[\\/]|\\\\)[^"'\r\n]+\1/gi,
-    "[LOCAL_PATH]",
+  return transformWithoutHttpUrls(
+    text,
+    (value) => redactPathTokens(value, stats),
     stats,
   );
-  next = replaceTracked(
-    next,
-    /\bfile:(?:\/\/)?[^\s`"'<>),;]+/gi,
-    "[LOCAL_PATH]",
-    stats,
-  );
-  next = transformWithoutHttpUrls(next, (value) => {
-    let transformed = value;
-    const prefix = "(^|[\\s\\[\\{:`\"'(=,>|;&@]|-[A-Za-z][A-Za-z0-9]*)";
-    transformed = replaceTracked(
-      transformed,
-      new RegExp(`${prefix}(\\.\\.?[\\\\/][^\\s\`"'<>);]+)`, "gm"),
-      "$1[LOCAL_PATH]",
-      stats,
-    );
-    transformed = replaceTracked(
-      transformed,
-      new RegExp(
-        `${prefix}([A-Za-z]:[\\\\/](?:(?:[^\\\\/\\s\\r\\n;\`"'<>]+[\\\\/])+[^\\\\/\\s\\r\\n;\`"'<>]+|[^\\\\/\\s\\r\\n;\`"'<>]+))`,
-        "gm",
-      ),
-      "$1[LOCAL_PATH]",
-      stats,
-    );
-    transformed = replaceTracked(
-      transformed,
-      new RegExp(
-        `${prefix}(\\/(?:(?:[^/\\s\\r\\n;\`"'<>]+\\/)+[^/\\s\\r\\n;\`"'<>]+|[^/\\s\\r\\n;\`"'<>]+))`,
-        "gm",
-      ),
-      "$1[LOCAL_PATH]",
-      stats,
-    );
-    transformed = replaceTracked(
-      transformed,
-      new RegExp(
-        `${prefix}(\\\\\\\\[^\\\\\\s\\r\\n;\`"'<>]+\\\\(?:[^\\\\\\s\\r\\n;\`"'<>]+\\\\)*[^\\\\\\s\\r\\n;\`"'<>]+)`,
-        "gm",
-      ),
-      "$1[LOCAL_PATH]",
-      stats,
-    );
-    transformed = replaceTracked(
-      transformed,
-      /~\/[^\s`"'<>);]+/g,
-      "[HOME_PATH]",
-      stats,
-    );
-    return transformed;
-  }, stats);
-  return next;
 }
 
 function redact(input, stats) {

--- a/skills/agent-transcript/scripts/agent-transcript
+++ b/skills/agent-transcript/scripts/agent-transcript
@@ -400,12 +400,19 @@ function transformWithoutHttpUrls(text, transform, stats) {
   );
 }
 
+function hasCompilerAttachedPrefix(text, index) {
+  if (index === 0) return false;
+  let i = index - 1;
+  if (!/[A-Za-z]/.test(text[i])) return false;
+  while (i > 0 && /[A-Za-z]/.test(text[i - 1])) i -= 1;
+  return i > 0 && text[i - 1] === "-";
+}
+
 function hasPathStartBoundary(text, index) {
   if (index === 0) return true;
   const prev = text[index - 1];
   if (/[\s`"'<>=:({[,;@]/.test(prev)) return true;
-  if (prev === "I" && index >= 2 && text[index - 2] === "-") return true;
-  return false;
+  return hasCompilerAttachedPrefix(text, index);
 }
 
 function startsLocalPath(text, index) {
@@ -453,11 +460,38 @@ function tryDelimitedLocalPath(text, index, open, close) {
   while (cursor < text.length && !/[\s<>]/.test(text[cursor])) {
     cursor += 1;
   }
-  if (cursor < innerStart + close.length) return null;
-  if (!text.startsWith(close, cursor - close.length)) return null;
-  const inner = text.slice(innerStart, cursor - close.length);
+  let tokenEnd = cursor;
+  while (tokenEnd > innerStart && /[,.;:!?]/.test(text[tokenEnd - 1])) {
+    tokenEnd -= 1;
+  }
+  if (tokenEnd < innerStart + close.length) return null;
+  if (!text.startsWith(close, tokenEnd - close.length)) return null;
+  const inner = text.slice(innerStart, tokenEnd - close.length);
   if (!looksLikeLocalPathToken(inner)) return null;
-  return { end: cursor, replacement: `${open}${pathLabel(inner)}${close}` };
+  return { end: tokenEnd, replacement: `${open}${pathLabel(inner)}${close}` };
+}
+
+function tryAnyDelimitedLocalPath(text, index) {
+  const ch = text[index];
+  if (ch === "`") {
+    return (
+      tryDelimitedLocalPath(text, index, "```", "```") ||
+      tryDelimitedLocalPath(text, index, "`", "`")
+    );
+  }
+  if (ch === "*") {
+    return (
+      tryDelimitedLocalPath(text, index, "**", "**") ||
+      tryDelimitedLocalPath(text, index, "*", "*")
+    );
+  }
+  if (ch === "_") {
+    return (
+      tryDelimitedLocalPath(text, index, "__", "__") ||
+      tryDelimitedLocalPath(text, index, "_", "_")
+    );
+  }
+  return null;
 }
 
 function consumeUnquotedLocalPath(text, start) {
@@ -469,7 +503,7 @@ function consumeUnquotedLocalPath(text, start) {
     if (/[\s`"'<>)}]/.test(ch)) break;
     if (ch === "]") {
       const next = text[index + 1];
-      if (next && /[A-Za-z0-9._[+-]/.test(next)) {
+      if (next && /[A-Za-z0-9._/[+-]/.test(next)) {
         index += 1;
         continue;
       }
@@ -494,12 +528,7 @@ function redactPathTokens(text, stats) {
       hits += 1;
       continue;
     }
-    let delimited = tryDelimitedLocalPath(text, index, "```", "```");
-    if (!delimited) delimited = tryDelimitedLocalPath(text, index, "**", "**");
-    if (!delimited) delimited = tryDelimitedLocalPath(text, index, "__", "__");
-    if (!delimited) delimited = tryDelimitedLocalPath(text, index, "`", "`");
-    if (!delimited) delimited = tryDelimitedLocalPath(text, index, "*", "*");
-    if (!delimited) delimited = tryDelimitedLocalPath(text, index, "_", "_");
+    const delimited = tryAnyDelimitedLocalPath(text, index);
     if (delimited) {
       out += delimited.replacement;
       index = delimited.end;

--- a/skills/agent-transcript/scripts/agent-transcript
+++ b/skills/agent-transcript/scripts/agent-transcript
@@ -303,6 +303,150 @@ function hasSetupBlob(text) {
   );
 }
 
+function replaceTracked(text, pattern, replacement, stats) {
+  const next = text.replace(pattern, replacement);
+  if (next !== text) stats.redactions++;
+  return next;
+}
+
+function decodePercentRuns(value) {
+  let current = String(value).replaceAll("+", " ");
+  for (let depth = 0; depth < 8; depth++) {
+    const malformed =
+      depth === 0
+        ? /%(?![0-9A-Fa-f]{2})/.test(current)
+        : /%(?=[A-Za-z0-9]{2})/.test(current);
+    if (malformed) return { value: current, complete: false };
+    if (!/%[0-9A-Fa-f]{2}/.test(current)) {
+      return { value: current, complete: true };
+    }
+    let invalid = false;
+    const decoded = current.replace(/(?:%[0-9A-Fa-f]{2})+/g, (encoded) => {
+      try {
+        return decodeURIComponent(encoded);
+      } catch {
+        invalid = true;
+        return encoded;
+      }
+    });
+    if (invalid) return { value: current, complete: false };
+    if (decoded === current) return { value: current, complete: true };
+    current = decoded.replaceAll("+", " ");
+  }
+  return { value: current, complete: false };
+}
+
+function isLocalPathText(value) {
+  const decoded = String(value).trim();
+  return /^(?:file:(?:\/\/)?|~\/|\.\.?[\\/]|\/(?!\/)|[A-Za-z]:[\\/]|\\\\)/i.test(
+    decoded,
+  );
+}
+
+function containsLocalPathValue(value) {
+  const decoded = decodePercentRuns(value);
+  if (!decoded.complete) return true;
+  if (isLocalPathText(decoded.value)) return true;
+  return (
+    /\bfile:(?:\/\/)?[^\s]+/i.test(decoded.value) ||
+    /(^|[\s\[\{:`"'(=,>|;&])\.\.?[\\/][^\s]+/m.test(decoded.value) ||
+    /(^|[\s\[\{:`"'(=,>|;&])[A-Za-z]:[\\/][^\s]+/m.test(decoded.value) ||
+    /(^|[\s\[\{:`"'(=,>|;&])\/(?!\/)[^\s]+/m.test(decoded.value) ||
+    /(^|[\s\[\{:`"'(=,>|;&])\\\\[^\\\s]+\\[^\s]+/m.test(decoded.value) ||
+    /(^|[\s\[\{:`"'(=,>|;&])~\/[^\s]+/m.test(decoded.value)
+  );
+}
+
+function sanitizeNetworkUrl(url, stats) {
+  let changed = false;
+  const sanitized = url.replace(
+    /([?&#])(?:([^=&#\s]*)=([^&#\s]*)|([^=&#\s]+))/g,
+    (whole, delimiter, assignedKey, value, flagKey) => {
+      const key = assignedKey ?? flagKey;
+      if (containsLocalPathValue(key)) {
+        changed = true;
+        return `${delimiter}[LOCAL_PATH]`;
+      }
+      if (assignedKey !== undefined && containsLocalPathValue(value)) {
+        changed = true;
+        return `${delimiter}${key}=[LOCAL_PATH]`;
+      }
+      return whole;
+    },
+  );
+  if (changed) stats.redactions++;
+  return sanitized;
+}
+
+function transformWithoutHttpUrls(text, transform, stats) {
+  const urls = [];
+  const protectedText = text.replace(/\bhttps?:\/\/[^\s`"'<>]+/gi, (url) => {
+    const punctuation = /[\])},.;!?]+$/.exec(url)?.[0] ?? "";
+    const coreUrl = punctuation ? url.slice(0, -punctuation.length) : url;
+    const key = `BEAMNETWORKURL${urls.length}END`;
+    const sanitized = stats ? sanitizeNetworkUrl(coreUrl, stats) : coreUrl;
+    urls.push(`${sanitized}${punctuation}`);
+    return key;
+  });
+  const transformed = transform(protectedText);
+  if (typeof transformed !== "string") return transformed;
+  return transformed.replace(
+    /BEAMNETWORKURL(\d+)END/g,
+    (_match, index) => urls[Number(index)],
+  );
+}
+
+function redactLocalPaths(text, stats) {
+  let next = text;
+  next = replaceTracked(
+    next,
+    /(["'])(?:file:(?:\/\/)?|\.\.?[\\/]|\/(?!\/)|[A-Za-z]:[\\/]|\\\\)[^"'\r\n]+\1/gi,
+    "[LOCAL_PATH]",
+    stats,
+  );
+  next = replaceTracked(
+    next,
+    /\bfile:(?:\/\/)?[^\s`"'<>),;]+/gi,
+    "[LOCAL_PATH]",
+    stats,
+  );
+  next = transformWithoutHttpUrls(next, (value) => {
+    let transformed = value;
+    transformed = replaceTracked(
+      transformed,
+      /(^|[\s\[\{:`"'(=,>|;&])(\.\.?[\\/][^\s`"'<>),;]+)/gm,
+      "$1[LOCAL_PATH]",
+      stats,
+    );
+    transformed = replaceTracked(
+      transformed,
+      /(^|[\s\[\{:`"'(=,>|;&])([A-Za-z]:[\\/](?:(?:[^\\/\r\n,;`"'<>]+[\\/])+[^\\/\s\r\n,;`"'<>]+|[^\\/\s\r\n,;`"'<>]+))/gm,
+      "$1[LOCAL_PATH]",
+      stats,
+    );
+    transformed = replaceTracked(
+      transformed,
+      /(^|[\s\[\{:`"'(=,>|;&])(\/(?:(?:[^/\r\n,;`"'<>]+\/)+[^/\s\r\n,;`"'<>]+|[^/\s\r\n,;`"'<>]+))/gm,
+      "$1[LOCAL_PATH]",
+      stats,
+    );
+    transformed = replaceTracked(
+      transformed,
+      /(^|[\s\[\{:`"'(=,>|;&])(\\\\[^\\\r\n,;`"'<>]+\\(?:[^\\\r\n,;`"'<>]+\\)*[^\\\s\r\n,;`"'<>]+)/gm,
+      "$1[LOCAL_PATH]",
+      stats,
+    );
+    transformed = replaceTracked(
+      transformed,
+      /~\/[^\s`"'<>),;]+/g,
+      "[HOME_PATH]",
+      stats,
+    );
+    return transformed;
+  }, stats);
+  return next;
+}
+
 function redact(input, stats) {
   let s = String(input ?? "");
   const rules = [
@@ -314,8 +458,6 @@ function redact(input, stats) {
     [/\b(?:Bearer|Basic)\s+[A-Za-z0-9._~+/=-]{16,}/gi, "[REDACTED_AUTH_HEADER]"],
     [/[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/gi, "[REDACTED_EMAIL]"],
     [/\b(?:\+?\d[\d .()-]{7,}\d)\b/g, "[REDACTED_PHONE]"],
-    [/\/Users\/[^\s`"'>)]+/g, "[LOCAL_PATH]"],
-    [/~\/[^\s`"'>)]+/g, "[HOME_PATH]"],
     [/([?&](?:token|key|secret|signature|sig|access_token|auth)=)[^\s`"'>&]+/gi, "$1[REDACTED]"],
   ];
   for (const [re, repl] of rules) {
@@ -323,7 +465,7 @@ function redact(input, stats) {
     s = s.replace(re, repl);
     if (s !== before) stats.redactions++;
   }
-  return s;
+  return redactLocalPaths(s, stats);
 }
 
 function unsafe(text) {

--- a/skills/agent-transcript/scripts/agent-transcript
+++ b/skills/agent-transcript/scripts/agent-transcript
@@ -400,6 +400,14 @@ function transformWithoutHttpUrls(text, transform, stats) {
   );
 }
 
+function hasPathStartBoundary(text, index) {
+  if (index === 0) return true;
+  const prev = text[index - 1];
+  if (/[\s`"'<>=:({[,;@]/.test(prev)) return true;
+  if (prev === "I" && index >= 2 && text[index - 2] === "-") return true;
+  return false;
+}
+
 function startsLocalPath(text, index) {
   const slice = text.slice(index);
   if (/^file:/i.test(slice)) return slice.match(/^file:(?:\/\/)?/i)?.[0] ?? "file:";
@@ -408,12 +416,14 @@ function startsLocalPath(text, index) {
   if (slice.startsWith("./")) return "./";
   if (slice.startsWith("\\\\")) return "\\\\";
   if (/^[A-Za-z]:[\\/]/.test(slice)) return slice.slice(0, 3);
-  if (slice.startsWith("/") && !slice.startsWith("//")) return "/";
+  if (slice.startsWith("/") && !slice.startsWith("//") && hasPathStartBoundary(text, index)) {
+    return "/";
+  }
   return "";
 }
 
 function isAdjacentFieldSeparator(text, index) {
-  return /[,;][A-Za-z_][\w-]*=/.test(text.slice(index));
+  return /^[,;][A-Za-z_][\w-]*=/.test(text.slice(index));
 }
 
 function looksLikeLocalPathToken(value) {
@@ -438,11 +448,16 @@ function tryQuotedLocalPath(text, index) {
 
 function tryDelimitedLocalPath(text, index, open, close) {
   if (!text.startsWith(open, index)) return null;
-  const end = text.indexOf(close, index + open.length);
-  if (end === -1) return null;
-  const inner = text.slice(index + open.length, end);
+  const innerStart = index + open.length;
+  let cursor = innerStart;
+  while (cursor < text.length && !/[\s<>]/.test(text[cursor])) {
+    cursor += 1;
+  }
+  if (cursor < innerStart + close.length) return null;
+  if (!text.startsWith(close, cursor - close.length)) return null;
+  const inner = text.slice(innerStart, cursor - close.length);
   if (!looksLikeLocalPathToken(inner)) return null;
-  return { end: end + close.length, replacement: `${open}${pathLabel(inner)}${close}` };
+  return { end: cursor, replacement: `${open}${pathLabel(inner)}${close}` };
 }
 
 function consumeUnquotedLocalPath(text, start) {
@@ -451,7 +466,15 @@ function consumeUnquotedLocalPath(text, start) {
   let index = start + kind.length;
   while (index < text.length) {
     const ch = text[index];
-    if (/[\s`"'<>)\]}]/.test(ch)) break;
+    if (/[\s`"'<>)}]/.test(ch)) break;
+    if (ch === "]") {
+      const next = text[index + 1];
+      if (next && /[A-Za-z0-9._[+-]/.test(next)) {
+        index += 1;
+        continue;
+      }
+      break;
+    }
     if ((ch === "," || ch === ";") && isAdjacentFieldSeparator(text, index)) break;
     index += 1;
   }

--- a/skills/agent-transcript/scripts/agent-transcript
+++ b/skills/agent-transcript/scripts/agent-transcript
@@ -419,14 +419,14 @@ function redactLocalPaths(text, stats) {
     const prefix = "(^|[\\s\\[\\{:`\"'(=,>|;&@]|-[A-Za-z][A-Za-z0-9]*)";
     transformed = replaceTracked(
       transformed,
-      new RegExp(`${prefix}(\\.\\.?[\\\\/][^\\s\`"'<>),;]+)`, "gm"),
+      new RegExp(`${prefix}(\\.\\.?[\\\\/][^\\s\`"'<>);]+)`, "gm"),
       "$1[LOCAL_PATH]",
       stats,
     );
     transformed = replaceTracked(
       transformed,
       new RegExp(
-        `${prefix}([A-Za-z]:[\\\\/](?:(?:[^\\\\/\\s\\r\\n,;\`"'<>]+[\\\\/])+[^\\\\/\\s\\r\\n,;\`"'<>]+|[^\\\\/\\s\\r\\n,;\`"'<>]+))`,
+        `${prefix}([A-Za-z]:[\\\\/](?:(?:[^\\\\/\\s\\r\\n;\`"'<>]+[\\\\/])+[^\\\\/\\s\\r\\n;\`"'<>]+|[^\\\\/\\s\\r\\n;\`"'<>]+))`,
         "gm",
       ),
       "$1[LOCAL_PATH]",
@@ -435,7 +435,7 @@ function redactLocalPaths(text, stats) {
     transformed = replaceTracked(
       transformed,
       new RegExp(
-        `${prefix}(\\/(?:(?:[^/\\s\\r\\n,;\`"'<>]+\\/)+[^/\\s\\r\\n,;\`"'<>]+|[^/\\s\\r\\n,;\`"'<>]+))`,
+        `${prefix}(\\/(?:(?:[^/\\s\\r\\n;\`"'<>]+\\/)+[^/\\s\\r\\n;\`"'<>]+|[^/\\s\\r\\n;\`"'<>]+))`,
         "gm",
       ),
       "$1[LOCAL_PATH]",
@@ -444,7 +444,7 @@ function redactLocalPaths(text, stats) {
     transformed = replaceTracked(
       transformed,
       new RegExp(
-        `${prefix}(\\\\\\\\[^\\\\\\s\\r\\n,;\`"'<>]+\\\\(?:[^\\\\\\s\\r\\n,;\`"'<>]+\\\\)*[^\\\\\\s\\r\\n,;\`"'<>]+)`,
+        `${prefix}(\\\\\\\\[^\\\\\\s\\r\\n;\`"'<>]+\\\\(?:[^\\\\\\s\\r\\n;\`"'<>]+\\\\)*[^\\\\\\s\\r\\n;\`"'<>]+)`,
         "gm",
       ),
       "$1[LOCAL_PATH]",
@@ -452,7 +452,7 @@ function redactLocalPaths(text, stats) {
     );
     transformed = replaceTracked(
       transformed,
-      /~\/[^\s`"'<>),;]+/g,
+      /~\/[^\s`"'<>);]+/g,
       "[HOME_PATH]",
       stats,
     );

--- a/skills/agent-transcript/scripts/agent-transcript.test.mjs
+++ b/skills/agent-transcript/scripts/agent-transcript.test.mjs
@@ -339,6 +339,112 @@ test("render keeps a URL field after a comma-bearing local path", () => {
   assert.doesNotMatch(output, /\/Users\/alice/);
 });
 
+test("render redacts a comma-bearing filename before an adjacent URL field", () => {
+  const dir = tempDir();
+  const session = path.join(dir, "session.jsonl");
+  writeJsonl(session, [
+    {
+      type: "response_item",
+      payload: {
+        role: "user",
+        content: [
+          {
+            type: "text",
+            text: "local=/Users/alice/Acme,Confidential.txt,url=https://example.test/docs",
+          },
+        ],
+      },
+    },
+    { type: "response_item", payload: { role: "assistant", content: [{ type: "text", text: "Done." }] } },
+  ]);
+
+  const output = run(["render", "--session", session]);
+  assert.match(output, /local=\[LOCAL_PATH\]/);
+  assert.match(output, /https:\/\/example\.test\/docs/);
+  assert.doesNotMatch(output, /\/Users\/alice/);
+  assert.doesNotMatch(output, /Confidential/);
+  assert.doesNotMatch(output, /Acme,/);
+});
+
+test("render redacts emphasis paths whose filenames contain the closer", () => {
+  const dir = tempDir();
+  const session = path.join(dir, "session.jsonl");
+  writeJsonl(session, [
+    {
+      type: "response_item",
+      payload: {
+        role: "user",
+        content: [
+          {
+            type: "text",
+            text: "Inspect _/Users/alice/client_secret.txt_",
+          },
+        ],
+      },
+    },
+    { type: "response_item", payload: { role: "assistant", content: [{ type: "text", text: "Done." }] } },
+  ]);
+
+  const output = run(["render", "--session", session]);
+  assert.match(output, /_\[LOCAL_PATH\]_/);
+  assert.doesNotMatch(output, /\/Users\/alice/);
+  assert.doesNotMatch(output, /client_secret/);
+  assert.doesNotMatch(output, /secret\.txt/);
+});
+
+test("render redacts unquoted paths with brackets in the filename", () => {
+  const dir = tempDir();
+  const session = path.join(dir, "session.jsonl");
+  writeJsonl(session, [
+    {
+      type: "response_item",
+      payload: {
+        role: "user",
+        content: [
+          {
+            type: "text",
+            text: "Read /Users/alice/[draft]Acquisition.txt",
+          },
+        ],
+      },
+    },
+    { type: "response_item", payload: { role: "assistant", content: [{ type: "text", text: "Done." }] } },
+  ]);
+
+  const output = run(["render", "--session", session]);
+  assert.match(output, /Read \[LOCAL_PATH\]/);
+  assert.doesNotMatch(output, /\/Users\/alice/);
+  assert.doesNotMatch(output, /Acquisition/);
+  assert.doesNotMatch(output, /\[draft\]/);
+});
+
+test("render leaves slash-separated prose alone", () => {
+  const dir = tempDir();
+  const session = path.join(dir, "session.jsonl");
+  writeJsonl(session, [
+    {
+      type: "response_item",
+      payload: {
+        role: "user",
+        content: [
+          {
+            type: "text",
+            text: "Discuss success/failure and and/or before /Users/alice/private/plan.md",
+          },
+        ],
+      },
+    },
+    { type: "response_item", payload: { role: "assistant", content: [{ type: "text", text: "Done." }] } },
+  ]);
+
+  const output = run(["render", "--session", session]);
+  assert.match(output, /success\/failure/);
+  assert.match(output, /and\/or/);
+  assert.match(output, /\[LOCAL_PATH\]/);
+  assert.doesNotMatch(output, /\/Users\/alice/);
+  assert.doesNotMatch(output, /private\/plan/);
+});
+
 test("render leaves literal URL placeholders in dialogue", () => {
   const dir = tempDir();
   const session = path.join(dir, "session.jsonl");

--- a/skills/agent-transcript/scripts/agent-transcript.test.mjs
+++ b/skills/agent-transcript/scripts/agent-transcript.test.mjs
@@ -81,6 +81,56 @@ test("render tokenizes Linux, Windows, file, and quoted paths without smashing H
   assert.doesNotMatch(output, /~\/notes/);
 });
 
+test("render redacts compiler-attached macOS paths", () => {
+  const dir = tempDir();
+  const session = path.join(dir, "session.jsonl");
+  writeJsonl(session, [
+    {
+      type: "response_item",
+      payload: {
+        role: "user",
+        content: [
+          {
+            type: "text",
+            text: "cc -I/Users/alice/private/include main.c",
+          },
+        ],
+      },
+    },
+    { type: "response_item", payload: { role: "assistant", content: [{ type: "text", text: "Done." }] } },
+  ]);
+
+  const output = run(["render", "--session", session]);
+  assert.match(output, /cc -I\[LOCAL_PATH\]/);
+  assert.doesNotMatch(output, /\/Users\/alice/);
+  assert.doesNotMatch(output, /private\/include/);
+});
+
+test("render keeps prose and URLs between two local paths", () => {
+  const dir = tempDir();
+  const session = path.join(dir, "session.jsonl");
+  writeJsonl(session, [
+    {
+      type: "response_item",
+      payload: {
+        role: "user",
+        content: [
+          {
+            type: "text",
+            text: "Read /Users/alice/a then https://example.test/docs and /Users/bob/b",
+          },
+        ],
+      },
+    },
+    { type: "response_item", payload: { role: "assistant", content: [{ type: "text", text: "Done." }] } },
+  ]);
+
+  const output = run(["render", "--session", session]);
+  assert.match(output, /Read \[LOCAL_PATH\] then https:\/\/example\.test\/docs and \[LOCAL_PATH\]/);
+  assert.doesNotMatch(output, /\/Users\/alice/);
+  assert.doesNotMatch(output, /\/Users\/bob/);
+});
+
 test("render drops raw tool outputs but keeps a compact tool summary", () => {
   const dir = tempDir();
   const session = path.join(dir, "session.jsonl");

--- a/skills/agent-transcript/scripts/agent-transcript.test.mjs
+++ b/skills/agent-transcript/scripts/agent-transcript.test.mjs
@@ -182,6 +182,83 @@ test("render redacts compiler response-file arguments", () => {
   assert.doesNotMatch(output, /args\.rsp/);
 });
 
+test("render redacts semicolon-adjacent local fields beside a URL", () => {
+  const dir = tempDir();
+  const session = path.join(dir, "session.jsonl");
+  writeJsonl(session, [
+    {
+      type: "response_item",
+      payload: {
+        role: "user",
+        content: [
+          {
+            type: "text",
+            text: "url=https://example.test/docs;local=/Users/alice/private",
+          },
+        ],
+      },
+    },
+    { type: "response_item", payload: { role: "assistant", content: [{ type: "text", text: "Done." }] } },
+  ]);
+
+  const output = run(["render", "--session", session]);
+  assert.match(output, /https:\/\/example\.test\/docs/);
+  assert.match(output, /local=\[LOCAL_PATH\]/);
+  assert.doesNotMatch(output, /\/Users\/alice/);
+  assert.doesNotMatch(output, /alice\/private/);
+});
+
+test("render redacts hyphenated local fields beside a URL", () => {
+  const dir = tempDir();
+  const session = path.join(dir, "session.jsonl");
+  writeJsonl(session, [
+    {
+      type: "response_item",
+      payload: {
+        role: "user",
+        content: [
+          {
+            type: "text",
+            text: "url=https://example.test/docs,local-path=/Users/alice/private",
+          },
+        ],
+      },
+    },
+    { type: "response_item", payload: { role: "assistant", content: [{ type: "text", text: "Done." }] } },
+  ]);
+
+  const output = run(["render", "--session", session]);
+  assert.match(output, /https:\/\/example\.test\/docs/);
+  assert.match(output, /local-path=\[LOCAL_PATH\]/);
+  assert.doesNotMatch(output, /\/Users\/alice/);
+  assert.doesNotMatch(output, /alice\/private/);
+});
+
+test("render leaves literal URL placeholders in dialogue", () => {
+  const dir = tempDir();
+  const session = path.join(dir, "session.jsonl");
+  writeJsonl(session, [
+    {
+      type: "response_item",
+      payload: {
+        role: "user",
+        content: [
+          {
+            type: "text",
+            text: "Explain BEAMNETWORKURL0END then https://example.test/docs",
+          },
+        ],
+      },
+    },
+    { type: "response_item", payload: { role: "assistant", content: [{ type: "text", text: "Done." }] } },
+  ]);
+
+  const output = run(["render", "--session", session]);
+  assert.match(output, /Explain BEAMNETWORKURL0END/);
+  assert.match(output, /https:\/\/example\.test\/docs/);
+  assert.doesNotMatch(output, /Explain undefined/);
+});
+
 test("render drops raw tool outputs but keeps a compact tool summary", () => {
   const dir = tempDir();
   const session = path.join(dir, "session.jsonl");

--- a/skills/agent-transcript/scripts/agent-transcript.test.mjs
+++ b/skills/agent-transcript/scripts/agent-transcript.test.mjs
@@ -260,6 +260,85 @@ test("render redacts unquoted paths with a comma in a filename", () => {
   assert.doesNotMatch(output, /plan\.md/);
 });
 
+test("render redacts markdown-emphasis local paths", () => {
+  const dir = tempDir();
+  const session = path.join(dir, "session.jsonl");
+  writeJsonl(session, [
+    {
+      type: "response_item",
+      payload: {
+        role: "user",
+        content: [
+          {
+            type: "text",
+            text: "Inspect **/Users/alice/private/plan.md** and _/Users/bob/secret.txt_",
+          },
+        ],
+      },
+    },
+    { type: "response_item", payload: { role: "assistant", content: [{ type: "text", text: "Done." }] } },
+  ]);
+
+  const output = run(["render", "--session", session]);
+  assert.match(output, /\[LOCAL_PATH\]/);
+  assert.doesNotMatch(output, /\/Users\/alice/);
+  assert.doesNotMatch(output, /\/Users\/bob/);
+  assert.doesNotMatch(output, /private\/plan/);
+  assert.doesNotMatch(output, /secret\.txt/);
+});
+
+test("render redacts backtick paths that contain a semicolon", () => {
+  const dir = tempDir();
+  const session = path.join(dir, "session.jsonl");
+  writeJsonl(session, [
+    {
+      type: "response_item",
+      payload: {
+        role: "user",
+        content: [
+          {
+            type: "text",
+            text: "Open `/Users/alice/Acme;Private/plan.md` and `~/Acme;Private/plan.md`",
+          },
+        ],
+      },
+    },
+    { type: "response_item", payload: { role: "assistant", content: [{ type: "text", text: "Done." }] } },
+  ]);
+
+  const output = run(["render", "--session", session]);
+  assert.match(output, /\[LOCAL_PATH\]/);
+  assert.match(output, /\[HOME_PATH\]/);
+  assert.doesNotMatch(output, /\/Users\/alice/);
+  assert.doesNotMatch(output, /;Private/);
+  assert.doesNotMatch(output, /plan\.md/);
+});
+
+test("render keeps a URL field after a comma-bearing local path", () => {
+  const dir = tempDir();
+  const session = path.join(dir, "session.jsonl");
+  writeJsonl(session, [
+    {
+      type: "response_item",
+      payload: {
+        role: "user",
+        content: [
+          {
+            type: "text",
+            text: "local=/Users/alice/a,url=https://example.test/docs",
+          },
+        ],
+      },
+    },
+    { type: "response_item", payload: { role: "assistant", content: [{ type: "text", text: "Done." }] } },
+  ]);
+
+  const output = run(["render", "--session", session]);
+  assert.match(output, /local=\[LOCAL_PATH\]/);
+  assert.match(output, /https:\/\/example\.test\/docs/);
+  assert.doesNotMatch(output, /\/Users\/alice/);
+});
+
 test("render leaves literal URL placeholders in dialogue", () => {
   const dir = tempDir();
   const session = path.join(dir, "session.jsonl");

--- a/skills/agent-transcript/scripts/agent-transcript.test.mjs
+++ b/skills/agent-transcript/scripts/agent-transcript.test.mjs
@@ -131,6 +131,57 @@ test("render keeps prose and URLs between two local paths", () => {
   assert.doesNotMatch(output, /\/Users\/bob/);
 });
 
+test("render redacts local fields adjacent to a protected URL", () => {
+  const dir = tempDir();
+  const session = path.join(dir, "session.jsonl");
+  writeJsonl(session, [
+    {
+      type: "response_item",
+      payload: {
+        role: "user",
+        content: [
+          {
+            type: "text",
+            text: "url=https://example.test/docs,local=/Users/alice/private",
+          },
+        ],
+      },
+    },
+    { type: "response_item", payload: { role: "assistant", content: [{ type: "text", text: "Done." }] } },
+  ]);
+
+  const output = run(["render", "--session", session]);
+  assert.match(output, /https:\/\/example\.test\/docs/);
+  assert.match(output, /local=\[LOCAL_PATH\]/);
+  assert.doesNotMatch(output, /\/Users\/alice/);
+  assert.doesNotMatch(output, /alice\/private/);
+});
+
+test("render redacts compiler response-file arguments", () => {
+  const dir = tempDir();
+  const session = path.join(dir, "session.jsonl");
+  writeJsonl(session, [
+    {
+      type: "response_item",
+      payload: {
+        role: "user",
+        content: [
+          {
+            type: "text",
+            text: "cc @/Users/alice/private/args.rsp",
+          },
+        ],
+      },
+    },
+    { type: "response_item", payload: { role: "assistant", content: [{ type: "text", text: "Done." }] } },
+  ]);
+
+  const output = run(["render", "--session", session]);
+  assert.match(output, /cc @\[LOCAL_PATH\]/);
+  assert.doesNotMatch(output, /\/Users\/alice/);
+  assert.doesNotMatch(output, /args\.rsp/);
+});
+
 test("render drops raw tool outputs but keeps a compact tool summary", () => {
   const dir = tempDir();
   const session = path.join(dir, "session.jsonl");

--- a/skills/agent-transcript/scripts/agent-transcript.test.mjs
+++ b/skills/agent-transcript/scripts/agent-transcript.test.mjs
@@ -234,6 +234,32 @@ test("render redacts hyphenated local fields beside a URL", () => {
   assert.doesNotMatch(output, /alice\/private/);
 });
 
+test("render redacts unquoted paths with a comma in a filename", () => {
+  const dir = tempDir();
+  const session = path.join(dir, "session.jsonl");
+  writeJsonl(session, [
+    {
+      type: "response_item",
+      payload: {
+        role: "user",
+        content: [
+          {
+            type: "text",
+            text: "Read /Users/alice/Acme,Private/plan.md",
+          },
+        ],
+      },
+    },
+    { type: "response_item", payload: { role: "assistant", content: [{ type: "text", text: "Done." }] } },
+  ]);
+
+  const output = run(["render", "--session", session]);
+  assert.match(output, /Read \[LOCAL_PATH\]/);
+  assert.doesNotMatch(output, /\/Users\/alice/);
+  assert.doesNotMatch(output, /Private\/plan/);
+  assert.doesNotMatch(output, /plan\.md/);
+});
+
 test("render leaves literal URL placeholders in dialogue", () => {
   const dir = tempDir();
   const session = path.join(dir, "session.jsonl");

--- a/skills/agent-transcript/scripts/agent-transcript.test.mjs
+++ b/skills/agent-transcript/scripts/agent-transcript.test.mjs
@@ -50,6 +50,37 @@ test("render redacts common secrets and local identifiers", () => {
   assert.doesNotMatch(output, /abcdefghijklmnopqrstuvwxyz123456/);
 });
 
+test("render tokenizes Linux, Windows, file, and quoted paths without smashing HTTP routes", () => {
+  const dir = tempDir();
+  const session = path.join(dir, "session.jsonl");
+  writeJsonl(session, [
+    {
+      type: "response_item",
+      payload: {
+        role: "user",
+        content: [
+          {
+            type: "text",
+            text: "~/notes/todo.md. Inspect /home/alice/project and C:\\Users\\bob\\src and file:///home/alice/x and '/home/alice/Client Secret/file.js' plus /Users/ahmed/project. See https://example.test/home/docs",
+          },
+        ],
+      },
+    },
+    { type: "response_item", payload: { role: "assistant", content: [{ type: "text", text: "Done." }] } },
+  ]);
+
+  const output = run(["render", "--session", session]);
+  assert.match(output, /\[LOCAL_PATH\]/);
+  assert.match(output, /\[HOME_PATH\]/);
+  assert.match(output, /https:\/\/example\.test\/home\/docs/);
+  assert.doesNotMatch(output, /\/home\/alice/);
+  assert.doesNotMatch(output, /C:\\Users\\bob/);
+  assert.doesNotMatch(output, /file:\/\/\/home\/alice/);
+  assert.doesNotMatch(output, /Client Secret/);
+  assert.doesNotMatch(output, /\/Users\/ahmed/);
+  assert.doesNotMatch(output, /~\/notes/);
+});
+
 test("render drops raw tool outputs but keeps a compact tool summary", () => {
   const dir = tempDir();
   const session = path.join(dir, "session.jsonl");

--- a/skills/agent-transcript/scripts/agent-transcript.test.mjs
+++ b/skills/agent-transcript/scripts/agent-transcript.test.mjs
@@ -418,6 +418,82 @@ test("render redacts unquoted paths with brackets in the filename", () => {
   assert.doesNotMatch(output, /\[draft\]/);
 });
 
+test("render redacts emphasis paths before trailing punctuation", () => {
+  const dir = tempDir();
+  const session = path.join(dir, "session.jsonl");
+  writeJsonl(session, [
+    {
+      type: "response_item",
+      payload: {
+        role: "user",
+        content: [
+          {
+            type: "text",
+            text: "Inspect **/Users/alice/private.txt**, please",
+          },
+        ],
+      },
+    },
+    { type: "response_item", payload: { role: "assistant", content: [{ type: "text", text: "Done." }] } },
+  ]);
+
+  const output = run(["render", "--session", session]);
+  assert.match(output, /\*\*\[LOCAL_PATH\]\*\*, please/);
+  assert.doesNotMatch(output, /\/Users\/alice/);
+  assert.doesNotMatch(output, /private\.txt/);
+});
+
+test("render redacts compiler-attached -L paths", () => {
+  const dir = tempDir();
+  const session = path.join(dir, "session.jsonl");
+  writeJsonl(session, [
+    {
+      type: "response_item",
+      payload: {
+        role: "user",
+        content: [
+          {
+            type: "text",
+            text: "cc -L/Users/alice/private/lib main.c",
+          },
+        ],
+      },
+    },
+    { type: "response_item", payload: { role: "assistant", content: [{ type: "text", text: "Done." }] } },
+  ]);
+
+  const output = run(["render", "--session", session]);
+  assert.match(output, /cc -L\[LOCAL_PATH\]/);
+  assert.doesNotMatch(output, /\/Users\/alice/);
+  assert.doesNotMatch(output, /private\/lib/);
+});
+
+test("render redacts bracketed directory components", () => {
+  const dir = tempDir();
+  const session = path.join(dir, "session.jsonl");
+  writeJsonl(session, [
+    {
+      type: "response_item",
+      payload: {
+        role: "user",
+        content: [
+          {
+            type: "text",
+            text: "Read /Users/alice/[draft]/Acquisition.txt",
+          },
+        ],
+      },
+    },
+    { type: "response_item", payload: { role: "assistant", content: [{ type: "text", text: "Done." }] } },
+  ]);
+
+  const output = run(["render", "--session", session]);
+  assert.match(output, /Read \[LOCAL_PATH\]/);
+  assert.doesNotMatch(output, /\/Users\/alice/);
+  assert.doesNotMatch(output, /Acquisition/);
+  assert.doesNotMatch(output, /\[draft\]/);
+});
+
 test("render leaves slash-separated prose alone", () => {
   const dir = tempDir();
   const session = path.join(dir, "session.jsonl");


### PR DESCRIPTION
## What Problem This Solves

`agent-transcript render` claims `redaction: local paths`, then pastes the result into public PR bodies. The helper only rewrote macOS `/Users/...` and `~/...`. Linux `/home/...`, Windows `C:\Users\...`, `file://` URIs, and quoted paths with spaces were left intact. A published transcript could include a username and a private project path while still reporting `safe: true`.

This is F001. @steipete closed [#139](https://github.com/openclaw/agent-skills/pull/139) after confirming the gap and rejecting a regex-only `/home/` plus drive-letter table. That table smashed ordinary HTTP routes such as `https://example.test/home/docs` and still leaked quoted paths with spaces. The required approach is to tokenize quoted or code spans, HTTP(S) URLs, local URIs, and plain path tokens, then redact only the local-path tokens.

This PR ports the existing beam tokenizer from [`beam-session.js`](https://github.com/openclaw/agent-skills/blob/main/skills/beam/scripts/beam-session.js) (landed in [#152](https://github.com/openclaw/agent-skills/pull/152)). HTTP(S) URLs are shielded first. Remaining path tokens, including `/home/`, `C:\`, `file://`, and quoted paths with spaces, are then rewritten to `[LOCAL_PATH]` (tilde home stays `[HOME_PATH]`).

The leak has been present since the skill was added in [`7d7427a`](https://github.com/openclaw/agent-skills/commit/7d7427a3) (2026-05-25), about 106 days.

Ref [#139](https://github.com/openclaw/agent-skills/pull/139)

## Evidence

Public command: `node skills/agent-transcript/scripts/agent-transcript render --session FILE`.

One JSONL user turn contained `/home/alice/project`, `C:\Users\bob\src`, `file:///home/alice/x`, quoted `'/home/alice/Client Secret/file.js'`, plus `/Users/ahmed/project` and `https://example.test/home/docs`.

Before this change (same `render --session` on unfixed `main`):

```console
$ node skills/agent-transcript/scripts/agent-transcript render --session session.jsonl
[user]
Inspect /home/alice/project and C:\Users\bob\src and file:///home/alice/x and '/home/alice/Client Secret/file.js' plus [LOCAL_PATH] and [HOME_PATH] See https://example.test/home/docs
```

The header still said `redaction: local paths`. Only `/Users/` and `~/` were rewritten. Linux, Windows, `file://`, and the spaced quoted path stayed visible.

After this change (same command, same shapes):

```console
$ node C:\Users\sebta\AppData\Local\Temp\at-f001-render.mjs
SESSION=C:\Users\sebta\AppData\Local\Temp\at-f001-1Q6OON\session.jsonl
[user]
Inspect [LOCAL_PATH] and [LOCAL_PATH] See https://example.test/home/docs
```

`/home/alice`, `C:\Users\bob`, `file:///home/alice`, and `Client Secret` are gone. `https://example.test/home/docs` is unchanged, which is the case that made the #139 table unsafe.

`node --test skills/agent-transcript/scripts/agent-transcript.test.mjs` on the unfixed script failed on `doesNotMatch /\/home\/alice/` (17 passed, 1 failed). After the tokenizer port, the same command reported 18 passed, 0 failed, including the HTTP-route assertion.

A later walk now tokenizes quoted strings, backtick spans, Markdown `*`/`_` wrappers, and unquoted path tokens. Unquoted tokens stop at `,name=` / `;name=` field separators so a comma inside a filename still redacts, while `local=/Users/alice/a,url=https://...` keeps the URL. macOS `node --test` on this tip: 29 passed in agent-transcript, 90 passed in beam + session-viewer.

## Real behavior proof

- **Behavior or issue addressed:** Public `agent-transcript render` output leaked Linux `/home/`, Windows `C:\Users\`, `file://`, and quoted local paths while advertising local-path redaction. HTTP routes such as `/home/docs` on a normal https URL must stay intact.
- **Real environment tested:** Windows 11, Node v24.19.0, repo at `C:\Users\sebta\.grok\tmp\openclaw-org-audit\clones\agent-skills` on branch `fix/transcript-path-tokenize` from `origin/main` `b86a912`.
- **Exact steps or command run after this patch:** Wrote a temp JSONL whose user text contained `/home/alice/project`, `C:\Users\bob\src`, `file:///home/alice/x`, `'/home/alice/Client Secret/file.js'`, `/Users/ahmed/project`, and `See https://example.test/home/docs`. Ran `node skills/agent-transcript/scripts/agent-transcript render --session` on that file (via `node C:\Users\sebta\AppData\Local\Temp\at-f001-render.mjs`).
- **Evidence after fix:** terminal output from the live render:

  ```console
  $ node C:\Users\sebta\AppData\Local\Temp\at-f001-render.mjs
  SESSION=C:\Users\sebta\AppData\Local\Temp\at-f001-1Q6OON\session.jsonl
  source: [LOCAL_SESSION]
  redaction: local paths, emails, phone-shaped strings, token-shaped strings, auth headers, auth query params
  stats: {"agent":"codex","sourceTruncated":false,"entries":1,"user":1,"assistant":0,"toolCalls":0,"toolOutputsDropped":0,"web":0,"redactions":4,"omittedUnsafe":0,"rawEntries":1}

  [user]
  Inspect [LOCAL_PATH] and [LOCAL_PATH] See https://example.test/home/docs
  ```

- **Observed result after fix:** The published markdown no longer contains `/home/alice`, `C:\Users\bob`, `file:///home/alice`, or `Client Secret`. The https documentation URL still contains `/home/docs`. Existing `/Users/` and `~/` redaction still occurs. Markdown `**path**`, backtick paths with `;`, and `local=...,url=https://...` now redact without eating the URL field.
- **What was not tested:** App-server `render-thread` mode. Live insertion into a GitHub PR body. Beam itself was not changed.

## Summary

- Keep secret, email, phone, and auth regex rules.
- Remove the two naive `/Users/` and `~/` table rows.
- Walk quoted, backtick, Markdown-wrapped, and unquoted path tokens instead of growing a delimiter regex.
- Coverage is a `render --session` regression that stays red on current `main` for `/home/` and `C:\Users\`, then green after this change, and that requires `https://example.test/home/docs` to survive.

