### PR TITLE
fix(beam): handle discovery and read boundaries exactly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Preserve Unicode and control characters in Autoreview's Codex configuration overrides and isolated Kimi TOML configuration.
 - Preserve provider conclusions, rejected findings, and distinct mixed-source claim variants; distinguish filtered and incomplete reviews from a scoped-clean result.
 - Publish redacted coding sessions through Beam's authenticated read-only catalog; accept readable and named share URLs, ignore persisted agent messages, and keep transcript items within receiver limits.
+- Let Beam discover exact-limit session stores, retry short transcript/metadata reads, and stop publication on unexpected EOF.
 - Make agent transcripts explicit-request-only and trim before previews or publication, retaining native hosted-session sharing and partial-source notices.
 - Bound agent-transcript session reads to 8 MiB and disclose partial source content in render, preview, append-body, and HTML output. Thanks @SebTardif.
 - Bound agent-transcript `find` and `html` discovery to 20,000 session files, with an integer override and correct exact-limit handling. Thanks @SebTardif.

--- a/skills/beam/README.md
+++ b/skills/beam/README.md
@@ -29,7 +29,10 @@ The `beam` helper is self-contained. It does not require `agent-transcript`,
 
 Beam refuses fuzzy discovery. If an exact session cannot be resolved or multiple
 exact candidates exist, publication stops without choosing the newest nearby
-session.
+session. Discovery permits up to 20,000 JSONL files across the native roots;
+non-session files and empty directories do not consume that budget. Reads retry
+short filesystem results and stop publication on unexpected EOF, so an incomplete
+read cannot be uploaded as a complete snapshot.
 
 ## Install
 

