### PR TITLE
fix(agent-transcript): read complete bounded source regions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Publish redacted coding sessions through Beam's authenticated read-only catalog; accept readable and named share URLs, ignore persisted agent messages, and keep transcript items within receiver limits.
 - Make agent transcripts explicit-request-only and trim before previews or publication, retaining native hosted-session sharing and partial-source notices.
 - Bound agent-transcript session reads to 8 MiB and disclose partial source content in render, preview, append-body, and HTML output. Thanks @SebTardif.
+- Retry short agent-transcript reads and fail on unexpected EOF before rendering or scoring incomplete session content.
 - Bound agent-transcript `find` and `html` discovery to 20,000 session files, with an integer override and correct exact-limit handling. Thanks @SebTardif.
 - Add opt-in session-viewer head/tail reads with `--max-read-bytes`, preserving complete exports by default and showing escaped truncation warnings; retry short reads and fail on unexpected EOF. Thanks @SebTardif.
 - Normalize session-viewer metadata and timestamps, improve searchable local HTML exports, and avoid the Windows shell when opening an export.

--- a/skills/agent-transcript/SKILL.md
+++ b/skills/agent-transcript/SKILL.md
@@ -40,6 +40,8 @@ at most 12,000 lines. `--max-read-bytes N` changes the byte limit. Preserve the
 visible partial-transcript notice and `sourceTruncated` stats through trimming,
 preview, and insertion; omitted source must never be described as complete.
 These are file-read limits, not limits on the separate app-server rendering mode.
+Short filesystem reads are retried. Unexpected EOF stops rendering or discovery
+instead of treating incomplete input as a complete session.
 
 Automatically trim the rendered Markdown **before showing, previewing, or
 inserting it**. Keep only task-relevant user prompts, visible decisions, terse

--- a/skills/agent-transcript/scripts/agent-transcript
+++ b/skills/agent-transcript/scripts/agent-transcript
@@ -705,22 +705,31 @@ async function renderTranscript(options) {
   return renderSession(options.session, options);
 }
 
