### PR TITLE
fix(autoreview): support authenticated proxy inference

### DIFF
--- a/skills/autoreview/SKILL.md
+++ b/skills/autoreview/SKILL.md
@@ -194,7 +194,16 @@ fails or returns an invalid report reports `reviewer_unavailable` with exit 1.
 A failed later pass never publishes a partial review report.
 
 ```json
-{"schema_version":1,"status":"reviewer_unavailable","exit_code":1,"engine":"codex","report_produced":false,"reason":"engine_failed","reviewer_exit_code":124,"timed_out":true}
+{
+  "schema_version": 1,
+  "status": "reviewer_unavailable",
+  "exit_code": 1,
+  "engine": "codex",
+  "report_produced": false,
+  "reason": "engine_failed",
+  "reviewer_exit_code": 124,
+  "timed_out": true
+}
 ```
 
 `reason` is `engine_failed`, `invalid_report`, or `runtime_validation_failed`

--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -727,6 +727,7 @@ def safe_proxy_url(value: str) -> bool:
 def proxy_credential_pattern(values: tuple[str, ...]) -> re.Pattern[str] | None:
     forms: set[str] = set()
     labeled_passwords: set[str] = set()
+    labeled_usernames: set[str] = set()
     for value in values:
         try:
             parsed = urllib.parse.urlsplit(value if "://" in value else f"http://{value}")
@@ -740,8 +741,8 @@ def proxy_credential_pattern(values: tuple[str, ...]) -> re.Pattern[str] | None:
         forms.add(base64.b64encode(user + b":" + password).decode("ascii"))
         encoded_userinfo = parsed.netloc.rsplit("@", 1)[0]
         raw_userinfo = user + (b":" + password if parsed.password is not None else b"")
-        # Keep username-only and empty-password auth in a URL context. A bare
-        # public label such as "u" or "openclaw" must not mask ordinary text.
+        # Always hide userinfo in URL contexts, even when it is a short public
+        # label such as "u" or "openclaw".
         if encoded_userinfo:
             forms.add(encoded_userinfo + "@")
             forms.add(urllib.parse.quote_from_bytes(raw_userinfo, safe="") + "%40")
@@ -749,6 +750,17 @@ def proxy_credential_pattern(values: tuple[str, ...]) -> re.Pattern[str] | None:
                 forms.add(raw_userinfo.decode("utf-8") + "@")
             except UnicodeDecodeError:
                 pass
+        if not parsed.password and user:
+            username_forms = {parsed.username, urllib.parse.quote_from_bytes(user, safe="")}
+            try:
+                username_forms.add(user.decode("utf-8"))
+            except UnicodeDecodeError:
+                pass
+            labeled_usernames.update(username_forms)
+            # Some proxies put their token in the username with no password.
+            # Hide standalone long values while preserving ordinary short labels.
+            if len(user) >= 16:
+                forms.update(username_forms)
         if parsed.password:
             forms.add(encoded_userinfo)
             # Short bare passwords are indistinguishable from prose or enum
@@ -783,13 +795,15 @@ def proxy_credential_pattern(values: tuple[str, ...]) -> re.Pattern[str] | None:
         # Percent escape casing is insignificant; credential casing is not.
         escaped = re.sub(r"%[0-9a-fA-F]{2}", lambda match: "(?i:" + match[0] + ")", escaped)
         patterns.append(escaped)
-    for password in labeled_passwords:
-        escaped = re.escape(password)
-        escaped = re.sub(r"%[0-9a-fA-F]{2}", lambda match: "(?i:" + match[0] + ")", escaped)
-        patterns.append(
-            r"(?i:\b(?:proxy[_-]?)?password[\"']?[ \t]*[:=][ \t]*[\"']?)"
-            + escaped + r"(?=$|[\s\"',;\)\]}])"
-        )
+    for label, credentials in (("password", labeled_passwords),
+                               ("(?:username|user)", labeled_usernames)):
+        for credential in credentials:
+            escaped = re.escape(credential)
+            escaped = re.sub(r"%[0-9a-fA-F]{2}", lambda match: "(?i:" + match[0] + ")", escaped)
+            patterns.append(
+                r"(?i:\b(?:proxy[_-]?)?" + label + r"[\"']?[ \t]*[:=][ \t]*[\"']?)"
+                + escaped + r"(?=$|[\s\"',;\)\]}])"
+            )
     return re.compile("|".join(patterns))
 
 

--- a/skills/autoreview/scripts/autoreview
+++ b/skills/autoreview/scripts/autoreview
@@ -361,6 +361,14 @@ CODEX_TRUST_PATH_ENV_KEYS = {
     "SSL_CERT_DIR",
     "SSL_CERT_FILE",
 }
