### PR TITLE
fix(skills): isolate copied Node module boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,3 +28,4 @@
 - Make Crabbox guidance portable and provider-neutral while preserving source-trust, remote-proof, and cleanup ownership boundaries.
 - Pin validation actions and Node.js 26, share reproducible Python/Node checks across local development and CI, typecheck the session viewer, and exercise native macOS sandbox controls alongside Linux/Windows regression coverage.
 - Declare the repository's native Node helpers as ES modules to avoid loader warnings when running from a development checkout.
+- Keep copied Beam, agent-transcript, and session-viewer helpers runnable inside CommonJS projects with skill-local module declarations.

--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ scripts/install-skills --force autoreview
 
 Symlinks are best for local development because changes in this checkout are
 immediately visible. Copies are better for portable or locked-down setups.
+Node-based skills declare their module format locally, so copied helpers also
+run inside CommonJS projects without installing dependencies.
 
 ## Codex And Claude
 

--- a/skills/agent-transcript/package.json
+++ b/skills/agent-transcript/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/skills/agent-transcript/scripts/agent-transcript.test.mjs
+++ b/skills/agent-transcript/scripts/agent-transcript.test.mjs
@@ -431,3 +431,15 @@ test("render and discovery fail instead of treating unexpected EOF as complete i
     );
   }
 });
+
+test("copied agent-transcript runs inside a CommonJS project without dependencies", () => {
+  const root = tempDir();
+  fs.writeFileSync(path.join(root, "package.json"), JSON.stringify({ type: "commonjs" }));
+  const installed = path.join(root, "installed-transcript");
+  fs.cpSync(path.dirname(path.dirname(script)), installed, { recursive: true });
+  const output = execFileSync(process.execPath, [path.join(installed, "scripts", "agent-transcript"), "--help"], {
+    cwd: root, encoding: "utf8", stdio: "pipe",
+    env: { ...process.env, NODE_OPTIONS: "", NODE_NO_WARNINGS: "" },
+  });
+  assert.match(output, /Usage:/);
+});

--- a/skills/beam/package.json
+++ b/skills/beam/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/skills/beam/scripts/beam.test.mjs
+++ b/skills/beam/scripts/beam.test.mjs
@@ -3,7 +3,7 @@ import fs from "node:fs";
 import http from "node:http";
 import os from "node:os";
 import path from "node:path";
-import { spawn } from "node:child_process";
+import { execFileSync, spawn } from "node:child_process";
 import test, { after } from "node:test";
 import {
   renderSession,
@@ -1397,4 +1397,16 @@ test("CLI loads its native module format without loader warnings", async () => {
   assert.equal(result.code, 0, result.stderr);
   assert.match(result.stdout, /Usage:/);
   assert.equal(result.stderr, "");
+});
+
+test("copied Beam runs inside a CommonJS project without dependencies", () => {
+  const root = tempDir();
+  fs.writeFileSync(path.join(root, "package.json"), JSON.stringify({ type: "commonjs" }));
+  const installed = path.join(root, "installed-beam");
+  fs.cpSync(path.dirname(path.dirname(script)), installed, { recursive: true });
+  const output = execFileSync(process.execPath, [path.join(installed, "scripts", "beam"), "--help"], {
+    cwd: root, encoding: "utf8", stdio: "pipe",
+    env: { ...process.env, NODE_OPTIONS: "", NODE_NO_WARNINGS: "" },
+  });
+  assert.match(output, /Usage:/);
 });

--- a/skills/session-viewer/package.json
+++ b/skills/session-viewer/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/skills/session-viewer/scripts/session-viewer.test.ts
+++ b/skills/session-viewer/scripts/session-viewer.test.ts
@@ -1070,3 +1070,17 @@ test("viewer escapes warning text and accepts legacy raw payloads", () => {
   const legacy = html.replace(',"warnings":[]', "");
   assert.equal(renderViewer(legacy).get("warnings")!.hidden, true);
 });
+
+test("copied viewer renders inside a CommonJS project without dependencies", async (t) => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "copied-viewer-"));
+  t.after(() => fs.rm(root, { recursive: true, force: true }));
+  await fs.writeFile(path.join(root, "package.json"), JSON.stringify({ type: "commonjs" }));
+  const installed = path.join(root, "installed-viewer");
+  await fs.cp(path.resolve("skills/session-viewer"), installed, { recursive: true });
+  const output = path.join(root, "viewer.html");
+  await execFileAsync(process.execPath, [path.join(installed, "scripts", "session-viewer.ts"), "--blank", "--out", output], {
+    cwd: root,
+    env: { ...process.env, NODE_OPTIONS: "", NODE_NO_WARNINGS: "" },
+  });
+  assert.match(await fs.readFile(output, "utf8"), /<!doctype html>/);
+});


### PR DESCRIPTION
Copied Node helpers inherited the destination project's module format. Inside a CommonJS project, Beam, agent-transcript, and session-viewer failed at their import statements even though installation succeeded. Give each skill its own minimal ES-module declaration so the runtime boundary travels with the copied skill.

This fixes the installation contract without renaming CLI entrypoints, adding dependencies, or relying on the canonical checkout's development manifest. README and Unreleased describe the behavior.

Three new copied-install regressions first failed. All 120 Node tests and the strict TypeScript check pass after the fix. Isolated Codex autoreview at P0–P2: `scoped-clean`, `patch is correct`, confidence `0.96`.

Live proof used the real `scripts/install-skills --mode copy` into a disposable CommonJS project, with no dependency install, followed by each installed CLI (help for Beam/transcript; actual HTML generation for the viewer):
```text
Before:
Installer: exit 0; copied three Node skills
beam: exit 1; import syntax error = true
agent-transcript: exit 1; import syntax error = true
session-viewer: exit 1; import syntax error = true

After:
Installer: exit 0; copied three Node skills
beam: exit 0; success output = true
agent-transcript: exit 0; success output = true
session-viewer: exit 0; success output = true
```
The synthetic project contained no node_modules and was removed afterward. The three per-skill tests independently copy only their own skill, so standalone testing remains possible.