+function readRegion(fd, start, length) {
+  const buffer = Buffer.alloc(length);
+  let offset = 0;
+  while (offset < length) {
+    const read = fs.readSync(fd, buffer, offset, length - offset, start + offset);
+    if (read === 0) {
+      throw new Error("session file ended before the expected read completed; retry the read");
+    }
+    offset += read;
+  }
+  return buffer.toString("utf8");
+}
+
 function readBoundedText(file, maxBytes = 220000) {
   const fd = fs.openSync(file, "r");
   try {
     const stat = fs.fstatSync(fd);
     if (stat.size <= maxBytes) {
-      const buffer = Buffer.alloc(stat.size);
-      const bytesRead = fs.readSync(fd, buffer, 0, stat.size, 0);
-      return { text: buffer.subarray(0, bytesRead).toString("utf8"), truncated: false };
+      return { text: readRegion(fd, 0, stat.size), truncated: false };
     }
     const half = Math.floor(maxBytes / 2);
-    const head = Buffer.alloc(half);
-    const tail = Buffer.alloc(half);
-    const headBytes = fs.readSync(fd, head, 0, half, 0);
-    const tailBytes = fs.readSync(fd, tail, 0, half, Math.max(0, stat.size - half));
+    const head = readRegion(fd, 0, half);
+    const tail = readRegion(fd, stat.size - half, half);
     return {
-      text: `${head.subarray(0, headBytes).toString("utf8")}\n[...middle omitted for scan...]\n${tail.subarray(0, tailBytes).toString("utf8")}`,
+      text: `${head}\n[...middle omitted for scan...]\n${tail}`,
       truncated: true,
     };
   } finally {

--- a/skills/agent-transcript/scripts/agent-transcript.test.mjs
+++ b/skills/agent-transcript/scripts/agent-transcript.test.mjs
@@ -3,12 +3,49 @@ import { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import test from "node:test";
+import test, { after } from "node:test";
+import { pathToFileURL } from "node:url";
 
 const script = path.resolve("skills/agent-transcript/scripts/agent-transcript");
+const tempDirs = [];
+
+after(() => {
+  for (const dir of tempDirs) fs.rmSync(dir, { recursive: true, force: true });
+});
 
 function tempDir() {
-  return fs.mkdtempSync(path.join(os.tmpdir(), "agent-transcript-test-"));
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-transcript-test-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function runWithLimitedReads(args, session, chunkSize, earlyEof = false) {
+  const preload = path.join(tempDir(), "limited-reads.mjs");
+  fs.writeFileSync(preload, `
+import fs from "node:fs";
+import path from "node:path";
+const open = fs.openSync, read = fs.readSync, close = fs.closeSync;
+const owned = new Set();
+let calls = 0;
+fs.openSync = (file, ...args) => {
+  const fd = open(file, ...args);
+  if (typeof file === "string" && path.resolve(file) === path.resolve(process.env.TEST_SESSION)) owned.add(fd);
+  return fd;
+};
+fs.closeSync = (fd) => { owned.delete(fd); return close(fd); };
+fs.readSync = (fd, buffer, offset, length, position) => {
+  if (owned.has(fd)) {
+    if (process.env.TEST_EOF === "1" && calls++ > 0) return 0;
+    length = Math.min(length, Number(process.env.TEST_CHUNK));
+  }
+  return read(fd, buffer, offset, length, position);
+};
+`);
+  return execFileSync(process.execPath, ["--import", pathToFileURL(preload).href, script, ...args], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+    env: { ...process.env, TEST_SESSION: session, TEST_CHUNK: String(chunkSize), TEST_EOF: earlyEof ? "1" : "0" },
+  });
 }
 
 function writeJsonl(file, rows) {
@@ -349,5 +386,48 @@ test("discovery rejects invalid and missing file limits", () => {
         (error) => /--max-discovery-files must be a positive integer/.test(String(error.stderr)),
       );
     }
+  }
+});
+
+test("render retries short reads without losing complete source messages", () => {
+  const session = path.join(tempDir(), "session.jsonl");
+  writeJsonl(session, [
+    { type: "user", message: { role: "user", content: "First complete message" } },
+    { type: "assistant", message: { role: "assistant", content: "Second complete message" } },
+  ]);
+  const output = runWithLimitedReads(["render", "--session", session], session, 13);
+  assert.match(output, /First complete message/);
+  assert.match(output, /Second complete message/);
+  assert.match(output, /"sourceTruncated":false/);
+});
+
+test("bounded rendering retries both head and tail reads", () => {
+  const session = path.join(tempDir(), "session.jsonl");
+  const row = (content) => JSON.stringify({ type: "user", message: { role: "user", content } });
+  fs.writeFileSync(session, `${row("First complete message")}\n${"x".repeat(2048)}\n${row("Last complete message")}\n`);
+  const output = runWithLimitedReads(["render", "--session", session, "--max-read-bytes", "256"], session, 13);
+  assert.match(output, /First complete message/);
+  assert.match(output, /Last complete message/);
+  assert.match(output, /"sourceTruncated":true/);
+});
+
+test("find retries short reads before scoring a session", () => {
+  const root = tempDir();
+  const session = path.join(root, "session.jsonl");
+  writeJsonl(session, [{ type: "user", message: { role: "user", content: "tail-search-marker" } }]);
+  const output = runWithLimitedReads(["find", "--root", root, "--query", "tail-search-marker"], session, 13);
+  assert.equal(JSON.parse(output)[0]?.file, session);
+});
+
+test("render and discovery fail instead of treating unexpected EOF as complete input", () => {
+  const root = tempDir();
+  const session = path.join(root, "session.jsonl");
+  const first = JSON.stringify({ type: "user", message: { role: "user", content: "First complete message" } }) + "\n";
+  fs.writeFileSync(session, first + JSON.stringify({ type: "assistant", message: { role: "assistant", content: "Last complete message" } }) + "\n");
+  for (const args of [["render", "--session", session], ["find", "--root", root, "--query", "First complete message"]]) {
+    assert.throws(
+      () => runWithLimitedReads(args, session, Buffer.byteLength(first), true),
+      (error) => error.status === 1 && error.stdout === "" && /ended before the expected read/.test(error.stderr),
+    );
   }
 });


### PR DESCRIPTION
Agent-transcript assumed a single filesystem read filled the requested range. A short read could render no messages or only the first message while still reporting `sourceTruncated: false`; discovery could also miss matching content. Refactor the full, head, and tail paths through one exact-region reader, retry short reads, and fail on unexpected EOF before rendering or scoring partial input.

Four new regression tests first failed on the prior implementation. All 21 transcript tests now pass, covering full/bounded rendering, discovery, and early EOF. The tests also clean up their own temporary fixtures. Skill documentation and Unreleased describe the read contract.

Live proof through the production `agent-transcript render` CLI:
```text
Before:
short-read: exit 0; messages = 0; sourceTruncated=false = true
early-eof: exit 0; messages = 1; sourceTruncated=false = true

After:
short-read: exit 0; messages = 2; sourceTruncated=false = true
early-eof: exit 1; session file ended before the expected read completed; retry the read
```
A Node preload restricted only the synthetic input descriptor to 13-byte reads, or returned EOF after the first complete record. The CLI used actual fixture bytes; no account, real session, or network access was involved. The temporary fixture was removed.

Isolated Codex autoreview at P0–P2: `scoped-clean`, `patch is correct`, confidence `0.96`. Existing caps, deliberate-truncation notices, redaction, and app-server behavior remain unchanged.