--- a/skills/beam/scripts/beam-session.js
+++ b/skills/beam/scripts/beam-session.js
@@ -36,11 +36,7 @@ function uniqueRealFiles(files) {
 }
 
 function walkJsonl(root, match, state, out) {
-  if (!root || !fs.existsSync(root)) return;
-  if (state.files >= state.maxFiles) {
-    state.exhausted = true;
-    return;
-  }
+  if (state.exhausted || !root || !fs.existsSync(root)) return;
   let entries;
   try {
     entries = fs.readdirSync(root, { withFileTypes: true });
@@ -48,10 +44,7 @@ function walkJsonl(root, match, state, out) {
     return;
   }
   for (const entry of entries) {
-    if (state.files >= state.maxFiles) {
-      state.exhausted = true;
-      break;
-    }
+    if (state.exhausted) break;
     if (entry.name === ".git" || entry.name === "node_modules") continue;
     const candidate = path.join(root, entry.name);
     if (entry.isDirectory()) {
@@ -59,6 +52,10 @@ function walkJsonl(root, match, state, out) {
       continue;
     }
     if (!entry.isFile() || !entry.name.endsWith(".jsonl")) continue;
+    if (state.files >= state.maxFiles) {
+      state.exhausted = true;
+      break;
+    }
     state.files++;
     if (match(entry.name, candidate)) out.push(candidate);
   }
@@ -79,9 +76,7 @@ function readPrefix(file, maxBytes = TRANSCRIPT_HEAD_BYTES) {
   try {
     const stat = fs.fstatSync(fd);
     const size = Math.min(stat.size, maxBytes);
-    const buffer = Buffer.alloc(size);
-    fs.readSync(fd, buffer, 0, size, 0);
-    return buffer.toString("utf8");
+    return readRegion(fd, 0, size);
   } finally {
     fs.closeSync(fd);
   }
@@ -145,8 +140,15 @@ export function resolveCodexSession(threadId, env = process.env, options = {}) {
 
 function readRegion(fd, start, length) {
   const buffer = Buffer.alloc(length);
-  const read = fs.readSync(fd, buffer, 0, length, start);
-  return buffer.subarray(0, read).toString("utf8");
+  let offset = 0;
+  while (offset < length) {
+    const read = fs.readSync(fd, buffer, offset, length - offset, start + offset);
+    if (read === 0) {
+      throw new Error("session file ended before the expected read completed; retry publication");
+    }
+    offset += read;
+  }
+  return buffer.toString("utf8");
 }
 
 function completeHead(text) {

--- a/skills/beam/scripts/beam.test.mjs
+++ b/skills/beam/scripts/beam.test.mjs
@@ -4,7 +4,7 @@ import http from "node:http";
 import os from "node:os";
 import path from "node:path";
 import { spawn } from "node:child_process";
-import test from "node:test";
+import test, { after } from "node:test";
 import {
   renderSession,
   resolveClaudeSession,
@@ -13,9 +13,16 @@ import {
 } from "./beam-session.js";
 
 const script = path.resolve("skills/beam/scripts/beam");
+const tempDirs = [];
+
+after(() => {
+  for (const dir of tempDirs) fs.rmSync(dir, { recursive: true, force: true });
+});
 
 function tempDir() {
-  return fs.mkdtempSync(path.join(os.tmpdir(), "beam-test-"));
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "beam-test-"));
+  tempDirs.push(dir);
+  return dir;
 }
 
 function writeJsonl(file, rows) {
@@ -223,6 +230,89 @@ test("standalone discovery fails closed when the file scan is incomplete", () =>
     () => resolveClaudeSession(id, { CLAUDE_CONFIG_DIR: configDir }, { maxFiles: 1 }),
     /discovery exceeded its file limit/,
   );
+});
+
+test("Claude discovery accepts the exact cap with trailing non-session entries", () => {
+  const configDir = tempDir();
+  const projectDir = path.join(configDir, "projects", "demo");
+  fs.mkdirSync(projectDir, { recursive: true });
+  const id = "exact-cap-session";
+  const session = path.join(projectDir, `${id}.jsonl`);
+  writeJsonl(session, [{ type: "user", sessionId: id, message: { content: "Exact cap" } }]);
+  fs.writeFileSync(path.join(projectDir, "z-notes.txt"), "not a session");
+  fs.mkdirSync(path.join(projectDir, "zz-empty"));
+  assert.equal(
+    resolveClaudeSession(id, { CLAUDE_CONFIG_DIR: configDir }, { maxFiles: 1 }).file,
+    fs.realpathSync(session),
+  );
+});
+
+test("Codex discovery shares an exact cap across active and empty archive roots", () => {
+  const codexHome = tempDir();
+  const active = path.join(codexHome, "sessions");
+  const archived = path.join(codexHome, "archived_sessions");
+  fs.mkdirSync(active);
+  fs.mkdirSync(archived);
+  const id = "exact-cap-session";
+  const session = path.join(active, `rollout-${id}.jsonl`);
+  writeJsonl(session, [{ type: "session_meta", payload: { id } }]);
+  assert.equal(
+    resolveCodexSession(id, { CODEX_HOME: codexHome }, { maxFiles: 1 }).file,
+    fs.realpathSync(session),
+  );
+  writeJsonl(path.join(archived, "other.jsonl"), []);
+  assert.throws(
+    () => resolveCodexSession(id, { CODEX_HOME: codexHome }, { maxFiles: 1 }),
+    /discovery exceeded its file limit/,
+  );
+});
+
+test("session rendering and metadata discovery retry short reads", (t) => {
+  const codexHome = tempDir();
+  fs.mkdirSync(path.join(codexHome, "sessions"));
+  const id = "short-read-session";
+  const session = path.join(codexHome, "sessions", `rollout-${id}.jsonl`);
+  writeJsonl(session, [
+    { type: "session_meta", payload: { id } },
+    { type: "event_msg", payload: { type: "user_message", message: "Complete message" } },
+  ]);
+  const read = fs.readSync;
+  t.mock.method(fs, "readSync", (fd, buffer, offset, length, position) =>
+    read(fd, buffer, offset, Math.min(length, 13), position));
+  assert.equal(resolveCodexSession(id, { CODEX_HOME: codexHome }).file, fs.realpathSync(session));
+  assert.deepEqual(renderSession(session, { source: "codex" }).items, [
+    { type: "userMessage", text: "Complete message" },
+  ]);
+});
+
+test("bounded session reads retain head and tail messages after short reads", (t) => {
+  const session = path.join(tempDir(), "session.jsonl");
+  const row = (message) => JSON.stringify({ type: "event_msg", payload: { type: "user_message", message } });
+  fs.writeFileSync(session, `${row("Head message")}\n${"x".repeat(8 * 1024 * 1024)}\n${row("Tail message")}\n`);
+  const read = fs.readSync;
+  t.mock.method(fs, "readSync", (fd, buffer, offset, length, position) =>
+    read(fd, buffer, offset, Math.min(length, 4096), position));
+  const rendered = renderSession(session, { source: "codex" });
+  assert.equal(rendered.truncated, true);
+  assert.deepEqual(rendered.items, [
+    { type: "userMessage", text: "Head message" },
+    { type: "userMessage", text: "Tail message" },
+  ]);
+});
+
+test("rendering and metadata discovery reject unexpected EOF", (t) => {
+  const codexHome = tempDir();
+  fs.mkdirSync(path.join(codexHome, "sessions"));
+  const id = "early-eof-session";
+  const session = path.join(codexHome, "sessions", `rollout-${id}.jsonl`);
+  writeJsonl(session, [{ type: "session_meta", payload: { id } }]);
+  const read = fs.readSync;
+  let calls = 0;
+  t.mock.method(fs, "readSync", (fd, buffer, offset, length, position) =>
+    calls++ === 0 ? read(fd, buffer, offset, Math.min(length, 13), position) : 0);
+  assert.throws(() => renderSession(session, { source: "codex" }), /ended before the expected read/);
+  calls = 0;
+  assert.throws(() => resolveCodexSession(id, { CODEX_HOME: codexHome }), /ended before the expected read/);
 });
 
 test("standalone Codex discovery verifies metadata across active and archived rollouts", () => {


### PR DESCRIPTION
Beam counted a scan as exhausted as soon as it reached the file cap, so an exact-limit store followed by a notes file or empty archive failed discovery. Its metadata and transcript readers also assumed one `readSync` filled the requested region, allowing incomplete input to be treated as a complete snapshot.

Count overflow only when another JSONL file is encountered. Use one exact-region reader for metadata and transcript windows: accumulate short reads and stop publication on unexpected EOF. Keep the existing caps, truncation disclosures, exact-identity rules, and standalone installation. Document the behavior; clean up the tests' own temporary directories after the suite.

Five new regression tests failed on the previous implementation. All 58 Beam tests now pass, including over-limit rejection and metadata/head/tail/EOF cases. Skill validation passes. Isolated Codex autoreview at P0–P2: `scoped-clean`, `patch is correct`, confidence `0.97`.

Live proof through the production `beam publish --dry-run --quiet` CLI:
```text
Before:
20000 JSONL files plus notes: exit 1; Claude session discovery exceeded its file limit
short-read: exit 1; the sanitized session contains no shareable messages
early-eof: exit 0; messages = 1

After:
20000 JSONL files plus notes: exit 0; Exact-cap proof present = true
short-read: exit 0; messages = 2
early-eof: exit 1; session file ended before the expected read completed; retry publication
```
The discovery fixture used 20,000 real synthetic files. Read fault injection used a Node preload restricted to the synthetic input descriptor: 13-byte reads, or EOF after its first complete record. The CLI read actual fixture bytes and produced the payload/error above; no receiver upload or account was used. All proof fixtures were removed.
