### PR TITLE
refactor(transcripts): remove unused parser state

### DIFF
--- a/skills/agent-transcript/scripts/agent-transcript
+++ b/skills/agent-transcript/scripts/agent-transcript
@@ -429,12 +429,8 @@ function toolCallFamily(row) {
 }
 
 function compactToolSummary(familyCounts, dropped) {
-  const families = new Map();
-  for (const [family, count] of familyCounts.entries()) {
-    families.set(family, (families.get(family) || 0) + count);
-  }
   const ordered = ["read", "write", "execute", "network", "other"]
-    .map((family) => [family, families.get(family) || 0])
+    .map((family) => [family, familyCounts.get(family) || 0])
     .filter(([, count]) => count > 0)
     .map(([family, count]) => `${count} ${family}`);
   const calls = ordered.length ? ordered.join(", ") : "0 tool";
@@ -780,7 +776,7 @@ function recentFiles(files, maxFiles) {
     .map((entry) => entry.file);
 }
 
-function candidateFiles(roots, terms, sinceMs, options = {}) {
+function candidateFiles(roots, sinceMs, options = {}) {
   return recentFiles(discoverSessionFiles(roots, sinceMs, options), Number(options["max-files"] || 400));
 }
 
@@ -793,7 +789,7 @@ function findSessions(options) {
     .split(/\s+/)
     .concat(query.match(/https?:\/\/\S+/g) || [])
     .filter(Boolean);
-  const files = candidateFiles(roots, terms, sinceMs, options);
+  const files = candidateFiles(roots, sinceMs, options);
   const scanBytes = Number(options["scan-bytes"] || 60000);
   const results = files
     .map((file) => scoreScanRecord(sessionScanRecord(file, scanBytes), terms, options.cwd))

--- a/skills/beam/scripts/beam-session.js
+++ b/skills/beam/scripts/beam-session.js
@@ -618,7 +618,7 @@ function addTool(stats, name) {
   stats.toolCalls++;
 }
 
-function pushMessage(items, _seen, type, input, stats, maxChars) {
+function pushMessage(items, type, input, stats, maxChars) {
   const text = sanitizeVisibleText(input, { stats, maxChars });
   if (text) items.push({ type, text });
 }
@@ -677,7 +677,6 @@ function activeClaudeRows(rows) {
 
 function parseClaude(rows, options) {
   const items = [];
-  const seen = new Set();
   const stats = { redactions: 0, toolCalls: 0, toolOutputsDropped: 0, toolFamilies: {} };
   let identity = null;
   for (const row of activeClaudeRows(rows)) {
@@ -699,8 +698,8 @@ function parseClaude(rows, options) {
     }
     if (row.type === "tool_use") addTool(stats, row.name || "tool_use");
     if (row.type === "tool_result") stats.toolOutputsDropped++;
-    if (role === "user") pushMessage(items, seen, "userMessage", visibleText(content ?? message), stats, options.maxChars);
-    if (role === "assistant") pushMessage(items, seen, "agentMessage", visibleText(content ?? message), stats, options.maxChars);
+    if (role === "user") pushMessage(items, "userMessage", visibleText(content ?? message), stats, options.maxChars);
+    if (role === "assistant") pushMessage(items, "agentMessage", visibleText(content ?? message), stats, options.maxChars);
   }
   return { source: "claude", identity, items, stats };
 }
@@ -709,15 +708,15 @@ function normalizedType(value) {
   return String(value || "").replace(/[^a-z0-9]/gi, "").toLowerCase();
 }
 
-function parseCodexItem(item, items, seen, stats, options) {
+function parseCodexItem(item, items, stats, options) {
   if (!isRecord(item)) return;
   const type = normalizedType(item.type);
   if (type === "usermessage") {
-    pushMessage(items, seen, "userMessage", visibleText(item.content ?? item.text ?? item.message), stats, options.maxChars);
+    pushMessage(items, "userMessage", visibleText(item.content ?? item.text ?? item.message), stats, options.maxChars);
     return;
   }
   if (type === "agentmessage") {
-    pushMessage(items, seen, "agentMessage", visibleText(item.content ?? item.text ?? item.message), stats, options.maxChars);
+    pushMessage(items, "agentMessage", visibleText(item.content ?? item.text ?? item.message), stats, options.maxChars);
     return;
   }
   if (["reasoning", "plan", "contextcompaction", "compaction"].includes(type)) return;
@@ -737,7 +736,6 @@ function parseCodexItem(item, items, seen, stats, options) {
 
 function parseCodex(rows, options) {
   const items = [];
-  const seen = new Set();
   const stats = { redactions: 0, toolCalls: 0, toolOutputsDropped: 0, toolFamilies: {} };
   let identity = null;
   const hasEventDialogue = rows.some((row) => {
@@ -759,9 +757,9 @@ function parseCodex(rows, options) {
     }
     if (row.type === "event_msg") {
       const type = normalizedType(payload.type);
-      if (type === "usermessage") pushMessage(items, seen, "userMessage", visibleText(payload.message ?? payload.content), stats, options.maxChars);
-      else if (type === "agentmessage") pushMessage(items, seen, "agentMessage", visibleText(payload.message ?? payload.content), stats, options.maxChars);
-      else if (type === "itemcompleted") parseCodexItem(payload.item, items, seen, stats, options);
+      if (type === "usermessage") pushMessage(items, "userMessage", visibleText(payload.message ?? payload.content), stats, options.maxChars);
+      else if (type === "agentmessage") pushMessage(items, "agentMessage", visibleText(payload.message ?? payload.content), stats, options.maxChars);
+      else if (type === "itemcompleted") parseCodexItem(payload.item, items, stats, options);
       continue;
     }
     if (row.type !== "response_item") continue;
@@ -771,7 +769,6 @@ function parseCodex(rows, options) {
       if (hasEventDialogue) continue;
       pushMessage(
         items,
-        seen,
         payload.role === "user" ? "userMessage" : "agentMessage",
         visibleText(payload.content),
         stats,


### PR DESCRIPTION
Remove Beam's unused message-deduplication sets and their argument plumbing. Simplify agent-transcript's tool summary to read the existing count map directly, and remove the unused search-terms argument from file discovery. The helpers remain independently installable, with their distinct transcript and redaction contracts intact.

Validation and live proof:
- Ran both real CLIs on a synthetic session before and after: agent-transcript's Markdown was byte-identical; Beam's dry-run upload payload was identical after excluding its expected wall-clock `updatedAt` field. Message order and tool counts were preserved.
- `node --test skills/agent-transcript/scripts/agent-transcript.test.mjs skills/beam/scripts/beam.test.mjs` → 70 passed, 0 failed/skipped.
- `python scripts/validate-skills` → `validated 8 skills`.
- Isolated Codex autoreview at P0–P2: `scoped-clean`, `patch is correct`, confidence `0.99`.

Behavior-preserving cleanup; no changelog or runtime/dependency changes.

Captured synthetic CLI comparison (no account or receiver upload):

```text
Base: 48fe5521c338a8814de9a642b33195149c9fa87d
Candidate: d1d5199dae9d5a4204eb704e2775ee1cde103f1d
beam: both CLI exits 0; 307 bytes; SHA-256 605972b8d712dc34c2f8cbf27cea2fd5dc0ad0e1fb197106d18a90bf27fc3f2f; before == after
agent-transcript: both CLI exits 0; 696 bytes; SHA-256 cf9825d384e45c934658a799114860cb303736717296ee7d4f2139619e36cb8a; before == after
Beam comparison excludes only updatedAt; its value was verified as a valid timestamp.
```

Both outputs preserve one user message, one assistant message, and the summary `1 read; raw tool outputs dropped: 1`. Beam uses its real `publish --dry-run --quiet` path; agent-transcript uses its real `render` command. The fixture contains only `Inspect the synthetic fixture.` and `Done.`, with a synthetic read call/output.
