### PR TITLE
fix(validation): require complete frontmatter delimiters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fix Claude reviewer startup when the CLI truncates piped help output, while retaining mandatory isolation checks. Thanks @phyrexia.
 - Add opt-in Autoreview `--status-output` to distinguish unavailable reviewers from clean, adverse, filtered, and incomplete reviews without changing existing report JSON or exit codes. Thanks @coygeek.
 - Provide shared Autoreview, Crabbox, behavior-validator, handoff, readme-standard, agent-transcript, session-viewer, and Beam workflows, with selectable symlink/copy installation and cross-platform skill validation.
+- Reject malformed frontmatter closing delimiters and report non-mapping YAML values accurately during skill validation.
 - Run explicitly requested reviews through isolated Codex, Claude, Amp, Pi, or Kimi engines, with structured findings, scoped attribution, progress, streaming diagnostics, dry-run preflight, and optional process deadlines.
 - Preserve complete Autoreview source and evidence without file or count caps, partitioning oversized inputs across review passes without truncation or partial-clean success.
 - Preserve base/index/working-tree source identity, literal paths, empty-source anchors, raw Git parents, and directory transitions; honor explicit local bases and normalize Git diff presentation.

--- a/README.md
+++ b/README.md
@@ -185,7 +185,8 @@ controls without a reviewer account or provider request.
 
 For a quick frontmatter-only check, run `scripts/validate-skills`. It checks
 every `skills/*/SKILL.md` for YAML frontmatter plus required `name` and
-`description`.
+`description` strings. Frontmatter must be a mapping enclosed by standalone
+`---` lines; trailing spaces or tabs are allowed on the closing line.
 
 Session exports can contain sensitive conversation data. Treat `session-viewer`
 HTML as local/private output unless it has been separately redacted and reviewed.

--- a/scripts/validate-skills
+++ b/scripts/validate-skills
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 import sys
 from pathlib import Path
 
@@ -27,15 +28,17 @@ def load_frontmatter(text: str) -> tuple[dict[object, object] | None, str | None
     if not text.startswith("---\n"):
         return None, "missing YAML frontmatter"
 
-    close = text.find("\n---", 4)
-    if close == -1:
+    close = re.search(r"^---[ \t]*$", text[4:], re.MULTILINE)
+    if close is None:
         return None, "unterminated YAML frontmatter"
 
     try:
-        data = yaml.load(text[4:close], Loader=NoAliasSafeLoader) or {}
+        data = yaml.load(text[4:4 + close.start()], Loader=NoAliasSafeLoader)
     except yaml.YAMLError as error:
         return None, f"invalid YAML: {error}"
 
+    if data is None:
+        data = {}
     if not isinstance(data, dict):
         return None, "YAML frontmatter must be a mapping"
     return data, None

--- a/scripts/validate-skills.test.py
+++ b/scripts/validate-skills.test.py
@@ -55,6 +55,28 @@ class ValidateSkillsTest(unittest.TestCase):
         self.assertEqual(result.returncode, 1)
         self.assertIn("unterminated YAML frontmatter", result.stderr)
 
+    def test_closing_delimiter_must_be_a_complete_line(self) -> None:
+        for delimiter in ("----", "---suffix"):
+            with self.subTest(delimiter=delimiter):
+                result = self.run_validator(
+                    {"sample": f"---\nname: sample\ndescription: Example\n{delimiter}\n"}
+                )
+                self.assertEqual(result.returncode, 1)
+                self.assertIn("unterminated YAML frontmatter", result.stderr)
+
+    def test_closing_delimiter_allows_trailing_whitespace(self) -> None:
+        result = self.run_validator(
+            {"sample": "---\nname: sample\ndescription: Example\n--- \t\n# Sample\n"}
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_falsey_yaml_values_are_not_mappings(self) -> None:
+        for value in ("false", "0", "[]", '""'):
+            with self.subTest(value=value):
+                result = self.run_validator({"sample": f"---\n{value}\n---\n"})
+                self.assertEqual(result.returncode, 1)
+                self.assertIn("YAML frontmatter must be a mapping", result.stderr)
+
     def test_invalid_yaml(self) -> None:
         result = self.run_validator(
             {"sample": '---\nname: [sample\ndescription: "Example"\n---\n'}


### PR DESCRIPTION
The validator accepted a closing line such as `---suffix` or `----` because it searched only for the delimiter prefix. Match a complete closing line instead, retaining trailing spaces/tabs. Also preserve the parsed YAML type until validation so `false`, `0`, `[]`, and an empty scalar produce the correct mapping error instead of being silently coerced to `{}`.

Regression tests first failed in six cases. After the fix, all 12 validator tests and the eight-skill catalog validation pass. README documents the delimiter and mapping contract; Unreleased records the fix.

Live proof through a copied production CLI and a disposable synthetic skill:
```text
Before:
closing delimiter '---suffix': exit 0; validated 1 skills
closing delimiter '---': exit 0; validated 1 skills

After:
closing delimiter '---suffix': exit 1; skills/sample/SKILL.md: unterminated YAML frontmatter
closing delimiter '---': exit 0; validated 1 skills
```
Isolated Codex autoreview at P0–P2: `scoped-clean`, `patch is correct`, confidence `0.98`. Existing YAML alias/tag safety checks remain intact.
