### PR TITLE
fix(node): declare native helper module format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,3 +24,4 @@
 - Normalize session-viewer metadata and timestamps, improve searchable local HTML exports, and avoid the Windows shell when opening an export.
 - Make Crabbox guidance portable and provider-neutral while preserving source-trust, remote-proof, and cleanup ownership boundaries.
 - Pin validation actions and Node.js 26, share reproducible Python/Node checks across local development and CI, typecheck the session viewer, and exercise native macOS sandbox controls alongside Linux/Windows regression coverage.
+- Declare the repository's native Node helpers as ES modules to avoid loader warnings when running from a development checkout.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "agent-skills-development",
   "private": true,
+  "type": "module",
   "scripts": {
     "typecheck": "tsc -p skills/session-viewer/tsconfig.json"
   },

--- a/skills/beam/scripts/beam.test.mjs
+++ b/skills/beam/scripts/beam.test.mjs
@@ -1299,3 +1299,12 @@ test("publish never prints access tokens on receiver errors", async (t) => {
   assert.doesNotMatch(result.stderr, /\nforged/);
   assert.doesNotMatch(`${result.stdout}\n${result.stderr}`, /super-secret-access-token/);
 });
+
+test("CLI loads its native module format without loader warnings", async () => {
+  const result = await run(["--help"], {
+    env: { NODE_OPTIONS: "", NODE_NO_WARNINGS: "" },
+  });
+  assert.equal(result.code, 0, result.stderr);
+  assert.match(result.stdout, /Usage:/);
+  assert.equal(result.stderr, "");
+});


### PR DESCRIPTION
The development manifest introduced in #249 omitted the module type. Node therefore reparsed the existing ES-module helpers and emitted `MODULE_TYPELESS_PACKAGE_JSON` warnings, including checkout paths, even for `beam --help`. Declare the existing module format explicitly; do not suppress warnings.

A new CLI regression test enables normal warning output and first failed on the old manifest. The complete Node suite (108 tests) and strict TypeScript check pass with the declaration.

Direct CLI proof, with `NODE_OPTIONS` and `NODE_NO_WARNINGS` cleared:
```text
Before: exit 0; usage printed = true; typeless-module warning = true; stderr bytes = 470
After:  exit 0; usage printed = true; typeless-module warning = false; stderr bytes = 0
```
Isolated Codex autoreview at P0–P2: `scoped-clean`, `patch is correct`, confidence `0.94`. Unreleased records the checkout-only warning fix. No dependency or runtime-floor change.
