### PR TITLE
docs: correct unreleased autoreview notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,7 @@
 
 ## Unreleased
 
-**Highlights:** Cross-platform transcript privacy, reliable isolated reviews, and controlled session sharing.
-
-- Redact Linux, Windows, file-URI, quoted, Markdown-wrapped, and Unicode local paths in agent transcripts while preserving HTTP links and surrounding prose; bound delimiter scanning before output truncation. Thanks @SebTardif.
+**Highlights:** Authenticated proxy support for isolated reviews, explicit reviewer availability, and controlled session sharing.
 - Support launcher-provided authenticated HTTP/SOCKS proxies in Autoreview, preserve external transport trust settings, and redact proxy credentials from diagnostics and reports without changing reviewer isolation.
 
 - Fix Claude reviewer startup when the CLI truncates piped help output, while retaining mandatory isolation checks. Thanks @phyrexia.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,14 @@
 
 **Highlights:** Authenticated proxy support for isolated reviews, explicit reviewer availability, and controlled session sharing.
 
-- Support launcher-provided authenticated HTTP/SOCKS proxies in Autoreview, preserve external transport trust settings, and redact proxy credentials from diagnostics and reports without changing reviewer isolation.
+- Support launcher-provided authenticated HTTP/SOCKS proxies in Autoreview, preserve external transport trust settings, and redact proxy credentials from diagnostics and reports without changing reviewer isolation. Thanks @fuller-stack-dev.
 - Fix Claude reviewer startup when the CLI truncates piped help output, while retaining mandatory isolation checks. Thanks @phyrexia.
 - Add opt-in Autoreview `--status-output` to distinguish unavailable reviewers from clean, adverse, filtered, and incomplete reviews without changing existing report JSON or exit codes. Thanks @coygeek.
 - Provide shared Autoreview, Crabbox, behavior-validator, handoff, readme-standard, agent-transcript, session-viewer, and Beam workflows, with selectable symlink/copy installation and cross-platform skill validation.
 - Run explicitly requested reviews through isolated Codex, Claude, Amp, Pi, or Kimi engines, with structured findings, scoped attribution, progress, streaming diagnostics, dry-run preflight, and optional process deadlines.
 - Preserve complete Autoreview source and evidence without file or count caps, partitioning oversized inputs across review passes without truncation or partial-clean success.
 - Preserve base/index/working-tree source identity, literal paths, empty-source anchors, raw Git parents, and directory transitions; honor explicit local bases and normalize Git diff presentation.
-- Remove the external TruffleHog requirement from Autoreview; keep isolated reviewer credential checks and leave any pre-send scanning to the caller.
+- Remove the external TruffleHog requirement from Autoreview; keep isolated reviewer credential checks and leave any pre-send scanning to the caller. Thanks @Patrick-Erichsen.
 - Keep reviewer input, authentication, temporary files, and tools isolated; protect captured evidence against mutation and topology changes, and confine macOS reviewer scratch access.
 - Allow explicit trusted OpenAI Responses route projection through Autoreview's existing Codex config override, retaining native provider defaults, isolated catalogue snapshots, and trusted caller HOME only for selected POSIX authentication helpers.
 - Preserve Unicode and control characters in Autoreview's Codex configuration overrides and isolated Kimi TOML configuration.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,8 @@
 ## Unreleased
 
 **Highlights:** Authenticated proxy support for isolated reviews, explicit reviewer availability, and controlled session sharing.
-- Support launcher-provided authenticated HTTP/SOCKS proxies in Autoreview, preserve external transport trust settings, and redact proxy credentials from diagnostics and reports without changing reviewer isolation.
 
+- Support launcher-provided authenticated HTTP/SOCKS proxies in Autoreview, preserve external transport trust settings, and redact proxy credentials from diagnostics and reports without changing reviewer isolation.
 - Fix Claude reviewer startup when the CLI truncates piped help output, while retaining mandatory isolation checks. Thanks @phyrexia.
 - Add opt-in Autoreview `--status-output` to distinguish unavailable reviewers from clean, adverse, filtered, and incomplete reviews without changing existing report JSON or exit codes. Thanks @coygeek.
 - Provide shared Autoreview, Crabbox, behavior-validator, handoff, readme-standard, agent-transcript, session-viewer, and Beam workflows, with selectable symlink/copy installation and cross-platform skill validation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ## Unreleased
 