+PROXY_ENV_KEYS = (
+    "ALL_PROXY", "HTTP_PROXY", "HTTPS_PROXY",
+    "all_proxy", "http_proxy", "https_proxy",
+)
+TRANSPORT_TRUST_PATH_ENV_KEYS = {
+    "NODE_EXTRA_CA_CERTS", "SSL_CERT_DIR", "SSL_CERT_FILE",
+    "CURL_CA_BUNDLE", "REQUESTS_CA_BUNDLE",
+}
 CODEX_MACOS_SCRATCH_ROOTS = ("/tmp", "/private/tmp", "/var/tmp", "/private/var/tmp")
 PROVIDER_CREDENTIAL_PATH_ENV_KEYS = {
     "AWS_CONFIG_FILE",
@@ -681,22 +689,177 @@ def safe_temp_root(repo: Path, *, engine: str | None = None) -> Path:
 
 
 def safe_proxy_url(value: str) -> bool:
+    # A proxy is launcher-provided transport, like the provider URL and API
+    # authentication. URL shape is not proof that it belongs to any runtime.
+    # Check before urlsplit, which silently removes some control characters.
+    if not value or any(char.isspace() or ord(char) < 32 or ord(char) == 127 for char in value):
+        return False
+    if "\\" in value or re.search(r"%(?![0-9a-fA-F]{2})", value):
+        return False
     try:
         candidate = value if "://" in value else f"http://{value}"
         parsed = urllib.parse.urlsplit(candidate)
-        _ = parsed.port
+        port = parsed.port
+        hostname = urllib.parse.unquote(parsed.hostname or "")
+        for part in (parsed.username, parsed.password):
+            if part is not None and any(
+                byte < 32 or byte == 127 for byte in urllib.parse.unquote_to_bytes(part)
+            ):
+                return False
     except ValueError:
         return False
     return (
         parsed.scheme.lower()
         in {"http", "https", "socks", "socks4", "socks4a", "socks5", "socks5h"}
-        and bool(parsed.hostname)
-        and parsed.username is None
-        and parsed.password is None
+        and bool(hostname)
+        and not any(char.isspace() or ord(char) < 32 or ord(char) == 127
+                    or char in "/\\@?#" for char in hostname)
+        and parsed.netloc.count("@") <= 1
+        and not parsed.netloc.endswith(":")
+        and port != 0
         and parsed.path in {"", "/"}
         and not parsed.query
         and not parsed.fragment
     )
+
+
+@functools.lru_cache(maxsize=8)
+def proxy_credential_pattern(values: tuple[str, ...]) -> re.Pattern[str] | None:
+    forms: set[str] = set()
+    labeled_passwords: set[str] = set()
+    for value in values:
+        try:
+            parsed = urllib.parse.urlsplit(value if "://" in value else f"http://{value}")
+            if parsed.username is None:
+                continue
+            user = urllib.parse.unquote_to_bytes(parsed.username)
+            password = urllib.parse.unquote_to_bytes(parsed.password or "")
+        except ValueError:
+            continue
+        forms.add(value)
+        forms.add(base64.b64encode(user + b":" + password).decode("ascii"))
+        encoded_userinfo = parsed.netloc.rsplit("@", 1)[0]
+        raw_userinfo = user + (b":" + password if parsed.password is not None else b"")
+        # Keep username-only and empty-password auth in a URL context. A bare
+        # public label such as "u" or "openclaw" must not mask ordinary text.
+        if encoded_userinfo:
+            forms.add(encoded_userinfo + "@")
+            forms.add(urllib.parse.quote_from_bytes(raw_userinfo, safe="") + "%40")
+            try:
+                forms.add(raw_userinfo.decode("utf-8") + "@")
+            except UnicodeDecodeError:
+                pass
+        if parsed.password:
+            forms.add(encoded_userinfo)
+            # Short bare passwords are indistinguishable from prose or enum
+            # values. Always hide them in auth/password contexts; additionally
+            # mask standalone longer values, including run-scoped proxy tokens.
+            if len(password) >= 8:
+                forms.add(parsed.password)
+            labeled_passwords.add(parsed.password)
+            for raw in (password, raw_userinfo):
+                try:
+                    decoded = raw.decode("utf-8")
+                    if raw != password or len(password) >= 8:
+                        forms.add(decoded)
+                    if raw == password:
+                        labeled_passwords.add(decoded)
+                except UnicodeDecodeError:
+                    pass
+                encoded = urllib.parse.quote_from_bytes(raw, safe="")
+                if raw != password or len(password) >= 8:
+                    forms.add(encoded)
+                if raw == password:
+                    labeled_passwords.add(encoded)
+    forms.discard("")
+    forms.update(urllib.parse.quote(form, safe="") for form in tuple(forms))
+    # Diagnostics and streamed JSON may escape strings before we see them.
+    forms.update(json.dumps(form, ensure_ascii=True)[1:-1] for form in tuple(forms))
+    if not forms:
+        return None
+    patterns = []
+    for form in sorted(forms, key=len, reverse=True):
+        escaped = re.escape(form)
+        # Percent escape casing is insignificant; credential casing is not.
+        escaped = re.sub(r"%[0-9a-fA-F]{2}", lambda match: "(?i:" + match[0] + ")", escaped)
+        patterns.append(escaped)
+    for password in labeled_passwords:
+        escaped = re.escape(password)
+        escaped = re.sub(r"%[0-9a-fA-F]{2}", lambda match: "(?i:" + match[0] + ")", escaped)
+        patterns.append(
+            r"(?i:\b(?:proxy[_-]?)?password[\"']?[ \t]*[:=][ \t]*[\"']?)"
+            + escaped + r"(?=$|[\s\"',;\)\]}])"
+        )
+    return re.compile("|".join(patterns))
+
+
+def redact_proxy_credentials(text: str) -> str:
+    pattern = proxy_credential_pattern(tuple(os.environ.get(key, "") for key in PROXY_ENV_KEYS))
+    return pattern.sub("[REDACTED]", text) if pattern else text
+
+
+def redact_proxy_report(value: Any) -> Any:
+    # Redact after validation, at serialization only. Keep the original report
+    # and exit-status decisions intact; never edit source snapshots or auth.
+    if isinstance(value, str):
+        return redact_proxy_credentials(value)
+    if isinstance(value, list):
+        return [redact_proxy_report(item) for item in value]
+    if isinstance(value, dict):
+        enums = {"overall_correctness", "priority", "category", "review_status", "target", "side"}
+        return {key: item if key in enums else redact_proxy_report(item)
+                for key, item in value.items()}
+    return value
+
+
+class ProxyRedactedOutput:
+    """Cover plain progress/error prints as well as the formatted reports."""
+
+    def __init__(self, stream: Any) -> None:
+        self.stream = stream
+        self.pending = ""
+        self.discarding_line = False
+        self.lock = threading.Lock()
+
+    def write(self, text: str) -> int:
+        # print() and other writers can split a URL across writes. Emit whole
+        # lines only; flush must not expose a still-incomplete credential.
+        with self.lock:
+            parts = text.split("\n")
+            for index, part in enumerate(parts):
+                newline = index < len(parts) - 1
+                if self.discarding_line:
+                    self.discarding_line = not newline
+                    continue
+                if len(self.pending) + len(part) > 65_536:
+                    self.pending = ""
+                    self.discarding_line = not newline
+                    self.stream.write("[output line suppressed: exceeds redaction buffer]\n")
+                    continue
+                self.pending += part
+                if newline:
+                    self.stream.write(redact_proxy_credentials(self.pending) + "\n")
+                    self.pending = ""
+        return len(text)
+
+    def flush(self) -> None:
+        self.stream.flush()
+
+    @property
+    def encoding(self) -> str | None:
+        return self.stream.encoding
+
+    def isatty(self) -> bool:
+        return self.stream.isatty()
+
+    def fileno(self) -> int:
+        return self.stream.fileno()
+
+    def finish(self) -> None:
+        with self.lock:
+            self.stream.write(redact_proxy_credentials(self.pending))
+            self.pending = ""
+            self.stream.flush()
 
 
 def safe_engine_env(
@@ -719,6 +882,7 @@ def safe_engine_env(
         "LC_ALL",
         "LOGNAME",
         "NO_PROXY",
+        "NODE_USE_ENV_PROXY",
         "PATHEXT",
         "SHELL",
         "SYSTEMROOT",
@@ -879,19 +1043,11 @@ def safe_engine_env(
             )
         )
     }
-    for key in (
-        "ALL_PROXY",
-        "HTTP_PROXY",
-        "HTTPS_PROXY",
-        "all_proxy",
-        "http_proxy",
-        "https_proxy",
-    ):
+    for key in PROXY_ENV_KEYS:
         value = env.get(key)
         if value and not safe_proxy_url(value):
             raise SystemExit(
-                f"unsafe credentialed or malformed proxy URL in {key}; "
-                "configure a credential-free proxy URL before running autoreview"
+                f"malformed proxy URL in {key}; configure a valid proxy URL before running autoreview"
             )
     env["PATH"] = safe_engine_path(repo, extra_paths)
     for key in ("HOME", "USERPROFILE"):
@@ -907,6 +1063,11 @@ def safe_engine_env(
         value = os.environ.get(key)
         if value and external_env_path(repo, value):
             env[key] = value
+    for key in TRANSPORT_TRUST_PATH_ENV_KEYS:
+        value = os.environ.get(key)
+        normalized = normalize_external_env_path_value(repo, key, value) if value else None
+        if normalized:
+            env[key] = normalized
     if engine == "codex":
         dbus_address = os.environ.get("DBUS_SESSION_BUS_ADDRESS")
         if dbus_address and safe_dbus_session_address(repo, dbus_address):
@@ -1672,7 +1833,7 @@ def bounded_field(text: str, limit: int) -> str:
 
 def display_escape(text: object, limit: int, *, multiline: bool = False) -> str:
     parts: list[str] = []
-    for char in str(text):
+    for char in redact_proxy_credentials(str(text)):
         codepoint = ord(char)
         if multiline and char == "\n":
             parts.append(char)
@@ -6954,7 +7115,7 @@ def main_impl() -> int:
     if args.json_output:
         atomic_write_text(
             Path(args.json_output),
-            json.dumps(report, indent=2) + "\n",
+            json.dumps(redact_proxy_report(report), indent=2) + "\n",
         )
 
     if args.output:
@@ -6984,8 +7145,15 @@ def main_impl() -> int:
 
 
 def sanitized_main() -> int:
+    stdout = ProxyRedactedOutput(sys.stdout)
+    stderr = ProxyRedactedOutput(sys.stderr)
     try:
-        return main()
+        try:
+            with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+                return main()
+        finally:
+            stdout.finish()
+            stderr.finish()
     except SystemExit as exc:
         if isinstance(exc.code, str):
             raise SystemExit(

--- a/skills/autoreview/tests/test_autoreview_hardening.py
+++ b/skills/autoreview/tests/test_autoreview_hardening.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import argparse
+import base64
 import contextlib
 import copy
 import io
@@ -18,6 +19,7 @@ import tempfile
 import threading
 import time
 import unittest
+import urllib.parse
 from unittest import mock
 from pathlib import Path, PureWindowsPath
 
@@ -4208,6 +4210,7 @@ class AutoreviewHardeningTests(unittest.TestCase):
             "proxy.example.invalid:8080",
             "socks4://proxy.example.invalid",
             "socks4a://proxy.example.invalid",
+            "http://[fe80::1%25en0]:8080",
         ):
             with self.subTest(value=value):
                 self.assertTrue(self.helper["safe_proxy_url"](value))
@@ -4217,20 +4220,20 @@ class AutoreviewHardeningTests(unittest.TestCase):
             "socks5://review-user:review-password@proxy.example.invalid:1080",
         ):
             with self.subTest(value=value):
-                self.assertFalse(self.helper["safe_proxy_url"](value))
+                self.assertTrue(self.helper["safe_proxy_url"](value))
 
-    def test_safe_engine_env_rejects_credentialed_proxy(self) -> None:
+    def test_safe_engine_env_rejects_malformed_proxy(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir, mock.patch.dict(
             os.environ,
             {
                 "HTTPS_PROXY": (
-                    "http://review-user:review-password@proxy.example.invalid:8080"
+                    "http://review-user:review-password@proxy.example.invalid:bad"
                 )
             },
             clear=False,
         ):
             repo = init_repo(Path(tempdir))
-            with self.assertRaisesRegex(SystemExit, "credentialed or malformed proxy"):
+            with self.assertRaisesRegex(SystemExit, "malformed proxy"):
                 self.helper["safe_engine_env"](repo, engine="codex")
 
     def test_safe_temp_root_rejects_reviewed_repo_parent(self) -> None:
@@ -6556,6 +6559,290 @@ os.execv(target, [str(target), *sys.argv[1:]])
             self.assertEqual(result.returncode, 1, result.stdout + result.stderr)
             self.assertIn("inputs: FAILED", result.stdout)
             self.assertIn("missing-dataset.json", result.stdout)
+
+PROXY_KEYS = ("HTTP_PROXY", "HTTPS_PROXY", "ALL_PROXY", "http_proxy", "https_proxy", "all_proxy")
+
+
+class AuthenticatedProxyTests(unittest.TestCase):
+    def setUp(self):
+        self.helper = load_helper()
+
+    def test_authenticated_proxy_urls_are_transport_not_openclaw_provenance(self):
+        for value in (
+            "http://user:password@proxy.example.invalid:8080",
+            "https://user:password@[::1]:8443/",
+            "socks5h://u:p%40ss%3Aword@proxy.example.invalid:1080",
+            "user:password@proxy.example.invalid:8080",
+            "http://user@proxy.example.invalid",
+            "http://:password@proxy.example.invalid",
+            "http://proxy.example.invalid:8080",
+            "proxy.example.invalid:8080",
+            "socks4a://proxy.example.invalid",
+        ):
+            with self.subTest(value=value):
+                self.assertTrue(self.helper["safe_proxy_url"](value))
+
+    def test_malformed_proxy_urls_still_fail_closed(self):
+        for value in (
+            "", "http://", "file:///proxy", "http://host:0", "http://host:65536",
+            "http://host:bad", "http://[::1", "http://host/path", "http://host?q=1",
+            "http://host#fragment", " http://host", "http://host\n", "http://ho\tst",
+            "http://user:p%0Ass@host", "http://user:p%00ss@host", "http://user:p%zz@host",
+            "http://user:p@ss@host", "http://user:p\\ass@host", "http://ho st",
+            "http://host%0a.example", "http://host%2f.example",
+        ):
+            with self.subTest(value=value):
+                self.assertFalse(self.helper["safe_proxy_url"](value))
+
+    def test_engine_env_preserves_authenticated_transport_without_marker_or_api_leak(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp).resolve()
+            repo = root / "repo"
+            repo.mkdir()
+            proxy = "http://fixture:transport-password@127.0.0.1:8080"
+            transport = {key: proxy for key in PROXY_KEYS}
+            transport.update({"NO_PROXY": "localhost", "NODE_USE_ENV_PROXY": "1"})
+            ca_keys = ("NODE_EXTRA_CA_CERTS", "SSL_CERT_FILE", "SSL_CERT_DIR",
+                       "CURL_CA_BUNDLE", "REQUESTS_CA_BUNDLE")
+            transport.update({key: str(root / "trust.pem") for key in ca_keys})
+            inherited = {**transport, "OPENAI_API_KEY": "provider-auth-fixture",
+                         "UNRELATED_SECRET": "not-for-review", "NODE_OPTIONS": "--require hostile"}
+            for engine in self.helper["ENGINES"]:
+                with self.subTest(engine=engine), mock.patch.dict(os.environ, inherited, clear=True):
+                    env = self.helper["safe_engine_env"](repo, engine=engine)
+                    for key, value in transport.items():
+                        self.assertEqual(env.get(key), value, key)
+                    self.assertNotIn("UNRELATED_SECRET", env)
+                    self.assertNotIn("NODE_OPTIONS", env)
+                    if engine == "codex":
+                        self.assertEqual(env["OPENAI_API_KEY"], "provider-auth-fixture")
+                    elif engine in {"claude", "amp"}:
+                        self.assertNotIn("OPENAI_API_KEY", env)
+
+    def test_repository_ca_paths_are_not_inherited(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            repo = root / "repo"
+            repo.mkdir()
+            certificate = repo / "trust.pem"
+            certificate.touch()
+            external_link = root / "trust-link.pem"
+            external_link.symlink_to(certificate)
+            for engine in self.helper["ENGINES"]:
+                for value in (str(certificate), str(external_link)):
+                    with self.subTest(engine=engine, value=value), mock.patch.dict(os.environ, {
+                        key: value for key in ("NODE_EXTRA_CA_CERTS", "SSL_CERT_FILE", "SSL_CERT_DIR",
+                                              "CURL_CA_BUNDLE", "REQUESTS_CA_BUNDLE")
+                    }, clear=True):
+                        env = self.helper["safe_engine_env"](repo, engine=engine)
+                        for key in ("NODE_EXTRA_CA_CERTS", "SSL_CERT_FILE", "SSL_CERT_DIR",
+                                    "CURL_CA_BUNDLE", "REQUESTS_CA_BUNDLE"):
+                            self.assertNotIn(key, env)
+
+    def proxy_fixture(self):
+        username = "u"
+        password = 'synthetic-p@ss:/+%"\\word'
+        userinfo = f"{username}:{password}"
+        encoded = urllib.parse.quote(password, safe="")
+        proxy = f"http://{username}:{encoded}@127.0.0.1:8080"
+        basic = base64.b64encode(userinfo.encode()).decode()
+        forms = (proxy, userinfo, f"{username}:{encoded}", password, encoded,
+                 "Proxy-Authorization: Basic " + basic)
+        return proxy, forms
+
+    def test_proxy_credentials_are_redacted_in_diagnostics_not_short_user_labels(self):
+        proxy, forms = self.proxy_fixture()
+        with mock.patch.dict(os.environ, {"HTTPS_PROXY": proxy}, clear=True):
+            for form in (*forms, *(json.dumps(form)[1:-1] for form in forms)):
+                with self.subTest(form=form):
+                    rendered = self.helper["display_escape"]("failure: " + form, 4000, multiline=True)
+                    self.assertNotIn(form, rendered)
+                    self.assertIn("[REDACTED]", rendered)
+            self.assertEqual(self.helper["display_escape"]("user u requests an update", 100),
+                             "user u requests an update")
+            for display in (self.helper["CodexStreamDisplay"](), self.helper["ClaudeStreamDisplay"]()):
+                self.assertNotIn(forms[0], display("stderr", "failure: " + forms[0]))
+
+    def test_real_stream_and_buffered_failure_keep_exit_semantics_without_disclosure(self):
+        proxy, forms = self.proxy_fixture()
+        source = "import os,sys; print(os.environ['HTTPS_PROXY']); print(os.environ['HTTPS_PROXY'],file=sys.stderr); sys.exit(7)"
+        with tempfile.TemporaryDirectory() as tmp, mock.patch.dict(os.environ, {"HTTPS_PROXY": proxy}, clear=False):
+            stdout, stderr = io.StringIO(), io.StringIO()
+            with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+                result = self.helper["run_with_heartbeat"](
+                    [sys.executable, "-c", source], Path(tmp), label="proxy-test", stream_output=True,
+                    env={"HTTPS_PROXY": proxy},
+                )
+            self.assertEqual(result.returncode, 7)
+            self.assertNotIn(proxy, stdout.getvalue() + stderr.getvalue())
+            failure = self.helper["ReviewerUnavailable"]("failed (7): " + result.stderr, result=result)
+            with mock.patch.dict(self.helper["sanitized_main"].__globals__, {
+                "main": mock.Mock(side_effect=failure),
+            }):
+                with self.assertRaises(SystemExit) as caught:
+                    self.helper["sanitized_main"]()
+            self.assertNotIn(proxy, str(caught.exception))
+            self.assertIn("failed (7)", str(caught.exception))
+            self.assertEqual(failure.returncode, 7)
+
+    def test_report_files_and_terminal_are_redacted_without_changing_verdict(self):
+        proxy, forms = self.proxy_fixture()
+        report = {"findings": [], "overall_correctness": "patch is incorrect",
+                  "overall_explanation": "provider says " + " | ".join(forms), "overall_confidence": 0.8}
+        with tempfile.TemporaryDirectory() as tmp, mock.patch.dict(os.environ, {"HTTPS_PROXY": proxy}, clear=True):
+            output = Path(tmp) / "report.json"
+            self.helper["atomic_write_text"](output, json.dumps(self.helper["redact_proxy_report"](report)))
+            saved = json.loads(output.read_text())
+            terminal = io.StringIO()
+            with contextlib.redirect_stdout(terminal):
+                self.helper["print_report"](report)
+            for form in forms:
+                self.assertNotIn(form, saved["overall_explanation"])
+                self.assertNotIn(form, terminal.getvalue())
+            self.assertEqual(saved["overall_correctness"], "patch is incorrect")
+            self.assertEqual(saved["findings"], [])
+            self.assertEqual(report["overall_explanation"], "provider says " + " | ".join(forms))
+
+    def test_codex_tools_do_not_inherit_transport_or_authentication(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            flags = self.helper["codex_config_isolation_flags"](root / "repo", root / "runtime")
+            self.assertIn('shell_environment_policy.inherit="core"', flags)
+            self.assertIn("shell_environment_policy.ignore_default_excludes=false", flags)
+            self.assertFalse(set(PROXY_KEYS) & self.helper["codex_tool_git_env"]().keys())
+
+    @unittest.skipIf(os.name == "nt", "POSIX executable fixture")
+    def test_cli_preserves_transport_and_redacts_streams_reports_and_failures(self):
+        proxy, forms = self.proxy_fixture()
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp).resolve()
+            repo = root / "repo"
+            repo.mkdir()
+            def git(*args):
+                subprocess.run(["git", "-C", str(repo), "-c", "user.name=Proxy Test",
+                                "-c", "user.email=proxy@example.invalid", "-c", "commit.gpgsign=false",
+                                *args], check=True, capture_output=True)
+            git("init", "-q")
+            (repo / "source.txt").write_text("before\n")
+            git("add", ".")
+            git("commit", "-qm", "fixture")
+            (repo / "source.txt").write_text("after\n")
+            fake = root / "codex-fixture"
+            fake.write_text(f"#!{sys.executable}\n" + '''import json, os, sys
+from pathlib import Path
+if "--version" in sys.argv:
+    print("codex-cli 0.0.0-test")
+    raise SystemExit(0)
+Path(os.environ["AUTOREVIEW_FAKE_PROXY_RECORD"]).write_text(json.dumps({
+    "proxy": os.environ["HTTPS_PROXY"], "auth": os.environ.get("OPENAI_API_KEY"), "argv": sys.argv,
+}))
+print(os.environ["HTTPS_PROXY"])
+print(os.environ["HTTPS_PROXY"], file=sys.stderr)
+if os.environ.get("AUTOREVIEW_FAKE_PROXY_EXIT"):
+    raise SystemExit(7)
+flag = "--output-last-message" if "--output-last-message" in sys.argv else "-o"
+Path(sys.argv[sys.argv.index(flag) + 1]).write_text(json.dumps({
+    "findings": [], "overall_correctness": "patch is incorrect",
+    "overall_explanation": "transport diagnostics: " + os.environ["HTTPS_PROXY"], "overall_confidence": 0.8,
+}))
+''')
+            fake.chmod(0o755)
+            home = root / "home"
+            home.mkdir()
+            record = root / "record.json"
+            human, report, status = (root / name for name in ("report.txt", "report.json", "status.json"))
+            env = {key: value for key, value in os.environ.items() if key in {"PATH", "TMPDIR", "TEMP", "TMP"}}
+            env.update({"HOME": str(home), "HTTPS_PROXY": proxy, "OPENAI_API_KEY": "opaque-provider-fixture",
+                        "AUTOREVIEW_FAKE_PROXY_RECORD": str(record)})
+            command = [sys.executable, str(SCRIPT), "--mode", "local", "--codex-bin", str(fake),
+                       "--output", str(human), "--json-output", str(report), "--status-output", str(status),
+                       "--stream-engine-output"]
+            result = subprocess.run(command, cwd=repo, env=env, capture_output=True, text=True)
+            self.assertNotEqual(result.returncode, 0, result.stdout + result.stderr)
+            self.assertTrue(report.exists(), result.stdout + result.stderr)
+            saved = json.loads(report.read_text())
+            self.assertEqual(saved["overall_correctness"], "patch is incorrect")
+            captured = json.loads(record.read_text())
+            self.assertEqual(captured["proxy"], proxy)
+            self.assertEqual(captured["auth"], "opaque-provider-fixture")
+            self.assertIn('shell_environment_policy.inherit="core"', captured["argv"])
+            published = result.stdout + result.stderr + human.read_text() + report.read_text()
+            for form in forms:
+                self.assertNotIn(form, published)
+            self.assertEqual(json.loads(status.read_text())["exit_code"], result.returncode)
+            env["AUTOREVIEW_FAKE_PROXY_EXIT"] = "1"
+            failed = subprocess.run(command, cwd=repo, env=env, capture_output=True, text=True)
+            self.assertNotEqual(failed.returncode, 0)
+            self.assertNotIn(proxy, failed.stdout + failed.stderr)
+            self.assertEqual(json.loads(status.read_text())["reviewer_exit_code"], 7)
+
+    def test_serialized_redaction_does_not_turn_short_passwords_into_json_syntax(self):
+        with mock.patch.dict(os.environ, {"HTTPS_PROXY": "http://u:1@localhost:8080"}, clear=True):
+            report = {"code": 1, "accepted": True, "explanation": "password=1", "u": "user u"}
+            saved = json.loads(json.dumps(self.helper["redact_proxy_report"](report)))
+            self.assertEqual(saved["code"], 1)
+            self.assertIs(saved["accepted"], True)
+            self.assertEqual(saved["explanation"], "[REDACTED]")
+            self.assertEqual(saved["u"], "user u")
+
+    def test_short_password_does_not_corrupt_prose_or_serialized_enums(self):
+        for password in ("a", "incorrect"):
+            with self.subTest(password=password), mock.patch.dict(os.environ, {
+                "HTTPS_PROXY": f"http://u:{password}@localhost:8080",
+            }, clear=True):
+                report = {"overall_correctness": "patch is incorrect", "review_status": "incomplete",
+                          "overall_explanation": "a branch has a bug", "findings": [{
+                              "priority": "P1", "category": "regression", "body": "password=" + password,
+                          }]}
+                saved = self.helper["redact_proxy_report"](report)
+                self.assertEqual(saved["overall_correctness"], "patch is incorrect")
+                self.assertEqual(saved["review_status"], "incomplete")
+                self.assertEqual(saved["overall_explanation"], "a branch has a bug")
+                self.assertEqual(saved["findings"][0]["priority"], "P1")
+                self.assertEqual(saved["findings"][0]["category"], "regression")
+                self.assertNotIn("password=" + password, saved["findings"][0]["body"])
+
+    def test_username_only_and_empty_password_are_hidden_in_url_contexts(self):
+        for suffix in ("", ":"):
+            with self.subTest(suffix=suffix), mock.patch.dict(os.environ, {
+                "HTTPS_PROXY": f"http://u%40name{suffix}@localhost:8080",
+            }, clear=True):
+                diagnostic = f"proxy=http://u@name{suffix}@LOCALHOST:8080/; user u@name is configured"
+                redacted = self.helper["redact_proxy_credentials"](diagnostic)
+                self.assertNotIn(f"u@name{suffix}@", redacted)
+                self.assertIn("user u@name is configured", redacted)
+
+    def test_output_redaction_covers_split_writes_and_final_unterminated_line(self):
+        proxy, _forms = self.proxy_fixture()
+        stream = io.StringIO()
+        with mock.patch.dict(os.environ, {"HTTPS_PROXY": proxy}, clear=True):
+            output = self.helper["ProxyRedactedOutput"](stream)
+            for char in proxy:
+                output.write(char)
+                output.flush()
+            self.assertEqual(stream.getvalue(), "")
+            output.write("\n")
+            self.assertEqual(stream.getvalue(), "[REDACTED]\n")
+            output.write(proxy)
+            output.finish()
+            self.assertEqual(stream.getvalue(), "[REDACTED]\n[REDACTED]")
+
+    def test_redacting_output_bounds_unterminated_lines_and_retains_stream_interface(self):
+        proxy, _forms = self.proxy_fixture()
+        stream = io.StringIO()
+        with mock.patch.dict(os.environ, {"HTTPS_PROXY": proxy}, clear=True):
+            output = self.helper["ProxyRedactedOutput"](stream)
+            output.write("x" * 65_537 + proxy)
+            self.assertLessEqual(len(output.pending), 65_536)
+            output.write("still the suppressed line\nnext line\n")
+            output.finish()
+            self.assertEqual(stream.getvalue(),
+                             "[output line suppressed: exceeds redaction buffer]\nnext line\n")
+            self.assertFalse(output.isatty())
+            self.assertEqual(output.encoding, stream.encoding)
+            with self.assertRaises(io.UnsupportedOperation):
+                output.fileno()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/skills/autoreview/tests/test_autoreview_hardening.py
+++ b/skills/autoreview/tests/test_autoreview_hardening.py
@@ -6815,6 +6815,44 @@ Path(sys.argv[sys.argv.index(flag) + 1]).write_text(json.dumps({
                 self.assertNotIn(f"u@name{suffix}@", redacted)
                 self.assertIn("user u@name is configured", redacted)
 
+    def test_long_username_only_tokens_are_redacted_outside_url_contexts(self):
+        token = 'synthetic-user-token@/+"\\value'
+        encoded = urllib.parse.quote(token, safe="")
+        forms = (token, encoded, urllib.parse.quote(encoded, safe=""),
+                 json.dumps(token)[1:-1])
+        for suffix in ("", ":"):
+            with self.subTest(suffix=suffix), mock.patch.dict(os.environ, {
+                "HTTPS_PROXY": f"http://{encoded}{suffix}@localhost:8080",
+            }, clear=True):
+                for form in forms:
+                    with self.subTest(form=form):
+                        rendered = self.helper["display_escape"]("rejected credential " + form, 4000)
+                        self.assertNotIn(form, rendered)
+                        self.assertIn("[REDACTED]", rendered)
+                        report = {"overall_correctness": "patch is incorrect",
+                                  "overall_explanation": "rejected credential " + form}
+                        saved = self.helper["redact_proxy_report"](report)
+                        self.assertNotIn(form, saved["overall_explanation"])
+                        self.assertEqual(saved["overall_correctness"], "patch is incorrect")
+
+    def test_username_only_redaction_preserves_short_labels_and_report_enums(self):
+        for username in ("u", "openclaw", "review-bot", "incorrect"):
+            for suffix in ("", ":"):
+                with self.subTest(username=username, suffix=suffix), mock.patch.dict(os.environ, {
+                    "HTTPS_PROXY": f"http://{username}{suffix}@localhost:8080",
+                }, clear=True):
+                    prose = f"user {username} is configured"
+                    self.assertEqual(self.helper["redact_proxy_credentials"](prose), prose)
+                    for label in ("username", "proxy_user", "proxy-username"):
+                        diagnostic = f'{label}="{username}"'
+                        redacted = self.helper["redact_proxy_credentials"](diagnostic)
+                        self.assertNotIn(diagnostic, redacted)
+                        self.assertIn("[REDACTED]", redacted)
+                    report = {"overall_correctness": "patch is incorrect",
+                              "review_status": "incomplete", "overall_explanation": prose,
+                              "findings": [{"priority": "P1", "category": "regression"}]}
+                    self.assertEqual(self.helper["redact_proxy_report"](report), report)
+
     def test_output_redaction_covers_split_writes_and_final_unterminated_line(self):
         proxy, _forms = self.proxy_fixture()
         stream = io.StringIO()

--- a/skills/autoreview/tests/test_autoreview_hardening.py
+++ b/skills/autoreview/tests/test_autoreview_hardening.py
@@ -6611,7 +6611,10 @@ class AuthenticatedProxyTests(unittest.TestCase):
                 with self.subTest(engine=engine), mock.patch.dict(os.environ, inherited, clear=True):
                     env = self.helper["safe_engine_env"](repo, engine=engine)
                     for key, value in transport.items():
-                        self.assertEqual(env.get(key), value, key)
+                        # Windows os.environ canonicalizes names to uppercase;
+                        # POSIX must retain each supplied casing independently.
+                        lookup_key = key.upper() if os.name == "nt" else key
+                        self.assertEqual(env.get(lookup_key), value, key)
                     self.assertNotIn("UNRELATED_SECRET", env)
                     self.assertNotIn("NODE_OPTIONS", env)
                     if engine == "codex":


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where autoreview stops before inference when its launcher supplies a valid authenticated proxy. This includes OpenClaw's managed secret-egress proxy, which authorizes a run and substitutes protected API credentials upstream.

## Why This Change Was Made

Treat proxy settings as launcher-provided transport, like existing provider authentication. Validate standard HTTP/SOCKS proxy URLs without inventing a runtime-ownership claim from a loopback address or CA filename. Preserve external CA paths and Node's existing proxy setting.

Keep reviewer isolation unchanged. Redact known proxy credential forms from progress, errors, formatted reports, and serialized JSON. The redactor handles split writes with a bounded line buffer; it is diagnostic protection, not a sandbox or a promise to detect arbitrary transformations of a secret.

## User Impact

Normal autoreview invocations can use authenticated proxy transport without new flags, extra configuration, or opting out of protected-secret access. Malformed proxy URLs and repository-owned trust paths remain rejected.

OpenClaw's WebSocket forwarding repair is a separate runtime dependency for protected-key WebSocket inference. This helper change alone does not repair that protocol path. The runtime repair and full canonical helper sync are in https://github.com/openclaw/openclaw/pull/143354.

## Evidence

- Final hardening suite: 222 tests run, one skipped, no failures. Includes regression coverage for standalone username-only proxy tokens and Windows environment-key casing.
- Engine compatibility, Codex sandbox, and inference-route suites: 71 tests passed.
- Skill validation: 8 skills validated.
- Independent source review plus fresh CLI autoreview completed. A reported Amp shell-exposure finding was checked against the generated adapter: only the fixed `autoreview_generate` tool is exposed, the outer prompt contains no review text, and the nested structured generation has no shell tools. Existing inventory and attestation tests passed; no isolation control was removed.
- Protected-store-only live autoreview completed an inference-backed review in an isolated affected-host checkout. The proxy recorded a substituted request, with no native login files, raw child API key, per-call opt-out, or credential output leak. That reviewer found the username-only proxy-token diagnostic gap, now fixed. The final repeat completed in 219 seconds with one substituted request and no captured credential leak. It returned exit 1 for a short-password redaction finding, assessed below, not a transport/authentication failure. The original scanner-enabled helper remains in this proof, so scanner removal is not being counted as a compatibility fix.

Commands:

```sh
python3.13 -m unittest discover -s skills/autoreview/tests -p test_autoreview_hardening.py
python3.13 -m unittest skills/autoreview/scripts/autoreview_test.py skills.autoreview.tests.test_codex_sandbox skills.autoreview.tests.test_codex_inference_route
uv run --python python3.13 --with-requirements requirements-dev.txt scripts/validate-skills
```

## Final review disposition and limits

The final live reviewer correctly observed that arbitrary bare passwords shorter than 8 bytes are not globally replaced. It did not establish its claimed reviewer-induced extraction path: reviewer tool environments do not inherit proxy authentication. Known URL, userinfo, Basic-auth and labeled-password forms are redacted; OpenClaw generates a 32-byte proxy token, which is also redacted when standalone. The inspected Codex proxy failures use fixed/redacted errors. No supported-client path emitting a bare short password was demonstrated. Four focused redaction/isolation tests passed, and this finding was not accepted as a source defect.

This is a diagnostic limit, not a universal no-disclosure claim. A demonstrated client error emitting a bare short credential should be addressed at that diagnostic boundary. The final live review's nonzero verdict remains recorded; it is not being reported as a clean tool verdict. The runtime/inference acceptance behavior passed without a per-call flag or alternate API-key source.
