### PR TITLE
chore(autoreview): remove retired scanner references

### DIFF
--- a/skills/autoreview/SKILL.md
+++ b/skills/autoreview/SKILL.md
@@ -144,10 +144,9 @@ or invoke an external secret scanner. Never work around an isolation failure.
 
 ### Intentional scanner-free policy
 
-TruffleHog is intentionally excluded because enterprise security teams may flag
-or restrict it. Keep approved scanning outside autoreview; reviewer findings
-happen after transmission. Reintroducing a scanner requires an explicit maintainer
-decision. See [#240](https://github.com/openclaw/agent-skills/pull/240) for rationale and history.
+Keep approved secret scanning outside autoreview; reviewer findings happen after
+transmission. Reintroducing a scanner requires an explicit maintainer decision.
+See [#240](https://github.com/openclaw/agent-skills/pull/240) for rationale and history.
 
 ### Reviewer isolation
 

--- a/skills/autoreview/tests/test_autoreview_hardening.py
+++ b/skills/autoreview/tests/test_autoreview_hardening.py
@@ -269,21 +269,6 @@ def installed_java() -> str | None:
     return java if probe.returncode == 0 else None
 
 
-def path_excluding_command(name: str) -> str:
-    """Build a PATH value with every directory that resolves ``name``
-    removed, so a subprocess launched with it cannot find that command
-    even when it is genuinely installed on the host running the tests.
-    """
-    kept = []
-    for part in os.environ.get("PATH", "").split(os.pathsep):
-        if not part:
-            continue
-        if (Path(part) / name).is_file():
-            continue
-        kept.append(part)
-    return os.pathsep.join(kept)
-
-
 class AutoreviewMixedTargetTests(unittest.TestCase):
     def setUp(self):
         self.helper = load_helper()
@@ -5774,45 +5759,6 @@ os.execv(target, [str(target), *sys.argv[1:]])
                 result.stdout,
                 r"engine check: codex[^\n]* UNAVAILABLE",
             )
-
-    @unittest.skipIf(os.name == "nt", "the fake executable is POSIX-only")
-    def test_dry_run_succeeds_without_trufflehog(self) -> None:
-        # Dry run needs only the reviewer CLI, with no external scanner.
-        with tempfile.TemporaryDirectory() as tempdir:
-            root = Path(tempdir)
-            repo = init_repo(root)
-            source = repo / "source.txt"
-            source.write_text("staged\n", encoding="utf-8")
-            git(repo, "add", "source.txt")
-            codex_bin = write_executable(
-                root / "codex",
-                fake_codex_script(),
-            )
-            env = {**os.environ, "CODEX_HOME": str(root)}
-            env["PATH"] = path_excluding_command("trufflehog")
-
-            result = subprocess.run(
-                [
-                    sys.executable,
-                    str(SCRIPT),
-                    "--mode",
-                    "local",
-                    "--engine",
-                    "codex",
-                    "--codex-bin",
-                    str(codex_bin),
-                    "--dry-run",
-                ],
-                cwd=repo,
-                env=env,
-                text=True,
-                capture_output=True,
-                check=False,
-            )
-
-            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
-            self.assertIn("prompt: OK", result.stdout)
-            self.assertRegex(result.stdout, r"engine check: codex[^\n]* OK\b")
 
     def test_dry_run_flag_exits_nonzero_when_codex_no_tools(self) -> None:
         # run_codex() unconditionally refuses --no-tools; --dry-run must


### PR DESCRIPTION
The retired credential scanner is no longer part of autoreview. Remove its obsolete missing-binary test and sole PATH-filtering helper, and describe the existing scanner-free policy without naming a retired dependency. This is the canonical cleanup for the corresponding OpenClaw removal.

Validation: all eight skills validated; all 22 remaining dry-run tests passed with Python 3.12; independent review completed before commit. Runtime behavior is unchanged.