-**Highlights:** Isolated reviews with complete source coverage, explicit reviewer availability, and controlled session sharing.
+**Highlights:** Cross-platform transcript privacy, reliable isolated reviews, and controlled session sharing.
+
+- Redact Linux, Windows, file-URI, quoted, Markdown-wrapped, and Unicode local paths in agent transcripts while preserving HTTP links and surrounding prose; bound delimiter scanning before output truncation. Thanks @SebTardif.
+- Support launcher-provided authenticated HTTP/SOCKS proxies in Autoreview, preserve external transport trust settings, and redact proxy credentials from diagnostics and reports without changing reviewer isolation.
 
 - Fix Claude reviewer startup when the CLI truncates piped help output, while retaining mandatory isolation checks. Thanks @phyrexia.
 - Add opt-in Autoreview `--status-output` to distinguish unavailable reviewers from clean, adverse, filtered, and incomplete reviews without changing existing report JSON or exit codes. Thanks @coygeek.
@@ -10,7 +13,7 @@
 - Run explicitly requested reviews through isolated Codex, Claude, Amp, Pi, or Kimi engines, with structured findings, scoped attribution, progress, streaming diagnostics, dry-run preflight, and optional process deadlines.
 - Preserve complete Autoreview source and evidence without file or count caps, partitioning oversized inputs across review passes without truncation or partial-clean success.
 - Preserve base/index/working-tree source identity, literal paths, empty-source anchors, raw Git parents, and directory transitions; honor explicit local bases and normalize Git diff presentation.
-- Restore mandatory TruffleHog scans of complete frozen inputs and every outgoing review pack, including account-access retries, while supporting root-owned scanner installations and exact Windows scan bytes.
+- Remove the external TruffleHog requirement from Autoreview; keep isolated reviewer credential checks and leave any pre-send scanning to the caller.
 - Keep reviewer input, authentication, temporary files, and tools isolated; protect captured evidence against mutation and topology changes, and confine macOS reviewer scratch access.
 - Allow explicit trusted OpenAI Responses route projection through Autoreview's existing Codex config override, retaining native provider defaults, isolated catalogue snapshots, and trusted caller HOME only for selected POSIX authentication helpers.
 - Preserve Unicode and control characters in Autoreview's Codex configuration overrides and isolated Kimi TOML configuration.


### PR DESCRIPTION
The Unreleased changelog still claims mandatory TruffleHog scans even though #240 and #244 intentionally removed that requirement. It also omits the authenticated-proxy behavior delivered by #243.

Correct those descriptions and highlight the implemented proxy support, with changelog credit for @fuller-stack-dev and @Patrick-Erichsen. This PR contains only notes for behavior already on main and has no dependency on an unmerged implementation.

## Verification and behavior evidence

- Read the complete final changelog and compared the changed entries with the canonical Autoreview skill and the merged implementations in #240, #243, and #244.
- Ran the production helper's proxy predicate with synthetic authenticated IPv4 and IPv6 loopback URLs: both accepted; a malformed port was rejected. No real credential was printed or provider invoked in that local smoke.
- #243 contains the affected-host, inference-backed proof for authenticated proxy transport. This documentation correction makes no new transport claim.
- Full repository validation passed locally: 8 skill frontmatters, 15 repository-script tests, and 292 Autoreview tests (one existing platform skip).
- Local-candidate and committed-branch Autoreview both completed scoped-clean through P2. The real CLI invocation on final head `5732b728ed44770d0f2a4f3fbc4203c17a95b9ad` was:

```sh
~/.claude/skills/autoreview/scripts/autoreview --mode branch --base origin/main --max-priority P2
```

Observed result: exit 0, `autoreview scoped-clean: no accepted/actionable findings in the selected Git scope and priority`; overall patch correctness 0.99. This executes the canonical isolated reviewer end to end. Exact-head Ubuntu and Windows CI is recorded in the proof comment.

The repository remains Git-distributed; no version tag or package release is proposed.
